### PR TITLE
Add missing VITE env vars to frontend deploy

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -34,6 +34,9 @@ jobs:
         run: pnpm --filter web build
         env:
           VITE_API_URL: https://api.v2.percymain.org/api
+          VITE_STRIPE_PUBLIC_KEY: ${{ vars.STRIPE_PUBLIC_KEY }}
+          VITE_MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
+          VITE_MAPS_MAP_ID: ${{ vars.MAPS_MAP_ID }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary
- `VITE_STRIPE_PUBLIC_KEY` was not set during production builds, so the frontend resolved donation/purchase price IDs from the **test** Stripe config instead of **live** — causing 404s from Stripe
- Also adds `VITE_MAPS_API_KEY` (from secrets) and `VITE_MAPS_MAP_ID` (from vars) which were similarly missing

All three env vars are required by the frontend (`apps/web/.env.example`) and were already configured in the v1 repo's CI workflow.

## Prerequisites
Ensure these are set in the `percy-main/website-v2` GitHub settings:
- **Var**: `STRIPE_PUBLIC_KEY` — the `pk_live_...` publishable key
- **Secret**: `MAPS_API_KEY` — Google Maps API key
- **Var**: `MAPS_MAP_ID` — Google Maps map ID

## Test plan
- [ ] Merge and verify deploy workflow passes
- [ ] Confirm donate flow uses live Stripe price IDs (check network tab for `price_1Qg3v7...`)
- [ ] Confirm Google Maps renders on location pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)