### PR TITLE
Auto-post confirmed team sheets to Facebook and Instagram

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "test:all": "pnpm test && pnpm test:integration"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@aws-sdk/client-s3": "^3.1022.0",
     "@aws-sdk/s3-request-presigner": "^3.1022.0",
     "@better-auth/infra": "^0.1.13",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,9 +14,21 @@ import type { Kysely, PostgresDialect } from "kysely";
 import type { Config } from "./config.ts";
 import { createAuth, type Auth } from "./features/auth/auth.ts";
 import {
+  createLlmClient,
+  type LlmClient,
+} from "./features/social-posting/caption.ts";
+import {
+  createMetaClient,
+  type MetaClient,
+} from "./features/social-posting/meta-client.ts";
+import {
   createS3DocumentStore,
   type S3DocumentStore,
 } from "./lib/s3-documents.ts";
+import {
+  createSocialMediaUploader,
+  type SocialMediaUploader,
+} from "./lib/s3-social-media.ts";
 import { createS3Uploader, type S3Uploader } from "./lib/s3-upload.ts";
 
 // Feature routes
@@ -40,6 +52,7 @@ import { paymentRoutes } from "./features/payments/routes.ts";
 import { webhookRoutes } from "./features/payments/webhook.ts";
 import { playCricketRoutes } from "./features/play-cricket/routes.ts";
 import { recordsRoutes } from "./features/records/routes.ts";
+import { socialPostingRoutes } from "./features/social-posting/routes.ts";
 import { sponsorshipRoutes } from "./features/sponsorship/routes.ts";
 import { treasurerRoutes } from "./features/treasurer/routes.ts";
 
@@ -52,6 +65,9 @@ declare module "fastify" {
     send: (email: Email) => Promise<void>;
     s3: S3Uploader;
     s3Documents: S3DocumentStore;
+    llm: LlmClient;
+    meta: MetaClient;
+    s3SocialMedia: SocialMediaUploader;
   }
 }
 
@@ -104,6 +120,11 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   const s3Documents = createS3DocumentStore(config);
   app.decorate("s3Documents", s3Documents);
 
