### PR TITLE
Add transfer news section to fantasy home

### DIFF
--- a/apps/api/src/features/fantasy/integration.test.ts
+++ b/apps/api/src/features/fantasy/integration.test.ts
@@ -20,6 +20,7 @@ import { SLOT_COUNTS } from "./scoring.ts";
 import {
   getEligiblePlayers,
   getMyTeam,
+  getRecentTransfers,
   populatePlayers,
   saveTeam,
   toggleEligibility,
@@ -624,6 +625,124 @@ describe("fantasy service (integration)", () => {
       expect(row).toBeTruthy();
       expect(row?.player_name).toBe(playerName);
       expect(row?.eligible).toBe(false); // default
+    });
+  });
+
+  describe("getRecentTransfers", () => {
+    const GW2_WED = new Date("2026-04-22T12:00:00Z"); // gameweek 2
+    const GW3_WED = new Date("2026-04-29T12:00:00Z"); // gameweek 3
+
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function seedSquad(playerCount = 11) {
+      const ids: string[] = [];
+      for (let i = 0; i < playerCount; i++) {
+        ids.push(await seedFantasyPlayer({ eligible: true, sandwichCost: 1 }));
+      }
+      return ids;
+    }
+
+    it("returns empty entries when no team exists", async () => {
+      const result = await getRecentTransfers(ctx.db)("1900");
+      expect(result.entries).toEqual([]);
+      expect(result.season).toBe("1900");
+    });
+
+    it("returns one entry per (team, gameweek) with real adds and drops", async () => {
+      vi.setSystemTime(GW2_WED);
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `rt-basic-${crypto.randomUUID()}@test.com`,
+        name: "Alex Young",
+      });
+      const season = getCurrentSeason();
+      const ids: string[] = [];
+      for (let i = 0; i < 11; i++) {
+        ids.push(
+          await seedFantasyPlayer({
+            eligible: true,
+            sandwichCost: 1,
+            playerName: `Original ${i}`,
+          }),
+        );
+      }
+      const replacement = await seedFantasyPlayer({
+        eligible: true,
+        sandwichCost: 1,
+        playerName: "New Guy",
+      });
+      await saveTeam(ctx.db)(userId, buildSquad(ids), season);
+
+      vi.setSystemTime(GW3_WED);
+      const swapped = buildSquad([...ids.slice(0, 10), replacement]);
+      await saveTeam(ctx.db)(userId, swapped, season);
+
+      const result = await getRecentTransfers(ctx.db)(season);
+      const entry = result.entries.find((e) => e.ownerName === "Alex Young");
+      expect(entry).toBeDefined();
+      expect(entry?.gameweek).toBe(3);
+      expect(entry?.added).toHaveLength(1);
+      expect(entry?.added[0]?.playerName).toBe("New Guy");
+      expect(entry?.dropped).toHaveLength(1);
+      expect(entry?.dropped[0]?.playerName).toBe("Original 10");
+    });
+
+    it("ignores config-only churn (captain/slot/WK versioning)", async () => {
+      vi.setSystemTime(GW2_WED);
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `rt-churn-${crypto.randomUUID()}@test.com`,
+        name: "Config Only",
+      });
+      const season = getCurrentSeason();
+      const ids = await seedSquad();
+      await saveTeam(ctx.db)(userId, buildSquad(ids), season);
+
+      vi.setSystemTime(GW3_WED);
+      const configChanged = buildSquad(ids).map((p, i) => ({
+        ...p,
+        isCaptain: i === 1,
+        isWicketkeeper: i === 1,
+      }));
+      await saveTeam(ctx.db)(userId, configChanged, season);
+
+      const result = await getRecentTransfers(ctx.db)(season);
+      expect(
+        result.entries.find((e) => e.ownerName === "Config Only"),
+      ).toBeUndefined();
+    });
+
+    it("respects the limit parameter", async () => {
+      vi.setSystemTime(GW2_WED);
+      const season = getCurrentSeason();
+      const makeTeamWithTransfer = async (name: string) => {
+        const { userId } = await seedTestUser(ctx.db, {
+          email: `rt-lim-${crypto.randomUUID()}@test.com`,
+          name,
+        });
+        const ids = await seedSquad();
+        const rep = await seedFantasyPlayer({
+          eligible: true,
+          sandwichCost: 1,
+        });
+        await saveTeam(ctx.db)(userId, buildSquad(ids), season);
+        vi.setSystemTime(GW3_WED);
+        await saveTeam(ctx.db)(
+          userId,
+          buildSquad([rep, ...ids.slice(1)]),
+          season,
+        );
+        vi.setSystemTime(GW2_WED);
+      };
+      await makeTeamWithTransfer("Limit A");
+      await makeTeamWithTransfer("Limit B");
+      await makeTeamWithTransfer("Limit C");
+
+      const capped = await getRecentTransfers(ctx.db)(season, 2);
+      expect(capped.entries.length).toBeLessThanOrEqual(2);
     });
   });
 });

