### PR TITLE
Port Play-Cricket background sync job

### DIFF
--- a/apps/api/src/features/play-cricket/api-client.ts
+++ b/apps/api/src/features/play-cricket/api-client.ts
@@ -1,14 +1,23 @@
+import {
+  GetMatchDetailResponse,
+  GetMatchSummaryResponse,
+  GetTeamsResponse,
+} from "./api-schemas.js";
+
 const API_BASE = "https://www.play-cricket.com/api/v2";
 
+export interface PlayCricketApiConfig {
+  apiToken: string;
+  siteId: string;
+}
+
 async function fetchPlayCricket(
+  config: PlayCricketApiConfig,
   path: string,
   params?: Record<string, string>,
 ): Promise<unknown> {
-  const token = process.env.PLAY_CRICKET_API_TOKEN;
-  if (!token) throw new Error("PLAY_CRICKET_API_TOKEN not set");
-
   const url = new URL(`${API_BASE}${path}`);
-  url.searchParams.set("api_token", token);
+  url.searchParams.set("api_token", config.apiToken);
   if (params) {
     for (const [key, value] of Object.entries(params)) {
       url.searchParams.set(key, value);
@@ -16,28 +25,75 @@ async function fetchPlayCricket(
   }
 
   const res = await fetch(url);
-  if (!res.ok) throw new Error(`Play Cricket API error: ${res.status}`);
-  return res.json() as Promise<unknown>;
+  const body = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `Play Cricket API error (HTTP ${res.status}): ${body.slice(0, 500)}`,
+    );
+  }
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    throw new Error(
+      `Play Cricket API returned non-JSON (HTTP ${res.status}): ${body.slice(0, 500)}`,
+    );
+  }
 }
 
+export function createApiClient(config: PlayCricketApiConfig) {
+  return {
+    async getMatchDetail(matchId: string) {
+      const json = await fetchPlayCricket(
+        config,
+        `/match_detail/${matchId}.json`,
+      );
+      return GetMatchDetailResponse.parse(json);
+    },
+
+    async getMatchesSummary(season: number) {
+      const json = await fetchPlayCricket(config, "/matches.json", {
+        site_id: config.siteId,
+        season: String(season),
+      });
+      return GetMatchSummaryResponse.parse(json);
+    },
+
+    async getTeams() {
+      const json = await fetchPlayCricket(
+        config,
+        `/sites/${config.siteId}/teams.json`,
+      );
+      return GetTeamsResponse.parse(json);
+    },
+
+    async getLeagueTable(divisionId: string) {
+      return fetchPlayCricket(config, `/league_table/${divisionId}.json`);
+    },
+
+    async getMatchScorecard(matchId: string) {
+      return fetchPlayCricket(config, `/match_detail/${matchId}.json`);
+    },
+  };
+}
+
+export type PlayCricketApiClient = ReturnType<typeof createApiClient>;
+
+// Standalone functions for backward compat with existing service.ts
+// These read from process.env — used only during route wiring, not in services
 export async function getMatchDetail(matchId: string): Promise<unknown> {
-  return fetchPlayCricket(`/match_detail/${matchId}.json`);
-}
-
-export async function getResultSummary(siteId: string, season: number): Promise<unknown> {
-  return fetchPlayCricket(`/result_summary/${siteId}.json`, {
-    season: String(season),
-  });
+  const config = getConfigFromEnv();
+  return createApiClient(config).getMatchScorecard(matchId);
 }
 
 export async function getLeagueTable(divisionId: string): Promise<unknown> {
-  return fetchPlayCricket(`/league_table/${divisionId}.json`);
+  const config = getConfigFromEnv();
+  return createApiClient(config).getLeagueTable(divisionId);
 }
 
