### PR TITLE
Add availability email notifications and shareable public link

### DIFF
--- a/apps/api/src/features/availability/routes.ts
+++ b/apps/api/src/features/availability/routes.ts
@@ -14,9 +14,14 @@ import {
   createRequestSchema,
   getActiveRequestsResponseSchema,
   getDateDetailResponseSchema,
+  getPublicRequestResponseSchema,
   getRequestResponseSchema,
   listRequestsResponseSchema,
   listRequestsSchema,
+  notifyPreviewResponseSchema,
+  notifyPreviewSchema,
+  notifySendResponseSchema,
+  notifySendSchema,
   overrideResponseSchema,
   previewFixturesResponseSchema,
   requestDateParamSchema,
@@ -32,12 +37,15 @@ import {
   createRequest,
   getActiveRequests,
   getDateDetail,
+  getPublicRequest,
   getRequest,
   listRequests,
   overrideResponse,
   previewFixtures,
+  previewNotifyRecipients,
   removeAssignment,
   respond,
+  sendAvailabilityNotification,
   updateRequestStatus,
 } from "./service.ts";
 
@@ -234,6 +242,60 @@ export const availabilityRoutes: FastifyPluginAsyncZod = async (app) => {
         });
       }
       return await preview(request.query.dateFrom, request.query.dateTo);
+    },
+  );
+
+  // ── Notification Routes ──
+
+  const previewRecipients = previewNotifyRecipients(app.db);
+  app.post(
+    "/availability/requests/:requestId/notify/preview",
+    {
+      preHandler: [officialRole],
+      schema: {
+        params: requestIdParamSchema,
+        body: notifyPreviewSchema,
+        response: { 200: notifyPreviewResponseSchema },
+      },
+    },
+    async (request) => {
+      return await previewRecipients(request.params.requestId, request.body);
+    },
+  );
+
+  const sendNotification = sendAvailabilityNotification(
+    app.db,
+    app.send,
+    app.config.BASE_URL,
+  );
+  app.post(
+    "/availability/requests/:requestId/notify/send",
+    {
+      preHandler: [officialRole],
+      schema: {
+        params: requestIdParamSchema,
+        body: notifySendSchema,
+        response: { 200: notifySendResponseSchema },
+      },
+    },
+    async (request) => {
+      return await sendNotification(request.params.requestId, request.body);
+    },
+  );
+
+  // ── Public Routes ──
+
+  const getPublic = getPublicRequest(app.db);
+  app.get(
+    "/availability/requests/:requestId/public",
+    {
+      schema: {
+        params: requestIdParamSchema,
+        response: { 200: getPublicRequestResponseSchema },
+      },
+    },
+    async (request) => {
+      return await getPublic(request.params.requestId);
     },
   );
 

--- a/apps/api/src/features/availability/schemas.ts
+++ b/apps/api/src/features/availability/schemas.ts
@@ -232,6 +232,49 @@ export const previewFixturesResponseSchema = z.object({
   fixtures: z.array(previewFixtureSchema),
 });
 
+// ── Notification schemas ──
+
+export const notifyPreviewSchema = z.object({
+  memberCategory: z.string().optional(),
+  membershipStatus: z.enum(["active", "lapsed"]).optional(),
+  additionalEmails: z.array(z.email()).optional(),
+});
+
+const recipientSchema = z.object({
+  email: z.string(),
+  name: z.string().nullable(),
+  source: z.enum(["filter", "manual"]),
+});
+
+export const notifyPreviewResponseSchema = z.object({
+  recipients: z.array(recipientSchema),
+});
+
+export const notifySendSchema = z.object({
+  recipients: z.array(
+    z.object({
+      email: z.email(),
+      name: z.string().nullable(),
+    }),
+  ),
+});
+
+export const notifySendResponseSchema = z.object({
+  sent: z.number(),
+});
+
+// ── Public request schema ──
+
+export const getPublicRequestResponseSchema = z.object({
+  request: z.object({
+    id: z.string(),
+    date_from: z.string(),
+    date_to: z.string(),
+    status: z.string(),
+  }),
+  fixtures: z.array(activeFixtureSchema),
+});
+
 // ── Types ──
 
 export type CreateRequest = z.infer<typeof createRequestSchema>;
@@ -240,3 +283,5 @@ export type OverrideResponse = z.infer<typeof overrideResponseSchema>;
 export type Respond = z.infer<typeof respondSchema>;
 export type UpdateRequestStatus = z.infer<typeof updateRequestStatusSchema>;
 export type ListRequests = z.infer<typeof listRequestsSchema>;
+export type NotifyPreview = z.infer<typeof notifyPreviewSchema>;
+export type NotifySend = z.infer<typeof notifySendSchema>;

--- a/apps/api/src/features/availability/service.ts
+++ b/apps/api/src/features/availability/service.ts
@@ -1,10 +1,15 @@
 import type { DB } from "@percy-main/db";
+import { AvailabilityRequest } from "@percy-main/email";
+import { render } from "@react-email/render";
 import type { Kysely } from "kysely";