--- a/apps/api/src/features/fantasy/routes.ts
+++ b/apps/api/src/features/fantasy/routes.ts
@@ -35,6 +35,8 @@ import {
   playerLeaderboardResponseSchema,
   populatePlayersResponseSchema,
   preSeasonStatsResponseSchema,
+  recentTransfersResponseSchema,
+  recentTransfersSchema,
   sandwichEfficiencyResponseSchema,
   sandwichEfficiencySchema,
   saveTeamResponseSchema,
@@ -67,6 +69,7 @@ import {
   getPlayerHistory,
   getPlayerLeaderboard,
   getPreSeasonStats,
+  getRecentTransfers,
   getSandwichEfficiency,
   getSeasonLeaderboard,
   getTeam,
@@ -120,6 +123,7 @@ export const fantasyRoutes: FastifyPluginAsyncZod = async (app) => {
   const chaosWeekCreate = createChaosWeek(app.db);
   const chaosWeekDelete = deleteChaosWeek(app.db);
   const shareData = getTeamShareData(app.db);
+  const recentTransfers = getRecentTransfers(app.db);
 
   // --- Public routes ---
 
@@ -135,6 +139,20 @@ export const fantasyRoutes: FastifyPluginAsyncZod = async (app) => {
       const { season } = request.query;
       // transferWindow is sync; wrap to satisfy return await pattern
       return await Promise.resolve(transferWindow(season));
+    },
+  );
+
+  app.get(
+    "/fantasy/transfer-news",
+    {
+      schema: {
+        querystring: recentTransfersSchema,
+        response: { 200: recentTransfersResponseSchema },
+      },
+    },
+    async (request) => {
+      const { season, limit } = request.query;
+      return await recentTransfers(season, limit);
     },
   );
 

--- a/apps/api/src/features/fantasy/schemas.ts
+++ b/apps/api/src/features/fantasy/schemas.ts
@@ -73,6 +73,11 @@ export const chaosWeekPublicSchema = z.object({
   gameweek: z.coerce.number().optional(),
 });
 
+export const recentTransfersSchema = z.object({
+  season: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(20).default(5),
+});
+
 export const createChaosWeekSchema = z.object({
   season: z.string().optional(),
   gameweekId: z.number().min(1),
@@ -240,6 +245,25 @@ export const highlightsResponseSchema = z.object({
     })
     .nullable(),
   gameweek: z.number(),
+  season: z.string(),
+});
+
+// getRecentTransfers — transfer news feed
+const transferPlayerSchema = z.object({
+  playCricketId: z.string(),
+  playerName: z.string(),
+});
+
+export const recentTransfersResponseSchema = z.object({
+  entries: z.array(
+    z.object({
+      teamId: z.number(),
+      ownerName: z.string(),
+      gameweek: z.number(),
+      added: z.array(transferPlayerSchema),
+      dropped: z.array(transferPlayerSchema),
+    }),
+  ),
   season: z.string(),
 });
 

--- a/apps/api/src/features/fantasy/service.ts
+++ b/apps/api/src/features/fantasy/service.ts
@@ -2750,3 +2750,136 @@ export function getTeamShareData(db: Kysely<DB>) {
     };
   };
 }
