### PR TITLE
Preserve captain/slot/WK history across gameweeks

### DIFF
--- a/apps/api/src/features/fantasy/integration.test.ts
+++ b/apps/api/src/features/fantasy/integration.test.ts
@@ -470,6 +470,94 @@ describe("fantasy service (integration)", () => {
         /transfers per gameweek/,
       );
     });
+
+    it("transfer + config change on a retained player in the same save both version correctly", async () => {
+      vi.setSystemTime(GW1_WED);
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `mixed-edit-${crypto.randomUUID()}@test.com`,
+      });
+      const season = getCurrentSeason();
+      const playerIds = await seedElevenPlayers();
+      const replacement = await seedFantasyPlayer({
+        eligible: true,
+        sandwichCost: 1,
+      });
+      const { teamId } = await saveTeam(ctx.db)(
+        userId,
+        buildSquad(playerIds),
+        season,
+      );
+
+      vi.setSystemTime(GW2_WED);
+      // In one save: swap player 10 (allrounder) for replacement, AND move
+      // captain from 0 to 1 on retained players.
+      const mixed = buildSquad([...playerIds.slice(0, 10), replacement]).map(
+        (p, i) => ({
+          ...p,
+          isCaptain: i === 1,
+        }),
+      );
+      await saveTeam(ctx.db)(userId, mixed, season);
+
+      // Retained captain-swap players are versioned
+      const p0Rows = await ctx.db
+        .selectFrom("fantasy_team_player")
+        .where("fantasy_team_id", "=", teamId)
+        .where("play_cricket_id", "=", playerIds[0])
+        .orderBy("gameweek_added", "asc")
+        .selectAll()
+        .execute();
+      expect(p0Rows).toHaveLength(2);
+      expect(p0Rows[0]?.is_captain).toBe(true);
+      expect(p0Rows[0]?.gameweek_removed).toBe(2);
+      expect(p0Rows[1]?.is_captain).toBe(false);
+
+      // Transferred-out player: single row, closed this GW
+      const p10Rows = await ctx.db
+        .selectFrom("fantasy_team_player")
+        .where("fantasy_team_id", "=", teamId)
+        .where("play_cricket_id", "=", playerIds[10])
+        .selectAll()
+        .execute();
+      expect(p10Rows).toHaveLength(1);
+      expect(p10Rows[0]?.gameweek_removed).toBe(2);
+
+      // New player: single row, added this GW
+      const newRows = await ctx.db
+        .selectFrom("fantasy_team_player")
+        .where("fantasy_team_id", "=", teamId)
+        .where("play_cricket_id", "=", replacement)
+        .selectAll()
+        .execute();
+      expect(newRows).toHaveLength(1);
+      expect(newRows[0]?.gameweek_added).toBe(2);
+      expect(newRows[0]?.gameweek_removed).toBeNull();
+
+      // Transfer count = 1 (only the real swap, not the captain move)
+      const view = await getMyTeam(ctx.db)(userId, season);
+      expect(view.transfersUsed).toBe(1);
+
+      // GW1 reconstruction: 11 original players with original captain
+      const gw1View = await ctx.db
+        .selectFrom("fantasy_team_player")
+        .where("fantasy_team_id", "=", teamId)
+        .where("gameweek_added", "<=", 1)
+        .where((eb) =>
+          eb.or([
+            eb("gameweek_removed", "is", null),
+            eb("gameweek_removed", ">", 1),
+          ]),
+        )
+        .selectAll()
+        .execute();
+      expect(gw1View).toHaveLength(11);
+      expect(gw1View.find((r) => r.is_captain)?.play_cricket_id).toBe(
+        playerIds[0],
+      );
+      expect(gw1View.map((r) => r.play_cricket_id).sort()).toEqual(
+        [...playerIds].sort(),
+      );
+    });
   });
 
   describe("toggleEligibility", () => {

--- a/apps/api/src/features/fantasy/integration.test.ts
+++ b/apps/api/src/features/fantasy/integration.test.ts
@@ -203,6 +203,275 @@ describe("fantasy service (integration)", () => {
     });
   });
 
