### PR TITLE
Fix 500 error when promoting users to admin

### DIFF
--- a/apps/api/src/features/admin/schemas.ts
+++ b/apps/api/src/features/admin/schemas.ts
@@ -30,7 +30,6 @@ export const listUsersSchema = z.object({
 });
 
 export const updateUserSchema = z.object({
-  userId: z.string(),
   name: z.string().optional(),
   email: z.email().optional(),
   role: z

--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -134,7 +134,7 @@ export function listUsers(db: Kysely<DB>) {
 }
 
 export function updateUser(db: Kysely<DB>) {
-  return async (userId: string, data: Omit<UpdateUser, "userId">) => {
+  return async (userId: string, data: UpdateUser) => {
     if (Object.values(data).filter((v) => v !== undefined).length > 0) {
       await db.updateTable("user").set(data).where("id", "=", userId).execute();
     }

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -5729,7 +5729,6 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        userId: string;
                         name?: string;
                         /** Format: email */
                         email?: string;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -10153,9 +10153,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "userId": {
-                    "type": "string"
-                  },
                   "name": {
                     "type": "string"
                   },
@@ -10180,10 +10177,7 @@
                   "banReason": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "userId"
-                ]
+                }
               }
             }
           }

--- a/apps/web/src/pages/admin/member-detail-modal.tsx
+++ b/apps/web/src/pages/admin/member-detail-modal.tsx
@@ -212,7 +212,6 @@ function AccountSection({
         api.PUT("/api/admin/users/{userId}", {
           params: { path: { userId } },
           body: {
-            userId,
             role: newRole as
               | "user"
               | "admin"


### PR DESCRIPTION
## Summary
- The `updateUserSchema` included `userId` in the request body, which got passed through to Kysely's `.set(data)` on the `user` table
- The `user` table has no `userId` column, causing PostgreSQL error `42703` on every update
- Removed `userId` from the body schema (it's already in the `:userId` URL param), updated the service type, and removed the redundant field from the frontend call

## Test plan
- [ ] Promote a user to admin in production — should succeed without 500
- [ ] Demote an admin back to user — should also work
- [ ] Update other user fields (ban, name, email) via the admin panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)