+
+/**
+ * Recent transfer activity across all teams.
+ *
+ * Returns one entry per (team, gameweek) where the team's active roster
+ * changed between gameweek-1 and gameweek. Adds/drops are computed via
+ * set-difference on the active roster, so config-only row churn
+ * (captain/slot/WK versioning) does not produce spurious entries.
+ *
+ * Ordered by gameweek DESC, then by max(fantasy_team_player.id) DESC
+ * within a gameweek (a proxy for recency since the table has no
+ * timestamp column — ids are monotonically assigned).
+ */
+export function getRecentTransfers(db: Kysely<DB>) {
+  return async (season?: string, limit = 5) => {
+    const s = season ?? getCurrentSeason();
+
+    const rows = await db
+      .selectFrom("fantasy_team_player as ftp")
+      .innerJoin("fantasy_team as ft", "ft.id", "ftp.fantasy_team_id")
+      .innerJoin("user as u", "u.id", "ft.user_id")
+      .innerJoin(
+        "fantasy_player as fp",
+        "fp.play_cricket_id",
+        "ftp.play_cricket_id",
+      )
+      .where("ft.season", "=", s)
+      .select([
+        "ftp.id",
+        "ftp.fantasy_team_id as teamId",
+        "ftp.play_cricket_id as playCricketId",
+        "ftp.gameweek_added as gameweekAdded",
+        "ftp.gameweek_removed as gameweekRemoved",
+        "u.name as ownerName",
+        "fp.player_name as playerName",
+      ])
+      .execute();
+
+    type Row = (typeof rows)[number];
+    const byTeam = new Map<number, Row[]>();
+    for (const r of rows) {
+      const list = byTeam.get(r.teamId);
+      if (list) list.push(r);
+      else byTeam.set(r.teamId, [r]);
+    }
+
+    interface Entry {
+      teamId: number;
+      ownerName: string;
+      gameweek: number;
+      added: Array<{ playCricketId: string; playerName: string }>;
+      dropped: Array<{ playCricketId: string; playerName: string }>;
+      orderId: number;
+    }
+
+    const entries: Entry[] = [];
+
+    for (const [teamId, teamRows] of byTeam) {
+      const ownerName = teamRows[0]?.ownerName ?? "Unknown";
+
+      const candidateGws = new Set<number>();
+      for (const r of teamRows) {
+        if (r.gameweekAdded > 1) candidateGws.add(r.gameweekAdded);
+        if (r.gameweekRemoved !== null && r.gameweekRemoved > 1) {
+          candidateGws.add(r.gameweekRemoved);
+        }
+      }
+
+      for (const gw of candidateGws) {
+        const prevActive = new Map<string, string>();
+        const currActive = new Map<string, string>();
+        for (const r of teamRows) {
+          const activeAtPrev =
+            r.gameweekAdded <= gw - 1 &&
+            (r.gameweekRemoved === null || r.gameweekRemoved > gw - 1);
+          const activeAtCurr =
+            r.gameweekAdded <= gw &&
+            (r.gameweekRemoved === null || r.gameweekRemoved > gw);
+          if (activeAtPrev) prevActive.set(r.playCricketId, r.playerName);
+          if (activeAtCurr) currActive.set(r.playCricketId, r.playerName);
+        }
+
+        const added: Entry["added"] = [];
+        for (const [playCricketId, playerName] of currActive) {
+          if (!prevActive.has(playCricketId)) {
+            added.push({ playCricketId, playerName });
+          }
+        }
+        const dropped: Entry["dropped"] = [];
+        for (const [playCricketId, playerName] of prevActive) {
+          if (!currActive.has(playCricketId)) {
+            dropped.push({ playCricketId, playerName });
+          }
+        }
+
+        if (added.length === 0 && dropped.length === 0) continue;
+        // Skip initial squads (previous roster empty). That's a brand-new
+        // team, not a transfer — all 11 players would otherwise show up
+        // as "added".
+        if (prevActive.size === 0) continue;
+
+        let orderId = 0;
+        for (const r of teamRows) {
+          if (r.gameweekAdded === gw || r.gameweekRemoved === gw) {
+            if (r.id > orderId) orderId = r.id;
+          }
+        }
+
+        entries.push({
+          teamId,
+          ownerName,
+          gameweek: gw,
+          added,
+          dropped,
+          orderId,
+        });
+      }
+    }
+
+    entries.sort((a, b) => b.gameweek - a.gameweek || b.orderId - a.orderId);
+
+    return {
+      entries: entries.slice(0, limit).map((e) => ({
+        teamId: e.teamId,
+        ownerName: e.ownerName,
+        gameweek: e.gameweek,
+        added: e.added,
+        dropped: e.dropped,
+      })),
+      season: s,
+    };
+  };
+}

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -930,6 +930,59 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/fantasy/transfer-news": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    season?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            entries: {
+                                teamId: number;
+                                ownerName: string;
+                                gameweek: number;
+                                added: {
+                                    playCricketId: string;
+                                    playerName: string;
+                                }[];
+                                dropped: {
+                                    playCricketId: string;
+                                    playerName: string;
+                                }[];
+                            }[];
+                            season: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/fantasy/chaos-week": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -1525,6 +1525,116 @@
         }
       }
     },