+  // Social posting (team sheets → FB/IG)
+  app.decorate("llm", createLlmClient(config));
+  app.decorate("meta", createMetaClient(config));
+  app.decorate("s3SocialMedia", createSocialMediaUploader(config));
+
   // Plugins
   await app.register(swagger, {
     openapi: {
@@ -147,6 +168,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(playCricketRoutes, { prefix: "/api" });
   await app.register(sponsorshipRoutes, { prefix: "/api" });
   await app.register(matchdayRoutes, { prefix: "/api" });
+  await app.register(socialPostingRoutes, { prefix: "/api" });
   await app.register(availabilityRoutes, { prefix: "/api" });
   await app.register(paymentRoutes, { prefix: "/api" });
   await app.register(adminRoutes, { prefix: "/api" });

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -60,14 +60,42 @@ const configSchema = z.object({
   SLACK_WEBHOOK_URL: z.url().optional(),
   PLAY_CRICKET_API_TOKEN: z.string().optional(),
   PLAY_CRICKET_SITE_ID: z.string().optional(),
+
+  // Social auto-posting (team sheets → Facebook + Instagram)
+  SOCIAL_POSTING_ENABLED: z.coerce.boolean().default(false),
+  META_FB_PAGE_ID: z.string().optional(),
+  META_FB_ACCESS_TOKEN: z.string().optional(),
+  META_IG_USER_ID: z.string().optional(),
+  ANTHROPIC_API_KEY: z.string().optional(),
+  S3_SOCIAL_MEDIA_BUCKET: z.string().optional(),
+  S3_SOCIAL_MEDIA_PREFIX: z.string().default("social-media/team-sheets"),
 });
 
 export type Config = z.infer<typeof configSchema>;
+
+const REQUIRED_WHEN_SOCIAL_ENABLED = [
+  "META_FB_PAGE_ID",
+  "META_FB_ACCESS_TOKEN",
+  "META_IG_USER_ID",
+  "ANTHROPIC_API_KEY",
+  "S3_SOCIAL_MEDIA_BUCKET",
+] as const satisfies ReadonlyArray<keyof Config>;
 
 /**
  * Parse and validate configuration from an environment object.
  * In production, pass process.env. In tests, pass a minimal object.
  */
 export function parseConfig(env: Record<string, string | undefined>): Config {
-  return configSchema.parse(env);
+  const config = configSchema.parse(env);
+
+  if (config.SOCIAL_POSTING_ENABLED) {
+    const missing = REQUIRED_WHEN_SOCIAL_ENABLED.filter((key) => !config[key]);
+    if (missing.length > 0) {
+      throw new Error(
+        `SOCIAL_POSTING_ENABLED=true but missing: ${missing.join(", ")}`,
+      );
+    }
+  }
+
+  return config;
 }

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -1,6 +1,7 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { getAuthSession, requireRole } from "../auth/middleware.ts";
 import { createApiClient } from "../play-cricket/api-client.ts";
+import { publishTeamSheet } from "../social-posting/service.ts";
 import {
   addPlayerResponseSchema,
   addPlayerSchema,
@@ -425,7 +426,33 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       const { user } = getAuthSession(request);
       const role = (user as { role?: string | null }).role ?? "user";
-      return await confirm(user.id, role, request.params.matchId, request.body);
+      const { matchId } = request.params;
+      const { isHome, matchTime, ...confirmBody } = request.body;
+
+      const result = await confirm(user.id, role, matchId, confirmBody);
+
+      // Fire-and-forget: kick off social posting after the confirm transaction
+      // completes. Errors are logged + Slack-alerted inside publishTeamSheet;
+      // they must never surface to the HTTP response.
+      publishTeamSheet({
+        db: app.db,
+        llm: app.llm,
+        meta: app.meta,
+        s3Social: app.s3SocialMedia,
+        slackWebhookUrl: app.config.SLACK_WEBHOOK_URL,
+        log: request.log,
+        enabled: app.config.SOCIAL_POSTING_ENABLED,
+      })({
+        matchdayId: matchId,
+        userId: user.id,
+        role,
+        isHome,
+        matchTime,
+      }).catch((err: unknown) => {
+        request.log.error({ err, matchId }, "Team sheet social publish failed");
+      });
+
+      return result;
     },
   );
 

--- a/apps/api/src/features/matchday/schemas.ts
+++ b/apps/api/src/features/matchday/schemas.ts
@@ -86,6 +86,8 @@ export const confirmTeamSchema = z.object({
       status: z.enum(["playing", "dropped_out", "no_show"]),
     }),
   ),
+  isHome: z.boolean(),
+  matchTime: z.string().nullable(),
 });
 
 export const markPaidSchema = z.object({

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -628,7 +628,7 @@ export function confirmTeam(db: Kysely<DB>) {
     userId: string,
     role: string,
     matchdayId: string,
-    data: ConfirmTeam,
+    data: Pick<ConfirmTeam, "playerStatuses">,
   ) => {
     const matchday = await db
       .selectFrom("matchday")

--- a/apps/api/src/features/social-posting/caption.ts
+++ b/apps/api/src/features/social-posting/caption.ts
@@ -1,0 +1,162 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { Config } from "../../config.ts";
+import type { TeamNewsData } from "../matchday/service.ts";
+
+export const CAPTION_PROMPT_VERSION = "v1";
+export const CAPTION_HASHTAG_SUFFIX =
+  "#PMCC #NTCL #cricket #percymain" as const;
+
+const MAX_LLM_CAPTION_CHARS = 220;
+const LLM_TIMEOUT_MS = 3000;
+
+const SYSTEM_PROMPT =
+  `You are drafting a short social-media caption for Percy Main Cricket Club's ` +
+  `match-day team announcement. You MUST use the provided fixture facts only. ` +
+  `Do not invent player names, stats, or commentary. Keep the tone upbeat but ` +
+  `understated.\n\n` +
+  `Voice / style rules:\n` +
+  `- Do not include hashtags (they are appended automatically).\n` +
+  `- Do not @-mention any account.\n` +
+  `- Do not use emojis unless they appear verbatim in the team/opposition name.\n` +
+  `- If a match sponsor is provided, thank them by name in the caption.\n` +
+  `- Do not thank sponsors that are not provided.\n` +
+  `- Max 220 characters (leaves room for the hashtag suffix).`;
+
+function buildUserPrompt(data: TeamNewsData, captainName: string): string {
+  return [
+    "Fixture:",
+    `- Team: ${data.teamName}`,
+    `- Opposition: ${data.opposition}`,
+    `- Date: ${formatDate(data.matchDate)}`,
+    `- Venue: ${data.isHome ? "home" : "away"}`,
+    `- Captain: ${captainName}`,
+    `- Match sponsor: ${data.matchSponsor?.name ?? "none"}`,
+  ].join("\n");
+}
+
+export interface LlmClient {
+  generateCaption: (args: {
+    systemPrompt: string;
+    userPrompt: string;
+    timeoutMs: number;
+  }) => Promise<string>;
+}
+
+export function createLlmClient(config: Config): LlmClient {
+  if (!config.ANTHROPIC_API_KEY) {
+    return {
+      generateCaption: () => {
+        throw new Error("ANTHROPIC_API_KEY not configured");
+      },
+    };
+  }
+
+  const client = new Anthropic({ apiKey: config.ANTHROPIC_API_KEY });
+
+  return {
+    async generateCaption({ systemPrompt, userPrompt, timeoutMs }) {
+      const response = await client.messages.create(
+        {
+          model: "claude-haiku-4-5",
+          max_tokens: 400,
+          system: systemPrompt,
+          messages: [{ role: "user", content: userPrompt }],
+          tools: [
+            {
+              name: "team_sheet_caption",
+              description: "Return the final team sheet caption.",
+              input_schema: {
+                type: "object",
+                required: ["caption"],
+                properties: {
+                  caption: { type: "string", maxLength: 280 },
+                },
+              },
+            },
+          ],
+          tool_choice: { type: "tool", name: "team_sheet_caption" },
+        },
+        { timeout: timeoutMs },
+      );
+
+      for (const block of response.content) {
+        if (block.type === "tool_use" && block.name === "team_sheet_caption") {
+          const input = block.input as { caption?: unknown };
+          if (typeof input.caption === "string") return input.caption;
+        }
+      }
+      throw new Error("LLM returned no caption tool_use block");
+    },
+  };
+}
+
+export interface CaptionResult {
+  caption: string;
+  source: "ai" | "fallback";
+  version: string;
+}
+
+export function generateCaption(llm: LlmClient) {
+  return async (data: TeamNewsData): Promise<CaptionResult> => {
+    const captainName = data.players[0]?.playerName ?? "the captain";
+    const userPrompt = buildUserPrompt(data, captainName);
+
+    try {
+      const raw = await llm.generateCaption({
+        systemPrompt: SYSTEM_PROMPT,
+        userPrompt,
+        timeoutMs: LLM_TIMEOUT_MS,
+      });
+
+      const stripped = stripHashtags(raw).trim();
+      if (!stripped || stripped.length > MAX_LLM_CAPTION_CHARS + 60) {
+        throw new Error("LLM caption out of bounds");
+      }
+
+      return {
+        caption: `${stripped}\n\n${CAPTION_HASHTAG_SUFFIX}`,
+        source: "ai",
+        version: CAPTION_PROMPT_VERSION,
+      };
+    } catch {
+      return {
+        caption: buildFallback(data, captainName),
+        source: "fallback",
+        version: CAPTION_PROMPT_VERSION,
+      };
+    }
+  };
+}
+
+function buildFallback(data: TeamNewsData, captainName: string): string {
+  const sponsorLine = data.matchSponsor
+    ? ` Thanks to our match sponsor ${data.matchSponsor.name}.`
+    : "";
+  const venueVerb = data.isHome ? "host" : "travel to";
+  return (
+    `Team sheet confirmed — ${data.teamName} ${venueVerb} ${data.opposition} ` +
+    `on ${formatDate(data.matchDate)}. Good luck to captain ${captainName} and ` +
+    `the lads.${sponsorLine}\n\n${CAPTION_HASHTAG_SUFFIX}`
+  );
+}
+
+function stripHashtags(text: string): string {
+  return text
+    .replace(/#\w+/g, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+function formatDate(iso: string): string {
+  const date = new Date(iso + "T12:00:00");
+  const day = date.getUTCDate();
+  const month = date.toLocaleDateString("en-GB", {
+    month: "long",
+    timeZone: "UTC",
+  });
+  const weekday = date.toLocaleDateString("en-GB", {
+    weekday: "long",
+    timeZone: "UTC",
+  });
+  return `${weekday} ${day} ${month}`;
+}

--- a/apps/api/src/features/social-posting/integration.test.ts
+++ b/apps/api/src/features/social-posting/integration.test.ts
@@ -1,0 +1,393 @@
+import type { FastifyBaseLogger } from "fastify";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { stubSocialMediaUploader } from "../../lib/s3-social-media.ts";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import type { LlmClient } from "./caption.ts";
+import type { MetaClient } from "./meta-client.ts";
+import {
+  claimPublication,
+  listPublications,
+  publishTeamSheet,
+  reconcilePublication,
+  retryPublication,
+} from "./service.ts";
+
+let ctx: TestContext;
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+}, 30_000);
+
+afterAll(async () => {
+  await stopTestContainer(ctx);
+});
+
+const silentLog = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as FastifyBaseLogger;
+
+const captionStub: LlmClient = {
+  generateCaption: vi
+    .fn()
+    .mockResolvedValue("Team sheet ready. Good luck lads."),
+};
+
+function makeMetaStub(overrides: Partial<MetaClient> = {}): MetaClient {
+  return {
+    postToFacebook: vi
+      .fn()
+      .mockResolvedValue({ externalPostId: "fb-" + crypto.randomUUID() }),
+    postToInstagram: vi
+      .fn()
+      .mockResolvedValue({ externalPostId: "ig-" + crypto.randomUUID() }),
+    ...overrides,
+  };
+}
+
+async function seedTeam() {
+  const id = `pct-${crypto.randomUUID()}`;
+  await ctx.db
+    .insertInto("play_cricket_team")
+    .values({ id, name: `Team ${id.slice(0, 6)}`, site_id: "site-1" })
+    .execute();
+  return id;
+}
+
+async function seedConfirmedMatchday(teamId: string, createdBy: string) {
+  const id = `md-${crypto.randomUUID()}`;
+  await ctx.db
+    .insertInto("matchday")
+    .values({
+      id,
+      play_cricket_team_id: teamId,
+      match_date: "2026-06-15",
+      opposition: "Benwell Hill CC",
+      created_by: createdBy,
+      status: "confirmed",
+    })
+    .execute();
+
+  const playerId = `mp-${crypto.randomUUID()}`;
+  await ctx.db
+    .insertInto("matchday_player")
+    .values({
+      id: playerId,
+      matchday_id: id,
+      member_id: null,
+      player_name: "Alex Young",
+      status: "playing",
+    })
+    .execute();
+
+  return id;
+}
+
+function makeDeps(overrides: { meta?: MetaClient; enabled?: boolean } = {}) {
+  return {
+    db: ctx.db,
+    llm: captionStub,
+    meta: overrides.meta ?? makeMetaStub(),
+    s3Social: stubSocialMediaUploader,
+    log: silentLog,
+    enabled: overrides.enabled ?? true,
+  };
+}
+
+describe("social-posting service (integration)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (captionStub.generateCaption as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "Team sheet ready. Good luck lads.",
+    );
+  });
+
+  it("publishes both platforms on happy path", async () => {
+    const { userId } = await seedTestUser(ctx.db, {
+      email: `sp-happy-${crypto.randomUUID()}@test.com`,
+      role: "admin",
+    });
+    const teamId = await seedTeam();
+    const matchdayId = await seedConfirmedMatchday(teamId, userId);
+
+    const meta = makeMetaStub();
+    const result = await publishTeamSheet(makeDeps({ meta }))({
+      matchdayId,
+      userId,
+      role: "admin",
+      isHome: true,
+      matchTime: "13:00",
+    });
+
+    expect(result).not.toHaveProperty("skipped");
+    if ("skipped" in result) throw new Error("unexpected skip");
+    expect(result.facebook.state).toBe("posted");
+    expect(result.instagram.state).toBe("posted");
+    expect(meta.postToFacebook).toHaveBeenCalledTimes(1);
+    expect(meta.postToInstagram).toHaveBeenCalledTimes(1);
+
+    const rows = await listPublications(ctx.db)(matchdayId);
+    expect(rows.items).toHaveLength(2);
+    for (const row of rows.items) {
+      expect(row.state).toBe("posted");
+      expect(row.external_post_id).toBeTruthy();
+    }
+  });
+
+  it("is idempotent — calling publishTeamSheet twice does not repost", async () => {
+    const { userId } = await seedTestUser(ctx.db, {
+      email: `sp-idem-${crypto.randomUUID()}@test.com`,
+      role: "admin",
+    });
+    const teamId = await seedTeam();
+    const matchdayId = await seedConfirmedMatchday(teamId, userId);
+
+    const meta = makeMetaStub();
+    const deps = makeDeps({ meta });
+    await publishTeamSheet(deps)({
+      matchdayId,
+      userId,
+      role: "admin",
+      isHome: true,
+      matchTime: null,
+    });
+
+    const second = await publishTeamSheet(deps)({
+      matchdayId,
+      userId,
+      role: "admin",
+      isHome: true,
+      matchTime: null,
+    });
+
+    if ("skipped" in second) throw new Error("unexpected skip");
+    expect(second.facebook.state).toBe("already_posted");
+    expect(second.instagram.state).toBe("already_posted");
+    expect(meta.postToFacebook).toHaveBeenCalledTimes(1);
+    expect(meta.postToInstagram).toHaveBeenCalledTimes(1);
+
+    const rows = await listPublications(ctx.db)(matchdayId);
+    expect(rows.items).toHaveLength(2);
+  });
+
+  it("serialises concurrent claims via the unique constraint", async () => {
+    const { userId } = await seedTestUser(ctx.db, {
+      email: `sp-conc-${crypto.randomUUID()}@test.com`,
+      role: "admin",
+    });
+    const teamId = await seedTeam();
+    const matchdayId = await seedConfirmedMatchday(teamId, userId);
+
+    const meta = makeMetaStub();
+    const deps = makeDeps({ meta });
+
+    const [a, b] = await Promise.all([
+      publishTeamSheet(deps)({
+        matchdayId,
+        userId,
+        role: "admin",
+        isHome: true,
+        matchTime: null,
+      }),
+      publishTeamSheet(deps)({
+        matchdayId,
+        userId,
+        role: "admin",
+        isHome: true,
+        matchTime: null,
+      }),
+    ]);
+
+    if ("skipped" in a || "skipped" in b) throw new Error("unexpected skip");
+
+    // Across the two concurrent calls, each platform should have been called
+    // exactly once on the Meta client.
+    expect(meta.postToFacebook).toHaveBeenCalledTimes(1);
+    expect(meta.postToInstagram).toHaveBeenCalledTimes(1);
+
+    const rows = await listPublications(ctx.db)(matchdayId);
+    expect(rows.items).toHaveLength(2);
+    for (const row of rows.items) {
+      expect(row.state).toBe("posted");
+    }
+  });
+
+  it("partial success + platform-specific retry does not re-post the good platform", async () => {
+    const { userId } = await seedTestUser(ctx.db, {
+      email: `sp-partial-${crypto.randomUUID()}@test.com`,
+      role: "admin",
+    });
+    const teamId = await seedTeam();
+    const matchdayId = await seedConfirmedMatchday(teamId, userId);
+
+    let igCalls = 0;
+    const meta = makeMetaStub({
+      postToInstagram: vi.fn(() => {
+        igCalls++;
+        if (igCalls === 1) return Promise.reject(new Error("IG blew up"));
+        return Promise.resolve({
+          externalPostId: `ig-${crypto.randomUUID()}`,
+        });
+      }),
+    });
+
+    const deps = makeDeps({ meta });
+    const first = await publishTeamSheet(deps)({
+      matchdayId,
+      userId,
+      role: "admin",
+      isHome: true,
+      matchTime: null,
+    });
+
+    if ("skipped" in first) throw new Error("unexpected skip");
+    expect(first.facebook.state).toBe("posted");
+    expect(first.instagram.state).toBe("failed");
+
+    const retry = await retryPublication(deps)({
+      matchdayId,
+      platform: "instagram",
+      userId,
+      role: "admin",
+      isHome: true,
+      matchTime: null,
+    });
+
+    expect(retry.state).toBe("posted");
+    expect(meta.postToFacebook).toHaveBeenCalledTimes(1); // never called again
+    expect(meta.postToInstagram).toHaveBeenCalledTimes(2);
+  });
+
+  it("reconcile marks a stuck claimed row as posted with the supplied external ID", async () => {
+    const { userId } = await seedTestUser(ctx.db, {
+      email: `sp-rec-posted-${crypto.randomUUID()}@test.com`,
+      role: "admin",
+    });
+    const teamId = await seedTeam();
+    const matchdayId = await seedConfirmedMatchday(teamId, userId);
+
+    const claim = await claimPublication(ctx.db, {
+      matchdayId,
+      platform: "facebook",
+      caption: "stub",
+      captionSource: "fallback",
+      captionVersion: "v1",
+      imageUrl: "https://example/test.png",
+    });
+    expect(claim.status).toBe("claimed");
+
+    const result = await reconcilePublication(ctx.db)({
+      matchdayId,
+      platform: "facebook",
+      outcome: "posted",
+      externalPostId: "fb-verified-123",
+    });
+    expect(result.state).toBe("posted");
+
+    const rows = await listPublications(ctx.db)(matchdayId);
+    const fb = rows.items.find((r) => r.platform === "facebook");
+    expect(fb?.state).toBe("posted");
+    expect(fb?.external_post_id).toBe("fb-verified-123");
+  });
+
+  it("reconcile marks a stuck claimed row as failed, unblocking retry", async () => {
+    const { userId } = await seedTestUser(ctx.db, {
+      email: `sp-rec-failed-${crypto.randomUUID()}@test.com`,
+      role: "admin",
+    });
+    const teamId = await seedTeam();
+    const matchdayId = await seedConfirmedMatchday(teamId, userId);
+
+    await claimPublication(ctx.db, {
+      matchdayId,
+      platform: "instagram",
+      caption: "stub",
+      captionSource: "fallback",
+      captionVersion: "v1",
+      imageUrl: "https://example/test.png",
+    });
+
+    await reconcilePublication(ctx.db)({
+      matchdayId,
+      platform: "instagram",
+      outcome: "failed",
+    });
+
+    const meta = makeMetaStub();
+    const retry = await retryPublication(makeDeps({ meta }))({
+      matchdayId,
+      platform: "instagram",
+      userId,
+      role: "admin",
+      isHome: true,
+      matchTime: null,
+    });
+    expect(retry.state).toBe("posted");
+  });
+
+  it("disabled flag short-circuits and inserts zero rows", async () => {
+    const { userId } = await seedTestUser(ctx.db, {
+      email: `sp-off-${crypto.randomUUID()}@test.com`,
+      role: "admin",
+    });
+    const teamId = await seedTeam();
+    const matchdayId = await seedConfirmedMatchday(teamId, userId);
+
+    const meta = makeMetaStub();
+    const result = await publishTeamSheet(makeDeps({ meta, enabled: false }))({
+      matchdayId,
+      userId,
+      role: "admin",
+      isHome: true,
+      matchTime: null,
+    });
+
+    expect(result).toEqual({ skipped: "feature disabled" });
+    expect(meta.postToFacebook).not.toHaveBeenCalled();
+    expect(meta.postToInstagram).not.toHaveBeenCalled();
+
+    const rows = await listPublications(ctx.db)(matchdayId);
+    expect(rows.items).toHaveLength(0);
+  });
+
+  it("DB rejects state=posted rows without an external_post_id", async () => {
+    const { userId } = await seedTestUser(ctx.db, {
+      email: `sp-constraint-${crypto.randomUUID()}@test.com`,
+      role: "admin",
+    });
+    const teamId = await seedTeam();
+    const matchdayId = await seedConfirmedMatchday(teamId, userId);
+
+    await claimPublication(ctx.db, {
+      matchdayId,
+      platform: "facebook",
+      caption: "stub",
+      captionSource: "fallback",
+      captionVersion: "v1",
+      imageUrl: "https://example/test.png",
+    });
+
+    await expect(
+      ctx.db
+        .updateTable("matchday_social_publication")
+        .set({ state: "posted" })
+        .where("matchday_id", "=", matchdayId)
+        .where("platform", "=", "facebook")
+        .execute(),
+    ).rejects.toThrow(/matchday_social_publication_posted_complete/);
+  });
+});

