### PR TITLE
Fix fantasy admin: player names and missing players

### DIFF
--- a/apps/api/src/features/fantasy/routes.ts
+++ b/apps/api/src/features/fantasy/routes.ts
@@ -5,6 +5,7 @@ import {
   requireAuth,
   requireRole,
 } from "../auth/middleware.ts";
+import { createApiClient } from "../play-cricket/api-client.ts";
 import { calculateFantasyScores } from "./calculate-scores.ts";
 import { getCurrentSeason } from "./gameweek.ts";
 import {
@@ -58,13 +59,21 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
 export const fantasyRoutes: FastifyPluginAsync = async (app) => {
+  const playCricketApi =
+    app.config.PLAY_CRICKET_API_TOKEN && app.config.PLAY_CRICKET_SITE_ID
+      ? createApiClient({
+          apiToken: app.config.PLAY_CRICKET_API_TOKEN,
+          siteId: app.config.PLAY_CRICKET_SITE_ID,
+        })
+      : undefined;
+
   // Wire up service factories
   const eligible = getEligiblePlayers(app.db);
   const myTeam = getMyTeam(app.db);
   const save = saveTeam(app.db);
   const list = listPlayers(app.db);
   const toggle = toggleEligibility(app.db);
-  const populate = populatePlayers(app.db);
+  const populate = populatePlayers(app.db, playCricketApi);
   const calcCosts = calculateSandwichCosts(app.db);
   const calcScores = calculateFantasyScores(app.db);
   const transferWindow = getTransferWindow();

--- a/apps/api/src/features/fantasy/service.ts
+++ b/apps/api/src/features/fantasy/service.ts
@@ -2,6 +2,7 @@
 import type { DB } from "@percy-main/db";
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
+import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 import { calculateSlotEffectivePoints } from "./calculate-scores.ts";
 import {
   BUDGET,
@@ -534,7 +535,10 @@ export function toggleEligibility(db: Kysely<DB>) {
   };
 }
 
-export function populatePlayers(db: Kysely<DB>) {
+export function populatePlayers(
+  db: Kysely<DB>,
+  apiClient?: PlayCricketApiClient,
+) {
   return async () => {
     // Get distinct players from match performance tables
     const battingPlayers = await db
@@ -564,6 +568,17 @@ export function populatePlayers(db: Kysely<DB>) {
     ]) {
       if (p.player_id && p.player_name) {
         playerMap.set(p.player_id, p.player_name);
+      }
+    }
+
+    // Also fetch all registered players from Play Cricket API
+    if (apiClient) {
+      const { players: apiPlayers } = await apiClient.getPlayers();
+      for (const p of apiPlayers) {
+        const id = String(p.member_id);
+        if (!playerMap.has(id)) {
+          playerMap.set(id, p.name);
+        }
       }
     }
 

--- a/apps/web/src/pages/admin/fantasy-tab.tsx
+++ b/apps/web/src/pages/admin/fantasy-tab.tsx
@@ -45,7 +45,7 @@ const DEFAULT_CONFIGS: Record<string, string> = {
 };
 
 interface Player {
-  name: string;
+  player_name: string;
   play_cricket_id: string;
   sandwich_cost: number;
   eligible: boolean;


### PR DESCRIPTION
## Summary
- **Player names not displaying**: Frontend referenced `player.name` but the API returns `player_name` from the database column — fixed the interface and template
- **Newly registered players missing**: `populatePlayers` only pulled from match performance tables, so players with no match history (e.g. Brian Storey) never appeared. Now also fetches all registered members via the Play Cricket `getPlayers()` API during population

## Test plan
- [ ] Verify player names now display in Admin → Fantasy → Players table
- [ ] Click "Refresh from Play Cricket" and confirm newly added players (e.g. Brian Storey) appear in the list
- [ ] Confirm existing players are not duplicated after re-populating

🤖 Generated with [Claude Code](https://claude.com/claude-code)