### PR TITLE
Admin sponsorship enhancements + sponsor phone field

### DIFF
--- a/apps/api/src/features/games/schemas.ts
+++ b/apps/api/src/features/games/schemas.ts
@@ -82,6 +82,7 @@ const sponsorSchema = z
     logoUrl: z.string().nullable(),
     message: z.string().nullable(),
     website: z.string().nullable(),
+    phone: z.string().nullable(),
   })
   .nullable();
 

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -67,6 +67,7 @@ export interface GameDetail extends GameListItem {
     logoUrl: string | null;
     message: string | null;
     website: string | null;
+    phone: string | null;
   } | null;
   lineup: {
     confirmed: boolean;
@@ -254,6 +255,7 @@ export function getGame(
           "sponsor_logo_url",
           "sponsor_message",
           "sponsor_website",
+          "sponsor_phone",
         ])
         .executeTakeFirst(),
       db
@@ -405,6 +407,7 @@ export function getGame(
             logoUrl: sponsorship.sponsor_logo_url,
             message: sponsorship.sponsor_message,
             website: sponsorship.sponsor_website,
+            phone: sponsorship.sponsor_phone,
           }
         : null,
       lineup,

--- a/apps/api/src/features/sponsorship/routes.ts
+++ b/apps/api/src/features/sponsorship/routes.ts
@@ -25,6 +25,7 @@ import {
   sponsorshipListSchema,
   sponsorshipUpdateSchema,
   successResponseSchema,
+  takenSlugsResponseSchema,
 } from "./schemas.ts";
 import {
   approveGameSponsorship,
@@ -38,6 +39,7 @@ import {
   getGameSponsorshipPrice,
   getPlayerSponsorForPlayer,
   getPlayerSponsorshipPrice,
+  getTakenPlayerSponsorshipSlugs,
   hasGamePendingSponsor,
   hasPlayerPendingSponsor,
   listGameSponsorships,
@@ -86,6 +88,7 @@ export const sponsorshipRoutes: FastifyPluginAsyncZod = async (app) => {
   const playerSponsor = getPlayerSponsorForPlayer(app.db);
   const playerPending = hasPlayerPendingSponsor(app.db);
   const allApproved = getAllApprovedPlayerSponsors(app.db);
+  const takenSlugs = getTakenPlayerSponsorshipSlugs(app.db);
   const createGamePayment = createGameSponsorshipPayment(
     app.db,
     stripe,
@@ -289,6 +292,20 @@ export const sponsorshipRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       const { page, pageSize, filter } = request.query;
       return await listPlayer(page, pageSize, filter);
+    },
+  );
+
+  app.get(
+    "/sponsorship/admin/player/taken-slugs",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        querystring: allApprovedSchema,
+        response: { 200: takenSlugsResponseSchema },
+      },
+    },
+    async (request) => {
+      return await takenSlugs(request.query.season);
     },
   );
 

--- a/apps/api/src/features/sponsorship/schemas.ts
+++ b/apps/api/src/features/sponsorship/schemas.ts
@@ -6,6 +6,7 @@ export const gameSponsorshipPaymentSchema = z.object({
   sponsorName: z.string().min(1),
   sponsorEmail: z.email(),
   sponsorWebsite: z.string().optional(),
+  sponsorPhone: z.string().optional(),
   sponsorLogoDataUrl: z.string().optional(),
   sponsorMessage: z.string().optional(),
 });
@@ -17,6 +18,7 @@ export const playerSponsorshipPaymentSchema = z.object({
   sponsorName: z.string().min(1),
   sponsorEmail: z.email(),
   sponsorWebsite: z.string().optional(),
+  sponsorPhone: z.string().optional(),
   sponsorLogoDataUrl: z.string().optional(),
   sponsorMessage: z.string().optional(),
 });