--- a/apps/api/src/features/social-posting/meta-client.ts
+++ b/apps/api/src/features/social-posting/meta-client.ts
@@ -1,0 +1,104 @@
+import type { Config } from "../../config.ts";
+import type { Platform } from "./schemas.ts";
+
+export class MetaError extends Error {
+  constructor(
+    public stage: "facebook" | "instagram_container" | "instagram_publish",
+    public status: number,
+    public body: string,
+  ) {
+    super(`Meta ${stage} failed with HTTP ${status}: ${body}`);
+    this.name = "MetaError";
+  }
+}
+
+export interface PostArgs {
+  caption: string;
+  imageUrl: string;
+}
+
+export interface PostResult {
+  externalPostId: string;
+}
+
+export interface MetaClient {
+  postToFacebook: (args: PostArgs) => Promise<PostResult>;
+  postToInstagram: (args: PostArgs) => Promise<PostResult>;
+}
+
+const BASE = "https://graph.facebook.com/v21.0";
+
+export function createMetaClient(config: Config): MetaClient {
+  async function postToFacebook(args: PostArgs): Promise<PostResult> {
+    if (!config.META_FB_PAGE_ID || !config.META_FB_ACCESS_TOKEN) {
+      throw new Error("Meta Facebook credentials not configured");
+    }
+
+    const params = new URLSearchParams({
+      url: args.imageUrl,
+      caption: args.caption,
+      access_token: config.META_FB_ACCESS_TOKEN,
+    });
+    const res = await fetch(`${BASE}/${config.META_FB_PAGE_ID}/photos`, {
+      method: "POST",
+      body: params,
+    });
+    if (!res.ok) throw new MetaError("facebook", res.status, await res.text());
+    const body = (await res.json()) as { id: string };
+    return { externalPostId: body.id };
+  }
+
+  async function postToInstagram(args: PostArgs): Promise<PostResult> {
+    if (!config.META_IG_USER_ID || !config.META_FB_ACCESS_TOKEN) {
+      throw new Error("Meta Instagram credentials not configured");
+    }
+
+    const containerRes = await fetch(
+      `${BASE}/${config.META_IG_USER_ID}/media`,
+      {
+        method: "POST",
+        body: new URLSearchParams({
+          image_url: args.imageUrl,
+          caption: args.caption,
+          access_token: config.META_FB_ACCESS_TOKEN,
+        }),
+      },
+    );
+    if (!containerRes.ok) {
+      throw new MetaError(
+        "instagram_container",
+        containerRes.status,
+        await containerRes.text(),
+      );
+    }
+    const containerBody = (await containerRes.json()) as { id: string };
+
+    const publishRes = await fetch(
+      `${BASE}/${config.META_IG_USER_ID}/media_publish`,
+      {
+        method: "POST",
+        body: new URLSearchParams({
+          creation_id: containerBody.id,
+          access_token: config.META_FB_ACCESS_TOKEN,
+        }),
+      },
+    );
+    if (!publishRes.ok) {
+      throw new MetaError(
+        "instagram_publish",
+        publishRes.status,
+        await publishRes.text(),
+      );
+    }
+    const publishBody = (await publishRes.json()) as { id: string };
+    return { externalPostId: publishBody.id };
+  }
+
+  return { postToFacebook, postToInstagram };
+}
+
+export function postFor(client: MetaClient, platform: Platform) {
+  return platform === "facebook"
+    ? client.postToFacebook.bind(client)
+    : client.postToInstagram.bind(client);
+}