+  describe("versioned captain/slot/WK history", () => {
+    // GW1 Wed and GW2 Wed — weekdays inside successive gameweeks given
+    // the 2026 season GW1 start of 2026-04-18 (Saturday).
+    const GW1_WED = new Date("2026-04-22T12:00:00Z");
+    const GW2_WED = new Date("2026-04-29T12:00:00Z");
+
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function seedElevenPlayers() {
+      const ids: string[] = [];
+      for (let i = 0; i < 11; i++) {
+        ids.push(await seedFantasyPlayer({ eligible: true, sandwichCost: 1 }));
+      }
+      return ids;
+    }
+
+    it("captain change in GW2 preserves GW1 captain on the closed row", async () => {
+      vi.setSystemTime(GW1_WED);
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cap-hist-${crypto.randomUUID()}@test.com`,
+      });
+      const season = getCurrentSeason();
+      const playerIds = await seedElevenPlayers();
+
+      const { teamId } = await saveTeam(ctx.db)(
+        userId,
+        buildSquad(playerIds),
+        season,
+      );
+
+      vi.setSystemTime(GW2_WED);
+      const capMoved = buildSquad(playerIds).map((p, i) => ({
+        ...p,
+        isCaptain: i === 1,
+      }));
+      await saveTeam(ctx.db)(userId, capMoved, season);
+
+      const rows = await ctx.db
+        .selectFrom("fantasy_team_player")
+        .where("fantasy_team_id", "=", teamId)
+        .where("play_cricket_id", "in", [playerIds[0], playerIds[1]])
+        .orderBy("gameweek_added", "asc")
+        .selectAll()
+        .execute();
+
+      const p0Gw1 = rows.find(
+        (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 1,
+      );
+      const p0Gw2 = rows.find(
+        (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 2,
+      );
+      const p1Gw1 = rows.find(
+        (r) => r.play_cricket_id === playerIds[1] && r.gameweek_added === 1,
+      );
+      const p1Gw2 = rows.find(
+        (r) => r.play_cricket_id === playerIds[1] && r.gameweek_added === 2,
+      );
+
+      expect(p0Gw1?.is_captain).toBe(true);
+      expect(p0Gw1?.gameweek_removed).toBe(2);
+      expect(p0Gw2?.is_captain).toBe(false);
+      expect(p0Gw2?.gameweek_removed).toBeNull();
+
+      expect(p1Gw1?.is_captain).toBe(false);
+      expect(p1Gw1?.gameweek_removed).toBe(2);
+      expect(p1Gw2?.is_captain).toBe(true);
+      expect(p1Gw2?.gameweek_removed).toBeNull();
+
+      // Reconstructed GW1 squad shows the original captain (11 players, 1 captain, p0)
+      const gw1View = await ctx.db
+        .selectFrom("fantasy_team_player")
+        .where("fantasy_team_id", "=", teamId)
+        .where("gameweek_added", "<=", 1)
+        .where((eb) =>
+          eb.or([
+            eb("gameweek_removed", "is", null),
+            eb("gameweek_removed", ">", 1),
+          ]),
+        )
+        .selectAll()
+        .execute();
+      expect(gw1View).toHaveLength(11);
+      const gw1Captain = gw1View.find((r) => r.is_captain);
+      expect(gw1Captain?.play_cricket_id).toBe(playerIds[0]);
+    });
+
+    it("slot_type change in GW2 preserves GW1 slot on the closed row", async () => {
+      vi.setSystemTime(GW1_WED);
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `slot-hist-${crypto.randomUUID()}@test.com`,
+      });
+      const season = getCurrentSeason();
+      const playerIds = await seedElevenPlayers();
+      await saveTeam(ctx.db)(userId, buildSquad(playerIds), season);
+
+      vi.setSystemTime(GW2_WED);
+      // Swap a batting slot (i=0) with a bowling slot (i=6) so the overall
+      // squad still satisfies SLOT_COUNTS. Move WK off i=0 too, since WK
+      // must be in a non-allrounder slot — i=0 is going to bowling, that's
+      // fine. But we also move captain off 0 because captain is allowed in
+      // either batting or bowling. Keeping captain on i=0 is valid.
+      const swapped = buildSquad(playerIds).map((p, i) => {
+        if (i === 0) return { ...p, slotType: "bowling" as const };
+        if (i === 6) return { ...p, slotType: "batting" as const };
+        return p;
+      });
+      await saveTeam(ctx.db)(userId, swapped, season);
+
+      const rows = await ctx.db
+        .selectFrom("fantasy_team_player")
+        .where("play_cricket_id", "in", [playerIds[0], playerIds[6]])
+        .selectAll()
+        .execute();
+
+      const p0Gw1 = rows.find(
+        (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 1,
+      );
+      const p0Gw2 = rows.find(
+        (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 2,
+      );
+      const p6Gw1 = rows.find(
+        (r) => r.play_cricket_id === playerIds[6] && r.gameweek_added === 1,
+      );
+      const p6Gw2 = rows.find(
+        (r) => r.play_cricket_id === playerIds[6] && r.gameweek_added === 2,
+      );
+
+      expect(p0Gw1?.slot_type).toBe("batting");
+      expect(p0Gw1?.gameweek_removed).toBe(2);
+      expect(p0Gw2?.slot_type).toBe("bowling");
+      expect(p6Gw1?.slot_type).toBe("bowling");
+      expect(p6Gw1?.gameweek_removed).toBe(2);
+      expect(p6Gw2?.slot_type).toBe("batting");
+    });
+
+    it("wicketkeeper change in GW2 preserves GW1 WK on the closed row", async () => {
+      vi.setSystemTime(GW1_WED);
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `wk-hist-${crypto.randomUUID()}@test.com`,
+      });
+      const season = getCurrentSeason();
+      const playerIds = await seedElevenPlayers();
+      await saveTeam(ctx.db)(userId, buildSquad(playerIds), season);
+
+      vi.setSystemTime(GW2_WED);
+      // Move WK from i=0 (batting) to i=1 (batting).
+      const wkMoved = buildSquad(playerIds).map((p, i) => ({
+        ...p,
+        isWicketkeeper: i === 1,
+      }));
+      await saveTeam(ctx.db)(userId, wkMoved, season);
+
+      const p0Rows = await ctx.db
+        .selectFrom("fantasy_team_player")
+        .where("play_cricket_id", "=", playerIds[0])
+        .orderBy("gameweek_added", "asc")
+        .selectAll()
+        .execute();
+
+      expect(p0Rows).toHaveLength(2);
+      expect(p0Rows[0]?.gameweek_added).toBe(1);
+      expect(p0Rows[0]?.is_wicketkeeper).toBe(true);
+      expect(p0Rows[0]?.gameweek_removed).toBe(2);
+      expect(p0Rows[1]?.gameweek_added).toBe(2);
+      expect(p0Rows[1]?.is_wicketkeeper).toBe(false);
+      expect(p0Rows[1]?.gameweek_removed).toBeNull();
+    });
+
+    it("multiple captain changes inside the same gameweek mutate in place (no row explosion)", async () => {
+      vi.setSystemTime(GW1_WED);
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `same-gw-churn-${crypto.randomUUID()}@test.com`,
+      });
+      const season = getCurrentSeason();
+      const playerIds = await seedElevenPlayers();
+      const { teamId } = await saveTeam(ctx.db)(
+        userId,
+        buildSquad(playerIds),
+        season,
+      );
+
+      // Flip captain around within GW1 (row is still-open for this gameweek)
+      for (const capIdx of [1, 2, 3, 4, 0]) {
+        const s = buildSquad(playerIds).map((p, i) => ({
+          ...p,
+          isCaptain: i === capIdx,
+        }));
+        await saveTeam(ctx.db)(userId, s, season);
+      }
+
+      const rows = await ctx.db
+        .selectFrom("fantasy_team_player")
+        .where("fantasy_team_id", "=", teamId)
+        .selectAll()
+        .execute();
+      expect(rows).toHaveLength(11);
+    });
+
+    it("config-only changes across gameweeks don't count as transfers", async () => {
+      vi.setSystemTime(GW1_WED);
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `no-transfer-count-${crypto.randomUUID()}@test.com`,
+      });
+      const season = getCurrentSeason();
+      const playerIds = await seedElevenPlayers();
+      await saveTeam(ctx.db)(userId, buildSquad(playerIds), season);
+
+      vi.setSystemTime(GW2_WED);
+      // Captain move — no roster change
+      const capMoved = buildSquad(playerIds).map((p, i) => ({
+        ...p,
+        isCaptain: i === 1,
+      }));
+      await saveTeam(ctx.db)(userId, capMoved, season);
+
+      const team = await getMyTeam(ctx.db)(userId, season);
+      expect(team.transfersUsed).toBe(0);
+      expect(team.maxTransfers).toBe(3);
+    });
+
+    it("real transfers in GW2 count against the 3-per-gameweek limit", async () => {
+      vi.setSystemTime(GW1_WED);
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `real-transfers-${crypto.randomUUID()}@test.com`,
+      });
+      const season = getCurrentSeason();
+      const playerIds = await seedElevenPlayers();
+      const replacementIds: string[] = [];
+      for (let i = 0; i < 4; i++) {
+        replacementIds.push(
+          await seedFantasyPlayer({ eligible: true, sandwichCost: 1 }),
+        );
+      }
+      await saveTeam(ctx.db)(userId, buildSquad(playerIds), season);
+
+      vi.setSystemTime(GW2_WED);
+      // Swap out three players — within limit
+      const threeOut = buildSquad([
+        replacementIds[0],
+        replacementIds[1],
+        replacementIds[2],
+        ...playerIds.slice(3),
+      ]);
+      await expect(
+        saveTeam(ctx.db)(userId, threeOut, season),
+      ).resolves.toBeDefined();
+
+      const afterThree = await getMyTeam(ctx.db)(userId, season);
+      expect(afterThree.transfersUsed).toBe(3);
+
+      // Try to add a 4th — should reject
+      const fourOut = buildSquad([
+        replacementIds[0],
+        replacementIds[1],
+        replacementIds[2],
+        replacementIds[3],
+        ...playerIds.slice(4),
+      ]);
+      await expect(saveTeam(ctx.db)(userId, fourOut, season)).rejects.toThrow(
+        /transfers per gameweek/,
+      );
+    });
+  });
+
   describe("toggleEligibility", () => {
     it("flips the eligible flag", async () => {
       const id = await seedFantasyPlayer({ eligible: true });

--- a/apps/api/src/features/fantasy/service.ts
+++ b/apps/api/src/features/fantasy/service.ts
@@ -163,38 +163,33 @@ export function getMyTeam(db: Kysely<DB>) {
       ])
       .execute();
 
-    // Count transfers this gameweek (only still-active ones, not reverted)
-    const transfersThisWeek = await db
-      .selectFrom("fantasy_team_player")
-      .where("fantasy_team_id", "=", team.id)
-      .where("gameweek_added", "=", gameweek)
-      .where((eb) =>
-        eb.or([
-          eb("gameweek_removed", "is", null),
-          eb("gameweek_removed", ">", gameweek),
-        ]),
-      )
-      .select(sql<number>`count(*)`.as("count"))
-      .executeTakeFirst();
+    // Transfers used this gameweek = count of play_cricket_ids active at
+    // `gameweek` that weren't active at `gameweek - 1`. Independent of
+    // config-only row churn (captain/slot/WK) and of the order the user
+    // made their swaps.
+    const previousActive =
+      gameweek <= 1
+        ? []
+        : await db
+            .selectFrom("fantasy_team_player")
+            .where("fantasy_team_id", "=", team.id)
+            .where("gameweek_added", "<=", gameweek - 1)
+            .where((eb) =>
+              eb.or([
+                eb("gameweek_removed", "is", null),
+                eb("gameweek_removed", ">", gameweek - 1),
+              ]),
+            )
+            .select("play_cricket_id")
+            .execute();
 
-    // Check if this is the user's initial squad (no players from before this gameweek)
-    const initialPlayers = await db
-      .selectFrom("fantasy_team_player")
-      .where("fantasy_team_id", "=", team.id)
-      .where("gameweek_added", "<", gameweek)
-      .where((eb) =>
-        eb.or([
-          eb("gameweek_removed", "is", null),
-          eb("gameweek_removed", ">", gameweek),
-        ]),
-      )
-      .select(sql<number>`count(*)`.as("count"))
-      .executeTakeFirst();
-
-    const isInitialSquad = Number(initialPlayers?.count ?? 0) === 0;
+    const previousActiveIds = new Set(
+      previousActive.map((p) => p.play_cricket_id),
+    );
+    const isInitialSquad = previousActiveIds.size === 0;
     const transfersUsed = isInitialSquad
       ? 0
-      : Number(transfersThisWeek?.count ?? 0);
+      : players.filter((p) => !previousActiveIds.has(p.play_cricket_id)).length;
 
     // Transfers are unlimited in pre-season or if this is the user's first squad
     const unlimitedTransfers = isPreSeason(s) || isInitialSquad;
@@ -409,44 +404,38 @@ export function saveTeam(db: Kysely<DB>) {
         }
       }
 
-      // Check transfer limit in-season
-      if (
-        currentPlayers.length > 0 &&
-        playersToAdd.length > 0 &&
-        !isPreSeason(s)
-      ) {
-        const hasSquadFromBefore = currentPlayers.some(
-          (p) => p.gameweek_added < gameweek,
+      // Check transfer limit in-season. A transfer is any play_cricket_id
+      // active at `gameweek` that wasn't active at `gameweek - 1`. This is
+      // independent of how many config-only row churns (captain/slot/WK)
+      // have occurred this gameweek, and independent of the order in which
+      // the user made their swaps.
+      if (!isPreSeason(s) && gameweek > 1) {
+        const previousActive = await trx
+          .selectFrom("fantasy_team_player")
+          .where("fantasy_team_id", "=", teamId)
+          .where("gameweek_added", "<=", gameweek - 1)
+          .where((eb) =>
+            eb.or([
+              eb("gameweek_removed", "is", null),
+              eb("gameweek_removed", ">", gameweek - 1),
+            ]),
+          )
+          .select("play_cricket_id")
+          .execute();
+
+        const previousActiveIds = new Set(
+          previousActive.map((p) => p.play_cricket_id),
         );
 
-        if (hasSquadFromBefore) {
-          const addedThisWeekBeingRemoved = playersToRemove.filter(
-            (p) => p.gameweek_added === gameweek,
+        if (previousActiveIds.size > 0) {
+          const netTransfers = Array.from(newPlayerIds).filter(
+            (id) => !previousActiveIds.has(id),
           ).length;
-
-          const persistedTransfers = await trx
-            .selectFrom("fantasy_team_player")
-            .where("fantasy_team_id", "=", teamId)
-            .where("gameweek_added", "=", gameweek)
-            .where((eb) =>
-              eb.or([
-                eb("gameweek_removed", "is", null),
-                eb("gameweek_removed", ">", gameweek),
-              ]),
-            )
-            .select(sql<string>`COUNT(*)`.as("count"))
-            .executeTakeFirst();
-
-          const previousTransfers = Number(persistedTransfers?.count ?? 0);
-          // Subtract cancelled transfers (added this week but being removed now)
-          // before adding new ones — removals haven't been applied to DB yet
-          const netTransfers =
-            previousTransfers - addedThisWeekBeingRemoved + playersToAdd.length;
 
           if (netTransfers > MAX_TRANSFERS_PER_GAMEWEEK) {
             throw httpError(
               400,
-              `You can only make ${MAX_TRANSFERS_PER_GAMEWEEK} transfers per gameweek. You have used ${previousTransfers} already.`,
+              `You can only make ${MAX_TRANSFERS_PER_GAMEWEEK} transfers per gameweek.`,
             );
           }
         }
@@ -476,29 +465,55 @@ export function saveTeam(db: Kysely<DB>) {
           .execute();
       }
 
-      // Update captain, slot_type, and is_wicketkeeper for existing players
+      // Update captain, slot_type, and is_wicketkeeper for retained players.
+      //
+      // Key rule for historical reconstruction: when a row was added in a
+      // prior (now-locked) gameweek, we must NOT mutate its flags in place,
+      // or we destroy the snapshot used to rescore that past gameweek.
+      // Instead, close the existing row (gameweek_removed = current gw) and
+      // insert a new row (gameweek_added = current gw) carrying the new
+      // flags. Rows added in the current gameweek are still open — mutating
+      // them in place is safe and avoids row explosion for repeated edits
+      // within the same gameweek.
       for (const player of players) {
-        if (currentPlayerIds.has(player.playCricketId)) {
-          const existing = currentPlayers.find(
-            (p) => p.play_cricket_id === player.playCricketId,
-          );
-          if (existing) {
-            const captainChanged = existing.is_captain !== player.isCaptain;
-            const slotChanged = existing.slot_type !== player.slotType;
-            const wkChanged =
-              existing.is_wicketkeeper !== player.isWicketkeeper;
-            if (captainChanged || slotChanged || wkChanged) {
-              await trx
-                .updateTable("fantasy_team_player")
-                .set({
-                  is_captain: player.isCaptain,
-                  slot_type: player.slotType,
-                  is_wicketkeeper: player.isWicketkeeper,
-                })
-                .where("id", "=", existing.id)
-                .execute();
-            }
-          }
+        if (!currentPlayerIds.has(player.playCricketId)) continue;
+        const existing = currentPlayers.find(
+          (p) => p.play_cricket_id === player.playCricketId,
+        );
+        if (!existing) continue;
+
+        const captainChanged = existing.is_captain !== player.isCaptain;
+        const slotChanged = existing.slot_type !== player.slotType;
+        const wkChanged = existing.is_wicketkeeper !== player.isWicketkeeper;
+        if (!captainChanged && !slotChanged && !wkChanged) continue;
+
+        if (existing.gameweek_added === gameweek) {
+          await trx
+            .updateTable("fantasy_team_player")
+            .set({
+              is_captain: player.isCaptain,
+              slot_type: player.slotType,
+              is_wicketkeeper: player.isWicketkeeper,
+            })
+            .where("id", "=", existing.id)
+            .execute();
+        } else {
+          await trx
+            .updateTable("fantasy_team_player")
+            .set({ gameweek_removed: gameweek })
+            .where("id", "=", existing.id)
+            .execute();
+          await trx
+            .insertInto("fantasy_team_player")
+            .values({
+              fantasy_team_id: teamId,
+              play_cricket_id: player.playCricketId,
+              is_captain: player.isCaptain,
+              gameweek_added: gameweek,
+              slot_type: player.slotType,
+              is_wicketkeeper: player.isWicketkeeper,
+            })
+            .execute();
         }
       }
 


### PR DESCRIPTION
## Summary

- Team edits that changed captain, slot, or wicketkeeper on a player already in the squad were mutating the `fantasy_team_player` row in place. That destroyed the snapshot used to rescore past gameweeks, so re-running `calculateFantasyScores` after any such edit recomputed locked gameweeks using the *new* flags.
- `saveTeam` now closes the existing row (`gameweek_removed = current gw`) and inserts a new row (`gameweek_added = current gw`) for any flag change on a row from a prior gameweek. Rows from the current still-open gameweek keep getting mutated in place so repeated edits within a single gameweek don't churn the table.
- Transfer-count logic is rewritten as a set difference between active `play_cricket_id`s at `gw` vs `gw−1`. This is independent of row churn and unaffected by the ordering of swaps. Applied in both `saveTeam` (budget check) and `getMyTeam` (display).
- `calculate-scores.ts` already filters by `gameweek_added <= gw AND (gameweek_removed IS NULL OR gameweek_removed > gw)`, so no scoring-engine changes were needed — historical reconstruction is automatic once the rows carry the right snapshots.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm format:check`
- [x] `pnpm --filter api test` (243 passed)
- [x] `pnpm --filter api test:integration` (190 passed — includes 6 new tests covering captain/slot/WK history, no row explosion for same-gw churn, transfer count ignoring config changes, and the 3-transfer limit still enforcing on real swaps)

## Note on retroactive repair

This fix prevents future drift. It can't restore captain/slot/WK flags that have already been overwritten for past gameweeks. Any currently-wrong GW1 scores need to be repaired by reconstructing the original team state (from screenshots/email) and backfilling rows manually, then re-running `calculateFantasyScores`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)