### PR TITLE
Fantasy week 1 improvements

### DIFF
--- a/apps/api/src/features/fantasy/routes.ts
+++ b/apps/api/src/features/fantasy/routes.ts
@@ -41,7 +41,6 @@ import {
   saveTeamSchema,
   seasonLeaderboardResponseSchema,
   seasonSchema,
-  seasonTimelineResponseSchema,
   successResponseSchema,
   teamDetailResponseSchema,
   teamIdSchema,
@@ -70,7 +69,6 @@ import {
   getPreSeasonStats,
   getSandwichEfficiency,
   getSeasonLeaderboard,
-  getSeasonTimeline,
   getTeam,
   getTeamShareData,
   getTransferWindow,
@@ -114,7 +112,6 @@ export const fantasyRoutes: FastifyPluginAsyncZod = async (app) => {
   const teams = listTeams(app.db);
   const teamDetail = getTeam(app.db);
   const gwDetail = getGameweekDetail(app.db);
-  const timeline = getSeasonTimeline(app.db);
   const playerHist = getPlayerHistory(app.db);
   const chipStatus = getChipStatus(app.db);
   const chipActivate = activateChip(app.db);
@@ -278,22 +275,6 @@ export const fantasyRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       const { teamId } = request.params;
       return await teamDetail(teamId);
-    },
-  );
-
-  app.get(
-    "/fantasy/teams/:teamId/timeline",
-    {
-      schema: {
-        params: teamIdSchema,
-        querystring: seasonSchema,
-        response: { 200: seasonTimelineResponseSchema },
-      },
-    },
-    async (request) => {
-      const { teamId } = request.params;
-      const { season } = request.query;
-      return await timeline(teamId, season);
     },
   );
 

--- a/apps/api/src/features/fantasy/schemas.ts
+++ b/apps/api/src/features/fantasy/schemas.ts
@@ -158,6 +158,7 @@ export const ownershipOverviewResponseSchema = z.object({
   ),
   teamCount: z.number(),
   gameweek: z.number(),
+  isFromPreviousSeason: z.boolean(),
 });
 
 // getSandwichEfficiency
@@ -310,6 +311,10 @@ export const teamDetailResponseSchema = z.object({
     season: z.string(),
     ownerName: z.string(),
     ownerId: z.string(),
+    seasonPoints: z.number(),
+    latestGameweek: z.number().nullable(),
+    latestGameweekPoints: z.number(),
+    gameweeksPlayed: z.number(),
   }),
   players: z.array(
     z.object({
@@ -320,21 +325,10 @@ export const teamDetailResponseSchema = z.object({
       slotType: slotTypeSchema,
       isWicketkeeper: z.boolean(),
       ownershipPct: z.number(),
+      seasonPoints: z.number(),
+      latestGameweekPoints: z.number(),
     }),
   ),
-});
-
-// getSeasonTimeline
-export const seasonTimelineResponseSchema = z.object({
-  timeline: z.array(
-    z.object({
-      gameweek: z.number(),
-      weeklyPoints: z.number(),
-      cumulativePoints: z.number(),
-    }),
-  ),
-  season: z.string(),
-  teamId: z.number(),
 });
 
 // getGameweekDetail

--- a/apps/api/src/features/fantasy/service.ts
+++ b/apps/api/src/features/fantasy/service.ts
@@ -1114,6 +1114,7 @@ export function getOwnershipOverview(db: Kysely<DB>) {
         differentials: [],
         teamCount: 0,
         gameweek,
+        isFromPreviousSeason: false,
       };
     }
 
@@ -1167,41 +1168,40 @@ export function getOwnershipOverview(db: Kysely<DB>) {
         captainPct,
       }));
 
-    // Build points map for differential ranking
+    // Build points map for differential ranking from current-season scores.
     const diffPointsMap = new Map<
       string,
       { playerName: string; points: number }
     >();
-    const lastCompletedGw = Math.max(0, gameweek - 1);
+    let isFromPreviousSeason = false;
 