--- a/apps/api/src/features/social-posting/routes.ts
+++ b/apps/api/src/features/social-posting/routes.ts
@@ -1,0 +1,90 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { getAuthSession, requireRole } from "../auth/middleware.ts";
+import {
+  matchIdParamSchema,
+  reconcileBodySchema,
+  reconcileResponseSchema,
+  retryBodySchema,
+  retryParamsSchema,
+  retryResponseSchema,
+  socialPublicationsResponseSchema,
+} from "./schemas.ts";
+import {
+  listPublications,
+  reconcilePublication,
+  retryPublication,
+} from "./service.ts";
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const socialPostingRoutes: FastifyPluginAsyncZod = async (app) => {
+  const adminRole = requireRole("admin");
+
+  const list = listPublications(app.db);
+  const reconcile = reconcilePublication(app.db);
+
+  app.get(
+    "/matchday/:matchId/social-publications",
+    {
+      preHandler: [adminRole],
+      schema: {
+        params: matchIdParamSchema,
+        response: { 200: socialPublicationsResponseSchema },
+      },
+    },
+    async (request) => {
+      return await list(request.params.matchId);
+    },
+  );
+
+  app.post(
+    "/matchday/:matchId/social-publications/:platform/retry",
+    {
+      preHandler: [adminRole],
+      schema: {
+        params: retryParamsSchema,
+        body: retryBodySchema,
+        response: { 200: retryResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      const role = (user as { role?: string | null }).role ?? "user";
+
+      return await retryPublication({
+        db: app.db,
+        llm: app.llm,
+        meta: app.meta,
+        s3Social: app.s3SocialMedia,
+        slackWebhookUrl: app.config.SLACK_WEBHOOK_URL,
+        log: request.log,
+        enabled: app.config.SOCIAL_POSTING_ENABLED,
+      })({
+        matchdayId: request.params.matchId,
+        platform: request.params.platform,
+        userId: user.id,
+        role,
+        isHome: request.body.isHome,
+        matchTime: request.body.matchTime,
+      });
+    },
+  );
+
+  app.post(
+    "/matchday/:matchId/social-publications/:platform/reconcile",
+    {
+      preHandler: [adminRole],
+      schema: {
+        params: retryParamsSchema,
+        body: reconcileBodySchema,
+        response: { 200: reconcileResponseSchema },
+      },
+    },
+    async (request) => {
+      return await reconcile({
+        matchdayId: request.params.matchId,
+        platform: request.params.platform,
+        ...request.body,
+      });
+    },
+  );
+};

--- a/apps/api/src/features/social-posting/schemas.ts
+++ b/apps/api/src/features/social-posting/schemas.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+export const platformSchema = z.enum(["facebook", "instagram"]);
+
+export const matchIdParamSchema = z.object({
+  matchId: z.string(),
+});
+
+export const retryParamsSchema = z.object({
+  matchId: z.string(),
+  platform: platformSchema,
+});
+
+export const retryBodySchema = z.object({
+  isHome: z.boolean(),
+  matchTime: z.string().nullable(),
+});
+
+export const reconcileBodySchema = z.discriminatedUnion("outcome", [
+  z.object({
+    outcome: z.literal("posted"),
+    externalPostId: z.string().min(1),
+  }),
+  z.object({
+    outcome: z.literal("failed"),
+  }),
+]);
+
+// ── Response schemas ──
+
+const publicationRowSchema = z.object({
+  id: z.string(),
+  matchday_id: z.string(),
+  platform: z.string(),
+  state: z.string(),
+  claimed_at: z.string(),
+  posted_at: z.string().nullable(),
+  external_post_id: z.string().nullable(),
+  caption: z.string(),
+  caption_source: z.string(),
+  image_url: z.string(),
+  last_error: z.string().nullable(),
+  attempt_count: z.number(),
+  updated_at: z.string(),
+});
+
+export const socialPublicationsResponseSchema = z.object({
+  items: z.array(publicationRowSchema),
+});
+
+export const retryResponseSchema = z.object({
+  state: z.enum(["posted", "failed", "already_posted", "in_flight"]),
+  externalPostId: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export const reconcileResponseSchema = z.object({
+  state: z.enum(["posted", "failed"]),
+});
+
+// ── Types ──
+
+export type Platform = z.infer<typeof platformSchema>;
+export type RetryBody = z.infer<typeof retryBodySchema>;
+export type ReconcileBody = z.infer<typeof reconcileBodySchema>;

--- a/apps/api/src/features/social-posting/service.test.ts
+++ b/apps/api/src/features/social-posting/service.test.ts
@@ -1,0 +1,86 @@
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { LlmClient } from "./caption.ts";
+import { CAPTION_HASHTAG_SUFFIX } from "./caption.ts";
+
+describe("caption assembly", () => {
+  it("appends the fixed hashtag suffix exactly once, even when LLM emits hashtags", async () => {
+    const llm: LlmClient = {
+      generateCaption: vi
+        .fn()
+        .mockResolvedValue("Up the club! #PMCC #percymain vibes"),
+    };
+
+    const { generateCaption } = await import("./caption.ts");
+    const result = await generateCaption(llm)({
+      teamName: "Percy Main 1st XI",
+      opposition: "Benwell Hill",
+      matchDate: "2026-06-15",
+      matchTime: "13:00",
+      isHome: true,
+      players: [{ playerName: "Alex Young", sponsorName: null }],
+      matchSponsor: null,
+    });
+
+    expect(result.source).toBe("ai");
+    const occurrences = result.caption.split(CAPTION_HASHTAG_SUFFIX).length - 1;
+    expect(occurrences).toBe(1);
+    expect(result.caption).not.toMatch(/#PMCC.*#PMCC/);
+  });
+
+  it("falls back to deterministic template when LLM errors", async () => {
+    const llm: LlmClient = {
+      generateCaption: vi.fn().mockRejectedValue(new Error("timeout")),
+    };
+
+    const { generateCaption } = await import("./caption.ts");
+    const result = await generateCaption(llm)({
+      teamName: "Percy Main 2nd XI",
+      opposition: "Tynemouth",
+      matchDate: "2026-06-22",
+      matchTime: null,
+      isHome: false,
+      players: [{ playerName: "Jane Smith", sponsorName: null }],
+      matchSponsor: { name: "Crossling", logoUrl: null },
+    });
+
+    expect(result.source).toBe("fallback");
+    expect(result.caption).toContain("travel to Tynemouth");
+    expect(result.caption).toContain("Crossling");
+    expect(result.caption.trim().endsWith(CAPTION_HASHTAG_SUFFIX)).toBe(true);
+  });
+});
+
+describe("publishTeamSheet (disabled)", () => {
+  it("returns a skipped marker when SOCIAL_POSTING_ENABLED is false", async () => {
+    const { publishTeamSheet } = await import("./service.ts");
+
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as FastifyBaseLogger;
+
+    const db = {} as unknown as Parameters<typeof publishTeamSheet>[0]["db"];
+
+    const result = await publishTeamSheet({
+      db,
+      llm: { generateCaption: vi.fn() },
+      meta: {
+        postToFacebook: vi.fn(),
+        postToInstagram: vi.fn(),
+      },
+      s3Social: { uploadTeamSheet: vi.fn() },
+      log,
+      enabled: false,
+    })({
+      matchdayId: "md-1",
+      userId: "user-1",
+      role: "admin",
+      isHome: true,
+      matchTime: null,
+    });
+
+    expect(result).toEqual({ skipped: "feature disabled" });
+  });
+});

--- a/apps/api/src/features/social-posting/service.ts
+++ b/apps/api/src/features/social-posting/service.ts
@@ -1,0 +1,461 @@
+import type { DB } from "@percy-main/db";
+import type { FastifyBaseLogger } from "fastify";
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+import type { SocialMediaUploader } from "../../lib/s3-social-media.ts";
+import { getTeamNewsData } from "../matchday/service.ts";
+import { generateTeamNewsImage } from "../matchday/team-news-image.ts";
+import { generateCaption, type LlmClient } from "./caption.ts";
+import { MetaError, postFor, type MetaClient } from "./meta-client.ts";
+import type { Platform, ReconcileBody } from "./schemas.ts";
+
+export interface PublishDeps {
+  db: Kysely<DB>;
+  llm: LlmClient;
+  meta: MetaClient;
+  s3Social: SocialMediaUploader;
+  slackWebhookUrl?: string;
+  log: FastifyBaseLogger;
+  enabled: boolean;
+}
+
+interface PublishInput {
+  matchdayId: string;
+  userId: string;
+  role: string;
+  isHome: boolean;
+  matchTime: string | null;
+}
+
+export type PublishResult =
+  | { skipped: "feature disabled" }
+  | {
+      facebook: PublishOneResult;
+      instagram: PublishOneResult;
+    };
+
+export type PublishOneResult =
+  | { state: "posted"; externalPostId: string }
+  | { state: "failed"; error: string }
+  | { state: "already_posted"; externalPostId: string }
+  | { state: "in_flight" };
+
+const PLATFORMS: Platform[] = ["facebook", "instagram"];
+
+export function publishTeamSheet(deps: PublishDeps) {
+  return async (input: PublishInput): Promise<PublishResult> => {
+    if (!deps.enabled) return { skipped: "feature disabled" };
+
+    const { db, log } = deps;
+
+    const data = await getTeamNewsData(db)(
+      input.userId,
+      input.role,
+      input.matchdayId,
+      input.isHome,
+      input.matchTime ?? undefined,
+    );
+
+    const captionResult = await generateCaption(deps.llm)(data);
+
+    let image: Buffer;
+    try {
+      image = await generateTeamNewsImage(data);
+    } catch (err) {
+      log.error(
+        { err, matchdayId: input.matchdayId },
+        "Image generation failed",
+      );
+      await notifySlack(deps.slackWebhookUrl, {
+        stage: "image",
+        matchdayId: input.matchdayId,
+        opposition: data.opposition,
+        matchDate: data.matchDate,
+        error: errorMessage(err),
+      });
+      throw err;
+    }
+
+    let imageUrl: string;
+    try {
+      imageUrl = await deps.s3Social.uploadTeamSheet({
+        matchdayId: input.matchdayId,
+        image,
+      });
+    } catch (err) {
+      log.error({ err, matchdayId: input.matchdayId }, "S3 upload failed");
+      await notifySlack(deps.slackWebhookUrl, {
+        stage: "s3",
+        matchdayId: input.matchdayId,
+        opposition: data.opposition,
+        matchDate: data.matchDate,
+        error: errorMessage(err),
+      });
+      throw err;
+    }
+
+    const [facebook, instagram] = await Promise.all(
+      PLATFORMS.map((platform) =>
+        publishOne(deps, {
+          matchdayId: input.matchdayId,
+          opposition: data.opposition,
+          matchDate: data.matchDate,
+          platform,
+          caption: captionResult.caption,
+          captionSource: captionResult.source,
+          captionVersion: captionResult.version,
+          imageUrl,
+        }),
+      ),
+    );
+
+    return { facebook, instagram };
+  };
+}
+
+interface PublishOneArgs {
+  matchdayId: string;
+  opposition: string;
+  matchDate: string;
+  platform: Platform;
+  caption: string;
+  captionSource: "ai" | "fallback";
+  captionVersion: string;
+  imageUrl: string;
+}
+
+async function publishOne(
+  deps: PublishDeps,
+  args: PublishOneArgs,
+): Promise<PublishOneResult> {
+  const { db, log } = deps;
+  const claim = await claimPublication(db, args);
+
+  if (claim.status === "already_posted") {
+    log.info(
+      {
+        matchdayId: args.matchdayId,
+        platform: args.platform,
+        externalPostId: claim.externalPostId,
+      },
+      "Social post already published; skipping",
+    );
+    return { state: "already_posted", externalPostId: claim.externalPostId };
+  }
+
+  if (claim.status === "in_flight") {
+    log.warn(
+      { matchdayId: args.matchdayId, platform: args.platform },
+      "Social post already in flight; skipping",
+    );
+    return { state: "in_flight" };
+  }
+
+  try {
+    const { externalPostId } = await postFor(
+      deps.meta,
+      args.platform,
+    )({ caption: args.caption, imageUrl: args.imageUrl });
+
+    await recordSuccess(db, claim.id, claim.token, externalPostId);
+    return { state: "posted", externalPostId };
+  } catch (err) {
+    const message = errorMessage(err);
+    await recordFailure(db, claim.id, claim.token, message);
+
+    log.error(
+      {
+        err,
+        matchdayId: args.matchdayId,
+        platform: args.platform,
+        claim: claim.token,
+      },
+      "Social post failed",
+    );
+    await notifySlack(deps.slackWebhookUrl, {
+      stage: args.platform,
+      matchdayId: args.matchdayId,
+      opposition: args.opposition,
+      matchDate: args.matchDate,
+      error:
+        err instanceof MetaError
+          ? `Meta ${err.stage} HTTP ${err.status}: ${err.body.slice(0, 400)}`
+          : message,
+      claim: claim.token,
+    });
+
+    return { state: "failed", error: message };
+  }
+}
+
+type ClaimResult =
+  | { status: "claimed"; id: string; token: string }
+  | { status: "already_posted"; externalPostId: string }
+  | { status: "in_flight" };
+
+export async function claimPublication(
+  db: Kysely<DB>,
+  args: {
+    matchdayId: string;
+    platform: Platform;
+    caption: string;
+    captionSource: "ai" | "fallback";
+    captionVersion: string;
+    imageUrl: string;
+  },
+): Promise<ClaimResult> {
+  const id = crypto.randomUUID();
+  const token = crypto.randomUUID();
+
+  const result = await sql<{
+    id: string;
+    state: string;
+    claim_token: string;
+    external_post_id: string | null;
+  }>`
+    INSERT INTO matchday_social_publication
+      (id, matchday_id, platform, state, claim_token,
+       caption, caption_source, caption_prompt_version, image_url)
+    VALUES (${id}, ${args.matchdayId}, ${args.platform}, 'claimed', ${token},
+            ${args.caption}, ${args.captionSource},
+            ${args.captionVersion}, ${args.imageUrl})
+    ON CONFLICT (matchday_id, platform) DO UPDATE
+      SET state = 'claimed',
+          claim_token = EXCLUDED.claim_token,
+          claimed_at = CURRENT_TIMESTAMP,
+          caption = EXCLUDED.caption,
+          caption_source = EXCLUDED.caption_source,
+          caption_prompt_version = EXCLUDED.caption_prompt_version,
+          image_url = EXCLUDED.image_url,
+          last_error = NULL,
+          attempt_count = matchday_social_publication.attempt_count + 1,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE matchday_social_publication.state = 'failed'
+        AND matchday_social_publication.external_post_id IS NULL
+    RETURNING id, state, claim_token, external_post_id
+  `.execute(db);
+
+  if (result.rows.length === 0) {
+    const existing = await db
+      .selectFrom("matchday_social_publication")
+      .where("matchday_id", "=", args.matchdayId)
+      .where("platform", "=", args.platform)
+      .select(["state", "external_post_id"])
+      .executeTakeFirstOrThrow();
+
+    if (existing.state === "posted" && existing.external_post_id) {
+      return {
+        status: "already_posted",
+        externalPostId: existing.external_post_id,
+      };
+    }
+    return { status: "in_flight" };
+  }
+
+  const row = result.rows[0];
+  return { status: "claimed", id: row.id, token: row.claim_token };
+}
+
+async function recordSuccess(
+  db: Kysely<DB>,
+  id: string,
+  token: string,
+  externalPostId: string,
+): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .updateTable("matchday_social_publication")
+    .set({
+      state: "posted",
+      external_post_id: externalPostId,
+      posted_at: now,
+      updated_at: now,
+      last_error: null,
+    })
+    .where("id", "=", id)
+    .where("claim_token", "=", token)
+    .execute();
+}
+
+async function recordFailure(
+  db: Kysely<DB>,
+  id: string,
+  token: string,
+  error: string,
+): Promise<void> {
+  const now = new Date().toISOString();
+  await db
+    .updateTable("matchday_social_publication")
+    .set({
+      state: "failed",
+      last_error: error,
+      updated_at: now,
+    })
+    .where("id", "=", id)
+    .where("claim_token", "=", token)
+    .execute();
+}
+
+// ── Status / retry / reconcile ──
+
+export function listPublications(db: Kysely<DB>) {
+  return async (matchdayId: string) => {
+    const items = await db
+      .selectFrom("matchday_social_publication")
+      .where("matchday_id", "=", matchdayId)
+      .select([
+        "id",
+        "matchday_id",
+        "platform",
+        "state",
+        "claimed_at",
+        "posted_at",
+        "external_post_id",
+        "caption",
+        "caption_source",
+        "image_url",
+        "last_error",
+        "attempt_count",
+        "updated_at",
+      ])
+      .orderBy("platform", "asc")
+      .execute();
+
+    return { items };
+  };
+}
+
+export function retryPublication(deps: PublishDeps) {
+  return async (input: {
+    matchdayId: string;
+    platform: Platform;
+    userId: string;
+    role: string;
+    isHome: boolean;
+    matchTime: string | null;
+  }): Promise<PublishOneResult> => {
+    if (!deps.enabled) return { state: "failed", error: "feature disabled" };
+
+    const data = await getTeamNewsData(deps.db)(
+      input.userId,
+      input.role,
+      input.matchdayId,
+      input.isHome,
+      input.matchTime ?? undefined,
+    );
+
+    const captionResult = await generateCaption(deps.llm)(data);
+    const image = await generateTeamNewsImage(data);
+    const imageUrl = await deps.s3Social.uploadTeamSheet({
+      matchdayId: input.matchdayId,
+      image,
+    });
+
+    return publishOne(deps, {
+      matchdayId: input.matchdayId,
+      opposition: data.opposition,
+      matchDate: data.matchDate,
+      platform: input.platform,
+      caption: captionResult.caption,
+      captionSource: captionResult.source,
+      captionVersion: captionResult.version,
+      imageUrl,
+    });
+  };
+}
+
+export function reconcilePublication(db: Kysely<DB>) {
+  return async (
+    input: {
+      matchdayId: string;
+      platform: Platform;
+    } & ReconcileBody,
+  ): Promise<{ state: "posted" | "failed" }> => {
+    const row = await db
+      .selectFrom("matchday_social_publication")
+      .where("matchday_id", "=", input.matchdayId)
+      .where("platform", "=", input.platform)
+      .select(["id", "state", "external_post_id"])
+      .executeTakeFirst();
+
+    if (!row) {
+      throw Object.assign(new Error("Publication row not found"), {
+        statusCode: 404,
+      });
+    }
+
+    if (row.state !== "claimed") {
+      throw Object.assign(
+        new Error(
+          `Cannot reconcile row in state '${row.state}'. Only claimed rows are reconcilable.`,
+        ),
+        { statusCode: 400 },
+      );
+    }
+
+    const now = new Date().toISOString();
+
+    if (input.outcome === "posted") {
+      await db
+        .updateTable("matchday_social_publication")
+        .set({
+          state: "posted",
+          external_post_id: input.externalPostId,
+          posted_at: now,
+          updated_at: now,
+          last_error: null,
+        })
+        .where("id", "=", row.id)
+        .execute();
+      return { state: "posted" };
+    }
+
+    await db
+      .updateTable("matchday_social_publication")
+      .set({
+        state: "failed",
+        last_error: "reconciled as failed by operator",
+        updated_at: now,
+      })
+      .where("id", "=", row.id)
+      .execute();
+    return { state: "failed" };
+  };
+}
+
+// ── Helpers ──
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+async function notifySlack(
+  webhookUrl: string | undefined,
+  data: {
+    stage: "image" | "s3" | "facebook" | "instagram";
+    matchdayId: string;
+    opposition: string;
+    matchDate: string;
+    error: string;
+    claim?: string;
+  },
+): Promise<void> {
+  if (!webhookUrl) return;
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text:
+          `:rotating_light: Social posting failed\n` +
+          `Fixture: ${data.matchdayId} vs ${data.opposition} on ${data.matchDate}\n` +
+          `Stage: ${data.stage}\n` +
+          (data.claim ? `Claim: ${data.claim}\n` : "") +
+          `Error: ${data.error}`,
+      }),
+    });
+  } catch {
+    // Swallow — Slack failures must never break the publish flow
+  }
+}

