### PR TITLE
Add renewal button for expired memberships

### DIFF
--- a/apps/web/src/components/members/membership.tsx
+++ b/apps/web/src/components/members/membership.tsx
@@ -1,6 +1,6 @@
 import { api, callApi } from "@/lib/api-client";
 import { useQuery } from "@tanstack/react-query";
-import { formatDate } from "date-fns";
+import { formatDate, isPast, parseISO } from "date-fns";
 import { Link } from "react-router";
 import { match } from "ts-pattern";
 
@@ -67,6 +67,14 @@ export function Membership() {
               <span className="font-semibold">Paid Until: </span>
               {formatDate(membership.paid_until, "dd/MM/yyyy")}
             </p>
+            {isPast(parseISO(membership.paid_until)) && (
+              <Link
+                className="mt-3 inline-block rounded-lg border border-blue-700 bg-white px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-50 focus:ring-4 focus:ring-blue-300 focus:outline-none"
+                to="/membership/pay"
+              >
+                Renew Membership
+              </Link>
+            )}
           </>
         ) : (
           <>

--- a/apps/web/src/pages/membership/membership-pay.tsx
+++ b/apps/web/src/pages/membership/membership-pay.tsx
@@ -58,7 +58,7 @@ function PayMembershipInner() {
 
   return (
     <div className="mx-auto max-w-2xl">
-      <h4>Thanks for joining the club!</h4>
+      <h4>Choose Your Membership</h4>
 
       <div className="mt-8">
         <section className="mb-12">


### PR DESCRIPTION
## Summary
- Show a "Renew Membership" button on the member dashboard when `paid_until` is in the past, linking to `/membership/pay`
- Update payment page heading from "Thanks for joining the club!" to "Choose Your Membership" so it works for renewals too

## Context
A member's direct debit failed, their membership expired, and there was no way to re-subscribe from the dashboard. This adds the missing renewal path.

See #106 for follow-up work on Stripe webhook handlers for proactive failure notifications.

## Test plan
- [ ] Log in as a member with an expired `paid_until` date — verify "Renew Membership" button appears
- [ ] Click the button — verify it navigates to `/membership/pay` and the flow works end-to-end
- [ ] Log in as a member with an active membership — verify no renewal button is shown
- [ ] Visit `/membership/pay` directly — verify heading says "Choose Your Membership"

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)