### PR TITLE
Fix flaky integration tests on CI

### DIFF
--- a/apps/api/src/features/admin/integration.test.ts
+++ b/apps/api/src/features/admin/integration.test.ts
@@ -60,7 +60,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/auth/integration.test.ts
+++ b/apps/api/src/features/auth/integration.test.ts
@@ -16,7 +16,7 @@ const emailDir = join(process.cwd(), ".emails");
 beforeAll(async () => {
   ctx = await startTestContainer();
   app = await buildTestApp(ctx.db, ctx.dialect);
-}, 30_000);
+});
 
 afterAll(async () => {
   await app.close();

--- a/apps/api/src/features/charges/integration.test.ts
+++ b/apps/api/src/features/charges/integration.test.ts
@@ -21,7 +21,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/contact/integration.test.ts
+++ b/apps/api/src/features/contact/integration.test.ts
@@ -10,7 +10,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/cricket-leaderboard/integration.test.ts
+++ b/apps/api/src/features/cricket-leaderboard/integration.test.ts
@@ -11,7 +11,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/fantasy/calculate-scores.integration.test.ts
+++ b/apps/api/src/features/fantasy/calculate-scores.integration.test.ts
@@ -15,7 +15,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/fantasy/integration.test.ts
+++ b/apps/api/src/features/fantasy/integration.test.ts
@@ -20,7 +20,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);
@@ -64,10 +64,7 @@ function buildSquad(playerIds: string[]): PlayerInput[] {
   }));
 }
 
-// TODO: Flaky on CI — startTestContainer() exceeds the 30s timeout on GitHub
-// Actions runners. All 8 tests pass locally. Needs investigation: either bump
-// the beforeAll timeout or diagnose why the container is slow on CI.
-describe.skip("fantasy service (integration)", () => {
+describe("fantasy service (integration)", () => {
   describe("getEligiblePlayers", () => {
     it("returns empty players array when no fantasy players exist", async () => {
       // Use a season that won't collide with other tests' data

--- a/apps/api/src/features/health/integration.test.ts
+++ b/apps/api/src/features/health/integration.test.ts
@@ -12,7 +12,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/junior/integration.test.ts
+++ b/apps/api/src/features/junior/integration.test.ts
@@ -11,7 +11,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/leaderboard/integration.test.ts
+++ b/apps/api/src/features/leaderboard/integration.test.ts
@@ -11,7 +11,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -22,7 +22,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/members/integration.test.ts
+++ b/apps/api/src/features/members/integration.test.ts
@@ -15,7 +15,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/payments/integration.test.ts
+++ b/apps/api/src/features/payments/integration.test.ts
@@ -53,7 +53,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -14,7 +14,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/sponsorship/integration.test.ts
+++ b/apps/api/src/features/sponsorship/integration.test.ts
@@ -17,7 +17,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/features/treasurer/integration.test.ts
+++ b/apps/api/src/features/treasurer/integration.test.ts
@@ -15,7 +15,7 @@ let ctx: TestContext;
 
 beforeAll(async () => {
   ctx = await startTestContainer();
-}, 30_000);
+});
 
 afterAll(async () => {
   await stopTestContainer(ctx);

--- a/apps/api/src/test/containers.ts
+++ b/apps/api/src/test/containers.ts
@@ -33,7 +33,7 @@ export interface TestContext {
  * Usage:
  * ```ts
  * let ctx: TestContext;
- * beforeAll(async () => { ctx = await startTestContainer(); }, 30_000);
+ * beforeAll(async () => { ctx = await startTestContainer(); });
  * afterAll(async () => { await stopTestContainer(ctx); });
  *
  * it("lists users", async () => {

--- a/docs/migration-status.md
+++ b/docs/migration-status.md
@@ -98,7 +98,7 @@ See [implementation-plan.md](./aws/implementation-plan.md) for the full plan.
     - [x] Recharts season timeline chart on history tab
     - [ ] Chaos week admin email sending (needs `packages/email` ChaosWeekAnnouncement template wiring)
     - [ ] Team share image generation (depends on Contentful player photos — deferred to Phase 5)
-    - [ ] Fix flaky fantasy integration tests on CI (`startTestContainer()` exceeds 30s timeout on GitHub Actions — currently skipped, passes locally)
+    - [x] Fix flaky fantasy integration tests on CI (`startTestContainer()` exceeds 30s timeout on GitHub Actions — currently skipped, passes locally)
     - **Note:** Fantasy team builder cannot be fully tested until admin side of fantasy is completed (player population, cost calculation, eligibility toggling)
   - [x] Be the Keeper game (2 pages)
   - [x] Static pages (privacy policy, nets redirect, payment confirmation)


### PR DESCRIPTION
## Summary

- Removed hardcoded 30s `beforeAll` timeout from all 16 integration test files — vitest's `hookTimeout: 60_000` now applies uniformly
- Un-skipped the fantasy service integration tests (8 tests, previously disabled via `describe.skip`)
- Updated `containers.ts` docstring to reflect the correct pattern
- Integration test count: 137 → 145

## Root cause

Every integration test passed a 30s timeout directly to `beforeAll`, overriding the vitest config's 60s `hookTimeout`. On GitHub Actions runners, testcontainer startup + migration execution occasionally exceeded 30s.

## Test plan

- [x] All 145 integration tests pass locally
- [x] All 192 unit tests pass
- [x] Typecheck, lint, format all pass
- [ ] CI passes on this PR (will confirm the fix works on GitHub Actions runners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)