--- a/apps/api/src/lib/s3-social-media.ts
+++ b/apps/api/src/lib/s3-social-media.ts
@@ -1,0 +1,84 @@
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { createHash } from "node:crypto";
+import type { Config } from "../config.ts";
+
+export interface UploadTeamSheetParams {
+  matchdayId: string;
+  image: Buffer;
+}
+
+export interface SocialMediaUploader {
+  uploadTeamSheet: (params: UploadTeamSheetParams) => Promise<string>;
+}
+
+/**
+ * Creates an S3 uploader for publicly-accessible social media images.
+ *
+ * Keys are content-addressed: `{prefix}/{matchdayId}/{sha256(image).slice(0,12)}.png`
+ * so a regenerated image with identical content reuses its URL (Meta cache-friendly),
+ * while a changed image gets a new URL on retry.
+ */
+export function createSocialMediaUploader(config: Config): SocialMediaUploader {
+  if (!config.S3_SOCIAL_MEDIA_BUCKET) {
+    return {
+      uploadTeamSheet() {
+        throw new Error(
+          "S3_SOCIAL_MEDIA_BUCKET not configured; social media uploader unavailable",
+        );
+      },
+    };
+  }
+
+  const clientOptions: ConstructorParameters<typeof S3Client>[0] = {
+    region: config.S3_REGION,
+  };
+  if (config.S3_ENDPOINT) {
+    clientOptions.endpoint = config.S3_ENDPOINT;
+    clientOptions.forcePathStyle = true;
+  }
+
+  const client = new S3Client(clientOptions);
+  const bucket = config.S3_SOCIAL_MEDIA_BUCKET;
+  const prefix = config.S3_SOCIAL_MEDIA_PREFIX;
+  const endpoint = config.S3_ENDPOINT;
+  const region = config.S3_REGION;
+
+  return {
+    async uploadTeamSheet({ matchdayId, image }) {
+      const hash = createHash("sha256")
+        .update(image)
+        .digest("hex")
+        .slice(0, 12);
+      const key = `${prefix}/${matchdayId}/${hash}.png`;
+
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: image,
+          ContentType: "image/png",
+          ACL: "public-read",
+        }),
+      );
+
+      if (endpoint) {
+        return `${endpoint}/${bucket}/${key}`;
+      }
+      return `https://${bucket}.s3.${region}.amazonaws.com/${key}`;
+    },
+  };
+}
+
+/**
+ * Stub uploader for tests — returns a deterministic fake URL and
+ * does not touch S3. Tests that assert on the URL can pattern-match
+ * against `https://test-bucket/...`.
+ */
+export const stubSocialMediaUploader: SocialMediaUploader = {
+  uploadTeamSheet({ matchdayId, image }) {
+    const hash = createHash("sha256").update(image).digest("hex").slice(0, 12);
+    return Promise.resolve(
+      `https://test-bucket/social-media/team-sheets/${matchdayId}/${hash}.png`,
+    );
+  },
+};

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -4568,6 +4568,8 @@ export interface paths {
                             /** @enum {string} */
                             status: "playing" | "dropped_out" | "no_show";
                         }[];
