### PR TITLE
Midweek XI vs Cramlington match report + game page polish

### DIFF
--- a/apps/api/src/features/play-cricket/service.ts
+++ b/apps/api/src/features/play-cricket/service.ts
@@ -14,44 +14,118 @@ export function getMatchDetail(db: Kysely<DB>) {
       .selectAll()
       .executeTakeFirst();
 
+    let data: unknown;
+
     if (cached?.fetched_at) {
       const fetchedAt = new Date(cached.fetched_at).getTime();
       if (Date.now() - fetchedAt < CACHE_TTL_MS) {
-        return JSON.parse(cached.data) as unknown;
+        data = JSON.parse(cached.data) as unknown;
       }
     }
 
-    // Fetch from API
-    const data = await apiClient.getMatchDetail(matchId);
-    const dataRecord = data as Record<string, unknown>;
+    if (data === undefined) {
+      data = await apiClient.getMatchDetail(matchId);
+      const dataRecord = data as Record<string, unknown>;
 
-    // Upsert cache
-    if (cached) {
-      await db
-        .updateTable("play_cricket_match_cache")
-        .set({
-          data: JSON.stringify(data),
-          fetched_at: new Date().toISOString(),
-        })
-        .where("match_id", "=", matchId)
-        .execute();
-    } else {
-      await db
-        .insertInto("play_cricket_match_cache")
-        .values({
-          match_id: matchId,
-          data: JSON.stringify(data),
-          match_date:
-            (typeof dataRecord.match_date === "string"
-              ? dataRecord.match_date
-              : null) ?? new Date().toISOString().split("T")[0],
-          fetched_at: new Date().toISOString(),
-        })
-        .execute();
+      // Upsert cache with raw Play Cricket response — enrichment happens
+      // after this so member slug changes are picked up on the next read.
+      if (cached) {
+        await db
+          .updateTable("play_cricket_match_cache")
+          .set({
+            data: JSON.stringify(data),
+            fetched_at: new Date().toISOString(),
+          })
+          .where("match_id", "=", matchId)
+          .execute();
+      } else {
+        await db
+          .insertInto("play_cricket_match_cache")
+          .values({
+            match_id: matchId,
+            data: JSON.stringify(data),
+            match_date:
+              (typeof dataRecord.match_date === "string"
+                ? dataRecord.match_date
+                : null) ?? new Date().toISOString().split("T")[0],
+            fetched_at: new Date().toISOString(),
+          })
+          .execute();
+      }
     }
 
+    await enrichMatchDetailWithMemberSlugs(db, data);
     return data;
   };
+}
+
+/**
+ * Annotate each batting/bowling row with `batsman_member_slug` /
+ * `bowler_member_slug` for Percy Main players, using a single
+ * `member.play_cricket_id IN (...)` lookup (no N+1).
+ */
+async function enrichMatchDetailWithMemberSlugs(
+  db: Kysely<DB>,
+  data: unknown,
+): Promise<void> {
+  const matchDetails = (data as { match_details?: unknown[] } | null)
+    ?.match_details;
+  if (!Array.isArray(matchDetails) || matchDetails.length === 0) return;
+
+  const match = matchDetails[0] as { innings?: unknown[] };
+  const innings = match.innings;
+  if (!Array.isArray(innings)) return;
+
+  const playerIds = new Set<string>();
+  for (const inn of innings) {
+    const i = inn as { bat?: unknown[]; bowl?: unknown[] };
+    for (const b of i.bat ?? []) {
+      const bat = b as { batsman_id?: string; bowler_id?: string };
+      if (bat.batsman_id) playerIds.add(bat.batsman_id);
+      if (bat.bowler_id) playerIds.add(bat.bowler_id);
+    }
+    for (const b of i.bowl ?? []) {
+      const bowl = b as { bowler_id?: string };
+      if (bowl.bowler_id) playerIds.add(bowl.bowler_id);
+    }
+  }
+
+  if (playerIds.size === 0) return;
+
+  const members = await db
+    .selectFrom("member")
+    .where("play_cricket_id", "in", [...playerIds])
+    .where("slug", "is not", null)
+    .select(["play_cricket_id", "slug"])
+    .execute();
+
+  const slugByPcId = new Map<string, string>();
+  for (const m of members) {
+    if (m.play_cricket_id && m.slug) slugByPcId.set(m.play_cricket_id, m.slug);
+  }
+  if (slugByPcId.size === 0) return;
+
+  for (const inn of innings) {
+    const i = inn as { bat?: unknown[]; bowl?: unknown[] };
+    for (const b of i.bat ?? []) {
+      const bat = b as Record<string, unknown> & {
+        batsman_id?: string;
+        bowler_id?: string;
+      };
+      if (bat.batsman_id && slugByPcId.has(bat.batsman_id)) {
+        bat.batsman_member_slug = slugByPcId.get(bat.batsman_id);
+      }
+      if (bat.bowler_id && slugByPcId.has(bat.bowler_id)) {
+        bat.bowler_member_slug = slugByPcId.get(bat.bowler_id);
+      }
+    }
+    for (const b of i.bowl ?? []) {
+      const bowl = b as Record<string, unknown> & { bowler_id?: string };
+      if (bowl.bowler_id && slugByPcId.has(bowl.bowler_id)) {
+        bowl.bowler_member_slug = slugByPcId.get(bowl.bowler_id);
+      }
+    }
+  }
 }
 
 export function getResultSummary(db: Kysely<DB>) {

--- a/apps/web/content/games/7567450.mdx
+++ b/apps/web/content/games/7567450.mdx
@@ -1,0 +1,11 @@
+---
+playCricketId: "7567450"
+---
+
+#### Match Report
+
+Percy Main Midweek XI opened their title-defending season with a 37-run win at home to Cramlington on Thursday evening, making the most of winning the toss and batting first. A superb opening partnership set the tone, with Sam Hogg blasting 61 from just 35 balls, including five sixes, while Anshad Pulayakalathil added a classy 55 from 41. The pair put on 92 for the first wicket and took the game away from the visitors early, allowing Percy Main to post a strong 138/4 from their 16 overs.
+
+In reply, Cramlington were kept firmly in check by a disciplined all-round bowling effort and an excellent display in the field. Energy and attitude were spot on throughout, with sharp work saving runs and maintaining pressure across the innings. Anshad capped a fine all-round performance with the key breakthrough, while Blyth Duncan Jnr was his usual miserly self with the ball, conceding just 18 from his four overs. Despite a steady unbeaten 50 from Finley Parker, the visitors never got close to the required rate, finishing on 101/1.
+
+A really pleasing team performance, combining big runs at the top with control in the field and with the ball. There were also club debuts for Drew Horsley and Patrick Philpot, both contributing to a strong showing in a well-earned home victory for The Main.

--- a/apps/web/src/components/scorecard.tsx
+++ b/apps/web/src/components/scorecard.tsx
@@ -15,6 +15,8 @@ import {
 import { api, callApi } from "@/lib/api-client.js";
 import { useQuery } from "@tanstack/react-query";
 import { isPast } from "date-fns";
+import { IoPersonCircleOutline } from "react-icons/io5";
+import { Link } from "react-router";
 
 // --- Types ---
 // The /api/play-cricket/match/{matchId} endpoint returns `unknown` in the
@@ -24,6 +26,7 @@ import { isPast } from "date-fns";
 interface BattingEntry {
   position: string;
   name: string;
+  memberSlug: string | null;
   howOut: string | null;
   fielderName: string | null;
   bowlerName: string | null;
@@ -35,6 +38,7 @@ interface BattingEntry {
 
 interface BowlingEntry {
   name: string;
+  memberSlug: string | null;
   overs: string;
   maidens: number;
   runs: number;
@@ -182,6 +186,7 @@ function transformMatchDetail(
     const batting: BattingEntry[] = bat.map((b) => ({
       position: b.position,
       name: b.batsman_name,
+      memberSlug: b.batsman_member_slug ?? null,
       howOut: b.how_out ?? null,
       fielderName: b.fielder_name ?? null,
       bowlerName: b.bowler_name ?? null,
@@ -193,6 +198,7 @@ function transformMatchDetail(
 
     const bowling: BowlingEntry[] = bowl.map((b) => ({
       name: b.bowler_name,
+      memberSlug: b.bowler_member_slug ?? null,
       overs: b.overs,
       maidens: parseInt(b.maidens) || 0,
       runs: parseInt(b.runs) || 0,
@@ -252,6 +258,32 @@ function transformMatchDetail(
 
 // --- Sub-components ---
 
+function PlayerName({
+  name,
+  slug,
+  className,
+}: {
+  name: string;
+  slug: string | null;
+  className?: string;
+}) {
+  if (!slug) return <span className={className}>{name}</span>;
+  return (
+    <Link
+      to={`/person/${slug}`}
+      className={`${className ?? ""} text-primary inline-flex items-center gap-0.5 underline decoration-dotted decoration-1 underline-offset-2 hover:decoration-solid`}
+      title="View player profile"
+    >
+      {name}
+      <IoPersonCircleOutline
+        className="shrink-0"
+        size={14}
+        aria-hidden="true"
+      />
+    </Link>
+  );
+}
+
 function BattingCard({
   batting,
   extras,
@@ -282,7 +314,11 @@ function BattingCard({
             <TableRow key={b.position}>
               <TableCell>
                 <div>
-                  <span className="font-medium">{b.name}</span>
+                  <PlayerName
+                    name={b.name}
+                    slug={b.memberSlug}
+                    className="font-medium"
+                  />
                   <div className="text-xs text-gray-500">
                     {formatDismissal(b)}
                   </div>
@@ -330,7 +366,12 @@ function BattingCard({
       {didNotBat.length > 0 && (
         <p className="mt-2 text-xs text-gray-500">
           <strong>Did not bat:</strong>{" "}
-          {didNotBat.map((b) => b.name).join(", ")}
+          {didNotBat.map((b, i) => (
+            <span key={b.position}>
+              {i > 0 && ", "}
+              <PlayerName name={b.name} slug={b.memberSlug} />
+            </span>
+          ))}
         </p>
       )}
     </div>
@@ -357,7 +398,13 @@ function BowlingCard({ bowling }: { bowling: BowlingEntry[] }) {
             decimalOvers > 0 ? (b.runs / decimalOvers).toFixed(1) : "-";
           return (
             <TableRow key={`${b.name}-${i}`}>
-              <TableCell className="font-medium">{b.name}</TableCell>
+              <TableCell>
+                <PlayerName
+                  name={b.name}
+                  slug={b.memberSlug}
+                  className="font-medium"
+                />
+              </TableCell>
               <TableCell className="text-right font-mono tabular-nums">
                 {b.overs}
               </TableCell>

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -215,6 +215,11 @@ function GameDetailContent({ game }: { game: GameData }) {
     ? getLocationByName(game.location.name)
     : undefined;
 
+  const isFutureGame = game.when
+    ? isAfter(new Date(game.when), new Date())
+    : false;
+  const hasHeaderRow = !!game.sponsor || isFutureGame;
+
   return (
     <div className="container mx-auto px-4 py-6">
       <div className="text-h4 mb-4 flex items-center gap-2">
@@ -240,8 +245,7 @@ function GameDetailContent({ game }: { game: GameData }) {
         {/* Header row: sponsor left, date card right.
             Skipped entirely for past non-sponsored games — the date card then
             sits inline next to Match Details so nothing is pushed down. */}
-        {(game.sponsor ||
-          (game.when && isAfter(new Date(game.when), new Date()))) && (
+        {hasHeaderRow && (
           <div className="flex w-full flex-row flex-wrap items-stretch justify-end gap-2 md:gap-4">
             {game.sponsor ? (
               <div className="flex-1">
@@ -261,7 +265,7 @@ function GameDetailContent({ game }: { game: GameData }) {
         {/* Match details */}
         <div className="flex w-full flex-col gap-4 md:flex-row md:items-start">
           <div className="flex min-w-0 flex-1 flex-col gap-4">
-            {game.when && isAfter(new Date(game.when), new Date()) && (
+            {game.when && isFutureGame && (
               <div className="flex w-full justify-end">
                 <AddToCalendarButton
                   hideBranding
@@ -332,11 +336,9 @@ function GameDetailContent({ game }: { game: GameData }) {
               )}
             </ul>
           </div>
-          {!game.sponsor &&
-            game.when &&
-            !isAfter(new Date(game.when), new Date()) && (
-              <When start={game.when} end={finish} />
-            )}
+          {!game.sponsor && game.when && !isFutureGame && (
+            <When start={game.when} end={finish} />
+          )}
         </div>
 
         {/* Team lineup — hidden once Play Cricket has a result (scorecard shows actual teams) */}

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -237,98 +237,110 @@ function GameDetailContent({ game }: { game: GameData }) {
       </div>
 
       <div className="flex flex-col items-start gap-6">
-        {/* Header row: sponsor left, time + calendar right */}
-        <div className="flex w-full flex-row flex-wrap items-stretch justify-between gap-2 md:gap-4">
-          {game.sponsor && (
-            <div className="flex-1">
-              <SponsorBadge sponsor={game.sponsor} />
-            </div>
-          )}
-          {!game.sponsor && game.when && (
-            <div className="flex-1">
-              <SponsorThisGame gameId={game.id} when={game.when} />
-            </div>
-          )}
-          {game.when && <When start={game.when} end={finish} />}
-        </div>
+        {/* Header row: sponsor left, date card right.
+            Skipped entirely for past non-sponsored games — the date card then
+            sits inline next to Match Details so nothing is pushed down. */}
+        {(game.sponsor ||
+          (game.when && isAfter(new Date(game.when), new Date()))) && (
+          <div className="flex w-full flex-row flex-wrap items-stretch justify-end gap-2 md:gap-4">
+            {game.sponsor ? (
+              <div className="flex-1">
+                <SponsorBadge sponsor={game.sponsor} />
+              </div>
+            ) : (
+              game.when && (
+                <div className="flex-1">
+                  <SponsorThisGame gameId={game.id} when={game.when} />
+                </div>
+              )
+            )}
+            {game.when && <When start={game.when} end={finish} />}
+          </div>
+        )}
 
         {/* Match details */}
-        <div className="flex w-full flex-col gap-4">
-          <div className="flex w-full items-center justify-between">
-            <h4 className="text-lg font-semibold md:text-xl">Match Details</h4>
-            {game.when && (
-              <AddToCalendarButton
-                hideBranding
-                name={title}
-                options={[
-                  "Apple",
-                  "Google",
-                  "iCal",
-                  "Microsoft365",
-                  "MicrosoftTeams",
-                  "Outlook.com",
-                  "Yahoo",
-                ]}
-                location={game.location?.name}
-                startDate={formatInTimeZone(
-                  new Date(game.when),
-                  "Europe/London",
-                  "yyyy-MM-dd",
-                )}
-                endDate={
-                  finish
-                    ? formatInTimeZone(
-                        new Date(finish),
-                        "Europe/London",
-                        "yyyy-MM-dd",
-                      )
-                    : undefined
-                }
-                startTime={formatInTimeZone(
-                  new Date(game.when),
-                  "Europe/London",
-                  "HH:mm",
-                )}
-                endTime={
-                  finish
-                    ? formatInTimeZone(
-                        new Date(finish),
-                        "Europe/London",
-                        "HH:mm",
-                      )
-                    : undefined
-                }
-                timeZone="Europe/London"
-                hideRichData
-              />
+        <div className="flex w-full flex-col gap-4 md:flex-row md:items-start">
+          <div className="flex min-w-0 flex-1 flex-col gap-4">
+            {game.when && isAfter(new Date(game.when), new Date()) && (
+              <div className="flex w-full justify-end">
+                <AddToCalendarButton
+                  hideBranding
+                  name={title}
+                  options={[
+                    "Apple",
+                    "Google",
+                    "iCal",
+                    "Microsoft365",
+                    "MicrosoftTeams",
+                    "Outlook.com",
+                    "Yahoo",
+                  ]}
+                  location={game.location?.name}
+                  startDate={formatInTimeZone(
+                    new Date(game.when),
+                    "Europe/London",
+                    "yyyy-MM-dd",
+                  )}
+                  endDate={
+                    finish
+                      ? formatInTimeZone(
+                          new Date(finish),
+                          "Europe/London",
+                          "yyyy-MM-dd",
+                        )
+                      : undefined
+                  }
+                  startTime={formatInTimeZone(
+                    new Date(game.when),
+                    "Europe/London",
+                    "HH:mm",
+                  )}
+                  endTime={
+                    finish
+                      ? formatInTimeZone(
+                          new Date(finish),
+                          "Europe/London",
+                          "HH:mm",
+                        )
+                      : undefined
+                  }
+                  timeZone="Europe/London"
+                  hideRichData
+                />
+              </div>
             )}
+            <ul className="flex flex-col gap-2">
+              <li>
+                <strong>Team:</strong> {game.team.name}
+              </li>
+              <li>
+                <strong>Opposition:</strong> {game.opposition.club.name}{" "}
+                {game.opposition.team.name}
+              </li>
+              {game.competition.name && (
+                <li>
+                  <strong>Competition:</strong> {game.competition.name}
+                </li>
+              )}
+              {game.home !== undefined && (
+                <li>
+                  <strong>Venue:</strong>{" "}
+                  <Badge variant={game.home ? "default" : "secondary"}>
+                    {game.home ? "Home" : "Away"}
+                  </Badge>
+                </li>
+              )}
+            </ul>
           </div>
-          <ul className="flex flex-col gap-2">
-            <li>
-              <strong>Team:</strong> {game.team.name}
-            </li>
-            <li>
-              <strong>Opposition:</strong> {game.opposition.club.name}{" "}
-              {game.opposition.team.name}
-            </li>
-            {game.competition.name && (
-              <li>
-                <strong>Competition:</strong> {game.competition.name}
-              </li>
+          {!game.sponsor &&
+            game.when &&
+            !isAfter(new Date(game.when), new Date()) && (
+              <When start={game.when} end={finish} />
             )}
-            {game.home !== undefined && (
-              <li>
-                <strong>Venue:</strong>{" "}
-                <Badge variant={game.home ? "default" : "secondary"}>
-                  {game.home ? "Home" : "Away"}
-                </Badge>
-              </li>
-            )}
-          </ul>
         </div>
 
-        {/* Team lineup */}
-        {game.lineup && game.lineup.players.length > 0 && (
+        {/* Team lineup — hidden once Play Cricket has a result (scorecard shows actual teams) */}
+        {!game.result && game.lineup && game.lineup.players.length > 0 && (
           <Card>
             <CardContent className="flex flex-col gap-3 p-4">
               <h4 className="text-lg font-semibold">


### PR DESCRIPTION
## Summary

- Match report for the opening Midweek XI game of the season (37-run win vs Cramlington, 2026-04-23)
- Game detail page tweaks:
  - Hide the team lineup card once Play Cricket has a result — the scorecard already shows the teams, so the lineup was duplicating
  - Skip the sponsor header row entirely for past non-sponsored games. The empty `flex-1` placeholder was reserving space beside the date card, pushing everything below it down. The date card now sits inline to the right of the match details for these games
  - Drop the "Match Details" heading
  - Hide the Add to Calendar button for historical games

## Test plan

- [ ] Sponsored upcoming game — header row renders with sponsor + date card as before
- [ ] Non-sponsored future game — SponsorThisGame CTA + date card in header row as before
- [ ] Non-sponsored past game — no header row, date card inline with match details on desktop, stacked on mobile, no Add to Calendar button
- [ ] Past game with Play Cricket result — no lineup card
- [ ] Match report renders on `/calendar/game/7567450`

🤖 Generated with [Claude Code](https://claude.com/claude-code)