### PR TITLE
Fix team news image download URL in production

### DIFF
--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -29,7 +29,8 @@ class ApiError extends Error {
   }
 }
 
-const API_BASE = (import.meta.env.VITE_API_URL as string | undefined) ?? "/api";
+export const API_BASE =
+  (import.meta.env.VITE_API_URL as string | undefined) ?? "/api";
 
 export const api = createClient<paths>({
   baseUrl: API_BASE.replace(/\/api$/, ""),

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -9,7 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
-import { api, callApi } from "@/lib/api-client";
+import { API_BASE, api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen.js";
 import { useSession } from "@/lib/auth-client";
 import { compressImage } from "@/lib/image-utils";
@@ -76,7 +76,7 @@ function DownloadTeamNewsButton({
     setDownloading(true);
     // Raw fetch: endpoint returns a PNG blob, not JSON — openapi-fetch can't handle binary downloads
     void fetch(
-      `/api/matchday/${encodeURIComponent(matchdayId)}/team-news-image?isHome=${isHome}${matchTime ? `&matchTime=${encodeURIComponent(matchTime)}` : ""}`,
+      `${API_BASE}/matchday/${encodeURIComponent(matchdayId)}/team-news-image?isHome=${isHome}${matchTime ? `&matchTime=${encodeURIComponent(matchTime)}` : ""}`,
       { credentials: "include" },
     )
       .then(async (res) => {


### PR DESCRIPTION
## Summary
- The team news image download button used a relative `/api/...` URL which in production resolved against the frontend domain (`www.percymain.org`), hitting CloudFront which returned the SPA's `index.html` instead of the PNG
- Now uses the shared `API_BASE` constant (which resolves to `https://api.v2.percymain.org/api` in production) so the request hits the actual API

## Test plan
- [ ] Deploy to production
- [ ] Click "Download Image" on a matchday with players — should download a valid PNG, not an HTML file

🤖 Generated with [Claude Code](https://claude.com/claude-code)