### PR TITLE
Fix news article links from /calendar/event/ to /calendar/game/

### DIFF
--- a/apps/web/content/news/2025/league-round-1.mdx
+++ b/apps/web/content/news/2025/league-round-1.mdx
@@ -12,6 +12,6 @@ With the weekend's cricket all wrapped up, both 1st and 2nd XI teams had good co
 
 Read about the weekend's action in our match reports:
 
-[1st XI vs Hexham Leazes](https://www.percymain.org/calendar/event/6820320/)
+[1st XI vs Hexham Leazes](/calendar/game/6820320)
 
-[2nd XI vs Stocksfield](https://www.percymain.org/calendar/event/6819685/)
+[2nd XI vs Stocksfield](/calendar/game/6819685)

--- a/apps/web/content/news/2025/weekend-results.mdx
+++ b/apps/web/content/news/2025/weekend-results.mdx
@@ -7,8 +7,8 @@ slug: weekend-results
 
 Two senior teams and a junior team in action this week, catch up on the results here...
 
-[1st XI vs Allendale CC](/calendar/event/6820327)
+[1st XI vs Allendale CC](/calendar/game/6820327)
 
-[2nd XI vs Lintz CC](/calendar/event/6819693)
+[2nd XI vs Lintz CC](/calendar/game/6819693)
 
-[U13s vs South Northumberland CC](/calendar/event/6950669)
+[U13s vs South Northumberland CC](/calendar/game/6950669)


### PR DESCRIPTION
## Summary

- Replace `/calendar/event/` with `/calendar/game/` in 2 news MDX files (5 occurrences)
- Convert absolute URLs to relative paths in `league-round-1.mdx`

Closes #48

## Test plan

- [x] Verified no remaining `/calendar/event/` references in content
- [ ] Verify corrected links resolve to valid game pages on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)