### PR TITLE
Fix auth client hitting wrong origin in production

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -2,7 +2,13 @@ import { passkeyClient } from "@better-auth/passkey/client";
 import { adminClient, twoFactorClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
+const apiUrl = (import.meta.env.VITE_API_URL as string | undefined) ?? "/api";
+// VITE_API_URL is e.g. "https://api.v2.percymain.org/api" — strip the /api
+// suffix since better-auth appends its own basePath (/api/auth).
+const baseURL = apiUrl.replace(/\/api$/, "");
+
 export const authClient = createAuthClient({
+  baseURL,
   plugins: [passkeyClient(), twoFactorClient(), adminClient()],
 });
 


### PR DESCRIPTION
## Summary
- `createAuthClient()` had no `baseURL`, so better-auth defaulted to the current page origin (`v2.percymain.org`) instead of the API server (`api.v2.percymain.org`)
- Auth requests (`/api/auth/get-session` etc.) were hitting CloudFront and getting 301 redirects
- Now derives `baseURL` from `VITE_API_URL`, stripping the `/api` suffix since better-auth appends its own `/api/auth` basePath

## Test plan
- [ ] Verify auth requests go to `api.v2.percymain.org/api/auth/*`
- [ ] Login/logout/session flows work in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)