+import { createElement } from "react";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 import type {
   AssignPlayer,
   CreateRequest,
   ListRequests,
+  NotifyPreview,
+  NotifySend,
   OverrideResponse,
   Respond,
   UpdateRequestStatus,
@@ -887,5 +892,181 @@ export function previewFixtures(
       .sort((a, b) => a.matchDate.localeCompare(b.matchDate));
 
     return { fixtures };
+  };
+}
+
+// ── Notification Services ──
+
+export function previewNotifyRecipients(db: Kysely<DB>) {
+  return async (requestId: string, data: NotifyPreview) => {
+    // Verify request exists
+    const request = await db
+      .selectFrom("availability_request")
+      .where("id", "=", requestId)
+      .select("id")
+      .executeTakeFirst();
+
+    if (!request) throwHttpError(404, "Availability request not found");
+
+    // Query members with optional filters (reuses admin listUsers pattern)
+    let query = db
+      .selectFrom("member")
+      .leftJoin(
+        (eb) =>
+          eb
+            .selectFrom("membership")
+            .select([
+              "membership.member_id",
+              "membership.id",
+              "membership.paid_until",
+            ])
+            .distinctOn("membership.member_id")
+            .orderBy("membership.member_id")
+            .orderBy("membership.paid_until", "desc")
+            .as("membership"),
+        (join) => join.onRef("membership.member_id", "=", "member.id"),
+      )
+      .where("member.deleted_at", "is", null)
+      .where("member.email", "is not", null);
+
+    if (data.memberCategory) {
+      query = query.where("member.member_category", "=", data.memberCategory);
+    }
+
+    if (data.membershipStatus) {
+      const now = new Date().toISOString();
+      if (data.membershipStatus === "active") {
+        query = query.where("membership.paid_until", ">", now);
+      } else if (data.membershipStatus === "lapsed") {
+        query = query
+          .where("membership.paid_until", "is not", null)
+          .where("membership.paid_until", "<=", now);
+      }
+    }
+
+    const members = await query
+      .select(["member.email", "member.name"])
+      .orderBy("member.name", "asc")
+      .execute();
+
+    const recipients: Array<{
+      email: string;
+      name: string | null;
+      source: "filter" | "manual";
+    }> = members.map((m) => ({
+      email: m.email,
+      name: m.name,
+      source: "filter" as const,
+    }));
+
+    // Merge in additional emails (deduplicated)
+    if (data.additionalEmails?.length) {
+      const existingEmails = new Set(
+        recipients.map((r) => r.email.toLowerCase()),
+      );
+      for (const email of data.additionalEmails) {
+        if (!existingEmails.has(email.toLowerCase())) {
+          recipients.push({ email, name: null, source: "manual" });
+          existingEmails.add(email.toLowerCase());
+        }
+      }
+    }
+
+    return { recipients };
+  };
+}
+
+export function sendAvailabilityNotification(
+  db: Kysely<DB>,
+  sendEmail: (email: {
+    to: string;
+    subject: string;
+    html: string;
+  }) => Promise<void>,
+  baseUrl: string,
+) {
+  return async (requestId: string, data: NotifySend) => {
+    // Fetch request details
+    const request = await db
+      .selectFrom("availability_request")
+      .where("id", "=", requestId)
+      .select(["id", "date_from", "date_to"])
+      .executeTakeFirst();
+
+    if (!request) throwHttpError(404, "Availability request not found");
+
+    // Count fixtures
+    const fixtureResult = await db
+      .selectFrom("availability_fixture")
+      .where("availability_request_id", "=", requestId)
+      .select(db.fn.countAll<string>().as("count"))
+      .executeTakeFirst();
+
+    const fixtureCount = Number(fixtureResult?.count ?? 0);
+    const imageBaseUrl = `${baseUrl}/images`;
+    const url = `${baseUrl}/availability/${requestId}`;
+
+    let sent = 0;
+    for (const recipient of data.recipients) {
+      const html = await render(
+        createElement(AvailabilityRequest.component, {
+          imageBaseUrl,
+          name: recipient.name,
+          dateFrom: request.date_from,
+          dateTo: request.date_to,
+          fixtureCount,
+          url,
+        }),
+      );
+
+      await sendEmail({
+        to: recipient.email,
+        subject: AvailabilityRequest.subject,
+        html,
+      });
+      sent++;
+    }
+
+    return { sent };
+  };
+}
+
+// ── Public Request ──
+
+export function getPublicRequest(db: Kysely<DB>) {
+  return async (requestId: string) => {
+    const request = await db
+      .selectFrom("availability_request")
+      .where("id", "=", requestId)
+      .where("status", "=", "open")
+      .select(["id", "date_from", "date_to", "status"])
+      .executeTakeFirst();
+
+    if (!request) throwHttpError(404, "Availability request not found");
+
+    const fixtures = await db
+      .selectFrom("availability_fixture")
+      .leftJoin(
+        "play_cricket_team",
+        "play_cricket_team.id",
+        "availability_fixture.play_cricket_team_id",
+      )
+      .where("availability_fixture.availability_request_id", "=", requestId)
+      .select([
+        "availability_fixture.id",
+        "availability_fixture.availability_request_id",
+        "availability_fixture.match_date",
+        "availability_fixture.play_cricket_team_id",
+        "availability_fixture.play_cricket_match_id",
+        "availability_fixture.opposition",
+        "availability_fixture.is_home",
+        "availability_fixture.competition_name",
+        "availability_fixture.match_time",
+        "play_cricket_team.name as team_name",
+      ])
+      .orderBy("availability_fixture.match_date", "asc")
+      .execute();
+
+    return { request, fixtures };
   };
 }

