### PR TITLE
Add local email viewer and fix auth email URLs

### DIFF
--- a/apps/api/src/features/auth/auth.ts
+++ b/apps/api/src/features/auth/auth.ts
@@ -15,6 +15,8 @@ export function createAuth(
   const baseURL = config.BASE_URL;
 
   return betterAuth({
+    baseURL,
+    basePath: "/api/auth",
     appName: config.BETTER_AUTH_RP_NAME,
     trustedOrigins: [baseURL, config.DEPLOY_PRIME_URL].filter(
       Boolean,

--- a/apps/email-viewer/index.html
+++ b/apps/email-viewer/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Local Email Viewer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/email-viewer/package.json
+++ b/apps/email-viewer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "email-viewer",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/email-viewer/src/App.tsx
+++ b/apps/email-viewer/src/App.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+
+interface EmailEntry {
+  id: string;
+  to: string;
+  subject: string;
+}
+
+export function App() {
+  const [emails, setEmails] = useState<EmailEntry[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [html, setHtml] = useState("");
+
+  useEffect(() => {
+    fetch("/api/emails")
+      .then((r) => r.json())
+      .then(setEmails);
+  }, []);
+
+  useEffect(() => {
+    if (!selected) {
+      setHtml("");
+      return;
+    }
+    fetch(`/api/email/${encodeURIComponent(selected)}`)
+      .then((r) => r.text())
+      .then(setHtml);
+  }, [selected]);
+
+  const formatTime = (iso: string) => {
+    try {
+      const d = new Date(iso);
+      return d.toLocaleString();
+    } catch {
+      return iso;
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", height: "100vh", fontFamily: "system-ui" }}>
+      {/* Email list */}
+      <div
+        style={{
+          width: 360,
+          borderRight: "1px solid #ddd",
+          overflowY: "auto",
+          background: "#fafafa",
+        }}
+      >
+        <div
+          style={{
+            padding: "12px 16px",
+            borderBottom: "1px solid #ddd",
+            fontWeight: 600,
+            fontSize: 14,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <span>Local Emails ({emails.length})</span>
+          <button
+            onClick={() =>
+              fetch("/api/emails")
+                .then((r) => r.json())
+                .then(setEmails)
+            }
+            style={{
+              border: "1px solid #ccc",
+              borderRadius: 4,
+              padding: "4px 8px",
+              cursor: "pointer",
+              fontSize: 12,
+              background: "white",
+            }}
+          >
+            Refresh
+          </button>
+        </div>
+        {emails.length === 0 && (
+          <div style={{ padding: 16, color: "#888", fontSize: 13 }}>
+            No emails yet. They&apos;ll appear here when the API sends them
+            locally.
+          </div>
+        )}
+        {emails.map((e) => (
+          <div
+            key={e.id}
+            onClick={() => setSelected(e.id)}
+            style={{
+              padding: "10px 16px",
+              borderBottom: "1px solid #eee",
+              cursor: "pointer",
+              background: selected === e.id ? "#e8f0fe" : "transparent",
+            }}
+          >
+            <div
+              style={{
+                fontSize: 13,
+                fontWeight: selected === e.id ? 600 : 400,
+                marginBottom: 2,
+              }}
+            >
+              {e.subject}
+            </div>
+            <div style={{ fontSize: 11, color: "#666" }}>
+              {e.to} &middot; {formatTime(e.id)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Email preview */}
+      <div style={{ flex: 1, overflow: "auto" }}>
+        {!selected ? (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              height: "100%",
+              color: "#888",
+            }}
+          >
+            Select an email to preview
+          </div>
+        ) : (
+          <iframe
+            srcDoc={html}
+            style={{ width: "100%", height: "100%", border: "none" }}
+            title="Email preview"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/email-viewer/src/main.tsx
+++ b/apps/email-viewer/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/email-viewer/tsconfig.json
+++ b/apps/email-viewer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/apps/email-viewer/vite.config.ts
+++ b/apps/email-viewer/vite.config.ts
@@ -1,0 +1,55 @@
+import react from "@vitejs/plugin-react";
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
+import { defineConfig } from "vite";
+
+const emailDir = join(process.cwd(), "../api/.emails");
+
+function emailApi() {
+  return {
+    name: "email-api",
+    configureServer(server: import("vite").ViteDevServer) {
+      server.middlewares.use("/api/emails", async (_req, res) => {
+        try {
+          const files = await readdir(emailDir);
+          const jsonFiles = files
+            .filter((f) => f.endsWith(".json"))
+            .sort()
+            .reverse();
+
+          const emails = await Promise.all(
+            jsonFiles.map(async (f) => {
+              const timestamp = f.replace(".json", "");
+              const meta = JSON.parse(
+                await readFile(join(emailDir, f), "utf-8"),
+              );
+              return { id: timestamp, ...meta };
+            }),
+          );
+
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify(emails));
+        } catch {
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify([]));
+        }
+      });
+
+      server.middlewares.use("/api/email/", async (req, res) => {
+        try {
+          const id = decodeURIComponent(req.url?.slice(1) ?? "");
+          const html = await readFile(join(emailDir, `${id}.html`), "utf-8");
+          res.setHeader("Content-Type", "text/html");
+          res.end(html);
+        } catch {
+          res.statusCode = 404;
+          res.end("Not found");
+        }
+      });
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [react(), emailApi()],
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "pnpm -r --parallel run dev",
     "dev:api": "pnpm --filter api dev",
     "dev:web": "pnpm --filter web dev",
+    "dev:email": "pnpm --filter email-viewer dev",
     "build": "pnpm -r run build",
     "build:api": "pnpm --filter api build",
     "build:web": "pnpm --filter web build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,31 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
 
+  apps/email-viewer:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+
   apps/web:
     dependencies:
       '@better-auth/passkey':


### PR DESCRIPTION
## Summary
- Add `apps/email-viewer/` — minimal Vite + React app for viewing locally-sent dev emails. Two-column layout (email list + HTML preview), reads from `apps/api/.emails/`. Run with `pnpm run dev:email`.
- Fix better-auth generating email links without the correct host/port (e.g. `http://localhost/api/auth/...` instead of `http://localhost:5173/api/auth/...`) by explicitly setting `baseURL` and `basePath` in the auth config.

## Test plan
- [ ] Start the API in dev mode, trigger an email (e.g. sign up)
- [ ] Run `pnpm run dev:email` and verify emails appear in the viewer
- [ ] Verify email verification/password reset links use `http://localhost:5173/api/auth/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)