-    if (lastCompletedGw > 0) {
-      const gwScores = await db
-        .selectFrom("fantasy_player_score as fps")
-        .innerJoin(
-          "fantasy_player as fp",
-          "fp.play_cricket_id",
-          "fps.play_cricket_id",
-        )
-        .where("fps.season", "=", s)
-        .where("fps.gameweek_id", "=", lastCompletedGw)
-        .select([
-          "fps.play_cricket_id",
-          "fp.player_name",
-          sql<string>`SUM(fps.total_points)`.as("total_points"),
-        ])
-        .groupBy(["fps.play_cricket_id", "fp.player_name"])
-        .execute();
+    const currentScores = await db
+      .selectFrom("fantasy_player_score as fps")
+      .innerJoin(
+        "fantasy_player as fp",
+        "fp.play_cricket_id",
+        "fps.play_cricket_id",
+      )
+      .where("fps.season", "=", s)
+      .select([
+        "fps.play_cricket_id",
+        "fp.player_name",
+        sql<string>`SUM(fps.total_points)`.as("total_points"),
+      ])
+      .groupBy(["fps.play_cricket_id", "fp.player_name"])
+      .having(sql`SUM(fps.total_points)`, ">", 0)
+      .execute();
 
-      for (const row of gwScores) {
-        diffPointsMap.set(row.play_cricket_id, {
-          playerName: row.player_name,
-          points: Number(row.total_points),
-        });
-      }
+    for (const row of currentScores) {
+      diffPointsMap.set(row.play_cricket_id, {
+        playerName: row.player_name,
+        points: Number(row.total_points),
+      });
     }
 
-    // Fall back to previous season totals from fantasy_player_score
-    if (diffPointsMap.size === 0 || lastCompletedGw === 0) {
+    // Fall back to previous season totals when the current season has no scores yet.
+    if (diffPointsMap.size === 0) {
+      isFromPreviousSeason = true;
       const prevSeason = getPreviousSeason(s);
       const prevScores = await db
         .selectFrom("fantasy_player_score as fps")
@@ -1221,15 +1221,13 @@ export function getOwnershipOverview(db: Kysely<DB>) {
         .execute();
 
       for (const row of prevScores) {
-        if (!diffPointsMap.has(row.play_cricket_id)) {
-          diffPointsMap.set(row.play_cricket_id, {
-            playerName: row.player_name,
-            points: Number(row.total_points),
-          });
-        }
+        diffPointsMap.set(row.play_cricket_id, {
+          playerName: row.player_name,
+          points: Number(row.total_points),
+        });
       }
 
-      // Fall back to raw match performance data if fantasy_player_score is empty
+      // Final fall back to raw match performance data if fantasy_player_score is empty.
       if (diffPointsMap.size === 0) {
         const rawPoints = await calculateSeasonPointsFromMatches(db, [
           prevSeason,
@@ -1253,7 +1251,14 @@ export function getOwnershipOverview(db: Kysely<DB>) {
       costMap,
     );
 
-    return { mostOwned, mostCaptained, differentials, teamCount, gameweek };
+    return {
+      mostOwned,
+      mostCaptained,
+      differentials,
+      teamCount,
+      gameweek,
+      isFromPreviousSeason,
+    };
   };
 }
 
@@ -1913,7 +1918,7 @@ export function getTeam(db: Kysely<DB>) {
       throw httpError(404, "Team not found.");
     }
 
-    const gameweek = getCurrentGameweek(team.season);
+    const currentGameweek = getCurrentGameweek(team.season);
 
     const players = await db
       .selectFrom("fantasy_team_player as ftp")
@@ -1923,11 +1928,11 @@ export function getTeam(db: Kysely<DB>) {
         "ftp.play_cricket_id",
       )
       .where("ftp.fantasy_team_id", "=", team.id)
-      .where("ftp.gameweek_added", "<=", gameweek)
+      .where("ftp.gameweek_added", "<=", currentGameweek)
       .where((eb) =>
         eb.or([
           eb("ftp.gameweek_removed", "is", null),
-          eb("ftp.gameweek_removed", ">", gameweek),
+          eb("ftp.gameweek_removed", ">", currentGameweek),
         ]),
       )
       .select([
@@ -1940,7 +1945,39 @@ export function getTeam(db: Kysely<DB>) {
       ])
       .execute();
 
-    const { ownershipMap } = await getOwnershipData(db, team.season, gameweek);
+    const { ownershipMap } = await getOwnershipData(
+      db,
+      team.season,
+      currentGameweek,
+    );
+
+    // Team-level weekly scores across the season.
+    const teamScores = await db
+      .selectFrom("fantasy_team_score")
+      .where("fantasy_team_id", "=", team.id)
+      .where("season", "=", team.season)
+      .select(["gameweek_id", "total_points"])
+      .orderBy("gameweek_id", "asc")
+      .execute();
+
+    const seasonPoints = teamScores.reduce((sum, s) => sum + s.total_points, 0);
+    const gameweeksPlayed = teamScores.length;
+    const latestGameweek =
+      teamScores.length > 0
+        ? (teamScores[teamScores.length - 1]?.gameweek_id ?? null)
+        : null;
+    const latestGameweekPoints =
+      teamScores.length > 0
+        ? (teamScores[teamScores.length - 1]?.total_points ?? 0)
+        : 0;
+
+    // Compute per-player effective points across the season for this team.
+    const effectivePointsBy = await computeTeamEffectivePoints(
+      db,
+      team.id,
+      team.season,
+      teamScores.map((ts) => ts.gameweek_id),
+    );
 
     return {
       team: {
@@ -1948,9 +1985,14 @@ export function getTeam(db: Kysely<DB>) {
         season: team.season,
         ownerName: team.ownerName,
         ownerId: team.ownerId,
+        seasonPoints,
+        latestGameweek,
+        latestGameweekPoints,
+        gameweeksPlayed,
       },
       players: players.map((p) => {
         const ownership = ownershipMap.get(p.play_cricket_id);
+        const eff = effectivePointsBy.get(p.play_cricket_id);
         return {
           playCricketId: p.play_cricket_id,
           playerName: p.player_name,
@@ -1959,10 +2001,160 @@ export function getTeam(db: Kysely<DB>) {
           slotType: p.slot_type as SlotType,
           isWicketkeeper: p.is_wicketkeeper,
           ownershipPct: ownership?.ownershipPct ?? 0,
+          seasonPoints: eff?.seasonPoints ?? 0,
+          latestGameweekPoints: eff?.latestGameweekPoints ?? 0,
         };
       }),
     };
   };
+}
+
+/**
+ * Load all squad memberships, player scores, and chip usages for this team,
+ * then compute per-player effective points (accounting for captain multiplier,
+ * slot/WK rules, triple-captain chip) for each gameweek in `gameweeks`, and
+ * return a per-player aggregate of season total and latest-gameweek totals.
+ */
+async function computeTeamEffectivePoints(
+  db: Kysely<DB>,
+  teamId: number,
+  season: string,
+  gameweeks: number[],
+): Promise<
+  Map<string, { seasonPoints: number; latestGameweekPoints: number }>
+> {
+  if (gameweeks.length === 0) return new Map();
+
+  const latestGameweek = gameweeks[gameweeks.length - 1] ?? null;
+
+  const memberships = await db
+    .selectFrom("fantasy_team_player")
+    .where("fantasy_team_id", "=", teamId)
+    .select([
+      "play_cricket_id",
+      "gameweek_added",
+      "gameweek_removed",
+      "is_captain",
+      "slot_type",
+      "is_wicketkeeper",
+    ])
+    .execute();
+
+  if (memberships.length === 0) return new Map();
+
+  const playerIds = Array.from(
+    new Set(memberships.map((m) => m.play_cricket_id)),
+  );
+
+  const scores = await db
+    .selectFrom("fantasy_player_score")
+    .where("season", "=", season)
+    .where("gameweek_id", "in", gameweeks)
+    .where("play_cricket_id", "in", playerIds)
+    .select([
+      "play_cricket_id",
+      "gameweek_id",
+      "batting_points",
+      "bowling_points",
+      "fielding_points",
+      "team_points",
+      "catches",
+      "stumpings",
+      "is_actual_keeper",
+    ])
+    .execute();
+
+  const chipRows = await db
+    .selectFrom("fantasy_chip_usage")
+    .where("fantasy_team_id", "=", teamId)
+    .where("season", "=", season)
+    .select(["gameweek_id", "chip_type"])
+    .execute();
+
+  const tripleCaptainGameweeks = new Set(
+    chipRows
+      .filter((c) => c.chip_type === "triple_captain")
+      .map((c) => c.gameweek_id),
+  );
+
+  // Group aggregated scores: (playerId, gameweek) -> summed score components.
+  interface GwScore {
+    battingPoints: number;
+    bowlingPoints: number;
+    fieldingPoints: number;
+    teamPoints: number;
+    catches: number;
+    stumpings: number;
+    isActualKeeper: boolean;
+  }
+  const scoresByPlayerGw = new Map<string, GwScore>();
+  const key = (playerId: string, gw: number) => `${playerId}::${gw}`;
+  for (const s of scores) {
+    const k = key(s.play_cricket_id, s.gameweek_id);
+    const existing = scoresByPlayerGw.get(k) ?? {
+      battingPoints: 0,
+      bowlingPoints: 0,
+      fieldingPoints: 0,
+      teamPoints: 0,
+      catches: 0,
+      stumpings: 0,
+      isActualKeeper: false,
+    };
+    existing.battingPoints += s.batting_points;
+    existing.bowlingPoints += s.bowling_points;
+    existing.fieldingPoints += s.fielding_points;
+    existing.teamPoints += s.team_points;
+    existing.catches += s.catches;
+    existing.stumpings += s.stumpings;
+    if (s.is_actual_keeper) existing.isActualKeeper = true;
+    scoresByPlayerGw.set(k, existing);
+  }
+
+  const result = new Map<
+    string,
+    { seasonPoints: number; latestGameweekPoints: number }
+  >();
+
+  for (const m of memberships) {
+    for (const gw of gameweeks) {
+      // Player only counts if in squad that gameweek.
+      if (m.gameweek_added > gw) continue;
+      if (m.gameweek_removed !== null && m.gameweek_removed <= gw) continue;
+
+      const s = scoresByPlayerGw.get(key(m.play_cricket_id, gw));
+      if (!s) continue;
+
+      const captainMultiplier = tripleCaptainGameweeks.has(gw)
+        ? CHIPS.triple_captain.captainMultiplier
+        : 2;
+
+      const effective = calculateSlotEffectivePoints({
+        slotType: m.slot_type as SlotType,
+        isFantasyWk: m.is_wicketkeeper,
+        battingPts: s.battingPoints,
+        bowlingPts: s.bowlingPoints,
+        fieldingPts: s.fieldingPoints,
+        teamPts: s.teamPoints,
+        catches: s.catches,
+        stumpings: s.stumpings,
+        isActualKeeper: s.isActualKeeper,
+        isCaptain: m.is_captain,
+        captainMultiplier,
+      });
+
+      const existing = result.get(m.play_cricket_id) ?? {
+        seasonPoints: 0,
+        latestGameweekPoints: 0,
+      };
+      existing.seasonPoints += effective;
+      if (gw === latestGameweek) {
+        existing.latestGameweekPoints += effective;
+      }
+      result.set(m.play_cricket_id, existing);
+    }
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -2145,32 +2337,6 @@ export function getGameweekDetail(db: Kysely<DB>) {
         };
       }),
     };
-  };
-}
-
-export function getSeasonTimeline(db: Kysely<DB>) {
-  return async (teamId: number, season?: string) => {
-    const s = season ?? getCurrentSeason();
-
-    const scores = await db
-      .selectFrom("fantasy_team_score")
-      .where("fantasy_team_id", "=", teamId)
-      .where("season", "=", s)
-      .select(["gameweek_id", "total_points"])
-      .orderBy("gameweek_id", "asc")
-      .execute();
-
-    let cumulative = 0;
-    const timeline = scores.map((sc) => {
-      cumulative += sc.total_points;
-      return {
-        gameweek: sc.gameweek_id,
-        weeklyPoints: sc.total_points,
-        cumulativePoints: cumulative,
-      };
-    });
-
-    return { timeline, season: s, teamId };
   };
 }
 

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -1063,6 +1063,7 @@ export interface paths {
                             }[];
                             teamCount: number;
                             gameweek: number;
+                            isFromPreviousSeason: boolean;
                         };
                     };
                 };