@@ -37,8 +39,9 @@ export const sponsorshipUpdateSchema = z.object({
   sponsorshipId: z.string(),
   displayName: z.string().optional(),
   notes: z.string().optional(),
-  sponsorLogoDataUrl: z.string().optional(),
+  sponsorLogoDataUrl: z.string().nullable().optional(),
   sponsorWebsite: z.string().nullable().optional(),
+  sponsorPhone: z.string().nullable().optional(),
 });
 
 export const playerSponsorshipManualSchema = z.object({
@@ -47,6 +50,7 @@ export const playerSponsorshipManualSchema = z.object({
   sponsorName: z.string().min(1),
   sponsorEmail: z.email(),
   sponsorWebsite: z.string().optional(),
+  sponsorPhone: z.string().optional(),
   sponsorLogoDataUrl: z.string().optional(),
   sponsorMessage: z.string().optional(),
   amountPence: z.number().int().positive(),
@@ -59,6 +63,7 @@ export const gameSponsorshipManualSchema = z.object({
   sponsorName: z.string().min(1),
   sponsorEmail: z.email(),
   sponsorWebsite: z.string().optional(),
+  sponsorPhone: z.string().optional(),
   sponsorLogoDataUrl: z.string().optional(),
   sponsorMessage: z.string().optional(),
   amountPence: z.number().int().positive(),
@@ -101,6 +106,7 @@ const gameSponsorshipRowSchema = z.object({
   sponsor_name: z.string(),
   sponsor_email: z.string(),
   sponsor_website: z.string().nullable(),
+  sponsor_phone: z.string().nullable(),
   sponsor_logo_url: z.string().nullable(),
   sponsor_message: z.string().nullable(),
   amount_pence: z.number(),
@@ -119,6 +125,7 @@ const playerSponsorshipRowSchema = z.object({
   sponsor_name: z.string(),
   sponsor_email: z.string(),
   sponsor_website: z.string().nullable(),
+  sponsor_phone: z.string().nullable(),
   sponsor_logo_url: z.string().nullable(),
   sponsor_message: z.string().nullable(),
   amount_pence: z.number(),
@@ -173,6 +180,10 @@ export const successResponseSchema = z.object({
 
 export const idResponseSchema = z.object({
   id: z.string(),
+});
+
+export const takenSlugsResponseSchema = z.object({
+  slugs: z.array(z.string()),
 });
 
 export type GameSponsorshipPayment = z.infer<

--- a/apps/api/src/features/sponsorship/service.ts
+++ b/apps/api/src/features/sponsorship/service.ts
@@ -87,6 +87,26 @@ export function hasPlayerPendingSponsor(db: Kysely<DB>) {
   };
 }
 
+export function getTakenPlayerSponsorshipSlugs(db: Kysely<DB>) {
+  return async (season?: number) => {
+    const targetSeason = season ?? new Date().getFullYear();
+
+    const rows = await db
+      .selectFrom("player_sponsorship")
+      .where("season", "=", targetSeason)
+      .where("paid_at", "is not", null)
+      .where("slug", "is not", null)
+      .select("slug")
+      .execute();
+
+    const slugs = rows
+      .map((r) => r.slug)
+      .filter((s): s is string => s !== null);
+
+    return { slugs };
+  };
+}
+
 export function getAllApprovedPlayerSponsors(db: Kysely<DB>) {
   return async (season?: number) => {
     const targetSeason = season ?? new Date().getFullYear();
@@ -228,6 +248,7 @@ export function createManualGameSponsorship(db: Kysely<DB>) {
         sponsor_name: data.sponsorName,
         sponsor_email: data.sponsorEmail,
         sponsor_website: data.sponsorWebsite ?? null,
+        sponsor_phone: data.sponsorPhone ?? null,
         sponsor_logo_url: data.sponsorLogoDataUrl ?? null,
         sponsor_message: data.sponsorMessage ?? null,
         amount_pence: data.amountPence,
@@ -258,6 +279,7 @@ export function createManualPlayerSponsorship(db: Kysely<DB>) {
         sponsor_name: data.sponsorName,
         sponsor_email: data.sponsorEmail,
         sponsor_website: data.sponsorWebsite ?? null,
+        sponsor_phone: data.sponsorPhone ?? null,
         sponsor_logo_url: data.sponsorLogoDataUrl ?? null,
         sponsor_message: data.sponsorMessage ?? null,
         amount_pence: data.amountPence,
@@ -274,19 +296,34 @@ export function createManualPlayerSponsorship(db: Kysely<DB>) {
   };
 }
 
+function validateLogoSize(logo: string | null | undefined) {
+  if (typeof logo === "string" && logo.length > 150_000) {
+    throw Object.assign(new Error("Logo must be under 150KB"), {
+      statusCode: 400,
+    });
+  }
+}
+
 export function updateGameSponsorship(db: Kysely<DB>) {
   return async (
     sponsorshipId: string,
     data: Omit<SponsorshipUpdate, "sponsorshipId">,
   ) => {
+    validateLogoSize(data.sponsorLogoDataUrl);
+
     await db
       .updateTable("game_sponsorship")
       .set({
         display_name: data.displayName,
         notes: data.notes,
-        sponsor_logo_url: data.sponsorLogoDataUrl,
+        ...(data.sponsorLogoDataUrl !== undefined
+          ? { sponsor_logo_url: data.sponsorLogoDataUrl }
+          : {}),
         ...(data.sponsorWebsite !== undefined
           ? { sponsor_website: data.sponsorWebsite }
+          : {}),
+        ...(data.sponsorPhone !== undefined
+          ? { sponsor_phone: data.sponsorPhone }
           : {}),
       })
       .where("id", "=", sponsorshipId)
@@ -301,14 +338,21 @@ export function updatePlayerSponsorship(db: Kysely<DB>) {
     sponsorshipId: string,
     data: Omit<SponsorshipUpdate, "sponsorshipId">,
   ) => {
+    validateLogoSize(data.sponsorLogoDataUrl);
+
     await db
       .updateTable("player_sponsorship")
       .set({
         display_name: data.displayName,
         notes: data.notes,
-        sponsor_logo_url: data.sponsorLogoDataUrl,
+        ...(data.sponsorLogoDataUrl !== undefined
+          ? { sponsor_logo_url: data.sponsorLogoDataUrl }
+          : {}),
         ...(data.sponsorWebsite !== undefined
           ? { sponsor_website: data.sponsorWebsite }
+          : {}),
+        ...(data.sponsorPhone !== undefined
+          ? { sponsor_phone: data.sponsorPhone }
           : {}),
       })
       .where("id", "=", sponsorshipId)
@@ -423,6 +467,7 @@ export function createGameSponsorshipPayment(
         sponsor_name: data.sponsorName,
         sponsor_email: data.sponsorEmail,
         sponsor_website: data.sponsorWebsite ?? null,
+        sponsor_phone: data.sponsorPhone ?? null,
         sponsor_logo_url: data.sponsorLogoDataUrl ?? null,
         sponsor_message: data.sponsorMessage ?? null,
         amount_pence: price.amountPence,
@@ -551,6 +596,7 @@ export function createPlayerSponsorshipPayment(
         sponsor_name: data.sponsorName,
         sponsor_email: data.sponsorEmail,
         sponsor_website: data.sponsorWebsite ?? null,
+        sponsor_phone: data.sponsorPhone ?? null,
         sponsor_logo_url: data.sponsorLogoDataUrl ?? null,
         sponsor_message: data.sponsorMessage ?? null,
         amount_pence: price.amountPence,

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -49,13 +49,13 @@ export function DialogContent({
       />
       <div
         className={cn(
-          "border-border bg-surface relative z-50 w-full max-w-lg rounded-lg border p-6 shadow-lg",
+          "border-border bg-surface relative z-50 flex max-h-[90vh] w-full max-w-lg flex-col rounded-lg border shadow-lg",
           className,
         )}
       >
         <button
           type="button"
-          className="text-muted hover:text-foreground absolute top-4 right-4 rounded-sm p-1"
+          className="text-muted hover:text-foreground absolute top-4 right-4 z-10 rounded-sm p-1"
           onClick={() => onOpenChange(false)}
           aria-label="Close"
         >
@@ -74,7 +74,7 @@ export function DialogContent({
             <line x1="6" y1="6" x2="18" y2="18" />
           </svg>
         </button>
-        {children}
+        <div className="overflow-y-auto p-6">{children}</div>
       </div>
     </div>
   );

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -2436,6 +2436,7 @@ export interface paths {
                                 logoUrl: string | null;
                                 message: string | null;
                                 website: string | null;
+                                phone: string | null;
                             } | null;
                             lineup: {
                                 confirmed: boolean;
@@ -2999,6 +3000,7 @@ export interface paths {
                                 sponsor_name: string;
                                 sponsor_email: string;
                                 sponsor_website: string | null;
+                                sponsor_phone: string | null;
                                 sponsor_logo_url: string | null;
                                 sponsor_message: string | null;
                                 amount_pence: number;
@@ -3054,6 +3056,7 @@ export interface paths {
                                 sponsor_name: string;
                                 sponsor_email: string;
                                 sponsor_website: string | null;
+                                sponsor_phone: string | null;
                                 sponsor_logo_url: string | null;
                                 sponsor_message: string | null;
                                 amount_pence: number;
@@ -3140,6 +3143,7 @@ export interface paths {
                         /** Format: email */
                         sponsorEmail: string;
                         sponsorWebsite?: string;
+                        sponsorPhone?: string;
                         sponsorLogoDataUrl?: string;
                         sponsorMessage?: string;
                     };
@@ -3199,6 +3203,7 @@ export interface paths {
                                 sponsor_name: string;
                                 sponsor_email: string;
                                 sponsor_website: string | null;
+                                sponsor_phone: string | null;
                                 sponsor_logo_url: string | null;
                                 sponsor_message: string | null;
                                 amount_pence: number;
@@ -3287,6 +3292,7 @@ export interface paths {
                         /** Format: email */
                         sponsorEmail: string;
                         sponsorWebsite?: string;
+                        sponsorPhone?: string;
                         sponsorLogoDataUrl?: string;
                         sponsorMessage?: string;
                     };
@@ -3347,6 +3353,7 @@ export interface paths {
                                 sponsor_name: string;
                                 sponsor_email: string;
                                 sponsor_website: string | null;
+                                sponsor_phone: string | null;
                                 sponsor_logo_url: string | null;
                                 sponsor_message: string | null;
                                 amount_pence: number;
@@ -3407,6 +3414,7 @@ export interface paths {
                                 sponsor_name: string;
                                 sponsor_email: string;
                                 sponsor_website: string | null;
+                                sponsor_phone: string | null;
                                 sponsor_logo_url: string | null;
                                 sponsor_message: string | null;
                                 amount_pence: number;
@@ -3421,6 +3429,45 @@ export interface paths {
                             total: number;
                             page: number;
                             pageSize: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sponsorship/admin/player/taken-slugs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    season?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            slugs: string[];
                         };
                     };
                 };
@@ -3630,6 +3677,7 @@ export interface paths {
                         /** Format: email */
                         sponsorEmail: string;
                         sponsorWebsite?: string;
+                        sponsorPhone?: string;
                         sponsorLogoDataUrl?: string;
                         sponsorMessage?: string;
                         amountPence: number;
@@ -3683,6 +3731,7 @@ export interface paths {
                         /** Format: email */
                         sponsorEmail: string;
                         sponsorWebsite?: string;
+                        sponsorPhone?: string;
                         sponsorLogoDataUrl?: string;
                         sponsorMessage?: string;
                         amountPence: number;
@@ -3734,8 +3783,9 @@ export interface paths {
                         sponsorshipId: string;
                         displayName?: string;
                         notes?: string;
-                        sponsorLogoDataUrl?: string;
+                        sponsorLogoDataUrl?: string | null;
                         sponsorWebsite?: string | null;
+                        sponsorPhone?: string | null;
                     };
                 };
             };
@@ -3783,8 +3833,9 @@ export interface paths {
                         sponsorshipId: string;
                         displayName?: string;
                         notes?: string;
-                        sponsorLogoDataUrl?: string;
+                        sponsorLogoDataUrl?: string | null;
                         sponsorWebsite?: string | null;
+                        sponsorPhone?: string | null;
                     };
                 };
             };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -4312,13 +4312,18 @@
                         "website": {
                           "nullable": true,
                           "type": "string"
+                        },
+                        "phone": {
+                          "nullable": true,
+                          "type": "string"
                         }
                       },
                       "required": [
                         "name",
                         "logoUrl",
                         "message",
-                        "website"
+                        "website",
+                        "phone"
                       ],
                       "additionalProperties": false
                     },
@@ -5322,6 +5327,10 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "sponsor_phone": {
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "sponsor_logo_url": {
                             "nullable": true,
                             "type": "string"
@@ -5366,6 +5375,7 @@
                           "sponsor_name",
                           "sponsor_email",
                           "sponsor_website",
+                          "sponsor_phone",
                           "sponsor_logo_url",
                           "sponsor_message",
                           "amount_pence",
@@ -5432,6 +5442,10 @@
                           "nullable": true,
                           "type": "string"
                         },
+                        "sponsor_phone": {
+                          "nullable": true,
+                          "type": "string"
+                        },
                         "sponsor_logo_url": {
                           "nullable": true,
                           "type": "string"
@@ -5472,6 +5486,7 @@
                         "sponsor_name",
                         "sponsor_email",
                         "sponsor_website",
+                        "sponsor_phone",
                         "sponsor_logo_url",
                         "sponsor_message",
                         "amount_pence",
@@ -5553,6 +5568,9 @@
                     "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
                   },
                   "sponsorWebsite": {
+                    "type": "string"
+                  },
+                  "sponsorPhone": {
                     "type": "string"
                   },
                   "sponsorLogoDataUrl": {
@@ -5647,6 +5665,10 @@
                           "nullable": true,
                           "type": "string"
                         },
+                        "sponsor_phone": {
+                          "nullable": true,
+                          "type": "string"
+                        },
                         "sponsor_logo_url": {
                           "nullable": true,
                           "type": "string"
@@ -5691,6 +5713,7 @@
                         "sponsor_name",
                         "sponsor_email",
                         "sponsor_website",
+                        "sponsor_phone",
                         "sponsor_logo_url",
                         "sponsor_message",
                         "amount_pence",
@@ -5776,6 +5799,9 @@
                     "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
                   },
                   "sponsorWebsite": {
+                    "type": "string"
+                  },
+                  "sponsorPhone": {
                     "type": "string"
                   },
                   "sponsorLogoDataUrl": {
@@ -5897,6 +5923,10 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "sponsor_phone": {
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "sponsor_logo_url": {
                             "nullable": true,
                             "type": "string"
@@ -5937,6 +5967,7 @@
                           "sponsor_name",
                           "sponsor_email",
                           "sponsor_website",
+                          "sponsor_phone",
                           "sponsor_logo_url",
                           "sponsor_message",
                           "amount_pence",
@@ -6048,6 +6079,10 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "sponsor_phone": {
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "sponsor_logo_url": {
                             "nullable": true,
                             "type": "string"
@@ -6092,6 +6127,7 @@
                           "sponsor_name",
                           "sponsor_email",
                           "sponsor_website",
+                          "sponsor_phone",
                           "sponsor_logo_url",
                           "sponsor_message",
                           "amount_pence",
@@ -6121,6 +6157,44 @@
                     "total",
                     "page",
                     "pageSize"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sponsorship/admin/player/taken-slugs": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "number"
+            },
+            "in": "query",
+            "name": "season",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "slugs": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "slugs"
                   ],
                   "additionalProperties": false
                 }
@@ -6326,6 +6400,9 @@
                   "sponsorWebsite": {
                     "type": "string"
                   },
+                  "sponsorPhone": {
+                    "type": "string"
+                  },
                   "sponsorLogoDataUrl": {
                     "type": "string"
                   },
@@ -6404,6 +6481,9 @@
                   "sponsorWebsite": {
                     "type": "string"
                   },
+                  "sponsorPhone": {
+                    "type": "string"
+                  },
                   "sponsorLogoDataUrl": {
                     "type": "string"
                   },
@@ -6475,9 +6555,14 @@
                     "type": "string"
                   },
                   "sponsorLogoDataUrl": {
+                    "nullable": true,
                     "type": "string"
                   },
                   "sponsorWebsite": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "sponsorPhone": {
                     "nullable": true,
                     "type": "string"
                   }
@@ -6541,9 +6626,14 @@
                     "type": "string"
                   },
                   "sponsorLogoDataUrl": {
+                    "nullable": true,
                     "type": "string"
                   },
                   "sponsorWebsite": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "sponsorPhone": {
                     "nullable": true,
                     "type": "string"
                   }

--- a/apps/web/src/lib/logo-resize.ts
+++ b/apps/web/src/lib/logo-resize.ts
@@ -1,0 +1,42 @@
+export const MAX_LOGO_BYTES = 150_000;
+
+export function resizeLogo(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const maxDim = 300;
+        let { width, height } = img;
+        if (width > maxDim || height > maxDim) {
+          const ratio = Math.min(maxDim / width, maxDim / height);
+          width = Math.round(width * ratio);
+          height = Math.round(height * ratio);
+        }
+
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          reject(new Error("Failed to create canvas context"));
+          return;
+        }
+        ctx.drawImage(img, 0, 0, width, height);
+
+        for (let q = 0.8; q >= 0.1; q -= 0.1) {
+          const dataUrl = canvas.toDataURL("image/jpeg", q);
+          if (dataUrl.length <= MAX_LOGO_BYTES) {
+            resolve(dataUrl);
+            return;
+          }
+        }
+        reject(new Error("Logo could not be compressed below 150KB"));
+      };
+      img.onerror = () => reject(new Error("Failed to load image"));
+      img.src = reader.result as string;
+    };
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}

--- a/apps/web/src/lib/people.ts
+++ b/apps/web/src/lib/people.ts
@@ -44,3 +44,7 @@ for (const mod of Object.values(modules)) {
 export function getPersonBySlug(slug: string): PersonData | undefined {
   return people.get(slug);
 }
+
+export function getAllPeople(): PersonData[] {
+  return Array.from(people.values());
+}

--- a/apps/web/src/pages/admin/documents-tab.tsx
+++ b/apps/web/src/pages/admin/documents-tab.tsx
@@ -316,7 +316,7 @@ function AssignUsersDialog({
         onOpenChange(v);
       }}
     >
-      <DialogContent className="max-h-[80vh] w-full max-w-lg overflow-y-auto">
+      <DialogContent className="max-h-[80vh]">
         <DialogHeader>
           <DialogTitle>Assign Document</DialogTitle>
         </DialogHeader>
@@ -463,7 +463,7 @@ function DocumentDetailModal({
 
   return (
     <Dialog open onOpenChange={() => onClose()}>
-      <DialogContent className="max-h-[90vh] w-full max-w-2xl overflow-y-auto p-6">
+      <DialogContent className="max-w-2xl">
         {isLoading ? (
           <div className="py-8 text-center text-gray-500">Loading...</div>
         ) : data ? (

--- a/apps/web/src/pages/admin/duplicates-tab.tsx
+++ b/apps/web/src/pages/admin/duplicates-tab.tsx
@@ -228,7 +228,7 @@ function MergePreviewModal({
         if (!open) onClose();
       }}
     >
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
+      <DialogContent className="sm:max-w-4xl">
         <DialogHeader>
           <DialogTitle>Merge Preview</DialogTitle>
         </DialogHeader>

--- a/apps/web/src/pages/admin/juniors-tab.tsx
+++ b/apps/web/src/pages/admin/juniors-tab.tsx
@@ -445,7 +445,7 @@ function LinkingDialog({
         if (!open) onClose();
       }}
     >
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Link Account - {junior.name}</DialogTitle>
         </DialogHeader>

--- a/apps/web/src/pages/admin/member-detail-modal.tsx
+++ b/apps/web/src/pages/admin/member-detail-modal.tsx
@@ -73,7 +73,7 @@ export function MemberDetailModal({ userId, onClose }: MemberDetailModalProps) {
 
   return (
     <Dialog open={true} onOpenChange={() => onClose()}>
-      <DialogContent className="max-h-[90vh] w-full max-w-2xl overflow-y-auto">
+      <DialogContent className="max-w-2xl">
         {isLoading || !data ? (
           <div className="py-12 text-center text-gray-500">Loading...</div>
         ) : (

--- a/apps/web/src/pages/admin/record-linking-tab.tsx
+++ b/apps/web/src/pages/admin/record-linking-tab.tsx
@@ -555,7 +555,7 @@ function DetailModal({
         if (!open) onClose();
       }}
     >
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{person.name}</DialogTitle>
           <div className="flex items-center gap-2 text-sm text-gray-500">

--- a/apps/web/src/pages/admin/sponsorships-tab.tsx
+++ b/apps/web/src/pages/admin/sponsorships-tab.tsx
@@ -24,14 +24,102 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
+import { resizeLogo } from "@/lib/logo-resize";
+import { getAllPeople } from "@/lib/people";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { formatDate, formatPence } from "./status-pill";
 
 const PAGE_SIZE = 20;
 
 type SubTab = "game" | "player";
 type FilterValue = "all" | "pending_payment" | "pending_approval" | "approved";
+
+function PlayerSelect({
+  value,
+  playerName,
+  takenSlugs,
+  onChange,
+}: {
+  value: string;
+  playerName: string;
+  takenSlugs: Set<string>;
+  onChange: (slug: string, name: string) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const available = useMemo(() => {
+    return getAllPeople()
+      .filter((p) => !p.hasLeftClub && !takenSlugs.has(p.slug))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [takenSlugs]);
+
+  const filtered = query.trim()
+    ? available.filter((p) =>
+        p.name.toLowerCase().includes(query.trim().toLowerCase()),
+      )
+    : available;
+
+  if (value) {
+    return (
+      <div className="flex items-center gap-2">
+        <div className="border-border bg-muted/30 flex-1 rounded border px-3 py-2 text-sm">
+          {playerName} <span className="text-gray-500">({value})</span>
+        </div>
+        <button
+          type="button"
+          className="text-xs text-blue-600 hover:underline"
+          onClick={() => onChange("", "")}
+        >
+          Change
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <Input
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setDropdownOpen(true);
+        }}
+        onFocus={() => setDropdownOpen(true)}
+        onBlur={() => setTimeout(() => setDropdownOpen(false), 150)}
+        placeholder="Search players..."
+      />
+      {dropdownOpen && (
+        <div className="border-border bg-surface absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded border shadow-lg">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-2 text-sm text-gray-500">
+              {query.trim()
+                ? "No matching players available"
+                : "No players available"}
+            </div>
+          ) : (
+            filtered.map((p) => (
+              <button
+                key={p.slug}
+                type="button"
+                className="block w-full px-3 py-2 text-left text-sm hover:bg-gray-100"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  onChange(p.slug, p.name);
+                  setQuery("");
+                  setDropdownOpen(false);
+                }}
+              >
+                {p.name}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function SponsorshipStatus({
   paid_at,
@@ -105,7 +193,7 @@ function InlineEdit({
   if (value) {
     return (
       <button
-        className="cursor-pointer text-left text-xs text-gray-700 hover:underline"
+        className="block cursor-pointer text-left text-xs text-gray-700 hover:underline"
         onClick={() => {
           setDraft(value);
           setEditing(true);
@@ -118,7 +206,7 @@ function InlineEdit({
 
   return (
     <button
-      className="cursor-pointer text-xs text-blue-600 hover:underline"
+      className="block cursor-pointer text-left text-xs text-blue-600 hover:underline"
       onClick={() => {
         setDraft("");
         setEditing(true);
@@ -138,18 +226,97 @@ function isValidUrl(value: string): boolean {
   }
 }
 
+function LogoEdit({
+  logoUrl,
+  alt,
+  onChange,
+}: {
+  logoUrl: string | null;
+  alt: string;
+  onChange: (dataUrl: string | null) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError(null);
+    setBusy(true);
+    try {
+      const dataUrl = await resizeLogo(file);
+      onChange(dataUrl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to process image");
+    } finally {
+      setBusy(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="space-y-1">
+      {logoUrl && (
+        <img
+          src={logoUrl}
+          alt={alt}
+          className="h-8 max-w-[80px] object-contain"
+        />
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => void handleFile(e)}
+      />
+      <div className="flex flex-wrap gap-1">
+        <button
+          type="button"
+          disabled={busy}
+          className="cursor-pointer text-xs text-blue-600 hover:underline disabled:opacity-50"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          {busy ? "Uploading..." : logoUrl ? "Change logo" : "Add logo"}
+        </button>
+        {logoUrl && (
+          <button
+            type="button"
+            disabled={busy}
+            className="cursor-pointer text-xs text-red-600 hover:underline disabled:opacity-50"
+            onClick={() => {
+              setError(null);
+              onChange(null);
+            }}
+          >
+            Remove
+          </button>
+        )}
+      </div>
+      {error && <div className="text-xs text-amber-600">{error}</div>}
+    </div>
+  );
+}
+
 function SponsorColumn({
   name,
   email,
   website,
+  phone,
   logoUrl,
   onWebsiteChange,
+  onPhoneChange,
+  onLogoChange,
 }: {
   name: string;
   email: string;
   website: string | null;
+  phone: string | null;
   logoUrl: string | null;
   onWebsiteChange?: (value: string | null) => void;
+  onPhoneChange?: (value: string | null) => void;
+  onLogoChange?: (dataUrl: string | null) => void;
 }) {
   return (
     <div className="space-y-0.5">
@@ -182,12 +349,36 @@ function SponsorColumn({
           <span className="text-xs text-gray-500">{website}</span>
         )
       ) : null}
-      {logoUrl && (
-        <img
-          src={logoUrl}
+      {onPhoneChange ? (
+        <div>
+          <InlineEdit
+            value={phone}
+            placeholder="Add phone"
+            onSave={onPhoneChange}
+          />
+        </div>
+      ) : phone ? (
+        <a
+          href={`tel:${phone}`}
+          className="text-xs text-blue-600 hover:underline"
+        >
+          {phone}
+        </a>
+      ) : null}
+      {onLogoChange ? (
+        <LogoEdit
+          logoUrl={logoUrl}
           alt={`${name} logo`}
-          className="h-8 max-w-[80px] object-contain"
+          onChange={onLogoChange}
         />
+      ) : (
+        logoUrl && (
+          <img
+            src={logoUrl}
+            alt={`${name} logo`}
+            className="h-8 max-w-[80px] object-contain"
+          />
+        )
       )}
     </div>
   );
@@ -205,6 +396,7 @@ function CreateGameSponsorshipDialog({
   const [sponsorName, setSponsorName] = useState("");
   const [sponsorEmail, setSponsorEmail] = useState("");
   const [website, setWebsite] = useState("");
+  const [phone, setPhone] = useState("");
   const [message, setMessage] = useState("");
   const [amount, setAmount] = useState("");
   const [displayName, setDisplayName] = useState("");
@@ -220,6 +412,7 @@ function CreateGameSponsorshipDialog({
             sponsorEmail: string;
             amountPence: number;
             sponsorWebsite?: string;
+            sponsorPhone?: string;
             sponsorMessage?: string;
             displayName?: string;
             notes?: string;
@@ -240,6 +433,7 @@ function CreateGameSponsorshipDialog({
     setSponsorName("");
     setSponsorEmail("");
     setWebsite("");
+    setPhone("");
     setMessage("");
     setAmount("");
     setDisplayName("");
@@ -254,6 +448,7 @@ function CreateGameSponsorshipDialog({
       sponsorName,
       sponsorEmail,
       ...(website ? { sponsorWebsite: website } : {}),
+      ...(phone ? { sponsorPhone: phone } : {}),
       ...(message ? { sponsorMessage: message } : {}),
       amountPence,
       ...(displayName ? { displayName } : {}),
@@ -304,6 +499,15 @@ function CreateGameSponsorshipDialog({
             <Input
               value={website}
               onChange={(e) => setWebsite(e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Phone</label>
+            <Input
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
               placeholder="Optional"
             />
           </div>
@@ -359,6 +563,223 @@ function CreateGameSponsorshipDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={createMutation.isPending}>
+              {createMutation.isPending ? "Creating..." : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CreatePlayerSponsorshipDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [slug, setSlug] = useState("");
+  const [playerName, setPlayerName] = useState("");
+  const [sponsorName, setSponsorName] = useState("");
+  const [sponsorEmail, setSponsorEmail] = useState("");
+  const [website, setWebsite] = useState("");
+  const [phone, setPhone] = useState("");
+  const [message, setMessage] = useState("");
+  const [amount, setAmount] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const takenSlugsQuery = useQuery({
+    queryKey: ["admin", "playerSponsorships", "takenSlugs"],
+    queryFn: () =>
+      callApi(api.GET("/api/sponsorship/admin/player/taken-slugs", {})),
+    enabled: open,
+  });
+
+  const takenSlugs = useMemo(
+    () => new Set(takenSlugsQuery.data?.slugs ?? []),
+    [takenSlugsQuery.data],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: (body: Record<string, unknown>) =>
+      callApi(
+        api.POST("/api/sponsorship/admin/player/manual", {
+          body: body as {
+            slug: string;
+            playerName: string;
+            sponsorName: string;
+            sponsorEmail: string;
+            amountPence: number;
+            sponsorWebsite?: string;
+            sponsorPhone?: string;
+            sponsorMessage?: string;
+            displayName?: string;
+            notes?: string;
+          },
+        }),
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["admin", "playerSponsorships"],
+      });
+      resetForm();
+      onOpenChange(false);
+    },
+  });
+
+  function resetForm() {
+    setSlug("");
+    setPlayerName("");
+    setSponsorName("");
+    setSponsorEmail("");
+    setWebsite("");
+    setPhone("");
+    setMessage("");
+    setAmount("");
+    setDisplayName("");
+    setNotes("");
+  }
+
+  function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    if (!slug || !playerName) return;
+    const amountPence = Math.round(parseFloat(amount) * 100);
+    createMutation.mutate({
+      slug,
+      playerName,
+      sponsorName,
+      sponsorEmail,
+      ...(website ? { sponsorWebsite: website } : {}),
+      ...(phone ? { sponsorPhone: phone } : {}),
+      ...(message ? { sponsorMessage: message } : {}),
+      amountPence,
+      ...(displayName ? { displayName } : {}),
+      ...(notes ? { notes } : {}),
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Player Sponsorship</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="mb-1 block text-sm font-medium">Player</label>
+            <PlayerSelect
+              value={slug}
+              playerName={playerName}
+              takenSlugs={takenSlugs}
+              onChange={(nextSlug, nextName) => {
+                setSlug(nextSlug);
+                setPlayerName(nextName);
+              }}
+            />
+            {takenSlugsQuery.isLoading && (
+              <div className="mt-1 text-xs text-gray-500">
+                Loading available players...
+              </div>
+            )}
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              Sponsor Name
+            </label>
+            <Input
+              value={sponsorName}
+              onChange={(e) => setSponsorName(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              Sponsor Email
+            </label>
+            <Input
+              type="email"
+              value={sponsorEmail}
+              onChange={(e) => setSponsorEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              Website URL
+            </label>
+            <Input
+              value={website}
+              onChange={(e) => setWebsite(e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Phone</label>
+            <Input
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Message</label>
+            <Input
+              value={message}
+              onChange={(e) => setMessage(e.target.value.slice(0, 100))}
+              placeholder="Optional (max 100 chars)"
+              maxLength={100}
+            />
+            <div className="mt-0.5 text-right text-xs text-gray-400">
+              {message.length}/100
+            </div>
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              Amount (GBP)
+            </label>
+            <Input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              min={0}
+              step={0.01}
+              required
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              Display Name
+            </label>
+            <Input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Notes</label>
+            <Input
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={createMutation.isPending || !slug || !playerName}
+            >
               {createMutation.isPending ? "Creating..." : "Create"}
             </Button>
           </DialogFooter>
@@ -425,6 +846,8 @@ function GameSponsorshipsTable({ filter }: { filter: FilterValue }) {
       displayName?: string | undefined;
       notes?: string | undefined;
       sponsorWebsite?: string | null | undefined;
+      sponsorPhone?: string | null | undefined;
+      sponsorLogoDataUrl?: string | null | undefined;
     }) =>
       callApi(
         api.PUT("/api/sponsorship/admin/game/{sponsorshipId}", {
@@ -469,11 +892,24 @@ function GameSponsorshipsTable({ filter }: { filter: FilterValue }) {
                   name={s.sponsor_name}
                   email={s.sponsor_email}
                   website={s.sponsor_website}
+                  phone={s.sponsor_phone}
                   logoUrl={s.sponsor_logo_url}
                   onWebsiteChange={(v) =>
                     updateMutation.mutate({
                       sponsorshipId: s.id,
                       sponsorWebsite: v,
+                    })
+                  }
+                  onPhoneChange={(v) =>
+                    updateMutation.mutate({
+                      sponsorshipId: s.id,
+                      sponsorPhone: v,
+                    })
+                  }
+                  onLogoChange={(v) =>
+                    updateMutation.mutate({
+                      sponsorshipId: s.id,
+                      sponsorLogoDataUrl: v,
                     })
                   }
                 />
@@ -653,6 +1089,8 @@ function PlayerSponsorshipsTable({ filter }: { filter: FilterValue }) {
       displayName?: string | undefined;
       notes?: string | undefined;
       sponsorWebsite?: string | null | undefined;
+      sponsorPhone?: string | null | undefined;
+      sponsorLogoDataUrl?: string | null | undefined;
     }) =>
       callApi(
         api.PUT("/api/sponsorship/admin/player/{sponsorshipId}", {
@@ -702,11 +1140,24 @@ function PlayerSponsorshipsTable({ filter }: { filter: FilterValue }) {
                   name={s.sponsor_name}
                   email={s.sponsor_email}
                   website={s.sponsor_website}
+                  phone={s.sponsor_phone}
                   logoUrl={s.sponsor_logo_url}
                   onWebsiteChange={(v) =>
                     updateMutation.mutate({
                       sponsorshipId: s.id,
                       sponsorWebsite: v,
+                    })
+                  }
+                  onPhoneChange={(v) =>
+                    updateMutation.mutate({
+                      sponsorshipId: s.id,
+                      sponsorPhone: v,
+                    })
+                  }
+                  onLogoChange={(v) =>
+                    updateMutation.mutate({
+                      sponsorshipId: s.id,
+                      sponsorLogoDataUrl: v,
                     })
                   }
                 />
@@ -832,7 +1283,8 @@ function PlayerSponsorshipsTable({ filter }: { filter: FilterValue }) {
 export function SponsorshipsTab() {
   const [subTab, setSubTab] = useState<SubTab>("game");
   const [filter, setFilter] = useState<FilterValue>("all");
-  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createGameDialogOpen, setCreateGameDialogOpen] = useState(false);
+  const [createPlayerDialogOpen, setCreatePlayerDialogOpen] = useState(false);
 
   return (
     <div className="space-y-4">
@@ -870,8 +1322,12 @@ export function SponsorshipsTab() {
           </SelectContent>
         </Select>
 
-        {subTab === "game" && (
-          <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
+        {subTab === "game" ? (
+          <Button size="sm" onClick={() => setCreateGameDialogOpen(true)}>
+            Create Sponsorship
+          </Button>
+        ) : (
+          <Button size="sm" onClick={() => setCreatePlayerDialogOpen(true)}>
             Create Sponsorship
           </Button>
         )}
@@ -884,10 +1340,14 @@ export function SponsorshipsTab() {
         <PlayerSponsorshipsTable filter={filter} />
       )}
 
-      {/* Create Dialog */}
+      {/* Create Dialogs */}
       <CreateGameSponsorshipDialog
-        open={createDialogOpen}
-        onOpenChange={setCreateDialogOpen}
+        open={createGameDialogOpen}
+        onOpenChange={setCreateGameDialogOpen}
+      />
+      <CreatePlayerSponsorshipDialog
+        open={createPlayerDialogOpen}
+        onOpenChange={setCreatePlayerDialogOpen}
       />
     </div>
   );

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -140,6 +140,9 @@ function SponsorBadge({
 }: {
   sponsor: NonNullable<GameData["sponsor"]>;
 }) {
+  const hasValidWebsite =
+    !!sponsor.website && /^https?:\/\//i.test(sponsor.website);
+
   const content = (
     <div className="flex w-full flex-col items-center gap-2 rounded-lg border border-orange-200 bg-orange-50 px-4 py-3">
       {sponsor.logoUrl && (
@@ -154,13 +157,20 @@ function SponsorBadge({
         <p
           className={cn(
             "text-lg font-semibold text-orange-800",
-            sponsor.website &&
-              /^https?:\/\//i.test(sponsor.website) &&
-              "underline decoration-dotted underline-offset-2",
+            hasValidWebsite && "underline decoration-dotted underline-offset-2",
           )}
         >
           {sponsor.name}
         </p>
+        {sponsor.phone && (
+          <a
+            href={`tel:${sponsor.phone}`}
+            className="mt-1 block text-sm text-orange-700 underline decoration-dotted underline-offset-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {sponsor.phone}
+          </a>
+        )}
       </div>
       {sponsor.message && (
         <p className="text-sm text-orange-600">{sponsor.message}</p>
@@ -168,10 +178,10 @@ function SponsorBadge({
     </div>
   );
 
-  if (sponsor.website && /^https?:\/\//i.test(sponsor.website)) {
+  if (hasValidWebsite) {
     return (
       <a
-        href={sponsor.website}
+        href={sponsor.website ?? ""}
         target="_blank"
         rel="noopener noreferrer"
         className="hover:opacity-80"

--- a/apps/web/src/pages/calendar/game-sponsor-checkout.tsx
+++ b/apps/web/src/pages/calendar/game-sponsor-checkout.tsx
@@ -12,12 +12,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
+import { resizeLogo } from "@/lib/logo-resize";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { IoChevronForward } from "react-icons/io5";
 import { Link, useParams } from "react-router";
 
-const MAX_LOGO_BYTES = 150_000;
 const MAX_MESSAGE_CHARS = 100;
 
 const currencyFormatter = new Intl.NumberFormat("en-GB", {
@@ -27,47 +27,6 @@ const currencyFormatter = new Intl.NumberFormat("en-GB", {
 });
 
 type Step = "details" | "paying" | "success";
-
-function resizeLogo(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const img = new Image();
-      img.onload = () => {
-        const maxDim = 300;
-        let { width, height } = img;
-        if (width > maxDim || height > maxDim) {
-          const ratio = Math.min(maxDim / width, maxDim / height);
-          width = Math.round(width * ratio);
-          height = Math.round(height * ratio);
-        }
-
-        const canvas = document.createElement("canvas");
-        canvas.width = width;
-        canvas.height = height;
-        const ctx = canvas.getContext("2d");
-        if (!ctx) {
-          reject(new Error("Failed to create canvas context"));
-          return;
-        }
-        ctx.drawImage(img, 0, 0, width, height);
-
-        for (let q = 0.8; q >= 0.1; q -= 0.1) {
-          const dataUrl = canvas.toDataURL("image/jpeg", q);
-          if (dataUrl.length <= MAX_LOGO_BYTES) {
-            resolve(dataUrl);
-            return;
-          }
-        }
-        reject(new Error("Logo could not be compressed below 150KB"));
-      };
-      img.onerror = () => reject(new Error("Failed to load image"));
-      img.src = reader.result as string;
-    };
-    reader.onerror = () => reject(new Error("Failed to read file"));
-    reader.readAsDataURL(file);
-  });
-}
 
 export function Component() {
   const { id } = useParams<{ id: string }>();
@@ -95,6 +54,7 @@ export function Component() {
   const [sponsorName, setSponsorName] = useState("");
   const [sponsorEmail, setSponsorEmail] = useState("");
   const [sponsorWebsite, setSponsorWebsite] = useState("");
+  const [sponsorPhone, setSponsorPhone] = useState("");
   const [sponsorMessage, setSponsorMessage] = useState("");
   const [logoDataUrl, setLogoDataUrl] = useState<string | null>(null);
   const [logoError, setLogoError] = useState<string | null>(null);
@@ -114,6 +74,7 @@ export function Component() {
             sponsorName,
             sponsorEmail,
             sponsorWebsite: sponsorWebsite || undefined,
+            sponsorPhone: sponsorPhone || undefined,
             sponsorLogoDataUrl: logoDataUrl ?? undefined,
             sponsorMessage: sponsorMessage || undefined,
           },
@@ -277,9 +238,20 @@ export function Component() {
               <Input
                 id="sponsorWebsite"
                 type="text"
-                placeholder="https://www.example.com"
+                placeholder="https://www.example.com (optional)"
                 value={sponsorWebsite}
                 onChange={(e) => setSponsorWebsite(e.target.value)}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="sponsorPhone">Phone</Label>
+              <Input
+                id="sponsorPhone"
+                type="tel"
+                placeholder="Optional"
+                value={sponsorPhone}
+                onChange={(e) => setSponsorPhone(e.target.value)}
               />
             </div>
 

--- a/apps/web/src/pages/junior-manager/junior-manager.tsx
+++ b/apps/web/src/pages/junior-manager/junior-manager.tsx
@@ -298,7 +298,7 @@ function PlayerDetailModal({
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-h-[90vh] w-full max-w-2xl overflow-y-auto">
+      <DialogContent className="max-w-2xl">
         {isLoading || !data ? (
           <div className="py-12 text-center text-gray-500">Loading...</div>
         ) : (

--- a/apps/web/src/pages/official/availability.tsx
+++ b/apps/web/src/pages/official/availability.tsx
@@ -1051,7 +1051,7 @@ function NotifyDialog({ requestId }: { requestId: string }) {
           if (!v) reset();
         }}
       >
-        <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+        <DialogContent className="max-h-[80vh] sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>Notify Members</DialogTitle>
           </DialogHeader>

--- a/apps/web/src/pages/person/player-sponsor.tsx
+++ b/apps/web/src/pages/person/player-sponsor.tsx
@@ -60,6 +60,16 @@ export function PlayerSponsor({ slug }: { slug: string }) {
         ) : (
           <p className="font-semibold text-green-800">{displayName}</p>
         )}
+        {sponsor.sponsor_phone && (
+          <p className="mt-1 text-sm text-green-700">
+            <a
+              href={`tel:${sponsor.sponsor_phone}`}
+              className="underline decoration-green-800/30 underline-offset-2 hover:decoration-green-800"
+            >
+              {sponsor.sponsor_phone}
+            </a>
+          </p>
+        )}
         {sponsor.sponsor_message && (
           <p className="mt-1 text-sm text-green-700 italic">
             {sponsor.sponsor_message}

--- a/apps/web/src/pages/person/sponsor-checkout.tsx
+++ b/apps/web/src/pages/person/sponsor-checkout.tsx
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
 import { getImageUrl, getPicture } from "@/lib/image-map";
+import { resizeLogo } from "@/lib/logo-resize";
 import { getPersonBySlug } from "@/lib/people";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
@@ -22,7 +23,6 @@ import { Link, useParams } from "react-router";
 
 const ANON_IMAGE = getImageUrl("/images/anon.jpg");
 const ANON_PICTURE = getPicture("/images/anon.jpg");
-const MAX_LOGO_BYTES = 150_000;
 const MAX_MESSAGE_CHARS = 100;
 
 const currencyFormatter = new Intl.NumberFormat("en-GB", {
@@ -32,48 +32,6 @@ const currencyFormatter = new Intl.NumberFormat("en-GB", {
 });
 
 type Step = "details" | "paying" | "success";
-
-function resizeLogo(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const img = new Image();
-      img.onload = () => {
-        const maxDim = 300;
-        let { width, height } = img;
-        if (width > maxDim || height > maxDim) {
-          const ratio = Math.min(maxDim / width, maxDim / height);
-          width = Math.round(width * ratio);
-          height = Math.round(height * ratio);
-        }
-
-        const canvas = document.createElement("canvas");
-        canvas.width = width;
-        canvas.height = height;
-        const ctx = canvas.getContext("2d");
-        if (!ctx) {
-          reject(new Error("Failed to create canvas context"));
-          return;
-        }
-        ctx.drawImage(img, 0, 0, width, height);
-
-        // Try progressively lower quality to fit under size limit
-        for (let q = 0.8; q >= 0.1; q -= 0.1) {
-          const dataUrl = canvas.toDataURL("image/jpeg", q);
-          if (dataUrl.length <= MAX_LOGO_BYTES) {
-            resolve(dataUrl);
-            return;
-          }
-        }
-        reject(new Error("Logo could not be compressed below 150KB"));
-      };
-      img.onerror = () => reject(new Error("Failed to load image"));
-      img.src = reader.result as string;
-    };
-    reader.onerror = () => reject(new Error("Failed to read file"));
-    reader.readAsDataURL(file);
-  });
-}
 
 export function Component() {
   const { slug } = useParams();
@@ -85,6 +43,7 @@ export function Component() {
   const [sponsorName, setSponsorName] = useState("");
   const [sponsorEmail, setSponsorEmail] = useState("");
   const [sponsorWebsite, setSponsorWebsite] = useState("");
+  const [sponsorPhone, setSponsorPhone] = useState("");
   const [sponsorMessage, setSponsorMessage] = useState("");
   const [logoDataUrl, setLogoDataUrl] = useState<string | null>(null);
   const [logoError, setLogoError] = useState<string | null>(null);
@@ -105,6 +64,7 @@ export function Component() {
             sponsorName,
             sponsorEmail,
             sponsorWebsite: sponsorWebsite || undefined,
+            sponsorPhone: sponsorPhone || undefined,
             sponsorLogoDataUrl: logoDataUrl ?? undefined,
             sponsorMessage: sponsorMessage || undefined,
           },
@@ -274,9 +234,20 @@ export function Component() {
               <Input
                 id="sponsorWebsite"
                 type="text"
-                placeholder="https://www.example.com"
+                placeholder="https://www.example.com (optional)"
                 value={sponsorWebsite}
                 onChange={(e) => setSponsorWebsite(e.target.value)}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="sponsorPhone">Phone</Label>
+              <Input
+                id="sponsorPhone"
+                type="tel"
+                placeholder="Optional"
+                value={sponsorPhone}
+                onChange={(e) => setSponsorPhone(e.target.value)}
               />
             </div>
 

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -269,6 +269,7 @@ export interface GameSponsorship {
   sponsor_logo_url: string | null;
   sponsor_message: string | null;
   sponsor_name: string;
+  sponsor_phone: string | null;
   sponsor_website: string | null;
   stripe_payment_intent_id: string | null;
 }
@@ -496,6 +497,7 @@ export interface PlayerSponsorship {
   sponsor_logo_url: string | null;
   sponsor_message: string | null;
   sponsor_name: string;
+  sponsor_phone: string | null;
   sponsor_website: string | null;
   stripe_payment_intent_id: string | null;
 }

--- a/packages/db/src/migrations/2026-04-23T13:30:31.000Z.ts
+++ b/packages/db/src/migrations/2026-04-23T13:30:31.000Z.ts
@@ -1,0 +1,20 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE game_sponsorship
+    ADD COLUMN sponsor_phone TEXT
+  `.execute(db);
+
+  await sql`
+    ALTER TABLE player_sponsorship
+    ADD COLUMN sponsor_phone TEXT
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE player_sponsorship DROP COLUMN sponsor_phone`.execute(
+    db,
+  );
+  await sql`ALTER TABLE game_sponsorship DROP COLUMN sponsor_phone`.execute(db);
+}


### PR DESCRIPTION
## Summary

- **Admin logo management** — inline Add/Change/Remove logo on every sponsorship row (game + player), reusing the existing `resizeLogo` compression (extracted to `lib/logo-resize.ts`, now shared with public checkout). Logo updates go through the existing `PUT /sponsorship/admin/{game,player}/{id}` endpoint; the update schema's `sponsorLogoDataUrl` is now nullable so `null` clears the image.
- **Manual player sponsor creation** — `CreatePlayerSponsorshipDialog` mirrors the game flow and uses a searchable `PlayerSelect` backed by the MDX player list. A new admin-only `GET /sponsorship/admin/player/taken-slugs` endpoint returns slugs with a paid sponsorship for the current season so taken players don't appear in the picker; the partial unique index on `(slug, season) WHERE paid_at IS NOT NULL` still guards against races.
- **Sponsor phone (Option A)** — new nullable `sponsor_phone TEXT` column on both sponsorship tables (migration `2026-04-23T13:30:31.000Z.ts`), plumbed through every payment/manual/update schema, both public checkout forms, both admin create dialogs, admin inline edit (same pattern as website), and display as `tel:` links on the player sponsor card and game detail badge.
- **Global dialog overflow fix** — `DialogContent` now caps at `max-h-[90vh]` with an internal scroll region; close button stays pinned to the panel. Six consumers had hand-rolled `max-h-[90vh] overflow-y-auto w-full` workarounds — stripped the redundant classes and kept deliberate width overrides + the one intentional `max-h-[80vh]`.
- **Visual tweak** — `InlineEdit` idle buttons are `display: block` so "Set display name" and "Add notes" stack on separate lines in the Details column.

## Test plan

- [ ] Admin → Sponsorships → Game tab: Add/Change/Remove logo on an existing row; confirm the image updates and Remove clears it
- [ ] Admin → Sponsorships → Player tab: same logo flow
- [ ] Admin → Sponsorships → Player tab: click Create Sponsorship; player picker only shows available players; selecting one auto-fills the name; submit creates an approved+paid record
- [ ] Open any admin create dialog on a shorter viewport — verify it caps at 90vh and scrolls internally
- [ ] Public `/person/sponsor/<slug>` and `/calendar/game/<id>/sponsor` checkout pages: phone field accepts input and persists through Stripe flow
- [ ] Admin inline-edit Phone on an existing sponsorship; confirm it saves and clears when emptied
- [ ] Approved player/game sponsor with phone set: renders as a `tel:` link on the display surface (player card / game detail)
- [ ] Running `pnpm -r typecheck`, `pnpm -r lint`, and `pnpm --filter api test` — all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)