+    "/api/fantasy/transfer-news": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "season",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 5,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "teamId": {
+                            "type": "number"
+                          },
+                          "ownerName": {
+                            "type": "string"
+                          },
+                          "gameweek": {
+                            "type": "number"
+                          },
+                          "added": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "playCricketId": {
+                                  "type": "string"
+                                },
+                                "playerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "playCricketId",
+                                "playerName"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "dropped": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "playCricketId": {
+                                  "type": "string"
+                                },
+                                "playerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "playCricketId",
+                                "playerName"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "teamId",
+                          "ownerName",
+                          "gameweek",
+                          "added",
+                          "dropped"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "season": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "entries",
+                    "season"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/fantasy/chaos-week": {
       "get": {
         "parameters": [

--- a/apps/web/src/pages/fantasy/fantasy.tsx
+++ b/apps/web/src/pages/fantasy/fantasy.tsx
@@ -97,6 +97,14 @@ function useTeams() {
   });
 }
 
+function useTransferNews() {
+  return useQuery({
+    queryKey: ["fantasy", "transfer-news"],
+    queryFn: () => callApi(api.GET("/api/fantasy/transfer-news")),
+    staleTime: 60_000,
+  });
+}
+
 function useTeamDetail(teamId: number | null) {
   return useQuery({
     queryKey: ["fantasy", "team", teamId],
@@ -148,6 +156,7 @@ function HomeTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
   const ownership = useOwnership();
   const sandwich = useSandwichEfficiency();
   const seasonBoard = useSeasonLeaderboard();
+  const transferNews = useTransferNews();
 
   return (
     <div className="space-y-6">
@@ -241,6 +250,49 @@ function HomeTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
               Locks in {tw.data?.daysUntilLock} day
               {tw.data?.daysUntilLock !== 1 ? "s" : ""}
             </span>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Transfer news */}
+      {transferNews.data && transferNews.data.entries.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Transfer News</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2 text-sm">
+              {transferNews.data.entries.map((e) => (
+                <li
+                  key={`${e.teamId}-${e.gameweek}`}
+                  className="flex items-start justify-between gap-3"
+                >
+                  <span>
+                    <span className="font-medium">{e.ownerName}</span>
+                    {e.added.length > 0 && (
+                      <>
+                        {" added "}
+                        <span className="font-medium text-green-700">
+                          {e.added.map((p) => p.playerName).join(", ")}
+                        </span>
+                      </>
+                    )}
+                    {e.added.length > 0 && e.dropped.length > 0 && " and"}
+                    {e.dropped.length > 0 && (
+                      <>
+                        {" dropped "}
+                        <span className="font-medium text-red-700">
+                          {e.dropped.map((p) => p.playerName).join(", ")}
+                        </span>
+                      </>
+                    )}
+                  </span>
+                  <span className="text-muted-foreground text-xs whitespace-nowrap">
+                    GW{e.gameweek}
+                  </span>
+                </li>
+              ))}
+            </ul>
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
## Summary
- Adds a "Transfer News" card to the fantasy home tab showing the 5 most recent transfer events.
- Format: `"{ownerName} added {X, Y} and dropped {A, B}" (GW{N})`. Multiple entries per team across gameweeks.
- Backend: new `getRecentTransfers` service and `GET /api/fantasy/transfer-news` route. Adds/drops are computed via set-difference on the active roster (`active(gw) - active(gw-1)` and reverse), so config-only row churn from PR #126 versioning doesn't appear. Initial squads are filtered out.
- Ordered by gameweek DESC, tiebroken by max `fantasy_team_player.id` DESC (the table has no `created_at`; ids are serial).

## Review notes
- **Base branch**: this PR targets `fantasy-gameweek-rollover` (#127), not `main`. Merge #127 first, then this rebases onto main cleanly.
- Per-(team, gameweek) granularity — one entry per team per gameweek. If per-save granularity is wanted (e.g., "Alex did 3 separate saves in GW2 → 3 entries"), that'd need a `created_at` column on `fantasy_team_player`.

## Test plan
- [x] New integration tests for `getRecentTransfers`: empty-DB, real-transfer entry, ignores config churn, respects limit
- [x] typecheck, lint, format:check clean
- [x] 267 unit tests pass
- [x] 19 fantasy integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)