@@ -1430,6 +1431,10 @@ export interface paths {
                                 season: string;
                                 ownerName: string;
                                 ownerId: string;
+                                seasonPoints: number;
+                                latestGameweek: number | null;
+                                latestGameweekPoints: number;
+                                gameweeksPlayed: number;
                             };
                             players: {
                                 playCricketId: string;
@@ -1440,54 +1445,9 @@ export interface paths {
                                 slotType: "batting" | "bowling" | "allrounder";
                                 isWicketkeeper: boolean;
                                 ownershipPct: number;
+                                seasonPoints: number;
+                                latestGameweekPoints: number;
                             }[];
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/fantasy/teams/{teamId}/timeline": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: {
-                    season?: string;
-                };
-                header?: never;
-                path: {
-                    teamId: number;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            timeline: {
-                                gameweek: number;
-                                weeklyPoints: number;
-                                cumulativePoints: number;
-                            }[];
-                            season: string;
-                            teamId: number;
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -1746,6 +1746,9 @@
                     },
                     "gameweek": {
                       "type": "number"
+                    },
+                    "isFromPreviousSeason": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -1753,7 +1756,8 @@
                     "mostCaptained",
                     "differentials",
                     "teamCount",
-                    "gameweek"
+                    "gameweek",
+                    "isFromPreviousSeason"
                   ],
                   "additionalProperties": false
                 }
