### PR TITLE
Re-fetch already-processed matches inside a 7-day window

### DIFF
--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -553,8 +553,10 @@ describe("play-cricket sync (integration)", () => {
     expect(latest.season).toBe(new Date().getFullYear());
   });
 
-  it("skips matches that are already processed", async () => {
+  it("skips already-processed matches outside the resync window", async () => {
     const matchId = 55500 + Math.floor(Math.random() * 1000);
+    // Dated well in the past so it falls outside the 7-day resync window.
+    const oldDate = "01/07/2024";
 
     await ctx.db
       .insertInto("match_result")
@@ -565,15 +567,15 @@ describe("play-cricket sync (integration)", () => {
         away_team_id: OPPONENT_TEAM_ID,
         home_team_name: "Percy Main 1st XI",
         away_team_name: "Opposition 1st XI",
-        match_date: "01/07/2026",
-        season: 2026,
+        match_date: oldDate,
+        season: 2024,
       })
       .execute();
 
     const api = createMockApi({
       getMatchesSummary: vi
         .fn()
-        .mockResolvedValue({ matches: [makeMatchSummary(matchId)] }),
+        .mockResolvedValue({ matches: [makeMatchSummary(matchId, oldDate)] }),
     });
 
     const sync = runSync(ctx.db, api);

--- a/apps/api/src/features/play-cricket/sync.test.ts
+++ b/apps/api/src/features/play-cricket/sync.test.ts
@@ -189,8 +189,8 @@ describe("runSync", () => {
     /* eslint-enable @typescript-eslint/unbound-method */
   });
 
-  it("skips already-processed matches", async () => {
-    // Return a match from the API
+  it("skips already-processed matches outside the resync window", async () => {
+    // Match dated well in the past so it's outside the resync window
     mockApi = createMockApi({
       getMatchesSummary: vi.fn().mockResolvedValue({
         matches: [
@@ -198,9 +198,9 @@ describe("runSync", () => {
             id: 12345,
             status: "Completed",
             published: "Yes",
-            last_updated: "2026-07-01",
-            season: "2026",
-            match_date: "01/07/2026",
+            last_updated: "2024-07-01",
+            season: "2024",
+            match_date: "01/07/2024",
             home_club_name: "Percy Main",
             home_team_name: "1st XI",
             home_team_id: "68498",
@@ -222,6 +222,66 @@ describe("runSync", () => {
     expect(result.matchesProcessed).toBe(0);
     // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock
     expect(mockApi.getMatchDetail).not.toHaveBeenCalled();
+  });
+
+  it("re-fetches already-processed matches inside the resync window", async () => {
+    // Match dated yesterday — well inside the 7-day resync window.
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const dd = String(yesterday.getDate()).padStart(2, "0");
+    const mm = String(yesterday.getMonth() + 1).padStart(2, "0");
+    const yyyy = yesterday.getFullYear();
+    const matchDateStr = `${dd}/${mm}/${yyyy}`;
+
+    mockApi = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          {
+            id: 12345,
+            status: "Completed",
+            published: "Yes",
+            last_updated: `${yyyy}-${mm}-${dd}`,
+            season: String(yyyy),
+            match_date: matchDateStr,
+            home_club_name: "Percy Main",
+            home_team_name: "1st XI",
+            home_team_id: "68498",
+            home_club_id: "134",
+            away_club_name: "Opposition",
+            away_team_name: "1st XI",
+            away_team_id: "99999",
+            away_club_id: "999",
+          },
+        ],
+      }),
+      // Detail with no scorecard — bails before any DB writes, but still
+      // proves we did re-fetch despite the match already being processed.
+      getMatchDetail: vi.fn().mockResolvedValue({
+        match_details: [
+          {
+            home_team_id: "68498",
+            home_team_name: "1st XI",
+            home_club_id: "134",
+            away_team_id: "99999",
+            away_team_name: "1st XI",
+            away_club_id: "999",
+            innings: [],
+            players: [],
+            result: "",
+            result_description: "",
+            result_applied_to: "",
+          },
+        ],
+      }),
+    });
+    // Mark it as already processed
+    mockSelectExecute.mockResolvedValueOnce([{ match_id: "12345" }]);
+
+    const sync = runSync(mockDb, mockApi);
+    await sync({ siteId: "134" });
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock
+    expect(mockApi.getMatchDetail).toHaveBeenCalledWith("12345");
   });
 
   it("records team sync errors without failing", async () => {

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -71,6 +71,7 @@ export { didBat, isJuniorTeam, isNotOut, parseDismissalType };
 // --- Main sync logic ---
 
 const DEADLINE_MS = 10 * 60 * 1000; // 10 minutes
+const RESYNC_WINDOW_DAYS = 7;
 
 type MatchDetailType = z.output<
   typeof GetMatchDetailResponse
@@ -377,11 +378,37 @@ async function syncMatches(
   resultCutoff.setDate(resultCutoff.getDate() - 14);
   resultCutoff.setHours(0, 0, 0, 0);
 
+  // Recent matches are re-fetched even if they already have a match_result
+  // row, so that late scorecard fills (captain adding players hours or days
+  // after the first sync) and result corrections actually land.
+  const resyncCutoff = new Date();
+  resyncCutoff.setDate(resyncCutoff.getDate() - RESYNC_WINDOW_DAYS);
+  resyncCutoff.setHours(0, 0, 0, 0);
+
   for (const { match, season } of allMatches) {
     const matchId = match.id.toString();
 
     try {
-      if (processedMatchIds.has(matchId)) continue;
+      // Validate match_date format (DD/MM/YYYY) up front so we can use it for
+      // the resync-window decision below.
+      if (
+        !match.match_date ||
+        !/^\d{2}\/\d{2}\/\d{4}$/.test(match.match_date)
+      ) {
+        continue;
+      }
+
+      const [dd, mm, yyyy] = match.match_date.split("/");
+      const matchDate = new Date(
+        parseInt(yyyy),
+        parseInt(mm) - 1,
+        parseInt(dd),
+      );
+
+      // Skip already-processed matches only when they're past the resync
+      // window. Inside the window, re-fetch — all writes are idempotent
+      // upserts, so this just refreshes performance + result rows.
+      if (processedMatchIds.has(matchId) && matchDate < resyncCutoff) continue;
 
       // Stop after deadline
       if (Date.now() - startTime > DEADLINE_MS) {
@@ -395,14 +422,6 @@ async function syncMatches(
       // Must have at least one innings with batting data
       const hasScorecard = detail.innings.some((inn) => inn.bat.length > 0);
       if (!hasScorecard) continue;
-
-      // Validate match_date format (DD/MM/YYYY)
-      if (
-        !match.match_date ||
-        !/^\d{2}\/\d{2}\/\d{4}$/.test(match.match_date)
-      ) {
-        continue;
-      }
 
       // Upsert teams from match detail
       await upsertTeamFromMatch(
@@ -487,12 +506,6 @@ async function syncMatches(
 
       // Store match result with cutoff logic
       const matchResult = (detail.result ?? "").trim();
-      const [dd, mm, yyyy] = match.match_date.split("/");
-      const matchDate = new Date(
-        parseInt(yyyy),
-        parseInt(mm) - 1,
-        parseInt(dd),
-      );
       const isRecent = matchDate > resultCutoff;
       const shouldWriteResult = matchResult || !isRecent;
 


### PR DESCRIPTION
## Summary

Once a match had any `match_result` row, the sync skipped it permanently. The most recent manual run logged `Sync complete: 0 matches processed` even though Play Cricket had partial scorecards waiting to be filled out — every match found in the API was already in `processedMatchIds` and got `continue`d at `sync.ts:383`.

This is the bug that's been masking partial data: captains routinely fill scorecards in stages. The first sync after Saturday play landed a partial scorecard *plus* a result row, and every subsequent run skipped the match even after more players appeared in Play Cricket.

> **Note**: This branches off `fantasy-week-1-improvements` (currently local-only). Includes the one commit `72bf860 Fantasy week 1 improvements` from that branch — re-target to that branch once it lands, or merge in this order.

## Change

- New `RESYNC_WINDOW_DAYS = 7` constant.
- Match-date parse moves up before the skip check (was duplicated lower down — second copy removed).
- Skip becomes `processedMatchIds.has(matchId) && matchDate < resyncCutoff`. Inside the window, re-fetch.

All performance + result writes are already idempotent upserts, so re-processing just refreshes rows. Fantasy recompute is unconditional (PR #121), so corrected scores propagate without extra wiring.

## Test plan

- [x] Unit tests updated:
  - Existing "skips already-processed matches" → renamed and dated `01/07/2024` (outside window).
  - New test: "re-fetches already-processed matches inside the resync window" verifies `getMatchDetail` *is* called for a yesterday-dated match.
- [x] `pnpm --filter api typecheck && lint && format:check` clean
- [ ] Confirm next manual sync trigger pulls fresh data for last weekend's matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)