+                        isHome: boolean;
+                        matchTime: string | null;
                     };
                 };
             };
@@ -4675,6 +4677,161 @@ export interface paths {
                             success: boolean;
                             emailsSent: number;
                             emailErrors: string[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/matchday/{matchId}/social-publications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    matchId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                matchday_id: string;
+                                platform: string;
+                                state: string;
+                                claimed_at: string;
+                                posted_at: string | null;
+                                external_post_id: string | null;
+                                caption: string;
+                                caption_source: string;
+                                image_url: string;
+                                last_error: string | null;
+                                attempt_count: number;
+                                updated_at: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/matchday/{matchId}/social-publications/{platform}/retry": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    matchId: string;
+                    platform: "facebook" | "instagram";
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        isHome: boolean;
+                        matchTime: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            state: "posted" | "failed" | "already_posted" | "in_flight";
+                            externalPostId?: string;
+                            error?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/matchday/{matchId}/social-publications/{platform}/reconcile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    matchId: string;
+                    platform: "facebook" | "instagram";
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        outcome: "posted";
+                        externalPostId: string;
+                    } | {
+                        /** @enum {string} */
+                        outcome: "failed";
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            state: "posted" | "failed";
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -7828,10 +7828,19 @@
                         "status"
                       ]
                     }
+                  },
+                  "isHome": {
+                    "type": "boolean"
+                  },
+                  "matchTime": {
+                    "nullable": true,
+                    "type": "string"
                   }
                 },
                 "required": [
-                  "playerStatuses"
+                  "playerStatuses",
+                  "isHome",
+                  "matchTime"
                 ]
               }
             }