--- a/apps/web/src/components/require-auth.tsx
+++ b/apps/web/src/components/require-auth.tsx
@@ -11,7 +11,8 @@ export function RequireAuth() {
   }
 
   if (!session) {
-    return <Navigate to="/auth/login" state={{ from: location }} replace />;
+    const returnTo = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/auth/login?returnTo=${returnTo}`} replace />;
   }
 
   return <Outlet />;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -5120,6 +5120,164 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/availability/requests/{requestId}/notify/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        memberCategory?: string;
+                        /** @enum {string} */
+                        membershipStatus?: "active" | "lapsed";
+                        additionalEmails?: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            recipients: {
+                                email: string;
+                                name: string | null;
+                                /** @enum {string} */
+                                source: "filter" | "manual";
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/availability/requests/{requestId}/notify/send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        recipients: {
+                            /** Format: email */
+                            email: string;
+                            name: string | null;
+                        }[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            sent: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/availability/requests/{requestId}/public": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            request: {
+                                id: string;
+                                date_from: string;
+                                date_to: string;
+                                status: string;
+                            };
+                            fixtures: {
+                                id: string;
+                                availability_request_id: string;
+                                match_date: string;
+                                play_cricket_team_id: string;
+                                play_cricket_match_id: string;
+                                opposition: string;
+                                is_home: boolean;
+                                competition_name: string | null;
+                                match_time: string | null;
+                                team_name: string | null;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/availability/active": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -8838,6 +8838,278 @@
         }
       }
     },
+    "/api/availability/requests/{requestId}/notify/preview": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "memberCategory": {
+                    "type": "string"
+                  },
+                  "membershipStatus": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "lapsed"
+                    ]
+                  },
+                  "additionalEmails": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "email",
+                      "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "recipients": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "email": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string",
+                            "enum": [
+                              "filter",
+                              "manual"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "email",
+                          "name",
+                          "source"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "recipients"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/availability/requests/{requestId}/notify/send": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "recipients": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                        },
+                        "name": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "email",
+                        "name"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "recipients"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sent": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "sent"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/availability/requests/{requestId}/public": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "request": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "date_from": {
+                          "type": "string"
+                        },
+                        "date_to": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "date_from",
+                        "date_to",
+                        "status"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "fixtures": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "availability_request_id": {
+                            "type": "string"
+                          },
+                          "match_date": {
+                            "type": "string"
+                          },
+                          "play_cricket_team_id": {
+                            "type": "string"
+                          },
+                          "play_cricket_match_id": {
+                            "type": "string"
+                          },
+                          "opposition": {
+                            "type": "string"
+                          },
+                          "is_home": {
+                            "type": "boolean"
+                          },
+                          "competition_name": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "match_time": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "team_name": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "availability_request_id",
+                          "match_date",
+                          "play_cricket_team_id",
+                          "play_cricket_match_id",
+                          "opposition",
+                          "is_home",
+                          "competition_name",
+                          "match_time",
+                          "team_name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "request",
+                    "fixtures"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/availability/active": {
       "get": {
         "responses": {

--- a/apps/web/src/pages/auth/email-confirmed.tsx
+++ b/apps/web/src/pages/auth/email-confirmed.tsx
@@ -1,8 +1,15 @@
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
-import { Link } from "react-router";
+import { Link, useSearchParams } from "react-router";
 
 export function Component() {
   useDocumentMeta("Email Confirmed");
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get("returnTo");
+
+  const loginUrl = returnTo
+    ? `/auth/login?returnTo=${encodeURIComponent(returnTo)}`
+    : "/auth/login";
+
   return (
     <div className="w-full rounded-lg bg-white shadow-sm sm:max-w-md">
       <div className="space-y-4 p-6 text-center sm:p-8">
@@ -14,7 +21,7 @@ export function Component() {
           account.
         </p>
         <Link
-          to="/auth/login"
+          to={loginUrl}
           className="bg-dark text-body inline-block rounded-md px-4 py-2 text-sm font-medium shadow transition hover:opacity-90"
         >
           Sign in

--- a/apps/web/src/pages/auth/login/email-password.tsx
+++ b/apps/web/src/pages/auth/login/email-password.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button.js";
 import { authClient } from "@/lib/auth-client.js";
 import { useMutation } from "@tanstack/react-query";
 import { useCallback, useEffect, useState, type FC } from "react";
-import { Link, useNavigate } from "react-router";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import type { LoginPhase } from "../login.js";
 
 interface Props {
@@ -35,6 +35,8 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get("returnTo");
 
   useEffect(() => {
     async function tryPasskeyAutofill() {
@@ -46,13 +48,13 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
         { autoFill: true },
         {
           onSuccess() {
-            void navigate("/members");
+            void navigate(returnTo ?? "/members");
           },
         },
       );
     }
     void tryPasskeyAutofill();
-  }, [navigate]);
+  }, [navigate, returnTo]);
 
   const signin = useMutation({
     mutationFn: async () => {
@@ -66,7 +68,7 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
         setPhase("2fa");
         return;
       }
-      void navigate("/members");
+      void navigate(returnTo ?? "/members");
     },
   });
 
@@ -74,7 +76,7 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
     mutationFn: () =>
       authClient.signIn.social({
         provider: "google",
-        callbackURL: "/members",
+        callbackURL: returnTo ?? "/members",
       }),
   });
 
@@ -145,7 +147,14 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
           )}
           <p className="text-sm font-light text-gray-500">
             Don&apos;t have an account yet?{" "}
-            <Link to="/auth/register" className="font-medium hover:underline">
+            <Link
+              to={
+                returnTo
+                  ? `/auth/register?returnTo=${encodeURIComponent(returnTo)}`
+                  : "/auth/register"
+              }
+              className="font-medium hover:underline"
+            >
               Sign up
             </Link>
           </p>

--- a/apps/web/src/pages/auth/register.tsx
+++ b/apps/web/src/pages/auth/register.tsx
@@ -36,18 +36,26 @@ export function Component() {
   const [ageConfirmed, setAgeConfirmed] = useState(false);
   const [ageError, setAgeError] = useState(false);
   const navigate = useNavigate();
+  const returnTo = searchParams.get("returnTo");
 
   const register = useMutation({
-    mutationFn: () =>
-      authClient.signUp.email({
+    mutationFn: () => {
+      const emailConfirmedUrl = returnTo
+        ? `${window.location.origin}/auth/email-confirmed?returnTo=${encodeURIComponent(returnTo)}`
+        : `${window.location.origin}/auth/email-confirmed/`;
+      return authClient.signUp.email({
         name,
         email,
         password,
-        callbackURL: `${window.location.origin}/auth/email-confirmed/`,
-      }),
+        callbackURL: emailConfirmedUrl,
+      });
+    },
     onSuccess(result) {
       if (!result.error) {
-        void navigate("/auth/registered");
+        const registeredUrl = returnTo
+          ? `/auth/registered?returnTo=${encodeURIComponent(returnTo)}`
+          : "/auth/registered";
+        void navigate(registeredUrl);
       }
     },
   });
@@ -56,7 +64,7 @@ export function Component() {
     mutationFn: () =>
       authClient.signIn.social({
         provider: "google",
-        callbackURL: "/members",
+        callbackURL: returnTo ?? "/members",
       }),
   });
 
@@ -199,7 +207,14 @@ export function Component() {
 
           <p className="text-sm font-light text-gray-500">
             Already have an account?{" "}
-            <Link to="/auth/login" className="font-medium hover:underline">
+            <Link
+              to={
+                returnTo
+                  ? `/auth/login?returnTo=${encodeURIComponent(returnTo)}`
+                  : "/auth/login"
+              }
+              className="font-medium hover:underline"
+            >
               Sign in
             </Link>
           </p>

--- a/apps/web/src/pages/auth/registered.tsx
+++ b/apps/web/src/pages/auth/registered.tsx
@@ -1,8 +1,15 @@
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
-import { Link } from "react-router";
+import { Link, useSearchParams } from "react-router";
 
 export function Component() {
   useDocumentMeta("Registration Complete");
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get("returnTo");
+
+  const loginUrl = returnTo
+    ? `/auth/login?returnTo=${encodeURIComponent(returnTo)}`
+    : "/auth/login";
+
   return (
     <div className="w-full rounded-lg bg-white shadow-sm sm:max-w-md">
       <div className="space-y-4 p-6 text-center sm:p-8">
@@ -15,7 +22,7 @@ export function Component() {
         </p>
         <p className="text-sm text-gray-500">
           Already verified?{" "}
-          <Link to="/auth/login" className="font-medium hover:underline">
+          <Link to={loginUrl} className="font-medium hover:underline">
             Sign in
           </Link>
         </p>

--- a/apps/web/src/pages/availability/public-availability.tsx
+++ b/apps/web/src/pages/availability/public-availability.tsx
@@ -1,0 +1,383 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useDocumentMeta } from "@/hooks/use-document-meta.js";
+import { api, callApi } from "@/lib/api-client";
+import type { paths } from "@/lib/api.gen.js";
+import { useSession } from "@/lib/auth-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { useCallback, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router";
+
+// ── Types ──
+
+type PublicData =
+  paths["/api/availability/requests/{requestId}/public"]["get"]["responses"][200]["content"]["application/json"];
+type Fixture = PublicData["fixtures"][number];
+
+interface DraftResponse {
+  matchDate: string;
+  status: "available" | "unavailable";
+  note?: string;
+}
+
+function getDraftKey(requestId: string) {
+  return `availability-draft-${requestId}`;
+}
+
+function loadDraft(requestId: string): DraftResponse[] | null {
+  try {
+    const raw = localStorage.getItem(getDraftKey(requestId));
+    if (!raw) return null;
+    return JSON.parse(raw) as DraftResponse[];
+  } catch {
+    return null;
+  }
+}
+
+function saveDraft(requestId: string, responses: DraftResponse[]) {
+  localStorage.setItem(getDraftKey(requestId), JSON.stringify(responses));
+}
+
+function clearDraft(requestId: string) {
+  localStorage.removeItem(getDraftKey(requestId));
+}
+
+// ── Component ──
+
+export function Component() {
+  useDocumentMeta("Availability");
+  const { requestId } = useParams<{ requestId: string }>();
+  const navigate = useNavigate();
+  const { data: session, isPending: sessionPending } = useSession();
+
+  const query = useQuery({
+    queryKey: ["availability", "public", requestId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/availability/requests/{requestId}/public", {
+          params: { path: { requestId: requestId ?? "" } },
+        }),
+      ),
+    enabled: !!requestId,
+  });
+
+  // Check for existing member record (only if signed in)
+  const memberQuery = useQuery({
+    queryKey: ["availability", "active"],
+    queryFn: () => callApi(api.GET("/api/availability/active")),
+    enabled: !!session,
+  });
+
+  const hasMemberRecord = memberQuery.data?.memberId != null;
+  const isSignedIn = !!session;
+
+  // Load draft from localStorage (once, on mount)
+  const initialResponses = useMemo(() => {
+    if (!requestId) return new Map<string, DraftResponse>();
+    const draft = loadDraft(requestId);
+    if (!draft) return new Map<string, DraftResponse>();
+    const map = new Map<string, DraftResponse>();
+    for (const r of draft) {
+      map.set(r.matchDate, r);
+    }
+    return map;
+  }, [requestId]);
+
+  const [responses, setResponses] =
+    useState<Map<string, DraftResponse>>(initialResponses);
+  const [submitted, setSubmitted] = useState(false);
+
+  // Populate from server responses if signed in and no draft exists
+  const serverResponses = useMemo(() => {
+    if (!memberQuery.data || !requestId) return null;
+    if (initialResponses.size > 0) return null;
+    const activeRequest = memberQuery.data.items.find(
+      (r) => r.id === requestId,
+    );
+    if (!activeRequest?.myResponses.length) return null;
+    const map = new Map<string, DraftResponse>();
+    for (const r of activeRequest.myResponses) {
+      map.set(r.match_date, {
+        matchDate: r.match_date,
+        status: r.status as "available" | "unavailable",
+        note: r.note ?? undefined,
+      });
+    }
+    return map;
+  }, [memberQuery.data, requestId, initialResponses.size]);
+
+  // Use server responses if we haven't interacted yet
+  const effectiveResponses =
+    responses.size > 0 ? responses : (serverResponses ?? responses);
+
+  const setDateResponse = useCallback(
+    (matchDate: string, status: "available" | "unavailable") => {
+      setResponses((prev) => {
+        // Merge with server responses if user hasn't interacted yet
+        const base = prev.size > 0 ? prev : (serverResponses ?? prev);
+        const next = new Map(base);
+        const existing = next.get(matchDate);
+        next.set(matchDate, {
+          matchDate,
+          status,
+          note: existing?.note,
+        });
+        return next;
+      });
+    },
+    [serverResponses],
+  );
+
+  const setDateNote = useCallback(
+    (matchDate: string, note: string) => {
+      setResponses((prev) => {
+        const base = prev.size > 0 ? prev : (serverResponses ?? prev);
+        const next = new Map(base);
+        const existing = next.get(matchDate);
+        if (existing) {
+          next.set(matchDate, { ...existing, note });
+        }
+        return next;
+      });
+    },
+    [serverResponses],
+  );
+
+  const queryClient = useQueryClient();
+
+  const submitMutation = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/availability/requests/{requestId}/respond", {
+          params: { path: { requestId: requestId ?? "" } },
+          body: {
+            responses: Array.from(effectiveResponses.values()).map((r) => ({
+              matchDate: r.matchDate,
+              status: r.status,
+              note: r.note ?? undefined,
+            })),
+          },
+        }),
+      ),
+    onSuccess: () => {
+      if (requestId) clearDraft(requestId);
+      setSubmitted(true);
+      void queryClient.invalidateQueries({
+        queryKey: ["availability"],
+      });
+    },
+  });
+
+  const handleSubmit = useCallback(() => {
+    if (!requestId) return;
+
+    if (!isSignedIn) {
+      // Save draft and redirect to register
+      saveDraft(requestId, Array.from(effectiveResponses.values()));
+      const returnTo = `/availability/${requestId}`;
+      void navigate(`/auth/register?returnTo=${encodeURIComponent(returnTo)}`);
+      return;
+    }
+
+    submitMutation.mutate();
+  }, [requestId, isSignedIn, effectiveResponses, navigate, submitMutation]);
+
+  if (query.isPending || sessionPending) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <p className="text-gray-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1>Availability</h1>
+        <p className="mt-4 text-center text-gray-500">
+          This availability request could not be found or is no longer open.
+        </p>
+      </div>
+    );
+  }
+
+  const data = query.data;
+  if (!data) return null;
+
+  // Group fixtures by date
+  const fixturesByDate = new Map<string, Fixture[]>();
+  for (const f of data.fixtures) {
+    const list = fixturesByDate.get(f.match_date) ?? [];
+    list.push(f);
+    fixturesByDate.set(f.match_date, list);
+  }
+  const dates = Array.from(fixturesByDate.keys()).sort();
+
+  const hasDraft = requestId ? loadDraft(requestId) !== null : false;
+  const hasResponses = effectiveResponses.size > 0;
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <h1 className="text-2xl font-bold">Availability</h1>
+
+      {hasDraft && isSignedIn && (
+        <Alert className="mt-4">
+          <AlertDescription>
+            You have unsaved responses from before you signed up. Review them
+            below and submit when ready.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {isSignedIn && !hasMemberRecord && !memberQuery.isPending && (
+        <Alert className="mt-4" variant="destructive">
+          <AlertDescription>
+            You need to complete your membership registration before you can
+            submit availability responses.{" "}
+            <Link to="/members" className="font-medium underline">
+              Go to Members Area
+            </Link>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {submitted && (
+        <Alert className="mt-4">
+          <AlertDescription>
+            Your availability has been saved. You can update your responses at
+            any time from the{" "}
+            <Link to="/members/availability" className="font-medium underline">
+              Members Area
+            </Link>
+            .
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="mt-4 flex flex-col gap-4">
+        {dates.map((date) => (
+          <DateCard
+            key={date}
+            date={date}
+            fixtures={fixturesByDate.get(date) ?? []}
+            response={effectiveResponses.get(date)}
+            onStatusChange={(status) => setDateResponse(date, status)}
+            onNoteChange={(note) => setDateNote(date, note)}
+            disabled={submitted}
+          />
+        ))}
+      </div>
+
+      {!submitted && dates.length > 0 && (
+        <div className="mt-6">
+          <Button
+            onClick={handleSubmit}
+            disabled={
+              !hasResponses ||
+              submitMutation.isPending ||
+              (isSignedIn && !hasMemberRecord)
+            }
+            className="w-full sm:w-auto"
+          >
+            {submitMutation.isPending
+              ? "Saving..."
+              : isSignedIn
+                ? "Submit Responses"
+                : "Sign Up & Submit"}
+          </Button>
+          {!isSignedIn && hasResponses && (
+            <p className="mt-2 text-sm text-gray-500">
+              You'll need to create an account to save your responses. Already
+              have one?{" "}
+              <Link
+                to={`/auth/login?returnTo=${encodeURIComponent(`/availability/${requestId}`)}`}
+                className="font-medium underline"
+              >
+                Sign in
+              </Link>
+            </p>
+          )}
+          {submitMutation.isError && (
+            <p className="mt-2 text-sm text-red-600">
+              Failed to save your responses. Please try again.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Date Card ──
+
+function DateCard({
+  date,
+  fixtures,
+  response,
+  onStatusChange,
+  onNoteChange,
+  disabled,
+}: {
+  date: string;
+  fixtures: Fixture[];
+  response: DraftResponse | undefined;
+  onStatusChange: (status: "available" | "unavailable") => void;
+  onNoteChange: (note: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="rounded border p-3">
+      <p className="mb-2 text-sm font-semibold">
+        {format(new Date(date), "EEEE d MMMM")}
+      </p>
+      <div className="mb-3 flex flex-col gap-1">
+        {fixtures.map((f) => (
+          <p key={f.id} className="text-sm text-gray-600">
+            {f.team_name ?? "Team"} {f.is_home ? "vs" : "@"} {f.opposition}
+            {f.competition_name && (
+              <span className="text-gray-400"> ({f.competition_name})</span>
+            )}
+          </p>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          className={`rounded px-3 py-1 text-sm ${
+            response?.status === "available"
+              ? "bg-green-600 text-white"
+              : "border bg-white text-gray-700 hover:bg-green-50"
+          }`}
+          onClick={() => onStatusChange("available")}
+          disabled={disabled}
+        >
+          Available
+        </button>
+        <button
+          className={`rounded px-3 py-1 text-sm ${
+            response?.status === "unavailable"
+              ? "bg-red-600 text-white"
+              : "border bg-white text-gray-700 hover:bg-red-50"
+          }`}
+          onClick={() => onStatusChange("unavailable")}
+          disabled={disabled}
+        >
+          Unavailable
+        </button>
+      </div>
+
+      {response?.status && (
+        <Textarea
+          className="mt-2"
+          placeholder="Optional note (e.g. free after 1pm)"
+          rows={1}
+          value={response.note ?? ""}
+          onChange={(e) => onNoteChange(e.target.value)}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/official/availability.tsx
+++ b/apps/web/src/pages/official/availability.tsx
@@ -1,6 +1,13 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -15,7 +22,7 @@ import type { paths } from "@/lib/api.gen.js";
 import { useSession } from "@/lib/auth-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { addDays, format } from "date-fns";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 
 // ── Derived API types ──
@@ -365,7 +372,7 @@ function RequestDetailView({ requestId }: { requestId: string }) {
         </Badge>
       </div>
 
-      <div className="mb-4">
+      <div className="mb-4 flex gap-2">
         {request.status === "open" ? (
           <Button
             variant="outline"
@@ -385,6 +392,17 @@ function RequestDetailView({ requestId }: { requestId: string }) {
             Reopen Request
           </Button>
         )}
+        <NotifyDialog requestId={requestId} />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            const url = `${window.location.origin}/availability/${requestId}`;
+            void navigator.clipboard.writeText(url);
+          }}
+        >
+          Copy Link
+        </Button>
       </div>
 
       {dates.length === 0 && (
@@ -927,6 +945,276 @@ function PlayerPool({
         )}
       </CardContent>
     </Card>
+  );
+}
+
+// ── Notify Dialog ──
+
+interface Recipient {
+  email: string;
+  name: string | null;
+  source: "filter" | "manual";
+}
+
+function NotifyDialog({ requestId }: { requestId: string }) {
+  const [open, setOpen] = useState(false);
+  const [memberCategory, setMemberCategory] = useState<string>("");
+  const [membershipStatus, setMembershipStatus] = useState<string>("");
+  const [manualEmails, setManualEmails] = useState("");
+  const [recipients, setRecipients] = useState<Recipient[]>([]);
+  const [checked, setChecked] = useState<Set<string>>(new Set());
+  const [previewed, setPreviewed] = useState(false);
+
+  const previewMutation = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/availability/requests/{requestId}/notify/preview", {
+          params: { path: { requestId } },
+          body: {
+            memberCategory: memberCategory || undefined,
+            membershipStatus:
+              (membershipStatus as "active" | "lapsed") || undefined,
+            additionalEmails: manualEmails
+              ? manualEmails
+                  .split(",")
+                  .map((e) => e.trim())
+                  .filter(Boolean)
+              : undefined,
+          },
+        }),
+      ),
+    onSuccess: (data) => {
+      setRecipients(data.recipients);
+      setChecked(new Set(data.recipients.map((r) => r.email)));
+      setPreviewed(true);
+    },
+  });
+
+  const sendMutation = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/availability/requests/{requestId}/notify/send", {
+          params: { path: { requestId } },
+          body: {
+            recipients: recipients
+              .filter((r) => checked.has(r.email))
+              .map((r) => ({ email: r.email, name: r.name })),
+          },
+        }),
+      ),
+    onSuccess: () => {
+      // Keep dialog open to show success
+    },
+  });
+
+  const toggleRecipient = useCallback((email: string) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(email)) {
+        next.delete(email);
+      } else {
+        next.add(email);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleAll = useCallback(() => {
+    setChecked((prev) => {
+      if (prev.size === recipients.length) {
+        return new Set();
+      }
+      return new Set(recipients.map((r) => r.email));
+    });
+  }, [recipients]);
+
+  const reset = useCallback(() => {
+    setRecipients([]);
+    setChecked(new Set());
+    setPreviewed(false);
+    setMemberCategory("");
+    setMembershipStatus("");
+    setManualEmails("");
+    sendMutation.reset();
+    previewMutation.reset();
+  }, [sendMutation, previewMutation]);
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        Notify Members
+      </Button>
+      <Dialog
+        open={open}
+        onOpenChange={(v: boolean) => {
+          setOpen(v);
+          if (!v) reset();
+        }}
+      >
+        <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Notify Members</DialogTitle>
+          </DialogHeader>
+
+          {sendMutation.isSuccess ? (
+            <div className="space-y-3">
+              <p className="text-sm text-green-600">
+                Sent {sendMutation.data.sent} email
+                {sendMutation.data.sent !== 1 ? "s" : ""}.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </Button>
+            </div>
+          ) : !previewed ? (
+            <div className="space-y-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium">
+                  Member Category
+                </label>
+                <Select
+                  value={memberCategory || "__all__"}
+                  onValueChange={(v) =>
+                    setMemberCategory(v === "__all__" ? "" : v)
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="All categories" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__all__">All categories</SelectItem>
+                    <SelectItem value="senior">Senior</SelectItem>
+                    <SelectItem value="junior">Junior</SelectItem>
+                    <SelectItem value="student">Student</SelectItem>
+                    <SelectItem value="bursary">Bursary</SelectItem>
+                    <SelectItem value="guest">Guest</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium">
+                  Membership Status
+                </label>
+                <Select
+                  value={membershipStatus || "__any__"}
+                  onValueChange={(v) =>
+                    setMembershipStatus(v === "__any__" ? "" : v)
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Any status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__any__">Any status</SelectItem>
+                    <SelectItem value="active">Active (paid up)</SelectItem>
+                    <SelectItem value="lapsed">Lapsed</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium">
+                  Additional Emails
+                </label>
+                <Input
+                  placeholder="email1@example.com, email2@example.com"
+                  value={manualEmails}
+                  onChange={(e) => setManualEmails(e.target.value)}
+                />
+                <p className="mt-1 text-xs text-gray-500">
+                  Comma-separated. These will be added to the filtered list.
+                </p>
+              </div>
+
+              <Button
+                onClick={() => previewMutation.mutate()}
+                disabled={previewMutation.isPending}
+              >
+                {previewMutation.isPending
+                  ? "Loading..."
+                  : "Preview Recipients"}
+              </Button>
+
+              {previewMutation.isError && (
+                <p className="text-sm text-red-600">
+                  Failed to load recipients.
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">
+                  {checked.size} of {recipients.length} selected
+                </p>
+                <button
+                  className="text-xs text-blue-600 hover:text-blue-800"
+                  onClick={toggleAll}
+                >
+                  {checked.size === recipients.length
+                    ? "Deselect all"
+                    : "Select all"}
+                </button>
+              </div>
+
+              <div className="max-h-60 overflow-y-auto rounded border">
+                {recipients.map((r) => (
+                  <label
+                    key={r.email}
+                    className="flex cursor-pointer items-center gap-3 border-b px-3 py-2 last:border-b-0 hover:bg-gray-50"
+                  >
+                    <Checkbox
+                      checked={checked.has(r.email)}
+                      onCheckedChange={() => toggleRecipient(r.email)}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm">
+                        {r.name ?? r.email}
+                        {r.source === "manual" && (
+                          <span className="ml-1 text-xs text-gray-400">
+                            (manual)
+                          </span>
+                        )}
+                      </p>
+                      {r.name && (
+                        <p className="truncate text-xs text-gray-500">
+                          {r.email}
+                        </p>
+                      )}
+                    </div>
+                  </label>
+                ))}
+              </div>
+
+              <div className="flex gap-2">
+                <Button
+                  onClick={() => sendMutation.mutate()}
+                  disabled={sendMutation.isPending || checked.size === 0}
+                >
+                  {sendMutation.isPending
+                    ? "Sending..."
+                    : `Send to ${checked.size} recipient${checked.size !== 1 ? "s" : ""}`}
+                </Button>
+                <Button variant="outline" onClick={reset}>
+                  Back
+                </Button>
+              </div>
+
+              {sendMutation.isError && (
+                <p className="text-sm text-red-600">
+                  Failed to send notifications.
+                </p>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -94,6 +94,10 @@ export const router = createBrowserRouter([
         path: "nets",
         lazy: () => import("./pages/nets.js"),
       },
+      {
+        path: "availability/:requestId",
+        lazy: () => import("./pages/availability/public-availability.js"),
+      },
 
       // Auth routes (minimal layout)
       {

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,5 +1,6 @@
 export { email } from "./email.ts";
 export { createSend } from "./send.ts";
+export { AvailabilityRequest } from "./templates/AvailabilityRequest.tsx";
 export { ChaosWeekAnnouncement } from "./templates/ChaosWeekAnnouncement.tsx";
 export { ChargeNotification } from "./templates/ChargeNotification.tsx";
 export { FantasyReminder } from "./templates/FantasyReminder.tsx";

--- a/packages/email/src/templates/AvailabilityRequest.tsx
+++ b/packages/email/src/templates/AvailabilityRequest.tsx
@@ -1,0 +1,87 @@
+// organize-imports-ignore — React must stay: tsx/esbuild uses classic JSX transform for workspace deps
+import React, { type FC } from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import { email } from "../email.ts";
+import * as styles from "../styles.ts";
+
+interface Props {
+  imageBaseUrl: string;
+  name: string | null;
+  dateFrom: string;
+  dateTo: string;
+  fixtureCount: number;
+  url: string;
+}
+
+const Component: FC<Props> = ({
+  name,
+  imageBaseUrl,
+  dateFrom,
+  dateTo,
+  fixtureCount,
+  url,
+}) => (
+  <Html>
+    <Head />
+    <Preview>
+      New availability request: {dateFrom} to {dateTo}
+    </Preview>
+    <Body style={styles.main}>
+      <Container style={styles.container}>
+        <Img
+          src={`${imageBaseUrl}/club_logo.png`}
+          width="100"
+          height="100"
+          alt="Percy Main Club Logo"
+          style={styles.logo}
+        />
+        <Text style={styles.paragraph}>Hi {name ?? "there"},</Text>
+        <Text style={styles.paragraph}>
+          A new availability request has been created for{" "}
+          <strong>
+            {dateFrom} to {dateTo}
+          </strong>{" "}
+          covering <strong>{fixtureCount}</strong> fixture
+          {fixtureCount === 1 ? "" : "s"}. Please let us know whether
+          you&apos;re available.
+        </Text>
+        <Section style={styles.btnContainer}>
+          <Button style={styles.button} href={url}>
+            View &amp; Respond
+          </Button>
+        </Section>
+        <Text style={styles.paragraph}>
+          Best,
+          <br />
+          Percy Main Cricket Club
+        </Text>
+        <Hr style={styles.hr} />
+        <Text style={styles.footer}>
+          Percy Main Cricket Club, St. Johns Terrace, North Shields, NE29 6HS
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export const AvailabilityRequest = email<Props>("Availability Request", {
+  preview: {
+    imageBaseUrl: "http://localhost:5173/images",
+    name: "Alex",
+    dateFrom: "2026-05-10",
+    dateTo: "2026-05-17",
+    fixtureCount: 4,
+    url: "http://localhost:5173/availability/abc-123",
+  },
+})(Component);


### PR DESCRIPTION
## Summary

- **Email notifications**: Officials can notify members about new availability requests via a "Notify Members" dialog on the request detail page. Recipients can be filtered by member category and membership status, with a preview step showing checkboxes before sending. Emails include a "View & Respond" link to the public availability page.
- **Shareable public link**: New public route at `/availability/:requestId` lets anyone view fixtures and toggle availability. Non-authenticated users get their draft saved to localStorage and are redirected through the signup flow, landing back on the page with responses pre-filled after login.
- **returnTo auth chain**: Login, register, registered, and email-confirmed pages now forward a `returnTo` query param through the full auth flow, enabling redirect-after-signup for any page.

## Test plan

- [ ] Create an availability request as an official
- [ ] Click "Notify Members" → filter by Senior category → preview recipients → send → check `.emails/` for rendered HTML
- [ ] Click "Copy Link" on request detail page → open in incognito
- [ ] On public page: toggle availability for dates → click "Sign Up & Submit" → confirm redirect to register with `returnTo` param
- [ ] Register → verify email → login → confirm landing back on availability page with draft pre-filled → submit
- [ ] Verify `pnpm run typecheck && pnpm run lint && pnpm format:check && pnpm --filter api test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)