### PR TITLE
Show confirmed team lineup on game detail pages

### DIFF
--- a/apps/api/src/features/games/schemas.ts
+++ b/apps/api/src/features/games/schemas.ts
@@ -85,8 +85,20 @@ const sponsorSchema = z
   })
   .nullable();
 
+const lineupPlayerSchema = z.object({
+  name: z.string(),
+});
+
+const lineupSchema = z
+  .object({
+    confirmedAt: z.string(),
+    players: z.array(lineupPlayerSchema),
+  })
+  .nullable();
+
 export const gameDetailResponseSchema = gameListItemSchema.extend({
   location: locationSchema,
   result: resultSchema,
   sponsor: sponsorSchema,
+  lineup: lineupSchema,
 });

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -68,6 +68,10 @@ export interface GameDetail extends GameListItem {
     message: string | null;
     website: string | null;
   } | null;
+  lineup: {
+    confirmedAt: string;
+    players: Array<{ name: string }>;
+  } | null;
 }
 
 // --- Helpers ---
@@ -226,34 +230,45 @@ export function getGame(
   return async (matchId: string): Promise<GameDetail | null> => {
     // Fetch match detail, DB data, and sponsorship in parallel
     // Match detail is the primary source — no season search needed
-    const [matchDetail, dbResult, sponsorship, manualResult] =
-      await Promise.all([
-        api.getMatchDetail(matchId).catch(() => null),
-        db
-          .selectFrom("match_result")
-          .where("match_id", "=", matchId)
-          .selectAll()
-          .executeTakeFirst(),
-        db
-          .selectFrom("game_sponsorship")
-          .where("game_id", "=", matchId)
-          .where("approved", "=", true)
-          .where("paid_at", "is not", null)
-          .select([
-            "sponsor_name",
-            "display_name",
-            "sponsor_logo_url",
-            "sponsor_message",
-            "sponsor_website",
-          ])
-          .executeTakeFirst(),
-        db
-          .selectFrom("matchday")
-          .where("play_cricket_match_id", "=", matchId)
-          .where("result_type", "is not", null)
-          .select(["result_type", "result_source"])
-          .executeTakeFirst(),
-      ]);
+    const [
+      matchDetail,
+      dbResult,
+      sponsorship,
+      manualResult,
+      confirmedMatchday,
+    ] = await Promise.all([
+      api.getMatchDetail(matchId).catch(() => null),
+      db
+        .selectFrom("match_result")
+        .where("match_id", "=", matchId)
+        .selectAll()
+        .executeTakeFirst(),
+      db
+        .selectFrom("game_sponsorship")
+        .where("game_id", "=", matchId)
+        .where("approved", "=", true)
+        .where("paid_at", "is not", null)
+        .select([
+          "sponsor_name",
+          "display_name",
+          "sponsor_logo_url",
+          "sponsor_message",
+          "sponsor_website",
+        ])
+        .executeTakeFirst(),
+      db
+        .selectFrom("matchday")
+        .where("play_cricket_match_id", "=", matchId)
+        .where("result_type", "is not", null)
+        .select(["result_type", "result_source"])
+        .executeTakeFirst(),
+      db
+        .selectFrom("matchday")
+        .where("play_cricket_match_id", "=", matchId)
+        .where("confirmed_at", "is not", null)
+        .select(["id", "confirmed_at"])
+        .executeTakeFirst(),
+    ]);
 
     const detail = matchDetail?.match_details[0];
     if (!detail) return null;
@@ -329,6 +344,23 @@ export function getGame(
         ? { name: matchSummary.groundName }
         : null;
 
+    // Build confirmed lineup if the team has been confirmed by an official
+    let lineup: GameDetail["lineup"] = null;
+    if (confirmedMatchday) {
+      const players = await db
+        .selectFrom("matchday_player")
+        .where("matchday_id", "=", confirmedMatchday.id)
+        .where("status", "=", "playing")
+        .select(["player_name"])
+        .orderBy("created_at", "asc")
+        .execute();
+
+      lineup = {
+        confirmedAt: confirmedMatchday.confirmed_at ?? "",
+        players: players.map((p) => ({ name: p.player_name })),
+      };
+    }
+
     // Build summary from match detail, enriching with cached summary where available
     const matchDate = detail.match_date ?? matchSummary?.matchDate ?? "";
     const matchTime = matchSummary?.matchTime ?? null;
@@ -376,6 +408,7 @@ export function getGame(
             website: sponsorship.sponsor_website,
           }
         : null,
+      lineup,
     };
   };
 }

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -2424,6 +2424,12 @@ export interface paths {
                                 message: string | null;
                                 website: string | null;
                             } | null;
+                            lineup: {
+                                confirmedAt: string;
+                                players: {
+                                    name: string;
+                                }[];
+                            } | null;
                         };
                     };
                 };
@@ -3922,6 +3928,44 @@ export interface paths {
                             }[];
                         };
                     };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/matchday/{matchId}/team-news-image": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    isHome?: string;
+                    matchTime?: string;
+                };
+                header?: never;
+                path: {
+                    matchId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
                 };
             };
         };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -4253,6 +4253,35 @@
                         "website"
                       ],
                       "additionalProperties": false
+                    },
+                    "lineup": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "confirmedAt": {
+                          "type": "string"
+                        },
+                        "players": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "confirmedAt",
+                        "players"
+                      ],
+                      "additionalProperties": false
                     }
                   },
                   "required": [
@@ -4272,7 +4301,8 @@
                     "sponsorLogoUrl",
                     "location",
                     "result",
-                    "sponsor"
+                    "sponsor",
+                    "lineup"
                   ],
                   "additionalProperties": false
                 }
@@ -6946,6 +6976,42 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/matchday/{matchId}/team-news-image": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "default": "true",
+              "type": "string"
+            },
+            "in": "query",
+            "name": "isHome",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "matchTime",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "matchId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
           }
         }
       }

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -317,6 +317,22 @@ function GameDetailContent({ game }: { game: GameData }) {
           </ul>
         </div>
 
+        {/* Confirmed team lineup */}
+        {game.lineup && game.lineup.players.length > 0 && (
+          <Card>
+            <CardContent className="flex flex-col gap-3 p-4">
+              <h4 className="text-lg font-semibold">Team</h4>
+              <ol className="list-inside list-decimal space-y-1">
+                {game.lineup.players.map((player, i) => (
+                  <li key={i} className="text-sm">
+                    {player.name}
+                  </li>
+                ))}
+              </ol>
+            </CardContent>
+          </Card>
+        )}
+
         {/* Result summary — full card if Play Cricket has data, badge-only for manual result */}
         {game.result ? (
           <ResultSummary result={game.result} />


### PR DESCRIPTION
## Summary
- When an official confirms a team in the matchday app, the confirmed lineup now appears on the public game detail page (linked from the calendar)
- The game detail API queries `matchday` + `matchday_player` via `play_cricket_match_id` to return players with status `playing`
- Frontend renders a numbered list of player names in a card between match details and the result summary

## Test plan
- [ ] Confirm a team via the official matchday panel
- [ ] Visit the corresponding game page from the calendar — lineup should appear
- [ ] Check a game with no confirmed matchday — no lineup section should render
- [ ] Check a game with a confirmed matchday but no playing players — no lineup section should render

🤖 Generated with [Claude Code](https://claude.com/claude-code)