### PR TITLE
Allow officials to set member availability manually

### DIFF
--- a/apps/api/src/features/availability/integration.test.ts
+++ b/apps/api/src/features/availability/integration.test.ts
@@ -12,9 +12,9 @@ import {
   getDateDetail,
   getRequest,
   listRequests,
-  overrideResponse,
   removeAssignment,
   respond,
+  setAvailability,
   updateRequestStatus,
 } from "./service.ts";
 
@@ -270,8 +270,8 @@ describe("availability service (integration)", () => {
     });
   });
 
-  describe("overrideResponse", () => {
-    it("overrides a player response", async () => {
+  describe("setAvailability", () => {
+    it("overrides an existing player response", async () => {
       const { userId } = await seedTestUser(ctx.db, {
         email: `override-${crypto.randomUUID()}@test.com`,
         role: "admin",
@@ -285,11 +285,10 @@ describe("availability service (integration)", () => {
       );
 
       // Dave says unavailable
-      const responseId = crypto.randomUUID();
       await ctx.db
         .insertInto("availability_response")
         .values({
-          id: responseId,
+          id: crypto.randomUUID(),
           availability_request_id: reqId,
           member_id: memberId,
           match_date: "2026-11-01",
@@ -300,20 +299,79 @@ describe("availability service (integration)", () => {
         .execute();
 
       // Official overrides to available
-      const result = await overrideResponse(ctx.db)(userId, responseId, {
-        status: "available",
-      });
+      const result = await setAvailability(ctx.db)(
+        userId,
+        reqId,
+        "2026-11-01",
+        memberId,
+        { status: "available" },
+      );
       expect(result.success).toBe(true);
 
-      // Verify
       const updated = await ctx.db
         .selectFrom("availability_response")
-        .where("id", "=", responseId)
+        .where("availability_request_id", "=", reqId)
+        .where("member_id", "=", memberId)
+        .where("match_date", "=", "2026-11-01")
         .selectAll()
         .executeTakeFirst();
       expect(updated).toBeDefined();
       expect(updated?.status).toBe("available");
       expect(updated?.overridden_by).toBe(userId);
+    });
+
+    it("creates a response for a member who hasn't responded", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `setavail-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam("SetAvail XI");
+      const reqId = await seedRequest(userId, "2026-11-08", "2026-11-14");
+      await seedFixture(reqId, teamId, "2026-11-08");
+      const memberId = await seedMember(
+        "Eve",
+        `eve-${crypto.randomUUID()}@test.com`,
+      );
+
+      const result = await setAvailability(ctx.db)(
+        userId,
+        reqId,
+        "2026-11-08",
+        memberId,
+        { status: "available" },
+      );
+      expect(result.success).toBe(true);
+
+      const created = await ctx.db
+        .selectFrom("availability_response")
+        .where("availability_request_id", "=", reqId)
+        .where("member_id", "=", memberId)
+        .where("match_date", "=", "2026-11-08")
+        .selectAll()
+        .executeTakeFirst();
+      expect(created).toBeDefined();
+      expect(created?.status).toBe("available");
+      expect(created?.overridden_by).toBe(userId);
+    });
+
+    it("404s when there's no fixture on the date", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `setavail-nofix-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam("NoFix XI");
+      const reqId = await seedRequest(userId, "2026-11-15", "2026-11-21");
+      await seedFixture(reqId, teamId, "2026-11-15");
+      const memberId = await seedMember(
+        "Frank",
+        `frank-${crypto.randomUUID()}@test.com`,
+      );
+
+      await expect(
+        setAvailability(ctx.db)(userId, reqId, "2026-11-20", memberId, {
+          status: "available",
+        }),
+      ).rejects.toThrow("No fixtures");
     });
   });
 

--- a/apps/api/src/features/availability/routes.ts
+++ b/apps/api/src/features/availability/routes.ts
@@ -22,12 +22,12 @@ import {
   notifyPreviewSchema,
   notifySendResponseSchema,
   notifySendSchema,
-  overrideResponseSchema,
   previewFixturesResponseSchema,
+  requestDateMemberParamSchema,
   requestDateParamSchema,
   requestIdParamSchema,
   respondSchema,
-  responseIdParamSchema,
+  setAvailabilitySchema,
   successResponseSchema,
   updateRequestStatusSchema,
 } from "./schemas.ts";
@@ -40,12 +40,12 @@ import {
   getPublicRequest,
   getRequest,
   listRequests,
-  overrideResponse,
   previewFixtures,
   previewNotifyRecipients,
   removeAssignment,
   respond,
   sendAvailabilityNotification,
+  setAvailability,
   updateRequestStatus,
 } from "./service.ts";
 
@@ -169,20 +169,26 @@ export const availabilityRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   );
 
-  const override = overrideResponse(app.db);
+  const setAvail = setAvailability(app.db);
   app.put(
-    "/availability/responses/:responseId/override",
+    "/availability/requests/:requestId/dates/:date/members/:memberId/availability",
     {
       preHandler: [officialRole],
       schema: {
-        params: responseIdParamSchema,
-        body: overrideResponseSchema,
+        params: requestDateMemberParamSchema,
+        body: setAvailabilitySchema,
         response: { 200: successResponseSchema },
       },
     },
     async (request) => {
       const { user } = getAuthSession(request);
-      return await override(user.id, request.params.responseId, request.body);
+      return await setAvail(
+        user.id,
+        request.params.requestId,
+        request.params.date,
+        request.params.memberId,
+        request.body,
+      );
     },
   );
 

--- a/apps/api/src/features/availability/schemas.ts
+++ b/apps/api/src/features/availability/schemas.ts
@@ -17,8 +17,10 @@ export const assignmentIdParamSchema = z.object({
   assignmentId: z.string(),
 });
 
-export const responseIdParamSchema = z.object({
-  responseId: z.string(),
+export const requestDateMemberParamSchema = z.object({
+  requestId: z.string(),
+  date: z.string().regex(isoDateRegex, "Must be YYYY-MM-DD format"),
+  memberId: z.string(),
 });
 
 // ── Body schemas ──
@@ -34,7 +36,7 @@ export const assignPlayerSchema = z.object({
   playerName: z.string().min(1),
 });
 
-export const overrideResponseSchema = z.object({
+export const setAvailabilitySchema = z.object({
   status: z.enum(["available", "unavailable"]),
 });
 
@@ -279,7 +281,7 @@ export const getPublicRequestResponseSchema = z.object({
 
 export type CreateRequest = z.infer<typeof createRequestSchema>;
 export type AssignPlayer = z.infer<typeof assignPlayerSchema>;
-export type OverrideResponse = z.infer<typeof overrideResponseSchema>;
+export type SetAvailability = z.infer<typeof setAvailabilitySchema>;
 export type Respond = z.infer<typeof respondSchema>;
 export type UpdateRequestStatus = z.infer<typeof updateRequestStatusSchema>;
 export type ListRequests = z.infer<typeof listRequestsSchema>;

--- a/apps/api/src/features/availability/service.test.ts
+++ b/apps/api/src/features/availability/service.test.ts
@@ -67,9 +67,9 @@ import {
   getDateDetail,
   getRequest,
   listRequests,
-  overrideResponse,
   removeAssignment,
   respond,
+  setAvailability,
   updateRequestStatus,
 } from "./service.ts";
 
@@ -184,21 +184,38 @@ describe("availability service", () => {
     });
   });
 
-  describe("overrideResponse", () => {
-    it("throws 404 for non-existent response", async () => {
+  describe("setAvailability", () => {
+    it("throws 404 when no fixture on date", async () => {
       mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
       await expect(
-        overrideResponse(db)("user-1", "missing", { status: "available" }),
-      ).rejects.toThrow("not found");
+        setAvailability(db)("user-1", "req-1", "2026-06-01", "member-1", {
+          status: "available",
+        }),
+      ).rejects.toThrow("No fixtures");
     });
 
-    it("updates response with override", async () => {
-      mockExecuteTakeFirst.mockResolvedValueOnce({ id: "resp-1" });
-      mockExecute.mockResolvedValueOnce(undefined);
+    it("throws 404 when member not found", async () => {
+      mockExecuteTakeFirst.mockResolvedValueOnce({ id: "fixture-1" }); // fixture lookup
+      mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // member lookup
+      await expect(
+        setAvailability(db)("user-1", "req-1", "2026-06-01", "missing", {
+          status: "available",
+        }),
+      ).rejects.toThrow("Member not found");
+    });
 
-      const result = await overrideResponse(db)("user-1", "resp-1", {
-        status: "available",
-      });
+    it("upserts availability with override", async () => {
+      mockExecuteTakeFirst.mockResolvedValueOnce({ id: "fixture-1" }); // fixture lookup
+      mockExecuteTakeFirst.mockResolvedValueOnce({ id: "member-1" }); // member lookup
+      mockExecute.mockResolvedValueOnce(undefined); // upsert
+
+      const result = await setAvailability(db)(
+        "user-1",
+        "req-1",
+        "2026-06-01",
+        "member-1",
+        { status: "available" },
+      );
       expect(result).toEqual({ success: true });
     });
   });

--- a/apps/api/src/features/availability/service.ts
+++ b/apps/api/src/features/availability/service.ts
@@ -10,8 +10,8 @@ import type {
   ListRequests,
   NotifyPreview,
   NotifySend,
-  OverrideResponse,
   Respond,
+  SetAvailability,
   UpdateRequestStatus,
 } from "./schemas.ts";
 
@@ -501,24 +501,56 @@ export function removeAssignment(db: Kysely<DB>) {
   };
 }
 
-export function overrideResponse(db: Kysely<DB>) {
-  return async (userId: string, responseId: string, data: OverrideResponse) => {
-    const response = await db
-      .selectFrom("availability_response")
-      .where("id", "=", responseId)
+export function setAvailability(db: Kysely<DB>) {
+  return async (
+    userId: string,
+    requestId: string,
+    date: string,
+    memberId: string,
+    data: SetAvailability,
+  ) => {
+    const fixture = await db
+      .selectFrom("availability_fixture")
+      .where("availability_request_id", "=", requestId)
+      .where("match_date", "=", date)
       .select("id")
       .executeTakeFirst();
 
-    if (!response) throwHttpError(404, "Response not found");
+    if (!fixture)
+      throwHttpError(404, "No fixtures on this date for this request");
+
+    const member = await db
+      .selectFrom("member")
+      .where("id", "=", memberId)
+      .where("deleted_at", "is", null)
+      .select("id")
+      .executeTakeFirst();
+
+    if (!member) throwHttpError(404, "Member not found");
+
+    const now = new Date().toISOString();
 
     await db
-      .updateTable("availability_response")
-      .set({
+      .insertInto("availability_response")
+      .values({
+        id: crypto.randomUUID(),
+        availability_request_id: requestId,
+        member_id: memberId,
+        match_date: date,
         status: data.status,
         overridden_by: userId,
-        updated_at: new Date().toISOString(),
+        created_at: now,
+        updated_at: now,
       })
-      .where("id", "=", responseId)
+      .onConflict((oc) =>
+        oc
+          .columns(["availability_request_id", "member_id", "match_date"])
+          .doUpdateSet({
+            status: data.status,
+            overridden_by: userId,
+            updated_at: now,
+          }),
+      )
       .execute();
 
     return { success: true };

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -5128,7 +5128,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/availability/responses/{responseId}/override": {
+    "/api/availability/requests/{requestId}/dates/{date}/members/{memberId}/availability": {
         parameters: {
             query?: never;
             header?: never;
@@ -5141,7 +5141,9 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    responseId: string;
+                    requestId: string;
+                    date: string;
+                    memberId: string;
                 };
                 cookie?: never;
             };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -8878,7 +8878,7 @@
         }
       }
     },
-    "/api/availability/responses/{responseId}/override": {
+    "/api/availability/requests/{requestId}/dates/{date}/members/{memberId}/availability": {
       "put": {
         "requestBody": {
           "required": true,
@@ -8908,7 +8908,24 @@
               "type": "string"
             },
             "in": "path",
-            "name": "responseId",
+            "name": "requestId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "in": "path",
+            "name": "date",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "memberId",
             "required": true
           }
         ],

--- a/apps/web/src/pages/official/availability.tsx
+++ b/apps/web/src/pages/official/availability.tsx
@@ -509,16 +509,21 @@ function TeamSelectionView({
     },
   });
 
-  const overrideMutation = useMutation({
+  const setAvailabilityMutation = useMutation({
     mutationFn: (data: {
-      responseId: string;
+      memberId: string;
       status: "available" | "unavailable";
     }) =>
       callApi(
-        api.PUT("/api/availability/responses/{responseId}/override", {
-          params: { path: { responseId: data.responseId } },
-          body: { status: data.status },
-        }),
+        api.PUT(
+          "/api/availability/requests/{requestId}/dates/{date}/members/{memberId}/availability",
+          {
+            params: {
+              path: { requestId, date, memberId: data.memberId },
+            },
+            body: { status: data.status },
+          },
+        ),
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
@@ -736,7 +741,6 @@ function TeamSelectionView({
               id: p.member_id,
               name: p.member_name ?? "Unknown",
               note: p.note,
-              responseId: p.id,
               overridden: !!p.overridden_by,
             }))}
             fixtures={fixtures}
@@ -747,8 +751,8 @@ function TeamSelectionView({
                 playerName: name,
               })
             }
-            onOverride={(responseId, status) =>
-              overrideMutation.mutate({ responseId, status })
+            onSetAvailability={(memberId, status) =>
+              setAvailabilityMutation.mutate({ memberId, status })
             }
             overrideStatus="unavailable"
             isAssigning={assignMutation.isPending}
@@ -766,7 +770,6 @@ function TeamSelectionView({
                 id: p.member_id,
                 name: p.member_name ?? "Unknown",
                 note: p.note,
-                responseId: p.id,
                 overridden: !!p.overridden_by,
               }))}
             fixtures={fixtures}
@@ -777,8 +780,8 @@ function TeamSelectionView({
                 playerName: name,
               })
             }
-            onOverride={(responseId, status) =>
-              overrideMutation.mutate({ responseId, status })
+            onSetAvailability={(memberId, status) =>
+              setAvailabilityMutation.mutate({ memberId, status })
             }
             overrideStatus="available"
             isAssigning={assignMutation.isPending}
@@ -805,36 +808,32 @@ function TeamSelectionView({
                       className="flex items-center justify-between text-sm"
                     >
                       <span>{p.name ?? "Unknown"}</span>
-                      {fixtures.length === 1 ? (
+                      <div className="flex gap-2">
                         <button
-                          className="text-xs text-blue-600 hover:text-blue-800"
-                          disabled={
-                            assignMutation.isPending ||
-                            fixtures[0].assignments.length >= 11
-                          }
+                          className="text-xs text-green-700 hover:text-green-900"
+                          disabled={setAvailabilityMutation.isPending}
                           onClick={() =>
-                            assignMutation.mutate({
-                              fixtureId: fixtures[0].id,
+                            setAvailabilityMutation.mutate({
                               memberId: p.id,
-                              playerName: p.name ?? "Unknown",
+                              status: "available",
                             })
                           }
                         >
-                          Assign
+                          Available
                         </button>
-                      ) : (
-                        <FixtureSelect
-                          fixtures={fixtures}
-                          onSelect={(fixtureId) =>
-                            assignMutation.mutate({
-                              fixtureId,
+                        <button
+                          className="text-xs text-red-600 hover:text-red-800"
+                          disabled={setAvailabilityMutation.isPending}
+                          onClick={() =>
+                            setAvailabilityMutation.mutate({
                               memberId: p.id,
-                              playerName: p.name ?? "Unknown",
+                              status: "unavailable",
                             })
                           }
-                          disabled={assignMutation.isPending}
-                        />
-                      )}
+                        >
+                          Unavailable
+                        </button>
+                      </div>
                     </div>
                   ))}
                   {filteredNoResponse.length > 50 && (
@@ -860,7 +859,7 @@ function PlayerPool({
   players,
   fixtures,
   onAssign,
-  onOverride,
+  onSetAvailability,
   overrideStatus,
   isAssigning,
 }: {
@@ -870,12 +869,14 @@ function PlayerPool({
     id: string;
     name: string;
     note: string | null;
-    responseId: string;
     overridden: boolean;
   }>;
   fixtures: FixtureWithAssignments[];
   onAssign: (fixtureId: string, memberId: string, name: string) => void;
-  onOverride: (responseId: string, status: "available" | "unavailable") => void;
+  onSetAvailability: (
+    memberId: string,
+    status: "available" | "unavailable",
+  ) => void;
   overrideStatus: "available" | "unavailable";
   isAssigning: boolean;
 }) {
@@ -913,7 +914,7 @@ function PlayerPool({
                 <div className="flex items-center gap-2">
                   <button
                     className="text-xs text-gray-400 hover:text-gray-600"
-                    onClick={() => onOverride(p.responseId, overrideStatus)}
+                    onClick={() => onSetAvailability(p.id, overrideStatus)}
                   >
                     {overrideStatus === "available"
                       ? "Mark available"


### PR DESCRIPTION
## Summary
- Replace `PUT /availability/responses/:responseId/override` with `PUT /availability/requests/:requestId/dates/:date/members/:memberId/availability` — the new endpoint upserts so it works whether or not the member has responded.
- "No Response" pool in the team selection UI swaps the direct *Assign* action for *Available* / *Unavailable* buttons. Availability is set first; assignment then happens from the *Available* pool as before.
- Either way, `overridden_by` is set to the acting official.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm format:check`
- [x] `pnpm --filter api test` (268 passing — includes new unit cases for fixture-missing, member-missing, and successful upsert)
- [ ] Integration tests (`pnpm --filter api test:integration`) — new cases cover override-existing, create-from-no-response, and 404 on no-fixture; not run locally
- [ ] Smoke test in the UI: open an active availability request, mark a No-Response member Available, verify they appear in the Available pool with the "(overridden)" tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)