@@ -8000,6 +8009,281 @@
                     "success",
                     "emailsSent",
                     "emailErrors"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/matchday/{matchId}/social-publications": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "matchId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "matchday_id": {
+                            "type": "string"
+                          },
+                          "platform": {
+                            "type": "string"
+                          },
+                          "state": {
+                            "type": "string"
+                          },
+                          "claimed_at": {
+                            "type": "string"
+                          },
+                          "posted_at": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "external_post_id": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "caption": {
+                            "type": "string"
+                          },
+                          "caption_source": {
+                            "type": "string"
+                          },
+                          "image_url": {
+                            "type": "string"
+                          },
+                          "last_error": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "attempt_count": {
+                            "type": "number"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "matchday_id",
+                          "platform",
+                          "state",
+                          "claimed_at",
+                          "posted_at",
+                          "external_post_id",
+                          "caption",
+                          "caption_source",
+                          "image_url",
+                          "last_error",
+                          "attempt_count",
+                          "updated_at"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/matchday/{matchId}/social-publications/{platform}/retry": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "isHome": {
+                    "type": "boolean"
+                  },
+                  "matchTime": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "isHome",
+                  "matchTime"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "matchId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "facebook",
+                "instagram"
+              ]
+            },
+            "in": "path",
+            "name": "platform",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "posted",
+                        "failed",
+                        "already_posted",
+                        "in_flight"
+                      ]
+                    },
+                    "externalPostId": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "state"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/matchday/{matchId}/social-publications/{platform}/reconcile": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "outcome": {
+                        "type": "string",
+                        "enum": [
+                          "posted"
+                        ]
+                      },
+                      "externalPostId": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "outcome",
+                      "externalPostId"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "outcome": {
+                        "type": "string",
+                        "enum": [
+                          "failed"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "outcome"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "matchId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "facebook",
+                "instagram"
+              ]
+            },
+            "in": "path",
+            "name": "platform",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "posted",
+                        "failed"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "state"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -17,6 +17,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format, parse } from "date-fns";
 import { useRef, useState } from "react";
 import { Link } from "react-router";
+import { SocialPublicationsPanel } from "./social-publications-panel";
 
 // ── Constants ──
 
