### PR TITLE
Roll over gameweek at Monday 00:00 UK, not Saturday

### DIFF
--- a/apps/api/src/features/fantasy/gameweek.test.ts
+++ b/apps/api/src/features/fantasy/gameweek.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getCurrentGameweek,
+  getCurrentSeason,
+  getPreviousSeason,
+  isGameweekLocked,
+  isPreSeason,
+} from "./gameweek.ts";
+
+describe("getCurrentSeason", () => {
+  it("returns a 4-digit year string", () => {
+    expect(getCurrentSeason()).toMatch(/^\d{4}$/);
+  });
+});
+
+describe("getPreviousSeason", () => {
+  it("returns one year less", () => {
+    expect(getPreviousSeason("2026")).toBe("2025");
+    expect(getPreviousSeason("2020")).toBe("2019");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCurrentGameweek — UK timezone matters. The 2026 season's GW1 start date
+// is Sat 2026-04-18 (per SEASON_GW1_DATES). UK is on BST (UTC+1) at that time
+// of year. For boundary tests, UK midnight = 23:00 UTC the previous day.
+// ---------------------------------------------------------------------------
+describe("getCurrentGameweek (2026 season)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- Pre-season ---
+  it("returns 0 several days before GW1", () => {
+    vi.setSystemTime(new Date("2026-04-13T12:00:00Z")); // Mon, pre-season
+    expect(getCurrentGameweek("2026")).toBe(0);
+  });
+
+  it("returns 0 just before GW1 Saturday", () => {
+    // Fri 2026-04-17 23:59 UK = 22:59 UTC (BST)
+    vi.setSystemTime(new Date("2026-04-17T22:59:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(0);
+  });
+
+  // --- GW1 match weekend ---
+  it("returns 1 at GW1 Saturday 00:00 UK", () => {
+    // Sat 2026-04-18 00:00 UK = 2026-04-17T23:00Z
+    vi.setSystemTime(new Date("2026-04-17T23:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(1);
+  });
+
+  it("returns 1 on GW1 Saturday midday", () => {
+    vi.setSystemTime(new Date("2026-04-18T12:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(1);
+  });
+
+  it("returns 1 on GW1 Sunday", () => {
+    vi.setSystemTime(new Date("2026-04-19T12:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(1);
+  });
+
+  it("returns 1 just before Monday rollover", () => {
+    // Sun 2026-04-19 23:59 UK = 22:59Z
+    vi.setSystemTime(new Date("2026-04-19T22:59:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(1);
+  });
+
+  // --- GW2 edit period ---
+  it("returns 2 at Monday 00:00 UK (rollover)", () => {
+    // Mon 2026-04-20 00:00 UK = 2026-04-19T23:00Z
+    vi.setSystemTime(new Date("2026-04-19T23:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(2);
+  });
+
+  it("returns 2 on Monday midday of GW2 edit period", () => {
+    vi.setSystemTime(new Date("2026-04-20T12:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(2);
+  });
+
+  it("returns 2 on Wednesday of GW2 edit period", () => {
+    vi.setSystemTime(new Date("2026-04-22T12:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(2);
+  });
+
+  it("returns 2 on Friday of GW2 edit period", () => {
+    vi.setSystemTime(new Date("2026-04-24T12:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(2);
+  });
+
+  // --- GW2 match weekend ---
+  it("returns 2 on GW2 Saturday", () => {
+    vi.setSystemTime(new Date("2026-04-25T12:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(2);
+  });
+
+  it("returns 2 on GW2 Sunday", () => {
+    vi.setSystemTime(new Date("2026-04-26T12:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(2);
+  });
+
+  // --- GW3 rollover ---
+  it("returns 3 on the Monday after GW2", () => {
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+    expect(getCurrentGameweek("2026")).toBe(3);
+  });
+});
+
+describe("isPreSeason (2026 season)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is true before GW1", () => {
+    vi.setSystemTime(new Date("2026-04-17T12:00:00Z"));
+    expect(isPreSeason("2026")).toBe(true);
+  });
+
+  it("is false on GW1 Saturday", () => {
+    vi.setSystemTime(new Date("2026-04-18T12:00:00Z"));
+    expect(isPreSeason("2026")).toBe(false);
+  });
+
+  it("is false during GW2 edit period", () => {
+    vi.setSystemTime(new Date("2026-04-20T12:00:00Z"));
+    expect(isPreSeason("2026")).toBe(false);
+  });
+});
+
+describe("isGameweekLocked (2026 season)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is false in pre-season", () => {
+    vi.setSystemTime(new Date("2026-04-17T12:00:00Z")); // Fri, pre-season
+    expect(isGameweekLocked("2026")).toBe(false);
+  });
+
+  it("is true on GW1 Saturday", () => {
+    vi.setSystemTime(new Date("2026-04-18T12:00:00Z"));
+    expect(isGameweekLocked("2026")).toBe(true);
+  });
+
+  it("is true on GW1 Sunday", () => {
+    vi.setSystemTime(new Date("2026-04-19T12:00:00Z"));
+    expect(isGameweekLocked("2026")).toBe(true);
+  });
+
+  it("is false on Monday (GW2 edit period)", () => {
+    vi.setSystemTime(new Date("2026-04-20T12:00:00Z"));
+    expect(isGameweekLocked("2026")).toBe(false);
+  });
+
+  it("is false on Friday (end of GW2 edit period)", () => {
+    vi.setSystemTime(new Date("2026-04-24T12:00:00Z"));
+    expect(isGameweekLocked("2026")).toBe(false);
+  });
+
+  it("is true on GW2 Saturday", () => {
+    vi.setSystemTime(new Date("2026-04-25T12:00:00Z"));
+    expect(isGameweekLocked("2026")).toBe(true);
+  });
+});

--- a/apps/api/src/features/fantasy/gameweek.ts
+++ b/apps/api/src/features/fantasy/gameweek.ts
@@ -2,12 +2,18 @@
  * Gameweek logic for fantasy cricket.
  *
  * The fantasy season follows the cricket season calendar year.
- * Each gameweek runs Saturday to Friday, aligned with weekend matches.
+ * Matches are played on Saturday-Sunday; each gameweek wraps one
+ * match weekend together with the preceding edit period:
  *
- * Lock deadline: Friday 23:59 UK time — teams are locked for the weekend.
- * Editing reopens: Monday 00:00 UK time.
+ *   Mon 00:00 UK  →  Fri 23:59 UK   edit period  (team unlocked)
+ *   Sat 00:00 UK  →  Sun 23:59 UK   match period (team locked)
  *
- * Pre-season (gameweek 0): before GW1 starts, unlimited team changes allowed.
+ * The gameweek number rolls over at Monday 00:00 UK — once the weekend's
+ * matches are done, the "current gameweek" becomes the *next* weekend's.
+ * GW1 is the exception: it has no edit period of its own (pre-season fills
+ * that role), so GW1 only covers Sat-Sun of the first weekend.
+ *
+ * Pre-season (gameweek 0): before GW1's Saturday. Unlimited team changes.
  * In-season (gameweek 1+): max 3 transfers per gameweek, unless it's the
  * player's first-ever squad selection (which is always unlimited).
  */
@@ -126,8 +132,10 @@ export function getPreviousSeason(season?: string): string {
 /**
  * Get the current gameweek number.
  *
- * Returns 0 for pre-season (before GW1 start date).
- * Returns 1+ during the season (each week runs Saturday to Friday).
+ * Returns 0 for pre-season (before GW1's Saturday).
+ * In-season, returns the gameweek whose matches are either currently being
+ * played (Sat-Sun of that gameweek) or are the next upcoming weekend
+ * (Mon-Fri). Rollover happens at Monday 00:00 UK time.
  */
 export function getCurrentGameweek(season?: string): number {
   const s = season ?? getCurrentSeason();
@@ -138,7 +146,11 @@ export function getCurrentGameweek(season?: string): number {
 
   const diffMs = ukNow.getTime() - gw1.getTime();
   const diffWeeks = Math.floor(diffMs / (7 * 24 * 60 * 60 * 1000));
-  return diffWeeks + 1;
+  // On Mon-Fri we're in the edit period for the *next* weekend's matches,
+  // so bump by 1. On Sat-Sun we're in the current weekend's matches.
+  const dayOfWeek = getUKDayOfWeek();
+  const isEditPeriod = dayOfWeek >= 1 && dayOfWeek <= 5;
+  return diffWeeks + 1 + (isEditPeriod ? 1 : 0);
 }
 
 /**

--- a/apps/api/src/features/fantasy/integration.test.ts
+++ b/apps/api/src/features/fantasy/integration.test.ts
@@ -204,10 +204,13 @@ describe("fantasy service (integration)", () => {
   });
 
   describe("versioned captain/slot/WK history", () => {
-    // GW1 Wed and GW2 Wed — weekdays inside successive gameweeks given
-    // the 2026 season GW1 start of 2026-04-18 (Saturday).
-    const GW1_WED = new Date("2026-04-22T12:00:00Z");
-    const GW2_WED = new Date("2026-04-29T12:00:00Z");
+    // Two consecutive in-season edit-period Wednesdays. Under the 2026
+    // season (GW1 starts Sat 2026-04-18), the gameweek rolls over on
+    // each Monday 00:00 UK:
+    //   Wed 2026-04-22 → GW2 (edit period for the Apr 25-26 weekend)
+    //   Wed 2026-04-29 → GW3 (edit period for the May 2-3 weekend)
+    const FIRST_WED = new Date("2026-04-22T12:00:00Z"); // gameweek 2
+    const SECOND_WED = new Date("2026-04-29T12:00:00Z"); // gameweek 3
 
     beforeEach(() => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -224,8 +227,8 @@ describe("fantasy service (integration)", () => {
       return ids;
     }
 
-    it("captain change in GW2 preserves GW1 captain on the closed row", async () => {
-      vi.setSystemTime(GW1_WED);
+    it("captain change in a later gameweek preserves the original captain on the closed row", async () => {
+      vi.setSystemTime(FIRST_WED);
       const { userId } = await seedTestUser(ctx.db, {
         email: `cap-hist-${crypto.randomUUID()}@test.com`,
       });
@@ -238,7 +241,7 @@ describe("fantasy service (integration)", () => {
         season,
       );
 
-      vi.setSystemTime(GW2_WED);
+      vi.setSystemTime(SECOND_WED);
       const capMoved = buildSquad(playerIds).map((p, i) => ({
         ...p,
         isCaptain: i === 1,
@@ -253,49 +256,49 @@ describe("fantasy service (integration)", () => {
         .selectAll()
         .execute();
 
-      const p0Gw1 = rows.find(
-        (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 1,
-      );
-      const p0Gw2 = rows.find(
+      const p0Early = rows.find(
         (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 2,
       );
-      const p1Gw1 = rows.find(
-        (r) => r.play_cricket_id === playerIds[1] && r.gameweek_added === 1,
+      const p0Late = rows.find(
+        (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 3,
       );
-      const p1Gw2 = rows.find(
+      const p1Early = rows.find(
         (r) => r.play_cricket_id === playerIds[1] && r.gameweek_added === 2,
       );
+      const p1Late = rows.find(
+        (r) => r.play_cricket_id === playerIds[1] && r.gameweek_added === 3,
+      );
 
-      expect(p0Gw1?.is_captain).toBe(true);
-      expect(p0Gw1?.gameweek_removed).toBe(2);
-      expect(p0Gw2?.is_captain).toBe(false);
-      expect(p0Gw2?.gameweek_removed).toBeNull();
+      expect(p0Early?.is_captain).toBe(true);
+      expect(p0Early?.gameweek_removed).toBe(3);
+      expect(p0Late?.is_captain).toBe(false);
+      expect(p0Late?.gameweek_removed).toBeNull();
 
-      expect(p1Gw1?.is_captain).toBe(false);
-      expect(p1Gw1?.gameweek_removed).toBe(2);
-      expect(p1Gw2?.is_captain).toBe(true);
-      expect(p1Gw2?.gameweek_removed).toBeNull();
+      expect(p1Early?.is_captain).toBe(false);
+      expect(p1Early?.gameweek_removed).toBe(3);
+      expect(p1Late?.is_captain).toBe(true);
+      expect(p1Late?.gameweek_removed).toBeNull();
 
-      // Reconstructed GW1 squad shows the original captain (11 players, 1 captain, p0)
-      const gw1View = await ctx.db
+      // Reconstructed earlier-gameweek squad shows the original captain (11 players, 1 captain, p0)
+      const earlyView = await ctx.db
         .selectFrom("fantasy_team_player")
         .where("fantasy_team_id", "=", teamId)
-        .where("gameweek_added", "<=", 1)
+        .where("gameweek_added", "<=", 2)
         .where((eb) =>
           eb.or([
             eb("gameweek_removed", "is", null),
-            eb("gameweek_removed", ">", 1),
+            eb("gameweek_removed", ">", 2),
           ]),
         )
         .selectAll()
         .execute();
-      expect(gw1View).toHaveLength(11);
-      const gw1Captain = gw1View.find((r) => r.is_captain);
-      expect(gw1Captain?.play_cricket_id).toBe(playerIds[0]);
+      expect(earlyView).toHaveLength(11);
+      const earlyCaptain = earlyView.find((r) => r.is_captain);
+      expect(earlyCaptain?.play_cricket_id).toBe(playerIds[0]);
     });
 
-    it("slot_type change in GW2 preserves GW1 slot on the closed row", async () => {
-      vi.setSystemTime(GW1_WED);
+    it("slot_type change in a later gameweek preserves the original slot on the closed row", async () => {
+      vi.setSystemTime(FIRST_WED);
       const { userId } = await seedTestUser(ctx.db, {
         email: `slot-hist-${crypto.randomUUID()}@test.com`,
       });
@@ -303,7 +306,7 @@ describe("fantasy service (integration)", () => {
       const playerIds = await seedElevenPlayers();
       await saveTeam(ctx.db)(userId, buildSquad(playerIds), season);
 
-      vi.setSystemTime(GW2_WED);
+      vi.setSystemTime(SECOND_WED);
       // Swap a batting slot (i=0) with a bowling slot (i=6) so the overall
       // squad still satisfies SLOT_COUNTS. Move WK off i=0 too, since WK
       // must be in a non-allrounder slot — i=0 is going to bowling, that's
@@ -322,29 +325,29 @@ describe("fantasy service (integration)", () => {
         .selectAll()
         .execute();
 
-      const p0Gw1 = rows.find(
-        (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 1,
-      );
-      const p0Gw2 = rows.find(
+      const p0Early = rows.find(
         (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 2,
       );
-      const p6Gw1 = rows.find(
-        (r) => r.play_cricket_id === playerIds[6] && r.gameweek_added === 1,
+      const p0Late = rows.find(
+        (r) => r.play_cricket_id === playerIds[0] && r.gameweek_added === 3,
       );
-      const p6Gw2 = rows.find(
+      const p6Early = rows.find(
         (r) => r.play_cricket_id === playerIds[6] && r.gameweek_added === 2,
       );
+      const p6Late = rows.find(
+        (r) => r.play_cricket_id === playerIds[6] && r.gameweek_added === 3,
+      );
 
-      expect(p0Gw1?.slot_type).toBe("batting");
-      expect(p0Gw1?.gameweek_removed).toBe(2);
-      expect(p0Gw2?.slot_type).toBe("bowling");
-      expect(p6Gw1?.slot_type).toBe("bowling");
-      expect(p6Gw1?.gameweek_removed).toBe(2);
-      expect(p6Gw2?.slot_type).toBe("batting");
+      expect(p0Early?.slot_type).toBe("batting");
+      expect(p0Early?.gameweek_removed).toBe(3);
+      expect(p0Late?.slot_type).toBe("bowling");
+      expect(p6Early?.slot_type).toBe("bowling");
+      expect(p6Early?.gameweek_removed).toBe(3);
+      expect(p6Late?.slot_type).toBe("batting");
     });
 
-    it("wicketkeeper change in GW2 preserves GW1 WK on the closed row", async () => {
-      vi.setSystemTime(GW1_WED);
+    it("wicketkeeper change in a later gameweek preserves the original WK on the closed row", async () => {
+      vi.setSystemTime(FIRST_WED);
       const { userId } = await seedTestUser(ctx.db, {
         email: `wk-hist-${crypto.randomUUID()}@test.com`,
       });
@@ -352,7 +355,7 @@ describe("fantasy service (integration)", () => {
       const playerIds = await seedElevenPlayers();
       await saveTeam(ctx.db)(userId, buildSquad(playerIds), season);
 
-      vi.setSystemTime(GW2_WED);
+      vi.setSystemTime(SECOND_WED);
       // Move WK from i=0 (batting) to i=1 (batting).
       const wkMoved = buildSquad(playerIds).map((p, i) => ({
         ...p,
@@ -368,16 +371,16 @@ describe("fantasy service (integration)", () => {
         .execute();
 
       expect(p0Rows).toHaveLength(2);
-      expect(p0Rows[0]?.gameweek_added).toBe(1);
+      expect(p0Rows[0]?.gameweek_added).toBe(2);
       expect(p0Rows[0]?.is_wicketkeeper).toBe(true);
-      expect(p0Rows[0]?.gameweek_removed).toBe(2);
-      expect(p0Rows[1]?.gameweek_added).toBe(2);
+      expect(p0Rows[0]?.gameweek_removed).toBe(3);
+      expect(p0Rows[1]?.gameweek_added).toBe(3);
       expect(p0Rows[1]?.is_wicketkeeper).toBe(false);
       expect(p0Rows[1]?.gameweek_removed).toBeNull();
     });
 
     it("multiple captain changes inside the same gameweek mutate in place (no row explosion)", async () => {
-      vi.setSystemTime(GW1_WED);
+      vi.setSystemTime(FIRST_WED);
       const { userId } = await seedTestUser(ctx.db, {
         email: `same-gw-churn-${crypto.randomUUID()}@test.com`,
       });
@@ -389,7 +392,7 @@ describe("fantasy service (integration)", () => {
         season,
       );
 
-      // Flip captain around within GW1 (row is still-open for this gameweek)
+      // Flip captain around within the same gameweek (row is still-open for this gameweek)
       for (const capIdx of [1, 2, 3, 4, 0]) {
         const s = buildSquad(playerIds).map((p, i) => ({
           ...p,
@@ -407,7 +410,7 @@ describe("fantasy service (integration)", () => {
     });
 
     it("config-only changes across gameweeks don't count as transfers", async () => {
-      vi.setSystemTime(GW1_WED);
+      vi.setSystemTime(FIRST_WED);
       const { userId } = await seedTestUser(ctx.db, {
         email: `no-transfer-count-${crypto.randomUUID()}@test.com`,
       });
@@ -415,7 +418,7 @@ describe("fantasy service (integration)", () => {
       const playerIds = await seedElevenPlayers();
       await saveTeam(ctx.db)(userId, buildSquad(playerIds), season);
 
-      vi.setSystemTime(GW2_WED);
+      vi.setSystemTime(SECOND_WED);
       // Captain move — no roster change
       const capMoved = buildSquad(playerIds).map((p, i) => ({
         ...p,
@@ -428,8 +431,8 @@ describe("fantasy service (integration)", () => {
       expect(team.maxTransfers).toBe(3);
     });
 
-    it("real transfers in GW2 count against the 3-per-gameweek limit", async () => {
-      vi.setSystemTime(GW1_WED);
+    it("real transfers in a later gameweek count against the 3-per-gameweek limit", async () => {
+      vi.setSystemTime(FIRST_WED);
       const { userId } = await seedTestUser(ctx.db, {
         email: `real-transfers-${crypto.randomUUID()}@test.com`,
       });
@@ -443,7 +446,7 @@ describe("fantasy service (integration)", () => {
       }
       await saveTeam(ctx.db)(userId, buildSquad(playerIds), season);
 
-      vi.setSystemTime(GW2_WED);
+      vi.setSystemTime(SECOND_WED);
       // Swap out three players — within limit
       const threeOut = buildSquad([
         replacementIds[0],
@@ -472,7 +475,7 @@ describe("fantasy service (integration)", () => {
     });
 
     it("transfer + config change on a retained player in the same save both version correctly", async () => {
-      vi.setSystemTime(GW1_WED);
+      vi.setSystemTime(FIRST_WED);
       const { userId } = await seedTestUser(ctx.db, {
         email: `mixed-edit-${crypto.randomUUID()}@test.com`,
       });
@@ -488,7 +491,7 @@ describe("fantasy service (integration)", () => {
         season,
       );
 
-      vi.setSystemTime(GW2_WED);
+      vi.setSystemTime(SECOND_WED);
       // In one save: swap player 10 (allrounder) for replacement, AND move
       // captain from 0 to 1 on retained players.
       const mixed = buildSquad([...playerIds.slice(0, 10), replacement]).map(
@@ -509,7 +512,7 @@ describe("fantasy service (integration)", () => {
         .execute();
       expect(p0Rows).toHaveLength(2);
       expect(p0Rows[0]?.is_captain).toBe(true);
-      expect(p0Rows[0]?.gameweek_removed).toBe(2);
+      expect(p0Rows[0]?.gameweek_removed).toBe(3);
       expect(p0Rows[1]?.is_captain).toBe(false);
 
       // Transferred-out player: single row, closed this GW
@@ -520,7 +523,7 @@ describe("fantasy service (integration)", () => {
         .selectAll()
         .execute();
       expect(p10Rows).toHaveLength(1);
-      expect(p10Rows[0]?.gameweek_removed).toBe(2);
+      expect(p10Rows[0]?.gameweek_removed).toBe(3);
 
       // New player: single row, added this GW
       const newRows = await ctx.db
@@ -530,31 +533,31 @@ describe("fantasy service (integration)", () => {
         .selectAll()
         .execute();
       expect(newRows).toHaveLength(1);
-      expect(newRows[0]?.gameweek_added).toBe(2);
+      expect(newRows[0]?.gameweek_added).toBe(3);
       expect(newRows[0]?.gameweek_removed).toBeNull();
 
       // Transfer count = 1 (only the real swap, not the captain move)
       const view = await getMyTeam(ctx.db)(userId, season);
       expect(view.transfersUsed).toBe(1);
 
-      // GW1 reconstruction: 11 original players with original captain
-      const gw1View = await ctx.db
+      // Earlier-gameweek reconstruction: 11 original players with original captain
+      const earlyView = await ctx.db
         .selectFrom("fantasy_team_player")
         .where("fantasy_team_id", "=", teamId)
-        .where("gameweek_added", "<=", 1)
+        .where("gameweek_added", "<=", 2)
         .where((eb) =>
           eb.or([
             eb("gameweek_removed", "is", null),
-            eb("gameweek_removed", ">", 1),
+            eb("gameweek_removed", ">", 2),
           ]),
         )
         .selectAll()
         .execute();
-      expect(gw1View).toHaveLength(11);
-      expect(gw1View.find((r) => r.is_captain)?.play_cricket_id).toBe(
+      expect(earlyView).toHaveLength(11);
+      expect(earlyView.find((r) => r.is_captain)?.play_cricket_id).toBe(
         playerIds[0],
       );
-      expect(gw1View.map((r) => r.play_cricket_id).sort()).toEqual(
+      expect(earlyView.map((r) => r.play_cricket_id).sort()).toEqual(
         [...playerIds].sort(),
       );
     });


### PR DESCRIPTION
## Summary
- `getCurrentGameweek` now rolls over at Monday 00:00 UK instead of Saturday. On Mon-Fri during the season, it returns the upcoming weekend's gameweek (the one being prepped for). On Sat-Sun it returns the current match weekend's gameweek.
- Previously, saves made during the Mon-Fri edit period after a match weekend landed with `gameweek_added` equal to the gameweek whose matches had already been played, silently modifying the historical squad used for scoring. #126 stopped row-mutation drift, but saves were still landing in the wrong gameweek.
- Fixes the banner showing "Gameweek 1" on Monday 2026-04-20 when it should have been "Gameweek 2" (prep for the Apr 25-26 weekend).
- The `getGameweekForDate` helper (used by scoring) is unchanged — matches are on Sat-Sun, which fall cleanly within the calendar-week-from-GW1 bucket.

## Test plan
- [x] New `gameweek.test.ts` with 24 unit tests covering boundary transitions (pre-season, GW1 Sat/Sun, Mon rollover, GW2 edit/match, Monday of GW3 rollover)
- [x] Shifted pin dates in the existing "versioned captain/slot/WK history" integration tests (GW1_WED/GW2_WED → FIRST_WED/SECOND_WED) — they now exercise two consecutive in-season edit-period Wednesdays
- [x] All 267 unit tests pass
- [x] All 191 integration tests pass
- [x] typecheck, lint, format:check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)