@@ -2421,13 +2425,30 @@
                         },
                         "ownerId": {
                           "type": "string"
+                        },
+                        "seasonPoints": {
+                          "type": "number"
+                        },
+                        "latestGameweek": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "latestGameweekPoints": {
+                          "type": "number"
+                        },
+                        "gameweeksPlayed": {
+                          "type": "number"
                         }
                       },
                       "required": [
                         "id",
                         "season",
                         "ownerName",
-                        "ownerId"
+                        "ownerId",
+                        "seasonPoints",
+                        "latestGameweek",
+                        "latestGameweekPoints",
+                        "gameweeksPlayed"
                       ],
                       "additionalProperties": false
                     },
@@ -2461,6 +2482,12 @@
                           },
                           "ownershipPct": {
                             "type": "number"
+                          },
+                          "seasonPoints": {
+                            "type": "number"
+                          },
+                          "latestGameweekPoints": {
+                            "type": "number"
                           }
                         },
                         "required": [
@@ -2470,7 +2497,9 @@
                           "isCaptain",
                           "slotType",
                           "isWicketkeeper",
-                          "ownershipPct"
+                          "ownershipPct",
+                          "seasonPoints",
+                          "latestGameweekPoints"
                         ],
                         "additionalProperties": false
                       }
@@ -2479,77 +2508,6 @@
                   "required": [
                     "team",
                     "players"
-                  ],
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/fantasy/teams/{teamId}/timeline": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "season",
-            "required": false
-          },
-          {
-            "schema": {
-              "type": "number"
-            },
-            "in": "path",
-            "name": "teamId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "timeline": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "gameweek": {
-                            "type": "number"
-                          },
-                          "weeklyPoints": {
-                            "type": "number"
-                          },
-                          "cumulativePoints": {
-                            "type": "number"
-                          }
-                        },
-                        "required": [
-                          "gameweek",
-                          "weeklyPoints",
-                          "cumulativePoints"
-                        ],
-                        "additionalProperties": false
-                      }
-                    },
-                    "season": {
-                      "type": "string"
-                    },
-                    "teamId": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "timeline",
-                    "season",
-                    "teamId"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/pages/admin/fantasy-tab.tsx
+++ b/apps/web/src/pages/admin/fantasy-tab.tsx
@@ -445,7 +445,7 @@ function ChaosWeeksSection() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>GW</TableHead>
+                  <TableHead>Gameweek</TableHead>
                   <TableHead>Name</TableHead>
                   <TableHead>Rule</TableHead>
                   <TableHead>Email</TableHead>