-export async function getTeams(siteId: string): Promise<unknown> {
-  return fetchPlayCricket(`/teams.json`, { site_id: siteId });
-}
-
-export async function getMatchScorecard(matchId: string): Promise<unknown> {
-  return fetchPlayCricket(`/match_detail/${matchId}.json`);
+function getConfigFromEnv(): PlayCricketApiConfig {
+  const apiToken = process.env.PLAY_CRICKET_API_TOKEN;
+  const siteId = process.env.PLAY_CRICKET_SITE_ID;
+  if (!apiToken) throw new Error("PLAY_CRICKET_API_TOKEN not set");
+  if (!siteId) throw new Error("PLAY_CRICKET_SITE_ID not set");
+  return { apiToken, siteId };
 }

--- a/apps/api/src/features/play-cricket/api-schemas.ts
+++ b/apps/api/src/features/play-cricket/api-schemas.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+
+// --- Match Summary (list of matches for a season) ---
+
+export const MatchSummaryMatch = z.object({
+  id: z.number(),
+  status: z.string(),
+  published: z.string(),
+  last_updated: z.string(),
+  league_name: z.string().optional(),
+  league_id: z.string().optional(),
+  competition_name: z.string().optional(),
+  competition_id: z.string().optional(),
+  competition_type: z.string().optional(),
+  match_type: z.string().optional(),
+  game_type: z.string().optional(),
+  season: z.string(),
+  match_date: z.string(),
+  match_time: z.string().optional(),
+  ground_name: z.string().optional(),
+  ground_id: z.string().optional(),
+  ground_latitude: z.string().optional(),
+  ground_longitude: z.string().optional(),
+  home_club_name: z.string(),
+  home_team_name: z.string(),
+  home_team_id: z.string(),
+  home_club_id: z.string(),
+  away_club_name: z.string(),
+  away_team_name: z.string(),
+  away_team_id: z.string(),
+  away_club_id: z.string(),
+  umpire_1_name: z.string().optional(),
+  umpire_1_id: z.string().optional(),
+  umpire_2_name: z.string().optional(),
+  umpire_2_id: z.string().optional(),
+  umpire_3_name: z.string().optional(),
+  umpire_3_id: z.string().optional(),
+  referee_name: z.string().optional(),
+  referee_id: z.string().optional(),
+  scorer_1_name: z.string().optional(),
+  scorer_1_id: z.string().optional(),
+  scorer_2_name: z.string().optional(),
+  scorer_2_id: z.string().optional(),
+});
+
+export type MatchSummaryMatch = z.output<typeof MatchSummaryMatch>;
+
+export const GetMatchSummaryResponse = z.object({
+  matches: z.array(MatchSummaryMatch),
+});
+
+// --- Match Detail (full scorecard) ---
+
+export const MatchDetailBat = z.object({
+  position: z.string(),
+  batsman_name: z.string(),
+  batsman_id: z.string(),
+  how_out: z.string().nullable().optional(),
+  fielder_name: z.string().nullable().optional(),
+  fielder_id: z.string().nullable().optional(),
+  bowler_name: z.string().nullable().optional(),
+  bowler_id: z.string().nullable().optional(),
+  runs: z.string(),
+  fours: z.string(),
+  sixes: z.string(),
+  balls: z.string(),
+});
+
+export type MatchDetailBat = z.output<typeof MatchDetailBat>;
+
+export const MatchDetailBowl = z.object({
+  bowler_name: z.string(),
+  bowler_id: z.string(),
+  overs: z.string(),
+  maidens: z.string(),
+  runs: z.string(),
+  wides: z.string(),
+  wickets: z.string(),
+  no_balls: z.string(),
+});
+
+export const MatchDetailFoW = z.object({
+  runs: z.string(),
+  wickets: z.number(),
+  batsman_out_name: z.string(),
+  batsman_out_id: z.string(),
+  batsman_in_name: z.string().optional().default(""),
+  batsman_in_id: z.string().optional().default(""),
+  batsman_in_runs: z.string().optional().default(""),
+});
+
+export const MatchDetailPlayer = z.object({
+  position: z.number(),
+  player_name: z.string(),
+  player_id: z.number().nullable(),
+  captain: z.boolean(),
+  wicket_keeper: z.boolean(),
+});
+
+export const MatchDetailInnings = z.object({
+  team_batting_name: z.string(),
+  team_batting_id: z.string(),
+  innings_number: z.number(),
+  extra_byes: z.string(),
+  extra_leg_byes: z.string(),
+  extra_wides: z.string(),
+  extra_no_balls: z.string(),
+  extra_penalty_runs: z.string(),
+  penalties_runs_awarded_in_other_innings: z.string(),
+  total_extras: z.string(),
+  runs: z.string(),
+  wickets: z.string(),
+  overs: z.string(),
+  declared: z.boolean().nullable().default(false),
+  revised_target_runs: z.string(),
+  revised_target_overs: z.string(),
+  bat: z.array(MatchDetailBat),
+  bowl: z.array(MatchDetailBowl),
+  fow: z.array(MatchDetailFoW),
+});
+
+export const MatchDetail = z.object({
+  id: z.number(),
+  home_team_name: z.string(),
+  home_team_id: z.string(),
+  home_club_name: z.string(),
+  home_club_id: z.string().optional().default(""),
+  away_team_name: z.string(),
+  away_team_id: z.string(),
+  away_club_name: z.string(),
+  away_club_id: z.string().optional().default(""),
+  toss: z.string().optional().default(""),
+  batted_first: z.string().optional().default(""),
+  result: z.string().optional().default(""),
+  result_description: z.string().optional().default(""),
+  result_applied_to: z.string().optional().default(""),
+  match_type: z.string().optional().default(""),
+  competition_type: z.string().optional().default(""),
+  match_date: z.string().optional().default(""),
+  season: z.string().optional().default(""),
+  players: z.array(
+    z.object({
+      home_team: z.array(MatchDetailPlayer).optional(),
+      away_team: z.array(MatchDetailPlayer).optional(),
+    }),
+  ),
+  innings: z.array(MatchDetailInnings),
+});
+
+export const GetMatchDetailResponse = z.object({
+  match_details: z.array(MatchDetail),
+});
+
+// --- Teams ---
+
+export const GetTeamsResponse = z.object({
+  teams: z.array(
+    z.object({
+      id: z.union([z.string(), z.number()]),
+      status: z.string(),
+      last_updated: z.string(),
+      site_id: z.union([z.string(), z.number()]),
+      team_name: z.string(),
+      other_team_name: z.string().optional().default(""),
+      nickname: z.string().optional().default(""),
+      team_captain: z.string().optional().default(""),
+    }),
+  ),
+});

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import assert from "node:assert/strict";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import {
   startTestContainer,
   stopTestContainer,
@@ -6,6 +7,8 @@ import {
   type TestContext,
 } from "../../test/containers.js";
 import { getTeams, getMatchDetail, getPlayerCareerStats } from "./service.js";
+import type { PlayCricketApiClient } from "./api-client.js";
+import { runSync } from "./sync.js";
 
 let ctx: TestContext;
 
@@ -197,5 +200,444 @@ describe("play-cricket service (integration)", () => {
       expect(result?.battingBySeasonRows).toHaveLength(2);
       expect(result?.bowlingBySeasonRows).toHaveLength(1);
     });
+  });
+});
+
+// --- Sync integration tests ---
+
+function createMockApi(
+  overrides: Partial<PlayCricketApiClient> = {},
+): PlayCricketApiClient {
+  return {
+    getTeams: vi.fn().mockResolvedValue({ teams: [] }),
+    getMatchesSummary: vi.fn().mockResolvedValue({ matches: [] }),
+    getMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
+    getLeagueTable: vi.fn().mockResolvedValue({}),
+    getMatchScorecard: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+const SITE_ID = "134";
+const OUR_TEAM_ID = "68498";
+const OPPONENT_TEAM_ID = "99999";
+
+function makeMatchSummary(id: number, matchDate = "01/07/2026") {
+  return {
+    id,
+    status: "Completed",
+    published: "Yes",
+    last_updated: "2026-07-01",
+    season: "2026",
+    match_date: matchDate,
+    home_club_name: "Percy Main",
+    home_team_name: "1st XI",
+    home_team_id: OUR_TEAM_ID,
+    home_club_id: SITE_ID,
+    away_club_name: "Opposition CC",
+    away_team_name: "1st XI",
+    away_team_id: OPPONENT_TEAM_ID,
+    away_club_id: "999",
+  };
+}
+
+function makeMatchDetail(matchId: number) {
+  return {
+    match_details: [
+      {
+        id: matchId,
+        home_team_name: "Percy Main 1st XI",
+        home_team_id: OUR_TEAM_ID,
+        home_club_name: "Percy Main",
+        home_club_id: SITE_ID,
+        away_team_name: "Opposition 1st XI",
+        away_team_id: OPPONENT_TEAM_ID,
+        away_club_name: "Opposition CC",
+        away_club_id: "999",
+        result: "Won by 5 wickets",
+        result_description: "Percy Main won",
+        result_applied_to: OUR_TEAM_ID,
+        players: [
+          {
+            home_team: [
+              {
+                position: 1,
+                player_name: "A Batsman",
+                player_id: 1001,
+                captain: false,
+                wicket_keeper: false,
+              },
+              {
+                position: 7,
+                player_name: "B Keeper",
+                player_id: 1002,
+                captain: false,
+                wicket_keeper: true,
+              },
+            ],
+            away_team: [
+              {
+                position: 1,
+                player_name: "X Bowler",
+                player_id: 2001,
+                captain: false,
+                wicket_keeper: false,
+              },
+            ],
+          },
+        ],
+        innings: [
+          {
+            team_batting_name: "Opposition 1st XI",
+            team_batting_id: OPPONENT_TEAM_ID,
+            innings_number: 1,
+            extra_byes: "0",
+            extra_leg_byes: "2",
+            extra_wides: "5",
+            extra_no_balls: "1",
+            extra_penalty_runs: "0",
+            penalties_runs_awarded_in_other_innings: "0",
+            total_extras: "8",
+            runs: "150",
+            wickets: "10",
+            overs: "45",
+            declared: false,
+            revised_target_runs: "0",
+            revised_target_overs: "0",
+            bat: [
+              {
+                position: "1",
+                batsman_name: "X Bowler",
+                batsman_id: "2001",
+                how_out: "ct",
+                fielder_name: "B Keeper",
+                fielder_id: "1002",
+                bowler_name: "C Bowler",
+                bowler_id: "1003",
+                runs: "45",
+                fours: "5",
+                sixes: "1",
+                balls: "60",
+              },
+              {
+                position: "2",
+                batsman_name: "Y Batsman",
+                batsman_id: "2002",
+                how_out: "ro",
+                fielder_name: "A Batsman",
+                fielder_id: "1001",
+                runs: "30",
+                fours: "3",
+                sixes: "0",
+                balls: "40",
+              },
+            ],
+            bowl: [
+              {
+                bowler_name: "C Bowler",
+                bowler_id: "1003",
+                overs: "10",
+                maidens: "2",
+                runs: "35",
+                wickets: "3",
+                wides: "1",
+                no_balls: "0",
+              },
+            ],
+            fow: [],
+          },
+          {
+            team_batting_name: "Percy Main 1st XI",
+            team_batting_id: OUR_TEAM_ID,
+            innings_number: 2,
+            extra_byes: "1",
+            extra_leg_byes: "0",
+            extra_wides: "3",
+            extra_no_balls: "0",
+            extra_penalty_runs: "0",
+            penalties_runs_awarded_in_other_innings: "0",
+            total_extras: "4",
+            runs: "155",
+            wickets: "5",
+            overs: "40",
+            declared: false,
+            revised_target_runs: "0",
+            revised_target_overs: "0",
+            bat: [
+              {
+                position: "1",
+                batsman_name: "A Batsman",
+                batsman_id: "1001",
+                how_out: "caught",
+                fielder_name: "X Bowler",
+                fielder_id: "2001",
+                bowler_name: "Z Bowler",
+                bowler_id: "2003",
+                runs: "85",
+                fours: "10",
+                sixes: "2",
+                balls: "100",
+              },
+              {
+                position: "2",
+                batsman_name: "B Keeper",
+                batsman_id: "1002",
+                how_out: "no",
+                runs: "60",
+                fours: "7",
+                sixes: "1",
+                balls: "70",
+              },
+            ],
+            bowl: [],
+            fow: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("play-cricket sync (integration)", () => {
+  it("syncs teams from API", async () => {
+    const api = createMockApi({
+      getTeams: vi.fn().mockResolvedValue({
+        teams: [
+          {
+            id: "68498",
+            status: "Active",
+            last_updated: "2026-01-01",
+            site_id: "134",
+            team_name: "1st XI",
+          },
+          {
+            id: "71066",
+            status: "Active",
+            last_updated: "2026-01-01",
+            site_id: "134",
+            team_name: "Under 13s",
+          },
+        ],
+      }),
+    });
+
+    const sync = runSync(ctx.db, api);
+    await sync({ siteId: SITE_ID });
+
+    const teams = await ctx.db
+      .selectFrom("play_cricket_team")
+      .where("site_id", "=", SITE_ID)
+      .selectAll()
+      .execute();
+
+    const teamNames = teams.map((t) => t.name);
+    expect(teamNames).toContain("1st XI");
+    expect(teamNames).toContain("Under 13s");
+
+    const juniorTeam = teams.find((t) => t.name === "Under 13s");
+    expect(juniorTeam?.is_junior).toBe(true);
+
+    const seniorTeam = teams.find((t) => t.name === "1st XI");
+    expect(seniorTeam?.is_junior).toBe(false);
+  });
+
+  it("stores batting, bowling, and fielding performances", async () => {
+    const matchId = 77700 + Math.floor(Math.random() * 1000);
+    const api = createMockApi({
+      getMatchesSummary: vi
+        .fn()
+        .mockResolvedValue({ matches: [makeMatchSummary(matchId)] }),
+      getMatchDetail: vi
+        .fn()
+        .mockResolvedValue(makeMatchDetail(matchId)),
+    });
+
+    const sync = runSync(ctx.db, api);
+    const result = await sync({ siteId: SITE_ID });
+
+    expect(result.matchesProcessed).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    // Check batting (our team batted in innings 2)
+    const batting = await ctx.db
+      .selectFrom("match_performance_batting")
+      .where("match_id", "=", matchId.toString())
+      .selectAll()
+      .execute();
+
+    expect(batting).toHaveLength(2);
+    const aBatsman = batting.find((b) => b.player_id === "1001");
+    assert(aBatsman, "Expected batting record for player 1001");
+    expect(aBatsman.runs).toBe(85);
+    expect(aBatsman.not_out).toBe(false);
+
+    const bKeeper = batting.find((b) => b.player_id === "1002");
+    assert(bKeeper, "Expected batting record for player 1002");
+    expect(bKeeper.runs).toBe(60);
+    expect(bKeeper.not_out).toBe(true);
+
+    // Check bowling (our team bowled in innings 1)
+    const bowling = await ctx.db
+      .selectFrom("match_performance_bowling")
+      .where("match_id", "=", matchId.toString())
+      .selectAll()
+      .execute();
+
+    expect(bowling).toHaveLength(1);
+    expect(bowling[0].player_id).toBe("1003");
+    expect(bowling[0].wickets).toBe(3);
+    expect(bowling[0].overs).toBe("10");
+
+    // Check fielding (our team fielded in innings 1)
+    const fielding = await ctx.db
+      .selectFrom("match_performance_fielding")
+      .where("match_id", "=", matchId.toString())
+      .selectAll()
+      .execute();
+
+    expect(fielding).toHaveLength(2);
+
+    const keeperFielding = fielding.find((f) => f.player_id === "1002");
+    assert(keeperFielding, "Expected fielding record for player 1002");
+    expect(keeperFielding.catches).toBe(1);
+    expect(keeperFielding.is_wicketkeeper).toBe(true);
+
+    const batsmanFielding = fielding.find((f) => f.player_id === "1001");
+    assert(batsmanFielding, "Expected fielding record for player 1001");
+    expect(batsmanFielding.run_outs).toBe(1);
+    expect(batsmanFielding.is_wicketkeeper).toBe(false);
+  });
+
+  it("stores match result", async () => {
+    const matchId = 88800 + Math.floor(Math.random() * 1000);
+    const api = createMockApi({
+      getMatchesSummary: vi
+        .fn()
+        .mockResolvedValue({ matches: [makeMatchSummary(matchId)] }),
+      getMatchDetail: vi
+        .fn()
+        .mockResolvedValue(makeMatchDetail(matchId)),
+    });
+
+    const sync = runSync(ctx.db, api);
+    await sync({ siteId: SITE_ID });
+
+    const result = await ctx.db
+      .selectFrom("match_result")
+      .where("match_id", "=", matchId.toString())
+      .selectAll()
+      .executeTakeFirst();
+
+    assert(result, "Expected match result to be stored");
+    expect(result.result).toBe("Won by 5 wickets");
+    expect(result.home_team_id).toBe(OUR_TEAM_ID);
+    expect(result.season).toBe(2026);
+  });
+
+  it("logs sync to play_cricket_sync_log", async () => {
+    const api = createMockApi();
+
+    const sync = runSync(ctx.db, api);
+    await sync({ siteId: SITE_ID });
+
+    const logs = await ctx.db
+      .selectFrom("play_cricket_sync_log")
+      .selectAll()
+      .execute();
+
+    expect(logs.length).toBeGreaterThanOrEqual(1);
+    const latest = logs[logs.length - 1];
+    expect(latest.completed_at).not.toBeNull();
+    expect(latest.season).toBe(new Date().getFullYear());
+  });
+
+  it("skips matches that are already processed", async () => {
+    const matchId = 55500 + Math.floor(Math.random() * 1000);
+
+    await ctx.db
+      .insertInto("match_result")
+      .values({
+        id: crypto.randomUUID(),
+        match_id: matchId.toString(),
+        home_team_id: OUR_TEAM_ID,
+        away_team_id: OPPONENT_TEAM_ID,
+        home_team_name: "Percy Main 1st XI",
+        away_team_name: "Opposition 1st XI",
+        match_date: "01/07/2026",
+        season: 2026,
+      })
+      .execute();
+
+    const api = createMockApi({
+      getMatchesSummary: vi
+        .fn()
+        .mockResolvedValue({ matches: [makeMatchSummary(matchId)] }),
+    });
+
+    const sync = runSync(ctx.db, api);
+    const result = await sync({ siteId: SITE_ID });
+
+    expect(result.matchesProcessed).toBe(0);
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock
+    expect(api.getMatchDetail).not.toHaveBeenCalled();
+  });
+
+  it("continues when individual match fails", async () => {
+    const goodMatchId = 66600 + Math.floor(Math.random() * 1000);
+    const badMatchId = goodMatchId + 1;
+
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          makeMatchSummary(badMatchId),
+          makeMatchSummary(goodMatchId),
+        ],
+      }),
+      getMatchDetail: vi.fn().mockImplementation((matchId: string) => {
+        if (matchId === badMatchId.toString()) {
+          throw new Error("API timeout");
+        }
+        return makeMatchDetail(goodMatchId);
+      }),
+    });
+
+    const sync = runSync(ctx.db, api);
+    const result = await sync({ siteId: SITE_ID });
+
+    expect(result.matchesProcessed).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("API timeout");
+  });
+
+  it("does not store result for recent matches without a result", async () => {
+    const matchId = 44400 + Math.floor(Math.random() * 1000);
+
+    const today = new Date();
+    const dd = String(today.getDate()).padStart(2, "0");
+    const mm = String(today.getMonth() + 1).padStart(2, "0");
+    const yyyy = today.getFullYear();
+    const todayStr = `${dd}/${mm}/${yyyy}`;
+
+    const matchSummary = makeMatchSummary(matchId, todayStr);
+    const matchDetail = makeMatchDetail(matchId);
+    matchDetail.match_details[0].result = "";
+
+    const api = createMockApi({
+      getMatchesSummary: vi
+        .fn()
+        .mockResolvedValue({ matches: [matchSummary] }),
+      getMatchDetail: vi.fn().mockResolvedValue(matchDetail),
+    });
+
+    const sync = runSync(ctx.db, api);
+    await sync({ siteId: SITE_ID });
+
+    const result = await ctx.db
+      .selectFrom("match_result")
+      .where("match_id", "=", matchId.toString())
+      .selectAll()
+      .executeTakeFirst();
+
+    expect(result).toBeUndefined();
   });
 });

--- a/apps/api/src/features/play-cricket/sync.test.ts
+++ b/apps/api/src/features/play-cricket/sync.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Kysely } from "kysely";
+import type { DB } from "@percy-main/db";
+import type { PlayCricketApiClient } from "./api-client.js";
+import {
+  isJuniorTeam,
+  isNotOut,
+  didBat,
+  parseDismissalType,
+  runSync,
+} from "./sync.js";
+
+// --- Helper tests ---
+
+describe("sync helpers", () => {
+  describe("isJuniorTeam", () => {
+    it("detects 'under' in team name", () => {
+      expect(isJuniorTeam("Under 11s")).toBe(true);
+    });
+
+    it("detects U followed by digits", () => {
+      expect(isJuniorTeam("U13")).toBe(true);
+      expect(isJuniorTeam("Percy Main U15")).toBe(true);
+    });
+
+    it("detects 'junior' and 'colts'", () => {
+      expect(isJuniorTeam("Junior XI")).toBe(true);
+      expect(isJuniorTeam("Colts")).toBe(true);
+    });
+
+    it("returns false for senior teams", () => {
+      expect(isJuniorTeam("1st XI")).toBe(false);
+      expect(isJuniorTeam("2nd XI")).toBe(false);
+    });
+  });
+
+  describe("isNotOut", () => {
+    it("returns true for null/undefined", () => {
+      expect(isNotOut(null)).toBe(true);
+      expect(isNotOut(undefined)).toBe(true);
+    });
+
+    it("returns true for not-out codes", () => {
+      expect(isNotOut("no")).toBe(true);
+      expect(isNotOut("dnb")).toBe(true);
+      expect(isNotOut("rtd")).toBe(true);
+      expect(isNotOut("")).toBe(true);
+    });
+
+    it("returns false for dismissal codes", () => {
+      expect(isNotOut("caught")).toBe(false);
+      expect(isNotOut("bowled")).toBe(false);
+      expect(isNotOut("lbw")).toBe(false);
+    });
+
+    // run out is considered "not out" for batting average purposes
+    it("returns true for run out", () => {
+      expect(isNotOut("ro")).toBe(true);
+    });
+  });
+
+  describe("didBat", () => {
+    it("returns false for null/undefined/empty/dnb", () => {
+      expect(didBat(null)).toBe(false);
+      expect(didBat(undefined)).toBe(false);
+      expect(didBat("")).toBe(false);
+      expect(didBat("dnb")).toBe(false);
+    });
+
+    it("returns true for batting dismissals", () => {
+      expect(didBat("caught")).toBe(true);
+      expect(didBat("bowled")).toBe(true);
+      expect(didBat("no")).toBe(true);
+    });
+  });
+
+  describe("parseDismissalType", () => {
+    it("returns null for null/undefined", () => {
+      expect(parseDismissalType(null)).toBeNull();
+      expect(parseDismissalType(undefined)).toBeNull();
+    });
+
+    it("parses catches", () => {
+      expect(parseDismissalType("ct")).toBe("catch");
+      expect(parseDismissalType("caught Smith")).toBe("catch");
+    });
+
+    it("parses stumpings", () => {
+      expect(parseDismissalType("st")).toBe("stumping");
+      expect(parseDismissalType("stumped Jones")).toBe("stumping");
+    });
+
+    it("parses run outs", () => {
+      expect(parseDismissalType("ro")).toBe("run_out");
+      expect(parseDismissalType("run out")).toBe("run_out");
+    });
+
+    it("returns null for bowled/lbw", () => {
+      expect(parseDismissalType("bowled")).toBeNull();
+      expect(parseDismissalType("lbw")).toBeNull();
+    });
+  });
+});
+
+// --- Sync service tests ---
+
+describe("runSync", () => {
+  let mockDb: Kysely<DB>;
+  let mockApi: PlayCricketApiClient;
+  let mockInsertExecute: ReturnType<typeof vi.fn>;
+  let mockSelectExecute: ReturnType<typeof vi.fn>;
+
+  function createMockDb() {
+    mockInsertExecute = vi.fn().mockResolvedValue([]);
+    mockSelectExecute = vi.fn().mockResolvedValue([]);
+
+    const chainable = {
+      selectFrom: vi.fn().mockReturnThis(),
+      insertInto: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      selectAll: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      distinct: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      onConflict: vi.fn().mockImplementation((cb: (oc: unknown) => unknown) => {
+        const ocBuilder = {
+          column: vi.fn().mockReturnValue({
+            doUpdateSet: vi.fn().mockReturnValue({
+              execute: mockInsertExecute,
+            }),
+          }),
+          columns: vi.fn().mockReturnValue({
+            doUpdateSet: vi.fn().mockReturnValue({
+              execute: mockInsertExecute,
+            }),
+          }),
+        };
+        cb(ocBuilder);
+        return { execute: mockInsertExecute };
+      }),
+      execute: mockSelectExecute,
+      executeTakeFirst: vi.fn().mockResolvedValue(undefined),
+    };
+
+    return chainable as unknown as Kysely<DB>;
+  }
+
+  function createMockApi(overrides: Partial<PlayCricketApiClient> = {}): PlayCricketApiClient {
+    return {
+      getTeams: vi.fn().mockResolvedValue({ teams: [] }),
+      getMatchesSummary: vi.fn().mockResolvedValue({ matches: [] }),
+      getMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
+      getLeagueTable: vi.fn().mockResolvedValue({}),
+      getMatchScorecard: vi.fn().mockResolvedValue({}),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = createMockDb();
+    mockApi = createMockApi();
+  });
+
+  it("returns zero matches when no matches exist", async () => {
+    const sync = runSync(mockDb, mockApi);
+    const result = await sync({ siteId: "134" });
+
+    expect(result.matchesProcessed).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock
+    expect(mockApi.getMatchesSummary).toHaveBeenCalledWith(new Date().getFullYear());
+  });
+
+  it("syncs extra seasons", async () => {
+    const sync = runSync(mockDb, mockApi);
+    await sync({ siteId: "134", extraSeasons: [2024, 2025] });
+
+    /* eslint-disable @typescript-eslint/unbound-method -- vi.fn() mocks */
+    expect(mockApi.getMatchesSummary).toHaveBeenCalledWith(2024);
+    expect(mockApi.getMatchesSummary).toHaveBeenCalledWith(2025);
+    expect(mockApi.getMatchesSummary).toHaveBeenCalledWith(new Date().getFullYear());
+    /* eslint-enable @typescript-eslint/unbound-method */
+  });
+
+  it("skips already-processed matches", async () => {
+    // Return a match from the API
+    mockApi = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          {
+            id: 12345,
+            status: "Completed",
+            published: "Yes",
+            last_updated: "2026-07-01",
+            season: "2026",
+            match_date: "01/07/2026",
+            home_club_name: "Percy Main",
+            home_team_name: "1st XI",
+            home_team_id: "68498",
+            home_club_id: "134",
+            away_club_name: "Opposition",
+            away_team_name: "1st XI",
+            away_team_id: "99999",
+            away_club_id: "999",
+          },
+        ],
+      }),
+    });
+    // Mark it as already processed
+    mockSelectExecute.mockResolvedValueOnce([{ match_id: "12345" }]);
+
+    const sync = runSync(mockDb, mockApi);
+    const result = await sync({ siteId: "134" });
+
+    expect(result.matchesProcessed).toBe(0);
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock
+    expect(mockApi.getMatchDetail).not.toHaveBeenCalled();
+  });
+
+  it("records team sync errors without failing", async () => {
+    mockApi = createMockApi({
+      getTeams: vi.fn().mockRejectedValue(new Error("Unauthorized")),
+    });
+
+    const sync = runSync(mockDb, mockApi);
+    const result = await sync({ siteId: "134" });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("Teams sync skipped");
+    expect(result.errors[0]).toContain("Unauthorized");
+  });
+
+  it("logs sync result to play_cricket_sync_log", async () => {
+    const sync = runSync(mockDb, mockApi);
+    await sync({ siteId: "134" });
+
+    // Should have called insertInto for the sync log
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock
+    expect(mockDb.insertInto).toHaveBeenCalledWith("play_cricket_sync_log");
+  });
+});

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -1,0 +1,579 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+import type { DB } from "@percy-main/db";
+import type { z } from "zod";
+import {
+  MatchDetailBat,
+  GetMatchDetailResponse,
+  type MatchSummaryMatch,
+} from "./api-schemas.js";
+
+import type { PlayCricketApiClient } from "./api-client.js";
+
+// --- Helpers ---
+
+const JUNIOR_PATTERNS = [/under/i, /\bU\d{2}\b/, /junior/i, /colts/i];
+
+function isJuniorTeam(teamName: string): boolean {
+  return JUNIOR_PATTERNS.some((p) => p.test(teamName));
+}
+
+const NOT_OUT_CODES = new Set(["no", "dnb", "rtd", "ro", "ret out", ""]);
+
+function isNotOut(howOut: string | null | undefined): boolean {
+  if (!howOut) return true;
+  return NOT_OUT_CODES.has(howOut.toLowerCase().trim());
+}
+
+function didBat(howOut: string | null | undefined): boolean {
+  if (!howOut) return false;
+  const code = howOut.toLowerCase().trim();
+  return code !== "dnb" && code !== "";
+}
+
+function parseDismissalType(
+  howOut: string | null | undefined,
+): "catch" | "stumping" | "run_out" | null {
+  if (!howOut) return null;
+  const code = howOut.toLowerCase().trim();
+  if (code === "ct" || code.startsWith("caught")) return "catch";
+  if (code === "st" || code.startsWith("stumped")) return "stumping";
+  if (code === "ro" || code.includes("run out")) return "run_out";
+  return null;
+}
+
+// --- Types ---
+
+export interface SyncConfig {
+  siteId: string;
+  /** Additional past seasons to sync (e.g. [2025]). Current year is always included. */
+  extraSeasons?: number[];
+}
+
+export interface SyncResult {
+  matchesProcessed: number;
+  errors: string[];
+}
+
+interface FieldingAgg {
+  playerName: string;
+  catches: number;
+  runOuts: number;
+  stumpings: number;
+  isWicketkeeper: boolean;
+}
+
+// --- Exported for testing ---
+
+export { isJuniorTeam, isNotOut, didBat, parseDismissalType };
+
+// --- Main sync logic ---
+
+const DEADLINE_MS = 10 * 60 * 1000; // 10 minutes
+
+type MatchDetailType = z.output<typeof GetMatchDetailResponse>["match_details"][number];
+
+function getWicketkeeperIds(
+  players: MatchDetailType["players"],
+  teamSide: "home" | "away",
+): Set<string> {
+  const keeperIds = new Set<string>();
+  for (const group of players) {
+    const squad =
+      teamSide === "home" ? group.home_team : group.away_team;
+    if (!squad) continue;
+    for (const player of squad) {
+      if (player.wicket_keeper && player.player_id != null) {
+        keeperIds.add(player.player_id.toString());
+      }
+    }
+  }
+  return keeperIds;
+}
+
+function extractFieldingCredits(
+  batEntries: Array<z.output<typeof MatchDetailBat>>,
+  keeperIds: Set<string>,
+): Map<string, FieldingAgg> {
+  const fielders = new Map<string, FieldingAgg>();
+
+  for (const bat of batEntries) {
+    const dismissalType = parseDismissalType(bat.how_out);
+    if (!dismissalType) continue;
+
+    const fielderId = bat.fielder_id;
+    const fielderName = bat.fielder_name;
+    if (!fielderId || !fielderName) continue;
+
+    let agg = fielders.get(fielderId);
+    if (!agg) {
+      agg = {
+        playerName: fielderName,
+        catches: 0,
+        runOuts: 0,
+        stumpings: 0,
+        isWicketkeeper: keeperIds.has(fielderId),
+      };
+      fielders.set(fielderId, agg);
+    }
+
+    switch (dismissalType) {
+      case "catch":
+        agg.catches++;
+        break;
+      case "run_out":
+        agg.runOuts++;
+        break;
+      case "stumping":
+        agg.stumpings++;
+        break;
+    }
+  }
+
+  return fielders;
+}
+
+// --- Core sync ---
+
+async function syncTeams(
+  db: Kysely<DB>,
+  api: PlayCricketApiClient,
+  siteId: string,
+  errors: string[],
+): Promise<void> {
+  try {
+    const teamsData = await api.getTeams();
+
+    for (const team of teamsData.teams) {
+      const teamId = team.id.toString();
+      await db
+        .insertInto("play_cricket_team")
+        .values({
+          id: teamId,
+          name: team.team_name,
+          is_junior: isJuniorTeam(team.team_name),
+          site_id: siteId,
+          last_updated: team.last_updated,
+        })
+        .onConflict((oc) =>
+          oc.column("id").doUpdateSet({
+            name: team.team_name,
+            is_junior: isJuniorTeam(team.team_name),
+            last_updated: team.last_updated,
+          }),
+        )
+        .execute();
+    }
+  } catch (err) {
+    const msg = `Teams sync skipped: ${err instanceof Error ? err.message : String(err)}`;
+    errors.push(msg);
+  }
+}
+
+async function upsertTeamFromMatch(
+  db: Kysely<DB>,
+  teamEntry: { id: string | undefined; name: string | undefined; clubId: string | undefined },
+  siteId: string,
+): Promise<void> {
+  if (!teamEntry.id || !teamEntry.name || teamEntry.clubId !== siteId) return;
+
+  const { id, name } = teamEntry;
+
+  await db
+    .insertInto("play_cricket_team")
+    .values({
+      id,
+      name,
+      is_junior: isJuniorTeam(name),
+      site_id: siteId,
+      last_updated: new Date().toISOString(),
+    })
+    .onConflict((oc) =>
+      oc.column("id").doUpdateSet({
+        name,
+        is_junior: isJuniorTeam(name),
+      }),
+    )
+    .execute();
+}
+
+async function storeBattingPerformances(
+  db: Kysely<DB>,
+  innings: Array<z.output<typeof MatchDetailBat>>,
+  matchId: string,
+  teamId: string,
+  competitionType: string,
+  matchDate: string,
+  season: number,
+): Promise<void> {
+  for (const bat of innings) {
+    if (!didBat(bat.how_out)) continue;
+
+    await db
+      .insertInto("match_performance_batting")
+      .values({
+        id: crypto.randomUUID(),
+        match_id: matchId,
+        player_id: bat.batsman_id,
+        player_name: bat.batsman_name,
+        team_id: teamId,
+        competition_type: competitionType,
+        match_date: matchDate,
+        season,
+        runs: parseInt(bat.runs) || 0,
+        balls: parseInt(bat.balls) || 0,
+        fours: parseInt(bat.fours) || 0,
+        sixes: parseInt(bat.sixes) || 0,
+        how_out: bat.how_out ?? "",
+        not_out: isNotOut(bat.how_out),
+      })
+      .onConflict((oc) =>
+        oc.columns(["match_id", "player_id"]).doUpdateSet({
+          player_name: bat.batsman_name,
+          runs: parseInt(bat.runs) || 0,
+          balls: parseInt(bat.balls) || 0,
+          fours: parseInt(bat.fours) || 0,
+          sixes: parseInt(bat.sixes) || 0,
+          how_out: bat.how_out ?? "",
+          not_out: isNotOut(bat.how_out),
+        }),
+      )
+      .execute();
+  }
+}
+
+async function storeBowlingPerformances(
+  db: Kysely<DB>,
+  bowlers: Array<{
+    bowler_name: string;
+    bowler_id: string;
+    overs: string;
+    maidens: string;
+    runs: string;
+    wickets: string;
+    wides: string;
+    no_balls: string;
+  }>,
+  matchId: string,
+  teamId: string,
+  competitionType: string,
+  matchDate: string,
+  season: number,
+): Promise<void> {
+  for (const bowl of bowlers) {
+    await db
+      .insertInto("match_performance_bowling")
+      .values({
+        id: crypto.randomUUID(),
+        match_id: matchId,
+        player_id: bowl.bowler_id,
+        player_name: bowl.bowler_name,
+        team_id: teamId,
+        competition_type: competitionType,
+        match_date: matchDate,
+        season,
+        overs: bowl.overs,
+        maidens: parseInt(bowl.maidens) || 0,
+        runs: parseInt(bowl.runs) || 0,
+        wickets: parseInt(bowl.wickets) || 0,
+        wides: parseInt(bowl.wides) || 0,
+        no_balls: parseInt(bowl.no_balls) || 0,
+      })
+      .onConflict((oc) =>
+        oc.columns(["match_id", "player_id"]).doUpdateSet({
+          player_name: bowl.bowler_name,
+          overs: bowl.overs,
+          maidens: parseInt(bowl.maidens) || 0,
+          runs: parseInt(bowl.runs) || 0,
+          wickets: parseInt(bowl.wickets) || 0,
+          wides: parseInt(bowl.wides) || 0,
+          no_balls: parseInt(bowl.no_balls) || 0,
+        }),
+      )
+      .execute();
+  }
+}
+
+async function storeFieldingPerformances(
+  db: Kysely<DB>,
+  fieldingCredits: Map<string, FieldingAgg>,
+  matchId: string,
+  teamId: string,
+  competitionType: string,
+  matchDate: string,
+  season: number,
+): Promise<void> {
+  for (const [fielderId, agg] of fieldingCredits) {
+    await db
+      .insertInto("match_performance_fielding")
+      .values({
+        id: crypto.randomUUID(),
+        match_id: matchId,
+        player_id: fielderId,
+        player_name: agg.playerName,
+        team_id: teamId,
+        competition_type: competitionType,
+        match_date: matchDate,
+        season,
+        catches: agg.catches,
+        run_outs: agg.runOuts,
+        stumpings: agg.stumpings,
+        is_wicketkeeper: agg.isWicketkeeper,
+      })
+      .onConflict((oc) =>
+        oc.columns(["match_id", "player_id"]).doUpdateSet({
+          player_name: agg.playerName,
+          catches: sql`match_performance_fielding.catches + excluded.catches`,
+          run_outs: sql`match_performance_fielding.run_outs + excluded.run_outs`,
+          stumpings: sql`match_performance_fielding.stumpings + excluded.stumpings`,
+          is_wicketkeeper: sql`match_performance_fielding.is_wicketkeeper OR excluded.is_wicketkeeper`,
+        }),
+      )
+      .execute();
+  }
+}
+
+async function syncMatches(
+  db: Kysely<DB>,
+  api: PlayCricketApiClient,
+  config: SyncConfig,
+  startTime: number,
+): Promise<SyncResult> {
+  const { siteId } = config;
+  const errors: string[] = [];
+  let matchesProcessed = 0;
+
+  // Step 1: Sync teams (non-blocking)
+  await syncTeams(db, api, siteId, errors);
+
+  // Step 2: Fetch all matches for each season
+  const currentYear = new Date().getFullYear();
+  const seasons = [...(config.extraSeasons ?? []), currentYear];
+  const allMatches: Array<{ match: MatchSummaryMatch; season: number }> = [];
+
+  for (const season of seasons) {
+    const matchesData = await api.getMatchesSummary(season);
+    for (const match of matchesData.matches) {
+      allMatches.push({ match, season });
+    }
+  }
+
+  // Step 3: Load already-processed match IDs
+  const processedRows = await db
+    .selectFrom("match_result")
+    .select("match_id")
+    .distinct()
+    .execute();
+  const processedMatchIds = new Set(processedRows.map((r) => r.match_id));
+
+  // Step 4: Process each match
+  const resultCutoff = new Date();
+  resultCutoff.setDate(resultCutoff.getDate() - 14);
+  resultCutoff.setHours(0, 0, 0, 0);
+
+  for (const { match, season } of allMatches) {
+    const matchId = match.id.toString();
+
+    try {
+      if (processedMatchIds.has(matchId)) continue;
+
+      // Stop after deadline
+      if (Date.now() - startTime > DEADLINE_MS) {
+        return { matchesProcessed, errors };
+      }
+
+      const detailData = await api.getMatchDetail(matchId);
+      const detail = detailData.match_details[0];
+      if (!detail) continue;
+
+      // Must have at least one innings with batting data
+      const hasScorecard = detail.innings.some((inn) => inn.bat.length > 0);
+      if (!hasScorecard) continue;
+
+      // Validate match_date format (DD/MM/YYYY)
+      if (!match.match_date || !/^\d{2}\/\d{2}\/\d{4}$/.test(match.match_date)) {
+        continue;
+      }
+
+      // Upsert teams from match detail
+      await upsertTeamFromMatch(
+        db,
+        { id: detail.home_team_id, name: detail.home_team_name, clubId: detail.home_club_id },
+        siteId,
+      );
+      await upsertTeamFromMatch(
+        db,
+        { id: detail.away_team_id, name: detail.away_team_name, clubId: detail.away_club_id },
+        siteId,
+      );
+
+      // Determine which teams are ours
+      const ourTeamIds = new Set<string>();
+      if (match.home_club_id === siteId) ourTeamIds.add(match.home_team_id);
+      if (match.away_club_id === siteId) ourTeamIds.add(match.away_team_id);
+
+      // Build keeper lookup
+      const homeKeeperIds = getWicketkeeperIds(detail.players, "home");
+      const awayKeeperIds = getWicketkeeperIds(detail.players, "away");
+
+      for (const innings of detail.innings) {
+        const battingTeamId = innings.team_batting_id;
+        const isBattingTeamOurs = ourTeamIds.has(battingTeamId);
+
+        const fieldingTeamId =
+          battingTeamId === match.home_team_id
+            ? match.away_team_id
+            : match.home_team_id;
+        const isFieldingTeamOurs = ourTeamIds.has(fieldingTeamId);
+
+        const fieldingKeeperIds =
+          fieldingTeamId === match.home_team_id
+            ? homeKeeperIds
+            : awayKeeperIds;
+
+        if (isBattingTeamOurs) {
+          await storeBattingPerformances(
+            db,
+            innings.bat,
+            matchId,
+            battingTeamId,
+            match.competition_type ?? "",
+            match.match_date,
+            season,
+          );
+        }
+
+        if (isFieldingTeamOurs) {
+          await storeBowlingPerformances(
+            db,
+            innings.bowl,
+            matchId,
+            fieldingTeamId,
+            match.competition_type ?? "",
+            match.match_date,
+            season,
+          );
+
+          const fieldingCredits = extractFieldingCredits(
+            innings.bat,
+            fieldingKeeperIds,
+          );
+          await storeFieldingPerformances(
+            db,
+            fieldingCredits,
+            matchId,
+            fieldingTeamId,
+            match.competition_type ?? "",
+            match.match_date,
+            season,
+          );
+        }
+      }
+
+      // Store match result with cutoff logic
+      const matchResult = (detail.result ?? "").trim();
+      const [dd, mm, yyyy] = match.match_date.split("/");
+      const matchDate = new Date(
+        parseInt(yyyy),
+        parseInt(mm) - 1,
+        parseInt(dd),
+      );
+      const isRecent = matchDate > resultCutoff;
+      const shouldWriteResult = matchResult || !isRecent;
+
+      if (shouldWriteResult) {
+        await db
+          .insertInto("match_result")
+          .values({
+            id: crypto.randomUUID(),
+            match_id: matchId,
+            home_team_id: detail.home_team_id,
+            away_team_id: detail.away_team_id,
+            home_team_name: detail.home_team_name,
+            away_team_name: detail.away_team_name,
+            result: matchResult,
+            result_description: detail.result_description ?? "",
+            result_applied_to: detail.result_applied_to ?? "",
+            competition_type: match.competition_type ?? "",
+            match_date: match.match_date,
+            season,
+          })
+          .onConflict((oc) =>
+            oc.column("match_id").doUpdateSet({
+              result: matchResult,
+              result_description: detail.result_description ?? "",
+              result_applied_to: detail.result_applied_to ?? "",
+            }),
+          )
+          .execute();
+      }
+
+      matchesProcessed++;
+    } catch (err) {
+      const msg = `Error processing match ${matchId}: ${err instanceof Error ? err.message : String(err)}`;
+      errors.push(msg);
+    }
+  }
+
+  return { matchesProcessed, errors };
+}
+
+// --- Public API ---
+
+/**
+ * Run a full Play-Cricket stats sync.
+ *
+ * Follows the curried factory pattern: `runSync(db, api)` returns an async
+ * function that accepts sync config and performs the sync.
+ *
+ * TODO: Wire up as EventBridge scheduled task or admin HTTP trigger
+ * TODO: Call calculateFantasyScores() after sync when fantasy pipeline is ported
+ */
+export function runSync(db: Kysely<DB>, api: PlayCricketApiClient) {
+  return async (config: SyncConfig): Promise<SyncResult> => {
+    const logId = crypto.randomUUID();
+    const startedAt = new Date().toISOString();
+    const startTime = Date.now();
+
+    try {
+      const result = await syncMatches(db, api, config, startTime);
+
+      // Log the sync
+      await db
+        .insertInto("play_cricket_sync_log")
+        .values({
+          id: logId,
+          started_at: startedAt,
+          completed_at: new Date().toISOString(),
+          season: new Date().getFullYear(),
+          matches_processed: result.matchesProcessed,
+          errors:
+            result.errors.length > 0
+              ? JSON.stringify(result.errors)
+              : null,
+        })
+        .execute();
+
+      return result;
+    } catch (err) {
+      // Try to log the failure
+      try {
+        await db
+          .insertInto("play_cricket_sync_log")
+          .values({
+            id: logId,
+            started_at: startedAt,
+            completed_at: new Date().toISOString(),
+            season: new Date().getFullYear(),
+            matches_processed: 0,
+            errors: JSON.stringify([String(err)]),
+          })
+          .execute();
+      } catch {
+        // Swallow logging failure
+      }
+
+      throw err;
+    }
+  };
+}