@@ -401,6 +402,8 @@ function MatchdayView({
   onBack: () => void;
 }) {
   const queryClient = useQueryClient();
+  const { data: session } = useSession();
+  const isAdmin = session?.user.role === "admin";
   const [searchQuery, setSearchQuery] = useState("");
   const [showAddForm, setShowAddForm] = useState(false);
   const [adHocName, setAdHocName] = useState("");
@@ -476,7 +479,7 @@ function MatchdayView({
       callApi(
         api.POST("/api/matchday/{matchId}/confirm", {
           params: { path: { matchId: matchdayId } },
-          body: input,
+          body: { ...input, isHome, matchTime },
         }),
       ),
     onSuccess: () => {
@@ -957,6 +960,15 @@ function MatchdayView({
               isFinished={data.matchday.status === "finished"}
               addExpenseMutation={addExpenseMutation}
               deleteExpenseMutation={deleteExpenseMutation}
+            />
+          )}
+
+          {/* Social posting status — admin-only, visible once confirmed */}
+          {isAdmin && data.matchday.status !== "pending" && (
+            <SocialPublicationsPanel
+              matchdayId={matchdayId}
+              isHome={isHome}
+              matchTime={matchTime}
             />
           )}
 

--- a/apps/web/src/pages/official/social-publications-panel.tsx
+++ b/apps/web/src/pages/official/social-publications-panel.tsx
@@ -1,0 +1,324 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { api, callApi } from "@/lib/api-client";
+import type { paths } from "@/lib/api.gen.js";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { useState } from "react";
+
+type Publications =
+  paths["/api/matchday/{matchId}/social-publications"]["get"]["responses"][200]["content"]["application/json"];
+type PublicationRow = Publications["items"][number];
+type Platform = "facebook" | "instagram";
+
+const PLATFORM_LABELS: Record<Platform, string> = {
+  facebook: "Facebook",
+  instagram: "Instagram",
+};
+
+const STATE_COLORS: Record<string, string> = {
+  claimed: "bg-yellow-100 text-yellow-800",
+  posted: "bg-green-100 text-green-800",
+  failed: "bg-red-100 text-red-800",
+};
+
+const STUCK_THRESHOLD_MS = 10 * 60 * 1000;
+
+function isStuckClaim(row: PublicationRow): boolean {
+  if (row.state !== "claimed") return false;
+  const claimedAt = new Date(row.claimed_at).getTime();
+  return Date.now() - claimedAt > STUCK_THRESHOLD_MS;
+}
+
+function externalUrl(platform: string, id: string): string | null {
+  if (platform === "facebook") return `https://facebook.com/${id}`;
+  if (platform === "instagram") return `https://instagram.com/p/${id}`;
+  return null;
+}
+
+export function SocialPublicationsPanel({
+  matchdayId,
+  isHome,
+  matchTime,
+}: {
+  matchdayId: string;
+  isHome: boolean;
+  matchTime: string | null;
+}) {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ["social-publications", matchdayId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/matchday/{matchId}/social-publications", {
+          params: { path: { matchId: matchdayId } },
+        }),
+      ),
+    refetchInterval: (q) => {
+      const items = q.state.data?.items ?? [];
+      return items.some((row) => row.state === "claimed") ? 5000 : false;
+    },
+  });
+
+  const retryMutation = useMutation({
+    mutationFn: (platform: Platform) =>
+      callApi(
+        api.POST(
+          "/api/matchday/{matchId}/social-publications/{platform}/retry",
+          {
+            params: { path: { matchId: matchdayId, platform } },
+            body: { isHome, matchTime },
+          },
+        ),
+      ),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ["social-publications", matchdayId],
+      }),
+  });
+
+  const [reconciling, setReconciling] = useState<Platform | null>(null);
+
+  const items = query.data?.items ?? [];
+
+  if (query.isPending) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Social Posting</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-gray-500">Loading…</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (query.isError) {
+    return null;
+  }
+
+  if (items.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Social Posting</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-gray-500">
+            No posting attempts yet. Posts are kicked off when a team is
+            confirmed.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Social Posting</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          {items.map((row) => {
+            const platform = row.platform as Platform;
+            const stuck = isStuckClaim(row);
+            const url =
+              row.state === "posted" && row.external_post_id
+                ? externalUrl(row.platform, row.external_post_id)
+                : null;
+
+            return (
+              <div
+                key={row.id}
+                className="flex items-center justify-between rounded border border-gray-200 px-3 py-2"
+              >
+                <div>
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium">
+                      {PLATFORM_LABELS[platform] ?? row.platform}
+                    </p>
+                    <span
+                      className={`rounded px-1.5 py-0.5 text-xs font-medium ${
+                        STATE_COLORS[row.state] ?? ""
+                      }`}
+                    >
+                      {stuck ? "needs reconciliation" : row.state}
+                    </span>
+                    {row.caption_source === "fallback" && (
+                      <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600">
+                        fallback caption
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 text-xs text-gray-500">
+                    {row.state === "posted" && row.posted_at && (
+                      <span>
+                        Posted{" "}
+                        {format(new Date(row.posted_at), "dd/MM/yyyy HH:mm")}
+                      </span>
+                    )}
+                    {row.state === "failed" && row.last_error && (
+                      <span className="text-red-600">{row.last_error}</span>
+                    )}
+                    {row.attempt_count > 1 && (
+                      <span className="ml-2">
+                        (attempts: {row.attempt_count})
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {url && (
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-xs text-blue-600 underline"
+                    >
+                      View
+                    </a>
+                  )}
+                  {row.state === "failed" && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={retryMutation.isPending}
+                      onClick={() => retryMutation.mutate(platform)}
+                    >
+                      Retry
+                    </Button>
+                  )}
+                  {stuck && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setReconciling(platform)}
+                    >
+                      Reconcile
+                    </Button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+          {retryMutation.isError && (
+            <p className="text-sm text-red-600">Retry failed.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <ReconcileDialog
+        matchdayId={matchdayId}
+        platform={reconciling}
+        onClose={() => setReconciling(null)}
+      />
+    </>
+  );
+}
+
+function ReconcileDialog({
+  matchdayId,
+  platform,
+  onClose,
+}: {
+  matchdayId: string;
+  platform: Platform | null;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [externalPostId, setExternalPostId] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: (
+      body:
+        | { outcome: "posted"; externalPostId: string }
+        | { outcome: "failed" },
+    ) => {
+      if (!platform) throw new Error("No platform selected");
+      return callApi(
+        api.POST(
+          "/api/matchday/{matchId}/social-publications/{platform}/reconcile",
+          {
+            params: { path: { matchId: matchdayId, platform } },
+            body,
+          },
+        ),
+      );
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["social-publications", matchdayId],
+      });
+      setExternalPostId("");
+      onClose();
+    },
+  });
+
+  const open = platform !== null;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (!o ? onClose() : null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Reconcile {platform ? (PLATFORM_LABELS[platform] ?? platform) : ""}{" "}
+            publication
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 text-sm">
+          <p>
+            This post is stuck in <code>claimed</code>. Confirm whether it
+            actually landed on{" "}
+            {platform ? PLATFORM_LABELS[platform] : "the platform"}.
+          </p>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-gray-600">
+              External post ID (only if the post did land)
+            </label>
+            <Input
+              placeholder="e.g. 17890… or pfbid0…"
+              value={externalPostId}
+              onChange={(e) => setExternalPostId(e.target.value)}
+            />
+          </div>
+          {mutation.isError && (
+            <p className="text-sm text-red-600">
+              Reconciliation failed. Try again or check the logs.
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => mutation.mutate({ outcome: "failed" })}
+            disabled={mutation.isPending}
+          >
+            Mark as failed
+          </Button>
+          <Button
+            onClick={() =>
+              mutation.mutate({
+                outcome: "posted",
+                externalPostId: externalPostId.trim(),
+              })
+            }
+            disabled={mutation.isPending || !externalPostId.trim()}
+          >
+            Mark as posted
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -335,6 +335,25 @@ export interface MatchdayPlayer {
   status: Generated<string>;
 }
 
+export interface MatchdaySocialPublication {
+  attempt_count: Generated<number>;
+  caption: string;
+  caption_prompt_version: string;
+  caption_source: string;
+  claim_token: string;
+  claimed_at: Generated<string>;
+  created_at: Generated<string>;
+  external_post_id: string | null;
+  id: string;
+  image_url: string;
+  last_error: string | null;
+  matchday_id: string;
+  platform: string;
+  posted_at: string | null;
+  state: string;
+  updated_at: Generated<string>;
+}
+
 export interface MatchFeeRate {
   amount_pence: number;
   competition_type: string | null;
@@ -578,6 +597,7 @@ export interface DB {
   matchday: Matchday;
   matchday_expense: MatchdayExpense;
   matchday_player: MatchdayPlayer;
+  matchday_social_publication: MatchdaySocialPublication;
   member: Member;
   membership: Membership;
   passkey: Passkey;

--- a/packages/db/src/migrations/2026-04-19T19:30:00.000Z_matchday_social_publication.ts
+++ b/packages/db/src/migrations/2026-04-19T19:30:00.000Z_matchday_social_publication.ts
@@ -1,0 +1,50 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE matchday_social_publication (
+      id TEXT PRIMARY KEY,
+      matchday_id TEXT NOT NULL REFERENCES matchday(id) ON DELETE CASCADE,
+      platform TEXT NOT NULL CHECK (platform IN ('facebook', 'instagram')),
+      state TEXT NOT NULL CHECK (state IN ('claimed', 'posted', 'failed')),
+      claim_token TEXT NOT NULL,
+      claimed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      posted_at TEXT,
+      external_post_id TEXT,
+      caption TEXT NOT NULL,
+      caption_source TEXT NOT NULL CHECK (caption_source IN ('ai', 'fallback')),
+      caption_prompt_version TEXT NOT NULL,
+      image_url TEXT NOT NULL,
+      last_error TEXT,
+      attempt_count INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+      CONSTRAINT matchday_social_publication_unique UNIQUE (matchday_id, platform),
+
+      CONSTRAINT matchday_social_publication_posted_complete CHECK (
+        (state <> 'posted') OR
+        (external_post_id IS NOT NULL AND posted_at IS NOT NULL)
+      ),
+
+      CONSTRAINT matchday_social_publication_external_id_immutable CHECK (
+        external_post_id IS NULL OR state = 'posted'
+      )
+    )
+  `.execute(db);
+
+  await sql`
+    CREATE INDEX matchday_social_publication_matchday_idx
+      ON matchday_social_publication (matchday_id)
+  `.execute(db);
+
+  await sql`
+    CREATE INDEX matchday_social_publication_state_idx
+      ON matchday_social_publication (state)
+      WHERE state IN ('claimed', 'failed')
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE matchday_social_publication`.execute(db);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.90.0
+        version: 0.90.0(zod@4.3.6)
       '@aws-sdk/client-s3':
         specifier: ^3.1022.0
         version: 3.1022.0
@@ -46,10 +49,10 @@ importers:
         version: 3.1022.0
       '@better-auth/infra':
         specifier: ^0.1.13
-        version: 0.1.13(c5ed1d55fcb91bfb734ecc8c43af85f6)
+        version: 0.1.13(9c70778cc91d7205870d3fa32646111b)
       '@better-auth/passkey':
         specifier: ^1.5.4
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
@@ -228,7 +231,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: ^1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -482,6 +485,15 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@authenio/xml-encryption@2.0.2':
     resolution: {integrity: sha512-cTlrKttbrRHEw3W+0/I609A2Matj5JQaRvfLtEIGZvlN0RaPi+3ANsMeqAyCAVlH/lUIW2tmtBlSMni74lcXeg==}
@@ -831,6 +843,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -3798,6 +3814,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xstate/fsm@1.6.5':
     resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
@@ -5114,6 +5131,10 @@ packages:
   json-schema-resolver@3.0.0:
     resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
     engines: {node: '>=20'}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -6532,6 +6553,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -6890,6 +6914,12 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@authenio/xml-encryption@2.0.2':
     dependencies:
@@ -7797,6 +7827,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -7851,10 +7883,10 @@ snapshots:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/infra@0.1.13(c5ed1d55fcb91bfb734ecc8c43af85f6)':
+  '@better-auth/infra@0.1.13(9c70778cc91d7205870d3fa32646111b)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1)
-      '@better-auth/sso': 1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
+      '@better-auth/sso': 1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
       better-call: 1.3.4(zod@4.3.6)
@@ -7908,9 +7940,9 @@ snapshots:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/sso@1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))':
+  '@better-auth/sso@1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
@@ -12365,6 +12397,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -14190,6 +14227,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary
- New `social-posting` feature kicks off fire-and-forget from `POST /matchday/:id/confirm`, generates a caption (Anthropic Haiku tool-use with a deterministic fallback) and a team-news image, uploads to a public S3 bucket, and posts to both Facebook and Instagram via the Meta Graph API.
- Duplicate posting is **impossible by construction**: new `matchday_social_publication` table has `UNIQUE (matchday_id, platform)` plus CHECK constraints, and the claim path is an atomic `INSERT … ON CONFLICT DO UPDATE WHERE state = 'failed'` so a `posted` row can never be re-claimed.
- Admin-only panel on the matchday page polls status while rows are `claimed`, shows per-platform state / external post ID / last error, and exposes retry + reconcile actions for the stuck-`claimed` recovery path.
- Ships **disabled by default** (`SOCIAL_POSTING_ENABLED=false`); config refinement errors at startup if enabled without Meta/Anthropic/S3 credentials.

See `SOCIAL_POSTING.md` for the full design discussion (not committed).

## Test plan
- [x] `pnpm run typecheck` — clean across all packages
- [x] `pnpm run lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm --filter api test` — 245 unit tests pass (incl. 3 new for caption assembly, fallback, disabled-flag short-circuit)
- [x] `pnpm --filter api test:integration src/features/social-posting` — 8 new integration tests pass: happy path, idempotency, concurrent claim serialisation (asserts each platform's Meta call fires exactly once across two `Promise.all`'d publish calls), partial success + IG-only retry (asserts FB Meta call count unchanged on retry), reconcile → posted, reconcile → failed then retry, disabled flag inserts zero rows, CHECK constraint rejects `state='posted'` without `external_post_id`.
- [ ] Manual smoke with real Meta credentials + `SOCIAL_POSTING_ENABLED=true` on a staging fixture (deferred to operator verification before enabling in prod).
- [ ] Alex to supply 3–5 historical caption examples for few-shot exemplars in `CAPTION_PROMPT_V1` (noted open item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)