### PR TITLE
Add junior cricket 2026 pages and fix sibling pricing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -132,6 +132,10 @@ pnpm run openapi:generate              # regenerate spec + frontend types
 - **Use `return await` in async route handlers** — preserves stack traces for error debugging
 - **Always add imports and their usage in the same edit** — lint hooks run on save and will strip unused imports. Never add an import in one edit and its usage in a separate edit.
 
+## Content Pages (MDX)
+
+The site has a file-based content page system for static informational pages. See `docs/content.md` for full documentation on how to create and structure content pages (file location, frontmatter, available MDX components, navigation). Use this when creating prose-heavy pages like announcements, codes of conduct, or club information — no router changes or code generation needed.
+
 ## Feature Folder Structure
 
 Each API feature is self-contained:

--- a/apps/api/src/features/junior/integration.test.ts
+++ b/apps/api/src/features/junior/integration.test.ts
@@ -58,7 +58,7 @@ describe("junior service (integration)", () => {
       expect(dependent?.sex).toBe("male");
     });
 
-    it("creates a charge with correct amount: 5000 for first, 3000 for additional", async () => {
+    it("creates a charge with correct amount: 5000 for first, 4000 for additional", async () => {
       // Use withMember: false so addDependents creates the member fresh
       // (no pre-existing member -> no pre-existing dependents -> existingCount=0)
       const email = `parent-charge-${crypto.randomUUID()}@test.com`;
@@ -94,8 +94,8 @@ describe("junior service (integration)", () => {
         .executeTakeFirst();
 
       expect(charge).toBeTruthy();
-      // First child = 5000, second child = 3000
-      expect(charge?.amount_pence).toBe(8000);
+      // First child = 5000, second child = 4000
+      expect(charge?.amount_pence).toBe(9000);
     });
 
     it("links charge to dependents via charge_dependent", async () => {

--- a/apps/api/src/features/junior/service.ts
+++ b/apps/api/src/features/junior/service.ts
@@ -4,7 +4,7 @@ import type { Kysely } from "kysely";
 import type { DependentInput } from "./schemas.ts";
 
 const FIRST_CHILD_FEE_PENCE = 5000;
-const ADDITIONAL_CHILD_FEE_PENCE = 3000;
+const ADDITIONAL_CHILD_FEE_PENCE = 4000;
 
 /**
  * Find an existing member by email or create a minimal record.

--- a/apps/web/content/pages/cricket/juniors/_index.mdx
+++ b/apps/web/content/pages/cricket/juniors/_index.mdx
@@ -9,3 +9,8 @@ Junior cricket is at the heart of Percy Main. We run teams across multiple age g
 Our sessions focus on fun, development and inclusion. Every child gets the chance to bat, bowl and field, and our qualified [coaching team](/cricket/juniors/coaches) work hard to make sure everyone feels welcome and supported. Safety is a priority — all coaches are DBS-checked and follow ECB Safe Hands guidelines.
 
 For details on training times, registration and what you need to get started, see our [Welcome to Junior Cricket 2026](/cricket/juniors/welcome-2026) page.
+
+<ContactForm
+  title="Get in Touch"
+  description="Questions about junior cricket? Drop us a message and we'll get back to you."
+/>

--- a/apps/web/content/pages/cricket/juniors/_index.mdx
+++ b/apps/web/content/pages/cricket/juniors/_index.mdx
@@ -1,16 +1,11 @@
 ---
 title: Juniors
-description: "Junior cricket coaching at Percy Main — meet the coaching team and find out about junior sessions."
+description: "Junior cricket at Percy Main — inclusive, safe and fun coaching for boys and girls of all abilities."
 menuOrder: 3
 ---
 
-##### Coaching Team
+Junior cricket is at the heart of Percy Main. We run teams across multiple age groups for boys and girls, from under-9s through to under-19s, and welcome players of all abilities — whether they've been playing for years or have never picked up a bat before.
 
-<PersonGrid>
-  <Person slug="tony-robson" role="Head Of Junior Section" />
-  <Person slug="paddy-rathbone" role="Coach - Juniors" />
-  <Person slug="jon-roys" role="Coach - Juniors" />
-  <Person slug="alex-young" role="Coach - Juniors" />
-  <Person slug="oli-robson" role="Coach - Juniors" />
-  <Person slug="steve-knight" role="Coach - Juniors" />
-</PersonGrid>
+Our sessions focus on fun, development and inclusion. Every child gets the chance to bat, bowl and field, and our qualified [coaching team](/cricket/juniors/coaches) work hard to make sure everyone feels welcome and supported. Safety is a priority — all coaches are DBS-checked and follow ECB Safe Hands guidelines.
+
+For details on training times, registration and what you need to get started, see our [Welcome to Junior Cricket 2026](/cricket/juniors/welcome-2026) page.

--- a/apps/web/content/pages/cricket/juniors/coaches.mdx
+++ b/apps/web/content/pages/cricket/juniors/coaches.mdx
@@ -1,0 +1,16 @@
+---
+title: Junior Coaches
+description: "Meet the coaching team behind junior cricket at Percy Main Cricket Club."
+menuOrder: 3
+---
+
+<PersonGrid>
+  <Person slug="tony-robson" role="Head Of Junior Section" />
+  <Person slug="jon-roys" role="Coach" />
+  <Person slug="paddy-rathbone" role="Coach" />
+  <Person slug="alex-young" role="Coach" />
+  <Person slug="bryan-cowey" role="Coach" />
+  <Person slug="oli-robson" role="Coach" />
+  <Person slug="steve-knight" role="Coach" />
+  <Person slug="martin-hughes" role="Coach" />
+</PersonGrid>

--- a/apps/web/content/pages/cricket/juniors/welcome-2026.mdx
+++ b/apps/web/content/pages/cricket/juniors/welcome-2026.mdx
@@ -1,0 +1,61 @@
+---
+title: Welcome to Junior Cricket 2026
+description: "Everything you need to know about junior cricket at Percy Main for the 2026 season — training times, registration, membership, kit and communication."
+menuOrder: 0
+---
+
+## Welcome to Junior Cricket 2026
+
+We're looking forward to another great season of junior cricket at The Main. Whether your child is returning or joining us for the first time, here's everything you need to know.
+
+## Training
+
+First practice sessions begin on **Tuesday 21st April 2026**.
+
+| Group                      | Day     | Time            |
+| -------------------------- | ------- | --------------- |
+| Boys U11s                  | Tuesday | 4.30pm - 5.45pm |
+| Boys U13/U15/U19s          | Tuesday | 6.00pm - 7.30pm |
+| Girls' Dynamos (ages 8-11) | TBC     | TBC             |
+
+**New for 2026** — we're launching **Girls' Dynamos** for 8-11 year olds. Date and time to be confirmed shortly — register your interest by getting in touch at the email below.
+
+The junior section is led by Tony Robson, alongside our [team of qualified coaches](/cricket/juniors/coaches). We'd love to welcome more parents into helping run teams — if you're interested, please speak to us about how to get involved.
+
+## Registration
+
+It's crucial that we have up-to-date information so that we can contact you when needed, and so our coaches have everything they need to keep players safe.
+
+To register, you'll need to create an account on this website and then fill in the junior registration form. All information is confidential and kept within the bounds of our [privacy policy](/legal/privacy).
+
+**How to register:**
+
+1. [Create an account](/auth/register) on the Percy Main website using **your details as parent/guardian** (or [log in](/auth/login) if you already have one)
+2. Go to [Junior Registration](/membership/junior) and add each of your children
+
+Please complete registration as soon as possible.
+
+## Annual Membership Donation
+
+Our annual membership donation remains unchanged, at **£50 per child** for the whole year and **£40 for each additional sibling**.
+
+Payment is taken online as part of the [junior registration](/membership/junior) process.
+
+As many of you may be aware, the cricket club is registered as a charity, and one of our core tenets is that no player be excluded from participation on financial grounds. If the cost is genuinely prohibitive, please speak to a member of the coaching team in the strictest confidence.
+
+## Kit
+
+The club's official kit supplier, VX3, has an [online kit shop](https://kit.percymain.org). There's no requirement to purchase new kit if it isn't needed, but should you wish to, games will be played in:
+
+- **Top** — Blue top: "Percy Main Cricket Club Opus Tee Youth". This has been discontinued by VX3 but is currently available at a discount in the [kit shop](https://kit.percymain.org) while stocks last — now might be a good time to buy
+- **Bottoms** — Dark tracksuit bottoms, in the kit shop: "Percy Main Cricket Club Primus Youth Skinny Pants" if you want club-branded kit
+
+## Communication
+
+We use WhatsApp groups as the primary means of communication and organisation. Once you've registered, you'll be added to the main **"PMCC Juniors 2026"** group, alongside any age-specific groups for your children.
+
+## Contact
+
+If you have any questions at any point in the season, please get in touch.
+
+Email [**juniors@percymain.org**](mailto:juniors@percymain.org)

--- a/apps/web/content/people/martin-hughes.mdx
+++ b/apps/web/content/people/martin-hughes.mdx
@@ -1,0 +1,6 @@
+---
+name: Martin Hughes
+slug: martin-hughes
+isDBSChecked: false
+hasLeftClub: false
+---

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
     "react-router": "^7.3.0",
     "recharts": "^3.8.0",
     "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
     "remark-mdx-frontmatter": "^5.2.0",
     "tailwind-merge": "^3.0.1",
     "tailwindcss": "^4.0.0",

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -315,3 +315,19 @@
 .mdx-content img {
   @apply h-auto max-w-full rounded-lg;
 }
+
+.mdx-content table {
+  @apply w-full border-collapse text-sm;
+}
+
+.mdx-content th {
+  @apply border-b-2 border-gray-200 bg-gray-50 px-4 py-2 text-left font-semibold text-gray-700;
+}
+
+.mdx-content td {
+  @apply border-b border-gray-100 px-4 py-2;
+}
+
+.mdx-content tr:last-child td {
+  @apply border-b-0;
+}

--- a/apps/web/src/pages/membership/membership-junior.tsx
+++ b/apps/web/src/pages/membership/membership-junior.tsx
@@ -20,7 +20,7 @@ import { useState } from "react";
 import { Link } from "react-router";
 
 const FIRST_CHILD_PRICE = 50;
-const ADDITIONAL_CHILD_PRICE = 30;
+const ADDITIONAL_CHILD_PRICE = 40;
 
 const SCHOOL_YEARS = [
   "Year 4",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import remarkFrontmatter from "remark-frontmatter";
+import remarkGfm from "remark-gfm";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import { defineConfig } from "vite";
 import { imagetools } from "vite-imagetools";
@@ -10,7 +11,7 @@ import { imagetools } from "vite-imagetools";
 export default defineConfig({
   plugins: [
     mdx({
-      remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter],
+      remarkPlugins: [remarkGfm, remarkFrontmatter, remarkMdxFrontmatter],
       providerImportSource: "@mdx-js/react",
     }),
     react(),

--- a/docs/content.md
+++ b/docs/content.md
@@ -1,0 +1,116 @@
+# Content Pages (MDX)
+
+The website has a file-based content page system built on MDX. Content pages are used for static informational pages like club info, codes of conduct, event announcements, and similar prose-heavy pages that don't need dynamic data fetching.
+
+## When to use content pages
+
+Use an MDX content page when:
+
+- The page is primarily static text, images, and links
+- It fits naturally into the site's content hierarchy (e.g. under `/cricket/`, `/charity/`)
+- It doesn't need authenticated data, API calls, or complex interactive state
+
+Use a React page component (in `apps/web/src/pages/`) instead when the page needs dynamic data fetching, authentication, forms, or significant interactivity.
+
+## File location and URL mapping
+
+Content pages live in `apps/web/content/pages/`. The file path maps directly to the URL:
+
+```
+content/pages/cricket/juniors/welcome-2026.mdx  →  /cricket/juniors/welcome-2026
+content/pages/charity/_index.mdx                →  /charity
+content/pages/cricket/kit-shop.mdx              →  /cricket/kit-shop
+```
+
+- `_index.mdx` files represent the directory itself (e.g. `cricket/_index.mdx` → `/cricket`)
+- Non-index files use their filename as the URL segment
+- The catch-all route in `router.tsx` (`path: "*"`) renders content pages via `content-page.tsx`
+
+## Frontmatter
+
+Every MDX file must have YAML frontmatter:
+
+```yaml
+---
+title: Page Title
+description: "Short description for SEO and document meta."
+menuOrder: 3
+---
+```
+
+| Field         | Required | Description                                                                            |
+| ------------- | -------- | -------------------------------------------------------------------------------------- |
+| `title`       | Yes      | Page title, shown in breadcrumbs and sidebar nav                                       |
+| `description` | No       | Meta description for SEO                                                               |
+| `menuOrder`   | No       | Sort order within parent section (default: 99). Lower numbers appear first in sidebar. |
+| `isMainMenu`  | No       | If `true`, the page appears in the site's top-level navigation menu                    |
+
+## Navigation and sidebar
+
+Content pages automatically get:
+
+- **Breadcrumbs** — built from the page hierarchy (e.g. Cricket > Juniors > Welcome 2026)
+- **Sidebar navigation** — shows sibling and child pages within the same top-level section
+- **Mobile sidebar** — collapsible menu on small screens
+
+The navigation tree is derived from the file structure. Pages are sorted by `menuOrder` within each level.
+
+## Available MDX components
+
+These components are available in any MDX file without importing:
+
+| Component        | Props                     | Description                                          |
+| ---------------- | ------------------------- | ---------------------------------------------------- |
+| `<Person>`       | `slug`, `role?`           | Person card with photo, name, role, and profile link |
+| `<PersonGrid>`   | `slugs?`, `children?`     | Grid layout for multiple Person cards                |
+| `<LeagueTable>`  | `divisionId`, `name?`     | Fetches and renders a league table from Play-Cricket |
+| `<Leaderboard>`  | —                         | Season batting/bowling leaderboard                   |
+| `<RecordsWall>`  | —                         | Club records display                                 |
+| `<EventPreview>` | `id`, `name`, `when`      | Event card linking to calendar                       |
+| `<GamePreview>`  | `playCricketId`           | Match card with result and link                      |
+| `<ContactForm>`  | `title?`, `description?`  | Contact form that posts to `/api/contact`            |
+| `<Image>`        | `src`, `alt?`, `caption?` | Optimised image with optional caption                |
+
+Standard markdown images (`![alt](src)`) are also routed through the optimised image pipeline.
+
+## Writing content
+
+- Use standard markdown for headings, lists, tables, links, bold/italic
+- Internal links use root-relative paths: `[privacy policy](/legal/privacy)`
+- Email links: `[juniors@percymain.org](mailto:juniors@percymain.org)`
+- External links use full URLs: `[kit shop](https://kit.percymain.org)`
+- MDX components can be used inline alongside markdown
+
+## Example page
+
+```mdx
+---
+title: Welcome to Junior Cricket 2026
+description: "Junior cricket info for the 2026 season."
+menuOrder: 0
+---
+
+## Training Times
+
+| Group     | Day     | Time            |
+| --------- | ------- | --------------- |
+| Boys U11s | Tuesday | 4.30pm - 5.45pm |
+
+[Register here](/membership/junior) to sign up.
+
+##### Coaching Team
+
+<PersonGrid>
+  <Person slug="tony-robson" role="Head Of Junior Section" />
+</PersonGrid>
+
+<ContactForm title="Get in Touch" />
+```
+
+## Adding a new content page
+
+1. Create a `.mdx` file in the appropriate directory under `apps/web/content/pages/`
+2. Add frontmatter with at least `title`
+3. Write content using markdown and the available MDX components
+4. The page is immediately available at the corresponding URL — no router changes needed
+5. No build step or code generation required

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
         version: 3.1022.0
       '@better-auth/infra':
         specifier: ^0.1.13
-        version: 0.1.13(9c70778cc91d7205870d3fa32646111b)
+        version: 0.1.13(c5ed1d55fcb91bfb734ecc8c43af85f6)
       '@better-auth/passkey':
         specifier: ^1.5.4
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
@@ -228,7 +228,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: ^1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -325,6 +325,9 @@ importers:
       remark-frontmatter:
         specifier: ^5.0.0
         version: 5.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       remark-mdx-frontmatter:
         specifier: ^5.2.0
         version: 5.2.0
@@ -5311,6 +5314,9 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@7.0.4:
     resolution: {integrity: sha512-t8eP0dXRJMtMvBojtkcsA7n48BkauktUKzfkPSCq85ZMTJ0v76Rke4DYz01omYpPTUh4p/f7HePgRo3ebG8+QQ==}
     engines: {node: '>= 16'}
@@ -5325,11 +5331,32 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
   mdast-util-frontmatter@2.0.1:
     resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -5367,6 +5394,27 @@ packages:
 
   micromark-extension-frontmatter@2.0.0:
     resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-extension-mdx-expression@3.0.1:
     resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
@@ -6095,6 +6143,9 @@ packages:
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-mdx-frontmatter@5.2.0:
     resolution: {integrity: sha512-U/hjUYTkQqNjjMRYyilJgLXSPF65qbLPdoESOkXyrwz2tVyhAnm4GUKhfXqOOS9W34M3545xEMq+aMpHgVjEeQ==}
 
@@ -6106,6 +6157,9 @@ packages:
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -7797,10 +7851,10 @@ snapshots:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/infra@0.1.13(9c70778cc91d7205870d3fa32646111b)':
+  '@better-auth/infra@0.1.13(c5ed1d55fcb91bfb734ecc8c43af85f6)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
-      '@better-auth/sso': 1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1)
+      '@better-auth/sso': 1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
       better-call: 1.3.4(zod@4.3.6)
@@ -7854,9 +7908,9 @@ snapshots:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/sso@1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))':
+  '@better-auth/sso@1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
@@ -12472,6 +12526,8 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-table@3.0.4: {}
+
   marked@7.0.4: {}
 
   math-intrinsics@1.1.0: {}
@@ -12480,6 +12536,13 @@ snapshots:
     dependencies:
       marked: 7.0.4
       react: 19.2.4
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -12506,6 +12569,63 @@ snapshots:
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12619,6 +12739,64 @@ snapshots:
       fault: 2.0.1
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-extension-mdx-expression@3.0.1:
@@ -13457,6 +13635,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-mdx-frontmatter@5.2.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -13489,6 +13678,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
## Summary

- New **Welcome to Junior Cricket 2026** content page (`/cricket/juniors/welcome-2026`) with training times, registration instructions, membership donation info, kit notes, and communication details
- New **Junior Coaches** page (`/cricket/juniors/coaches`) with person cards for all 8 coaches
- Rewrote juniors index (`/cricket/juniors`) with intro text and contact form
- Added person file for Martin Hughes
- **Fixed additional child fee: £30 → £40** in both frontend display and backend calculation
- Added `remark-gfm` for GFM table support in MDX content pages
- Added MDX table styles
- Documented content page system in `docs/content.md` and referenced in `CLAUDE.md`

## Test plan

- [ ] Visit `/cricket/juniors` — intro text, links to coaches and welcome page, contact form
- [ ] Visit `/cricket/juniors/welcome-2026` — tables render correctly, all links work
- [ ] Visit `/cricket/juniors/coaches` — all 8 coach cards render with photos (Martin Hughes placeholder)
- [ ] Visit `/membership/junior` — verify additional child price shows £40
- [ ] Sidebar navigation shows all junior sub-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)