### PR TITLE
Fix CORS error on PUT requests in production

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -114,6 +114,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(cors, {
     origin: config.BASE_URL,
     credentials: true,
+    methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE"],
     allowedHeaders: [
       "Content-Type",
       "Authorization",


### PR DESCRIPTION
## Summary

- `@fastify/cors` defaults `methods` to `GET,HEAD,POST` — PUT/PATCH/DELETE were never included in the preflight `Access-Control-Allow-Methods` header
- The browser accepted the preflight (204) but blocked the actual PUT request because it wasn't in the allowed methods list
- This only affected production because locally Vite proxies `/api` requests (same-origin, no CORS enforcement)
- The sponsor website update endpoint is currently the only PUT route, which is why no other endpoints were affected

## Test plan

- [ ] Deploy and verify sponsor website URL can be updated from admin panel in production
- [ ] Verify other admin actions (approve, reject, manual create) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)