--- a/docs/migration-status.md
+++ b/docs/migration-status.md
@@ -56,7 +56,7 @@ See [implementation-plan.md](./aws/implementation-plan.md) for the full plan.
 - [x] Dockerfile (multi-stage, ARM-ready for Graviton)
 - [x] 78 unit tests + 69 integration tests (testcontainers), all passing
 - [x] Port full Stripe webhook handler logic (checkout, invoice, payment_intent)
-- [ ] Port Play-Cricket background sync job
+- [x] Port Play-Cricket background sync job
 - [ ] Port fantasy score calculation pipeline
 
 ### AWS infrastructure (not yet started)


### PR DESCRIPTION
## Summary

- Ports the Play-Cricket match data sync pipeline from v1 to v2
- Adapts from SQLite/LibSQL raw SQL to Kysely query builder with PostgreSQL native booleans
- Follows curried factory DI pattern: `runSync(db, api)(config)`
- Adds Zod schemas for Play-Cricket API responses and refactors api-client for DI

### What it syncs
Teams, batting/bowling/fielding performances, and match results from the Play-Cricket external API. Fielding credits are derived from batting dismissals with wicketkeeper detection. Preserves the v1 10-minute deadline, 14-day result cutoff, and error-per-match isolation.

### New files
- `api-schemas.ts` — Zod schemas for Play-Cricket API responses
- `sync.ts` — Sync service (curried factory, no process.env access)
- `sync.test.ts` — Unit tests for helpers and sync orchestration

### Modified files
- `api-client.ts` — Added `createApiClient(config)` factory with DI
- `integration.test.ts` — Added 7 sync integration tests (testcontainers)
- `docs/migration-status.md` — Checked off the item

### Follow-up work
- Wire up as EventBridge scheduled task or admin HTTP trigger
- Call `calculateFantasyScores()` after sync when fantasy pipeline is ported
- Refactor existing `service.ts` to use `createApiClient` instead of standalone functions that read `process.env`

## Test plan

- [x] Unit tests pass (`pnpm --filter api test`) — 113 tests
- [x] Integration tests pass (`pnpm --filter api test:integration`) — 91 tests
- [x] Typecheck passes
- [x] Lint passes
- [x] Build passes
- [ ] Verify sync against real Play-Cricket API (requires API token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)