### PR TITLE
Redesign junior manager with player detail modal

### DIFF
--- a/apps/api/src/features/junior/schemas.ts
+++ b/apps/api/src/features/junior/schemas.ts
@@ -108,6 +108,7 @@ export const playerDetailResponseSchema = z.object({
   name: z.string(),
   sex: z.string(),
   dob: z.string(),
+  created_at: z.string(),
   school_year: z.string().nullable(),
   played_before: z.boolean().nullable(),
   previous_cricket: z.string().nullable(),
@@ -129,4 +130,6 @@ export const playerDetailResponseSchema = z.object({
   parent_email: z.string(),
   parent_address: z.string().nullable(),
   parent_postcode: z.string().nullable(),
+  emergency_contact_name: z.string().nullable(),
+  emergency_contact_telephone: z.string().nullable(),
 });

--- a/apps/api/src/features/junior/service.ts
+++ b/apps/api/src/features/junior/service.ts
@@ -323,6 +323,7 @@ export function getPlayerDetail(db: Kysely<DB>) {
         "dependent.name",
         "dependent.sex",
         "dependent.dob",
+        "dependent.created_at",
         "dependent.school_year",
         "dependent.played_before",
         "dependent.previous_cricket",
@@ -344,6 +345,8 @@ export function getPlayerDetail(db: Kysely<DB>) {
         "member.email as parent_email",
         "member.address as parent_address",
         "member.postcode as parent_postcode",
+        "member.emergency_contact_name",
+        "member.emergency_contact_telephone",
       ])
       .executeTakeFirst();
 

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -53,6 +53,27 @@ export function DialogContent({
           className,
         )}
       >
+        <button
+          type="button"
+          className="text-muted hover:text-foreground absolute top-4 right-4 rounded-sm p-1"
+          onClick={() => onOpenChange(false)}
+          aria-label="Close"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
         {children}
       </div>
     </div>

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -747,6 +747,7 @@ export interface paths {
                             name: string;
                             sex: string;
                             dob: string;
+                            created_at: string;
                             school_year: string | null;
                             played_before: boolean | null;
                             previous_cricket: string | null;
@@ -768,6 +769,8 @@ export interface paths {
                             parent_email: string;
                             parent_address: string | null;
                             parent_postcode: string | null;
+                            emergency_contact_name: string | null;
+                            emergency_contact_telephone: string | null;
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -1040,6 +1040,9 @@
                     "dob": {
                       "type": "string"
                     },
+                    "created_at": {
+                      "type": "string"
+                    },
                     "school_year": {
                       "nullable": true,
                       "type": "string"
@@ -1122,6 +1125,14 @@
                     "parent_postcode": {
                       "nullable": true,
                       "type": "string"
+                    },
+                    "emergency_contact_name": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "emergency_contact_telephone": {
+                      "nullable": true,
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1129,6 +1140,7 @@
                     "name",
                     "sex",
                     "dob",
+                    "created_at",
                     "school_year",
                     "played_before",
                     "previous_cricket",
@@ -1149,7 +1161,9 @@
                     "parent_telephone",
                     "parent_email",
                     "parent_address",
-                    "parent_postcode"
+                    "parent_postcode",
+                    "emergency_contact_name",
+                    "emergency_contact_telephone"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/pages/junior-manager/junior-manager.tsx
+++ b/apps/web/src/pages/junior-manager/junior-manager.tsx
@@ -1,6 +1,11 @@
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   Table,
   TableBody,
@@ -15,11 +20,14 @@ import type { paths } from "@/lib/api.gen";
 import { useSession } from "@/lib/auth-client";
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { Fragment, useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router";
 
 type Player =
   paths["/api/junior/teams/{teamId}/players"]["get"]["responses"]["200"]["content"]["application/json"][number];
+
+type PlayerDetail =
+  paths["/api/junior/players/{dependentId}"]["get"]["responses"]["200"]["content"]["application/json"];
 
 function useTeams() {
   return useQuery({
@@ -97,11 +105,7 @@ function TeamsDashboard() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <p className="text-sm text-gray-500">
-        You have access to {teams.length} team{teams.length !== 1 ? "s" : ""}.
-        Select a team to view players.
-      </p>
+    <div className="flex flex-col gap-6">
       {teams.map((team) => (
         <TeamCard key={team.id} teamId={team.id} teamName={team.name} />
       ))}
@@ -110,153 +114,317 @@ function TeamsDashboard() {
 }
 
 function TeamCard({ teamId, teamName }: { teamId: string; teamName: string }) {
-  const [expanded, setExpanded] = useState(false);
-  const {
-    data: players,
-    isPending,
-    isError,
-    isSuccess,
-  } = usePlayers(teamId, expanded);
+  const { data: players, isPending, isError } = usePlayers(teamId, true);
 
   return (
     <Card>
-      <CardHeader className="p-0">
-        <button
-          type="button"
-          className="flex w-full items-center justify-between p-6 text-left"
-          aria-expanded={expanded}
-          onClick={() => setExpanded(!expanded)}
-        >
-          <CardTitle className="flex items-center gap-2">
-            {teamName}
-            {players && <Badge variant="secondary">{players.length}</Badge>}
-          </CardTitle>
-          <span className="text-sm text-gray-400">
-            {expanded ? "Collapse" : "Expand"}
-          </span>
-        </button>
+      <CardHeader className="pb-0">
+        <CardTitle className="flex items-center gap-2">
+          {teamName}
+          {players && <Badge variant="secondary">{players.length}</Badge>}
+        </CardTitle>
       </CardHeader>
-      {expanded && (
-        <CardContent>
-          {isPending && (
-            <p className="text-sm text-gray-500">Loading players...</p>
-          )}
-          {isError && (
-            <p className="text-sm text-red-600">Failed to load players.</p>
-          )}
-          {isSuccess && players.length === 0 && (
-            <p className="text-sm text-gray-500">
-              No players registered in this team.
-            </p>
-          )}
-          {isSuccess && players.length > 0 && (
-            <PlayersTable players={players} />
-          )}
-        </CardContent>
-      )}
+      <CardContent>
+        {isPending && (
+          <p className="text-sm text-gray-500">Loading players...</p>
+        )}
+        {isError && (
+          <p className="text-sm text-red-600">Failed to load players.</p>
+        )}
+        {players && players.length > 0 && <PlayersTable players={players} />}
+      </CardContent>
     </Card>
   );
 }
 
 function PlayersTable({ players }: { players: Player[] }) {
-  const [expandedPlayer, setExpandedPlayer] = useState<string | null>(null);
+  const [selectedPlayerId, setSelectedPlayerId] = useState<string | null>(null);
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Name</TableHead>
-          <TableHead>DOB</TableHead>
-          <TableHead>Parent</TableHead>
-          <TableHead>Contact</TableHead>
-          <TableHead>Details</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {players.map((player) => (
-          <Fragment key={player.id}>
-            <TableRow>
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>DOB</TableHead>
+            <TableHead>Parent</TableHead>
+            <TableHead className="hidden sm:table-cell">Contact</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {players.map((player) => (
+            <TableRow
+              key={player.id}
+              className="cursor-pointer hover:bg-gray-50"
+              onClick={() => setSelectedPlayerId(player.id)}
+            >
               <TableCell className="font-medium">{player.name}</TableCell>
               <TableCell>{format(player.dob, "dd/MM/yyyy")}</TableCell>
               <TableCell>{player.parent_name}</TableCell>
-              <TableCell>
+              <TableCell className="hidden sm:table-cell">
                 <div className="flex flex-col gap-0.5 text-xs">
-                  <a
-                    href={`mailto:${player.parent_email}`}
-                    className="text-blue-600 hover:underline"
-                  >
-                    {player.parent_email}
-                  </a>
+                  <span>{player.parent_email}</span>
                   <span>{player.parent_telephone}</span>
                 </div>
               </TableCell>
-              <TableCell>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    setExpandedPlayer(
-                      expandedPlayer === player.id ? null : player.id,
-                    )
-                  }
-                >
-                  {expandedPlayer === player.id ? "Hide" : "View"}
-                </Button>
-              </TableCell>
             </TableRow>
-            {expandedPlayer === player.id && (
-              <TableRow>
-                <TableCell colSpan={5}>
-                  <div className="rounded bg-gray-50 p-4">
-                    <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                      <dt className="font-medium text-gray-500">Player Name</dt>
-                      <dd>{player.name}</dd>
-                      <dt className="font-medium text-gray-500">
-                        Date of Birth
-                      </dt>
-                      <dd>{format(player.dob, "dd/MM/yyyy")}</dd>
-                      <dt className="font-medium text-gray-500">Sex</dt>
-                      <dd className="capitalize">{player.sex}</dd>
-                      <dt className="font-medium text-gray-500">Registered</dt>
-                      <dd>{format(player.created_at, "dd/MM/yyyy")}</dd>
-                      <dt className="mt-3 font-medium text-gray-500">
-                        Parent / Guardian
-                      </dt>
-                      <dd className="mt-3">{player.parent_name}</dd>
-                      <dt className="font-medium text-gray-500">Email</dt>
-                      <dd>
-                        <a
-                          href={`mailto:${player.parent_email}`}
-                          className="text-blue-600 hover:underline"
-                        >
-                          {player.parent_email}
-                        </a>
-                      </dd>
-                      <dt className="font-medium text-gray-500">Telephone</dt>
-                      <dd>{player.parent_telephone}</dd>
-                      <dt className="font-medium text-gray-500">Address</dt>
-                      <dd>
-                        {player.parent_address}
-                        {player.parent_postcode && (
-                          <>, {player.parent_postcode}</>
-                        )}
-                      </dd>
-                      <dt className="mt-3 font-medium text-gray-500">
-                        Emergency Contact
-                      </dt>
-                      <dd className="mt-3">{player.emergency_contact_name}</dd>
-                      <dt className="font-medium text-gray-500">
-                        Emergency Phone
-                      </dt>
-                      <dd>{player.emergency_contact_telephone}</dd>
-                    </dl>
-                  </div>
-                </TableCell>
-              </TableRow>
-            )}
-          </Fragment>
-        ))}
-      </TableBody>
-    </Table>
+          ))}
+        </TableBody>
+      </Table>
+      {selectedPlayerId && (
+        <PlayerDetailModal
+          dependentId={selectedPlayerId}
+          onClose={() => setSelectedPlayerId(null)}
+        />
+      )}
+    </>
+  );
+}
+
+function usePlayerDetail(dependentId: string) {
+  return useQuery({
+    queryKey: ["juniorManager", "playerDetail", dependentId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/junior/players/{dependentId}", {
+          params: { path: { dependentId } },
+        }),
+      ),
+  });
+}
+
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  if (children === null || children === undefined || children === "") {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-xs font-medium text-gray-500">{label}</dt>
+      <dd className="text-sm">{children}</dd>
+    </div>
+  );
+}
+
+function DetailSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h3 className="mb-2 text-sm font-semibold text-gray-700">{title}</h3>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-3">{children}</dl>
+    </div>
+  );
+}
+
+function ContactRow({
+  label,
+  name,
+  phone,
+  email,
+}: {
+  label: string;
+  name: string | null;
+  phone: string | null;
+  email?: string | null;
+}) {
+  if (!name && !phone && !email) return null;
+  return (
+    <div className="col-span-2 flex flex-col gap-0.5">
+      <dt className="text-xs font-medium text-gray-500">{label}</dt>
+      <dd className="text-sm">
+        <span>{name}</span>
+        {phone && (
+          <>
+            {" \u2014 "}
+            <a href={`tel:${phone}`} className="text-blue-600 hover:underline">
+              {phone}
+            </a>
+          </>
+        )}
+        {email && (
+          <>
+            {" \u2014 "}
+            <a
+              href={`mailto:${email}`}
+              className="text-blue-600 hover:underline"
+            >
+              {email}
+            </a>
+          </>
+        )}
+      </dd>
+    </div>
+  );
+}
+
+function ConsentRow({
+  label,
+  value,
+  description,
+}: {
+  label: string;
+  value: boolean | null;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-xs font-medium text-gray-500">{label}</dt>
+      <dd className="text-sm">
+        <span>{value ? "Yes" : "No"}</span>
+        <p className="mt-0.5 text-xs text-gray-400">{description}</p>
+      </dd>
+    </div>
+  );
+}
+
+function PlayerDetailModal({
+  dependentId,
+  onClose,
+}: {
+  dependentId: string;
+  onClose: () => void;
+}) {
+  const { data, isLoading } = usePlayerDetail(dependentId);
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-h-[90vh] w-full max-w-2xl overflow-y-auto">
+        {isLoading || !data ? (
+          <div className="py-12 text-center text-gray-500">Loading...</div>
+        ) : (
+          <PlayerDetailContent player={data} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PlayerDetailContent({ player }: { player: PlayerDetail }) {
+  return (
+    <div className="flex flex-col gap-6">
+      <DialogHeader>
+        <DialogTitle>{player.name}</DialogTitle>
+      </DialogHeader>
+
+      <DetailSection title="Emergency Contact">
+        <ContactRow
+          label="Parent / Guardian"
+          name={player.parent_name}
+          phone={player.parent_telephone}
+          email={player.parent_email}
+        />
+        <ContactRow
+          label="Alt Contact"
+          name={player.alt_contact_name}
+          phone={player.alt_contact_phone}
+        />
+        <ContactRow
+          label="Emergency Contact"
+          name={player.emergency_contact_name}
+          phone={player.emergency_contact_telephone}
+        />
+      </DetailSection>
+
+      <hr className="border-gray-200" />
+
+      <DetailSection title="Health">
+        <DetailRow label="GP Surgery">{player.gp_surgery}</DetailRow>
+        <DetailRow label="GP Phone">
+          {player.gp_phone && (
+            <a
+              href={`tel:${player.gp_phone}`}
+              className="text-blue-600 hover:underline"
+            >
+              {player.gp_phone}
+            </a>
+          )}
+        </DetailRow>
+        <DetailRow label="Medical Info">{player.medical_info}</DetailRow>
+        <DetailRow label="Disability">
+          {player.has_disability ? (player.disability_type ?? "Yes") : "No"}
+        </DetailRow>
+      </DetailSection>
+
+      <hr className="border-gray-200" />
+
+      <DetailSection title="Details">
+        <DetailRow label="Date of Birth">
+          {format(player.dob, "dd/MM/yyyy")}
+        </DetailRow>
+        <DetailRow label="Sex">
+          <span className="capitalize">{player.sex}</span>
+        </DetailRow>
+        <DetailRow label="School Year">{player.school_year}</DetailRow>
+        <DetailRow label="Address">
+          {player.parent_address}
+          {player.parent_postcode && <>, {player.parent_postcode}</>}
+        </DetailRow>
+        <DetailRow label="Registered">
+          {format(player.created_at, "dd/MM/yyyy")}
+        </DetailRow>
+      </DetailSection>
+
+      <hr className="border-gray-200" />
+
+      <DetailSection title="Cricket">
+        <DetailRow label="Played Before">
+          {player.played_before === null
+            ? null
+            : player.played_before
+              ? "Yes"
+              : "No"}
+        </DetailRow>
+        <DetailRow label="Previous Cricket">
+          {player.previous_cricket}
+        </DetailRow>
+      </DetailSection>
+
+      <hr className="border-gray-200" />
+
+      <DetailSection title="Consents">
+        <ConsentRow
+          label="Emergency Medical Consent"
+          value={player.emergency_medical_consent}
+          description="Parent authorises emergency medical treatment if they cannot be reached"
+        />
+        <ConsentRow
+          label="Medical Fitness Declaration"
+          value={player.medical_fitness_declaration}
+          description="Parent confirms the child is fit to participate in cricket"
+        />
+        <ConsentRow
+          label="Photo Consent"
+          value={player.photo_consent}
+          description="Photos and videos may be used on the club website and social media"
+        />
+        <ConsentRow
+          label="Data Protection"
+          value={player.data_protection_consent}
+          description="Personal data may be stored and used for club administration"
+        />
+        <ConsentRow
+          label="WhatsApp Consent"
+          value={player.whatsapp_consent}
+          description="Parent can be contacted via WhatsApp for team updates"
+        />
+        {player.alt_contact_whatsapp_consent !== null && (
+          <ConsentRow
+            label="Alt Contact WhatsApp"
+            value={player.alt_contact_whatsapp_consent}
+            description="Alt contact can be contacted via WhatsApp for team updates"
+          />
+        )}
+      </DetailSection>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces view/hide expand rows with a modal that opens on row click, fetching full player detail from the API
- Modal sections: emergency contact (name + number on same row), health, details, cricket, consents (each with descriptions)
- Teams load player lists eagerly — no more expand/collapse
- Adds close button (X) to all dialogs for better mobile usability
- Adds `created_at`, `emergency_contact_name`, `emergency_contact_telephone` to the player detail API endpoint

## Test plan
- [ ] Open `/junior-manager`, verify teams and player lists load immediately
- [ ] Click a player row, verify modal opens with full details
- [ ] Check emergency contact section shows name and number on same row
- [ ] Check all consents show descriptions
- [ ] Close modal via X button and via backdrop click
- [ ] Test on mobile viewport — modal should fill screen with visible close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)