### PR TITLE
Fix form inputs, duplicate logo, and login redirect

### DIFF
--- a/apps/web/src/components/form/simple-input.tsx
+++ b/apps/web/src/components/form/simple-input.tsx
@@ -1,3 +1,5 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import type { FC } from "react";
 
 type Props = React.DetailedHTMLProps<
@@ -12,19 +14,9 @@ export const SimpleInput: FC<Props> = ({ label, ...inputProps }) => {
     return <input {...inputProps} name={inputProps.id} />;
   }
   return (
-    <div className="group relative z-0 mt-2 mb-5 w-full">
-      <input
-        {...inputProps}
-        name={inputProps.id}
-        className="peer block w-full appearance-none border-0 border-b-2 border-gray-300 bg-transparent text-sm text-gray-900 focus:border-blue-600 focus:ring-0 focus:outline-none"
-        placeholder=" "
-      />
-      <label
-        htmlFor={inputProps.id}
-        className="absolute top-3 origin-[0] -translate-y-7 scale-75 transform text-sm text-gray-500 duration-300 peer-placeholder-shown:translate-y-0 peer-placeholder-shown:scale-100 peer-focus:start-0 peer-focus:-translate-y-7 peer-focus:scale-75 peer-focus:font-medium peer-focus:text-blue-600 rtl:peer-focus:left-auto rtl:peer-focus:translate-x-1/4"
-      >
-        {label}
-      </label>
+    <div className="mb-4 w-full space-y-2">
+      <Label htmlFor={inputProps.id}>{label}</Label>
+      <Input {...inputProps} name={inputProps.id} />
     </div>
   );
 };

--- a/apps/web/src/layouts/auth-layout.tsx
+++ b/apps/web/src/layouts/auth-layout.tsx
@@ -1,12 +1,8 @@
-import { Logo } from "@/components/logo.js";
 import { Outlet } from "react-router";
 
 export function AuthLayout() {
   return (
-    <div className="bg-creamy flex min-h-screen flex-col items-center justify-center px-4">
-      <div className="mb-6">
-        <Logo size="lg" />
-      </div>
+    <div className="bg-creamy flex flex-col items-center px-4 py-12">
       <Outlet />
     </div>
   );

--- a/apps/web/src/pages/auth/login/email-password.tsx
+++ b/apps/web/src/pages/auth/login/email-password.tsx
@@ -55,19 +55,19 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
   }, [navigate]);
 
   const signin = useMutation({
-    mutationFn: () =>
-      authClient.signIn.email(
-        { email, password },
-        {
-          onSuccess(response) {
-            if ("twoFactorRedirect" in response.data) {
-              setPhase("2fa");
-              return;
-            }
-            void navigate("/members");
-          },
-        },
-      ),
+    mutationFn: async () => {
+      const result = await authClient.signIn.email({ email, password });
+      if (result.error)
+        throw new Error(result.error.message ?? "Sign in failed");
+      return result.data;
+    },
+    onSuccess(data) {
+      if (data && "twoFactorRedirect" in data) {
+        setPhase("2fa");
+        return;
+      }
+      void navigate("/members");
+    },
   });
 
   const googleSignIn = useMutation({
@@ -86,11 +86,7 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
     [signin],
   );
 
-  const error =
-    signin.error ??
-    signin.data?.error ??
-    googleSignIn.error ??
-    googleSignIn.data?.error;
+  const error = signin.error ?? googleSignIn.error ?? googleSignIn.data?.error;
 
   return (
     <section>


### PR DESCRIPTION
## Summary
- **Form inputs**: Replace broken floating-label `SimpleInput` with standard shadcn `Label` + `Input` components
- **Duplicate logo**: Remove second logo from auth layout (header already shows it), adjust layout padding
- **Login redirect**: Move `navigate("/members")` to react-query `onSuccess` so session cookie is set before navigation

## Test plan
- [ ] Visit login page — single logo visible, no duplicate
- [ ] Sign in with email/password — redirects to /members
- [ ] Sign in with Google — redirects to /members
- [ ] Check change password page — labels display above inputs correctly
- [ ] Check register page — inputs display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)