--- a/apps/web/src/pages/fantasy/fantasy.tsx
+++ b/apps/web/src/pages/fantasy/fantasy.tsx
@@ -12,19 +12,8 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
-import { useSession } from "@/lib/auth-client";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
 import { Link, useSearchParams } from "react-router";
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
 import { ScoringRulesContent } from "./fantasy-rules.js";
 
 // ---------------------------------------------------------------------------
@@ -124,22 +113,6 @@ function useTeamDetail(teamId: number | null) {
   });
 }
 
-function useTimeline(teamId: number | null) {
-  return useQuery({
-    queryKey: ["fantasy", "timeline", teamId],
-    queryFn: () => {
-      if (teamId === null) throw new Error("teamId is required");
-      return callApi(
-        api.GET("/api/fantasy/teams/{teamId}/timeline", {
-          params: { path: { teamId } },
-        }),
-      );
-    },
-    enabled: teamId !== null,
-    staleTime: 5 * 60_000,
-  });
-}
-
 // ---------------------------------------------------------------------------
 // Skeleton
 // ---------------------------------------------------------------------------
@@ -152,7 +125,7 @@ function Skeleton({ className = "" }: { className?: string }) {
 // Home Tab
 // ---------------------------------------------------------------------------
 
-function HomeTab() {
+function HomeTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
   const tw = useTransferWindow();
   const stats = usePreSeasonStats();
   const highlights = useHighlights();
@@ -246,7 +219,7 @@ function HomeTab() {
         <Card>
           <CardContent className="flex flex-col items-center gap-1 py-6">
             <span className="text-lg font-semibold text-green-600">
-              Transfer window open — GW{tw.data?.gameweek}
+              Transfer window open — Gameweek {tw.data?.gameweek}
             </span>
             <span className="text-muted-foreground text-sm">
               Locks in {tw.data?.daysUntilLock} day
@@ -406,7 +379,14 @@ function HomeTab() {
         {ownership.data && ownership.data.differentials.length > 0 && (
           <Card>
             <CardHeader>
-              <CardTitle>Differential Picks</CardTitle>
+              <CardTitle>
+                Differential Picks
+                {ownership.data.isFromPreviousSeason && (
+                  <Badge variant="secondary" className="ml-2">
+                    Previous Season
+                  </Badge>
+                )}
+              </CardTitle>
             </CardHeader>
             <CardContent>
               <Table>
@@ -498,14 +478,20 @@ function HomeTab() {
                   <TableHead>#</TableHead>
                   <TableHead>Team</TableHead>
                   <TableHead className="text-right">Points</TableHead>
-                  <TableHead className="text-right">GWs</TableHead>
+                  <TableHead className="text-right">Gameweeks</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {seasonBoard.data.entries.slice(0, 5).map((e) => (
-                  <TableRow key={e.teamId}>
+                  <TableRow
+                    key={e.teamId}
+                    className="cursor-pointer"
+                    onClick={() => onViewTeam(e.teamId)}
+                  >
                     <TableCell>{e.rank}</TableCell>
-                    <TableCell>{e.ownerName}</TableCell>
+                    <TableCell className="text-primary font-medium">
+                      {e.ownerName}
+                    </TableCell>
                     <TableCell className="text-right">
                       {e.totalPoints}
                     </TableCell>
@@ -545,10 +531,25 @@ function HighlightCard({
 // Leaderboards Tab
 // ---------------------------------------------------------------------------
 
-function LeaderboardsTab() {
+function LeaderboardsTab({
+  onViewTeam,
+}: {
+  onViewTeam: (teamId: number) => void;
+}) {
   const [params, setParams] = useSearchParams();
   const subTab = params.get("lb") ?? "season";
-  const [selectedGw, setSelectedGw] = useState<number | undefined>(undefined);
+
+  const gwParam = params.get("gw");
+  const selectedGw =
+    gwParam !== null && gwParam !== "" && !Number.isNaN(Number(gwParam))
+      ? Number(gwParam)
+      : undefined;
+
+  function setSelectedGw(gw: number) {
+    const next = new URLSearchParams(params);
+    next.set("gw", String(gw));
+    setParams(next, { replace: true });
+  }
 
   return (
     <div className="space-y-4">
@@ -561,6 +562,7 @@ function LeaderboardsTab() {
             onClick={() => {
               const next = new URLSearchParams(params);
               next.set("lb", t);
+              if (t !== "weekly") next.delete("gw");
               setParams(next, { replace: true });
             }}
           >
@@ -569,16 +571,24 @@ function LeaderboardsTab() {
         ))}
       </div>
 
-      {subTab === "season" && <SeasonLeaderboard />}
+      {subTab === "season" && <SeasonLeaderboard onViewTeam={onViewTeam} />}
       {subTab === "weekly" && (
-        <WeeklyLeaderboard selectedGw={selectedGw} onSelectGw={setSelectedGw} />
+        <WeeklyLeaderboard
+          selectedGw={selectedGw}
+          onSelectGw={setSelectedGw}
+          onViewTeam={onViewTeam}
+        />
       )}
       {subTab === "players" && <PlayerLeaderboard />}
     </div>
   );
 }
 
-function SeasonLeaderboard() {
+function SeasonLeaderboard({
+  onViewTeam,
+}: {
+  onViewTeam: (teamId: number) => void;
+}) {
   const { data, isPending, error } = useSeasonLeaderboard();
 
   if (isPending) return <LoadingTable rows={10} cols={4} />;
@@ -596,14 +606,20 @@ function SeasonLeaderboard() {
           <TableHead>#</TableHead>
           <TableHead>Team</TableHead>
           <TableHead className="text-right">Points</TableHead>
-          <TableHead className="text-right">GWs</TableHead>
+          <TableHead className="text-right">Gameweeks</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {data.entries.map((e) => (
-          <TableRow key={e.teamId}>
+          <TableRow
+            key={e.teamId}
+            className="cursor-pointer"
+            onClick={() => onViewTeam(e.teamId)}
+          >
             <TableCell>{e.rank}</TableCell>
-            <TableCell>{e.ownerName}</TableCell>
+            <TableCell className="text-primary font-medium">
+              {e.ownerName}
+            </TableCell>
             <TableCell className="text-right">{e.totalPoints}</TableCell>
             <TableCell className="text-right">{e.gameweeksPlayed}</TableCell>
           </TableRow>
@@ -616,9 +632,11 @@ function SeasonLeaderboard() {
 function WeeklyLeaderboard({
   selectedGw,
   onSelectGw,
+  onViewTeam,
 }: {
   selectedGw: number | undefined;
   onSelectGw: (gw: number) => void;
+  onViewTeam: (teamId: number) => void;
 }) {
   const { data, isPending, error } = useWeeklyLeaderboard(selectedGw);
 
@@ -658,9 +676,15 @@ function WeeklyLeaderboard({
           </TableHeader>
           <TableBody>
             {data.entries.map((e) => (
-              <TableRow key={e.teamId}>
+              <TableRow
+                key={e.teamId}
+                className="cursor-pointer"
+                onClick={() => onViewTeam(e.teamId)}
+              >
                 <TableCell>{e.rank}</TableCell>
-                <TableCell>{e.ownerName}</TableCell>
+                <TableCell className="text-primary font-medium">
+                  {e.ownerName}
+                </TableCell>
                 <TableCell className="text-right">{e.weeklyPoints}</TableCell>
               </TableRow>
             ))}
@@ -695,7 +719,7 @@ function PlayerLeaderboard() {
             <TableHead className="text-right">Bowl</TableHead>
             <TableHead className="text-right">Field</TableHead>
             <TableHead className="text-right">Total</TableHead>
-            <TableHead className="text-right">MP</TableHead>
+            <TableHead className="text-right">Matches</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -722,13 +746,8 @@ function PlayerLeaderboard() {
 // All Teams Tab
 // ---------------------------------------------------------------------------
 
-function AllTeamsTab() {
+function AllTeamsTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
   const { data, isPending, error } = useTeams();
-  const [viewTeamId, setViewTeamId] = useState<number | null>(null);
-
-  if (viewTeamId !== null) {
-    return <TeamView teamId={viewTeamId} onBack={() => setViewTeamId(null)} />;
-  }
 
   if (isPending) return <LoadingTable rows={8} cols={2} />;
   if (error)
@@ -753,7 +772,7 @@ function AllTeamsTab() {
           <TableRow
             key={t.id}
             className="cursor-pointer"
-            onClick={() => setViewTeamId(t.id)}
+            onClick={() => onViewTeam(t.id)}
           >
             <TableCell className="text-primary font-medium">
               {t.ownerName}
@@ -768,6 +787,10 @@ function AllTeamsTab() {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Team detail view
+// ---------------------------------------------------------------------------
+
 function TeamView({ teamId, onBack }: { teamId: number; onBack: () => void }) {
   const { data, isPending, error } = useTeamDetail(teamId);
 
@@ -781,12 +804,46 @@ function TeamView({ teamId, onBack }: { teamId: number; onBack: () => void }) {
     (a, b) => (slotOrder[a.slotType] ?? 3) - (slotOrder[b.slotType] ?? 3),
   );
 
+  const { latestGameweek } = data.team;
+
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       <Button variant="outline" size="sm" onClick={onBack}>
-        &larr; All Teams
+        &larr; Back
       </Button>
       <h3 className="text-lg font-semibold">{data.team.ownerName}</h3>
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+        <Card>
+          <CardContent className="flex flex-col items-center py-6">
+            <span className="text-3xl font-bold">{data.team.seasonPoints}</span>
+            <span className="text-muted-foreground text-sm">Season points</span>
+          </CardContent>
+        </Card>
+        {latestGameweek !== null && (
+          <Card>
+            <CardContent className="flex flex-col items-center py-6">
+              <span className="text-3xl font-bold">
+                {data.team.latestGameweekPoints}
+              </span>
+              <span className="text-muted-foreground text-sm">
+                Gameweek {latestGameweek} points
+              </span>
+            </CardContent>
+          </Card>
+        )}
+        <Card>
+          <CardContent className="flex flex-col items-center py-6">
+            <span className="text-3xl font-bold">
+              {data.team.gameweeksPlayed}
+            </span>
+            <span className="text-muted-foreground text-sm">
+              Gameweeks played
+            </span>
+          </CardContent>
+        </Card>
+      </div>
+
       <Table>
         <TableHeader>
           <TableRow>
@@ -794,6 +851,10 @@ function TeamView({ teamId, onBack }: { teamId: number; onBack: () => void }) {
             <TableHead>Slot</TableHead>
             <TableHead className="text-center">Cost</TableHead>
             <TableHead className="text-right">Owned</TableHead>
+            <TableHead className="text-right">Season</TableHead>
+            {latestGameweek !== null && (
+              <TableHead className="text-right">GW{latestGameweek}</TableHead>
+            )}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -819,130 +880,19 @@ function TeamView({ teamId, onBack }: { teamId: number; onBack: () => void }) {
                 </span>
               </TableCell>
               <TableCell className="text-right">{p.ownershipPct}%</TableCell>
+              <TableCell className="text-right font-medium">
+                {p.seasonPoints}
+              </TableCell>
+              {latestGameweek !== null && (
+                <TableCell className="text-right">
+                  {p.latestGameweekPoints}
+                </TableCell>
+              )}
             </TableRow>
           ))}
         </TableBody>
       </Table>
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// History Tab (requires auth)
-// ---------------------------------------------------------------------------
-
-function HistoryTab() {
-  const { data: session } = useSession();
-  const seasonBoard = useSeasonLeaderboard();
-
-  if (!session) {
-    return (
-      <Card>
-        <CardContent className="py-6 text-center">
-          <p>
-            <Link to="/auth/login" className="text-primary underline">
-              Sign in
-            </Link>{" "}
-            to view your team history.
-          </p>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  // Find user's team from season leaderboard
-  const myTeam = seasonBoard.data?.entries.find(
-    (e) => e.ownerName === session.user.name,
-  );
-
-  if (seasonBoard.isPending) return <LoadingTable rows={5} cols={3} />;
-
-  if (!myTeam) {
-    return (
-      <Card>
-        <CardContent className="text-muted-foreground py-6 text-center">
-          No scoring history yet. Your history will appear after your first
-          scored gameweek.
-        </CardContent>
-      </Card>
-    );
-  }
-
-  return <TimelineView teamId={myTeam.teamId} ownerName={myTeam.ownerName} />;
-}
-
-function TimelineView({
-  teamId,
-  ownerName,
-}: {
-  teamId: number;
-  ownerName: string;
-}) {
-  const { data, isPending } = useTimeline(teamId);
-
-  if (isPending) return <LoadingTable rows={5} cols={3} />;
-  if (!data?.timeline.length) {
-    return (
-      <p className="text-muted-foreground text-center">
-        No gameweeks scored yet.
-      </p>
-    );
-  }
-
-  const chartData = data.timeline.map((t) => ({
-    name: `GW${t.gameweek}`,
-    weekly: t.weeklyPoints,
-    cumulative: t.cumulativePoints,
-  }));
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{ownerName}&apos;s Season Timeline</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="h-64 w-full">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart
-              data={chartData}
-              margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" tick={{ fontSize: 12 }} />
-              <YAxis tick={{ fontSize: 12 }} />
-              <Tooltip />
-              <Line
-                type="monotone"
-                dataKey="cumulative"
-                name="Cumulative"
-                stroke="#2563eb"
-                strokeWidth={2}
-                dot={{ r: 4 }}
-              />
-              <Line
-                type="monotone"
-                dataKey="weekly"
-                name="Weekly"
-                stroke="#9ca3af"
-                strokeWidth={1}
-                strokeDasharray="4 4"
-                dot={{ r: 3 }}
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-        <div className="mt-3 flex gap-6 text-sm">
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-0.5 w-4 bg-blue-600" /> Cumulative
-            points
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-0.5 w-4 border-t-2 border-dashed border-gray-400" />{" "}
-            Weekly points
-          </span>
-        </div>
-      </CardContent>
-    </Card>
   );
 }
 
@@ -975,14 +925,33 @@ export function Component() {
   );
   const [params, setParams] = useSearchParams();
   const tab = params.get("tab") ?? "home";
-  const { data: session } = useSession();
+
+  const teamParam = params.get("team");
+  const viewTeamId =
+    teamParam !== null && teamParam !== "" && !Number.isNaN(Number(teamParam))
+      ? Number(teamParam)
+      : null;
 
   function setTab(t: string) {
     const next = new URLSearchParams(params);
     next.set("tab", t);
-    // Clean up sub-params when switching tabs
+    // Clean up sub-params when switching tabs so stale state doesn't leak across.
     next.delete("lb");
+    next.delete("gw");
+    next.delete("team");
     setParams(next, { replace: true });
+  }
+
+  function onViewTeam(teamId: number) {
+    const next = new URLSearchParams(params);
+    next.set("team", String(teamId));
+    setParams(next);
+  }
+
+  function onBackFromTeam() {
+    const next = new URLSearchParams(params);
+    next.delete("team");
+    setParams(next);
   }
 
   return (
@@ -994,27 +963,27 @@ export function Component() {
           <TabsTrigger value="home">Home</TabsTrigger>
           <TabsTrigger value="teams">All Teams</TabsTrigger>
           <TabsTrigger value="leaderboards">Leaderboards</TabsTrigger>
-          {session && <TabsTrigger value="history">History</TabsTrigger>}
           <TabsTrigger value="rules">Rules</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="home">
-          <HomeTab />
-        </TabsContent>
-        <TabsContent value="teams">
-          <AllTeamsTab />
-        </TabsContent>
-        <TabsContent value="leaderboards">
-          <LeaderboardsTab />
-        </TabsContent>
-        {session && (
-          <TabsContent value="history">
-            <HistoryTab />
-          </TabsContent>
+        {viewTeamId !== null ? (
+          <TeamView teamId={viewTeamId} onBack={onBackFromTeam} />
+        ) : (
+          <>
+            <TabsContent value="home">
+              <HomeTab onViewTeam={onViewTeam} />
+            </TabsContent>
+            <TabsContent value="teams">
+              <AllTeamsTab onViewTeam={onViewTeam} />
+            </TabsContent>
+            <TabsContent value="leaderboards">
+              <LeaderboardsTab onViewTeam={onViewTeam} />
+            </TabsContent>
+            <TabsContent value="rules">
+              <ScoringRulesContent />
+            </TabsContent>
+          </>
         )}
-        <TabsContent value="rules">
-          <ScoringRulesContent />
-        </TabsContent>
       </Tabs>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Clickable leaderboard rows** — season + weekly leaderboards (and the home-page top 5) now link through to a team's detail view via `?team=<id>` in the URL, so Back goes back to the tab you came from and team pages are shareable. Weekly leaderboard's gameweek selection also moved into the URL (`?gw=`).
- **Team detail view** — three stats cards at the top (season points, latest gameweek points, gameweeks played) and two new player-table columns for season and latest-gameweek **effective** points (captain multiplier + slot/WK rules + triple-captain chip applied). One query pass over the team's membership history, scores, and chip usage avoids per-gameweek round trips.
- **Differential Picks bug fix** — was falling through to the previous season whenever `currentGameweek - 1 === 0`. Now sums `fantasy_player_score` for the current season (no gameweek filter), matching Sandwich Efficiency's behaviour. Falls back to the previous season only when the current season has no scores yet, with a `Previous Season` badge on the card when it does.
- **History tab removed** — the per-user timeline chart overlapped with `/members/fantasy`. Tab, `TimelineView`, `useTimeline`, the `recharts` import, the backend `GET /fantasy/teams/:id/timeline` route, `getSeasonTimeline`, and `seasonTimelineResponseSchema` are all gone.
- **Abbreviations** — `GW` / `GWs` / `MP` spelled out in table headers and body text (fantasy page + admin chaos-weeks table). `GW1`/`GW2` pills on the weekly leaderboard kept as-is (space is tight there).

## Test plan

- [x] `pnpm run typecheck && pnpm run lint && pnpm format:check && pnpm --filter api test` (all green)
- [x] `pnpm run build` (all workspaces build)
- [ ] Manual: visit `/fantasy`, click a leaderboard row, confirm URL updates and Back returns to the tab
- [ ] Manual: team detail shows season/weekly/gameweeks cards and per-player columns populated
- [ ] Manual: Differentials card shows 2026 GW1 numbers (not last season's totals); badge appears only when falling back

🤖 Generated with [Claude Code](https://claude.com/claude-code)