### PR TITLE
Accident and incident reporting

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -30,6 +30,7 @@ import { documentRoutes } from "./features/documents/routes.ts";
 import { fantasyRoutes } from "./features/fantasy/routes.ts";
 import { gamesRoutes } from "./features/games/routes.ts";
 import { healthRoutes } from "./features/health/routes.ts";
+import { incidentReportRoutes } from "./features/incident-report/routes.ts";
 import { juniorRoutes } from "./features/junior/routes.ts";
 import { leaderboardRoutes } from "./features/leaderboard/routes.ts";
 import { matchdayRoutes } from "./features/matchday/routes.ts";
@@ -156,6 +157,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(cricketLeaderboardRoutes, { prefix: "/api" });
   await app.register(recordsRoutes, { prefix: "/api" });
   await app.register(contactRoutes, { prefix: "/api" });
+  await app.register(incidentReportRoutes, { prefix: "/api" });
   await app.register(webhookRoutes, { prefix: "/api" });
   await app.register(ogImageRoutes, { prefix: "/api" });
 

--- a/apps/api/src/features/incident-report/integration.test.ts
+++ b/apps/api/src/features/incident-report/integration.test.ts
@@ -1,0 +1,242 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import type { IncidentReportSubmission } from "./schemas.ts";
+import {
+  createIncidentReportSubmission,
+  getIncidentReport,
+  listIncidentReports,
+  updateIncidentReport,
+} from "./service.ts";
+
+// Render is React-heavy; stub it out for the integration test. We're not
+// testing email rendering here — only the DB round-trip.
+vi.mock("@react-email/render", () => ({
+  render: vi.fn().mockResolvedValue("<html></html>"),
+}));
+
+let ctx: TestContext;
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestContainer(ctx);
+});
+
+function validSubmission(
+  overrides: Partial<IncidentReportSubmission> = {},
+): IncidentReportSubmission {
+  return {
+    reporterName: "Jane Doe",
+    reporterEmail: "jane@example.com",
+    reporterRelationship: "member",
+    prefersNoContact: false,
+    affectedIsMinor: false,
+    occurredAt: "2026-04-24T18:30:00.000Z",
+    location: "Main pitch",
+    incidentType: "injury",
+    description: "Twisted ankle in fielding practice.",
+    injuryOccurred: true,
+    firstAidGiven: true,
+    medicalTreatmentRequired: false,
+    declarationConfirmed: true,
+    ...overrides,
+  };
+}
+
+describe("incident-report (integration)", () => {
+  it("persists a full submission through the real schema", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = createIncidentReportSubmission(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id } = await submit(
+      validSubmission({
+        reporterName: "Full Submission",
+        reporterPhone: "07123456789",
+        affectedName: "Junior Player",
+        affectedRelationship: "member",
+        affectedContact: "parent@example.com",
+        affectedIsMinor: true,
+        activity: "Junior training",
+        natureOfInjury: "Sprained ankle",
+        bodyPartsAffected: "Left ankle",
+        injurySeverity: "minor",
+        firstAiderName: "Coach Smith",
+        firstAidDetails: "Ice pack applied",
+        immediateActions: "Stopped training, contacted parent",
+        witnesses: "Coach Smith, Player B",
+      }),
+    );
+
+    const row = await ctx.db
+      .selectFrom("accident_incident_report")
+      .where("id", "=", id)
+      .selectAll()
+      .executeTakeFirst();
+
+    expect(row).toBeTruthy();
+    expect(row?.reporter_name).toBe("Full Submission");
+    expect(row?.reporter_phone).toBe("07123456789");
+    expect(row?.reporter_relationship).toBe("member");
+    expect(row?.affected_name).toBe("Junior Player");
+    expect(row?.affected_relationship).toBe("member");
+    expect(row?.affected_contact).toBe("parent@example.com");
+    expect(row?.affected_is_minor).toBe(true);
+    expect(row?.incident_type).toBe("injury");
+    expect(row?.nature_of_injury).toBe("Sprained ankle");
+    expect(row?.injury_severity).toBe("minor");
+    expect(row?.first_aid_given).toBe(true);
+    expect(row?.first_aider_name).toBe("Coach Smith");
+    expect(row?.declaration_confirmed).toBe(true);
+    expect(row?.status).toBe("new");
+    expect(row?.severity).toBeNull();
+    expect(row?.riddor_required).toBeNull();
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "jane@example.com" }),
+    );
+  });
+
+  it("accepts a minimal submission with optional fields omitted", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = createIncidentReportSubmission(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id } = await submit({
+      reporterName: "Minimal",
+      reporterEmail: "minimal@example.com",
+      reporterRelationship: "visitor",
+      prefersNoContact: false,
+      affectedIsMinor: false,
+      occurredAt: "2026-04-24T10:00:00.000Z",
+      location: "Car park",
+      incidentType: "near_miss",
+      description: "Almost slipped on wet floor.",
+      injuryOccurred: false,
+      firstAidGiven: false,
+      medicalTreatmentRequired: false,
+      declarationConfirmed: true,
+    });
+
+    const row = await ctx.db
+      .selectFrom("accident_incident_report")
+      .where("id", "=", id)
+      .selectAll()
+      .executeTakeFirst();
+
+    expect(row).toBeTruthy();
+    expect(row?.reporter_phone).toBeNull();
+    expect(row?.affected_name).toBeNull();
+    expect(row?.activity).toBeNull();
+    expect(row?.injury_severity).toBeNull();
+    expect(row?.first_aider_name).toBeNull();
+    expect(row?.incident_type).toBe("near_miss");
+  });
+
+  it("honeypot submission does not insert a row", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = createIncidentReportSubmission(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const before = await ctx.db
+      .selectFrom("accident_incident_report")
+      .select((eb) => eb.fn.countAll<string>().as("total"))
+      .executeTakeFirstOrThrow();
+
+    const result = await submit({
+      ...validSubmission({ reporterEmail: "bot@example.com" }),
+      website: "http://spam.example.com",
+    } as IncidentReportSubmission);
+
+    // Fake id so bots can't detect rejection from the response.
+    expect(result.id).toBeDefined();
+    expect(send).not.toHaveBeenCalled();
+
+    const after = await ctx.db
+      .selectFrom("accident_incident_report")
+      .select((eb) => eb.fn.countAll<string>().as("total"))
+      .executeTakeFirstOrThrow();
+
+    expect(Number(after.total)).toBe(Number(before.total));
+  });
+
+  it("round-trips through list + get + update", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = createIncidentReportSubmission(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id } = await submit(
+      validSubmission({ reporterName: "Round-trip Tester" }),
+    );
+
+    // List finds it (status=new).
+    const list = await listIncidentReports(ctx.db)({
+      page: 1,
+      pageSize: 100,
+      status: "new",
+    });
+    expect(list.reports.some((r) => r.id === id)).toBe(true);
+
+    // Get hydrates camelCase fields.
+    const detail = await getIncidentReport(ctx.db)(id);
+    expect(detail).not.toBeNull();
+    expect(detail?.declarationConfirmed).toBe(true);
+    expect(detail?.status).toBe("new");
+    expect(detail?.severity).toBeNull();
+
+    // Update sets admin fields without disturbing others.
+    await updateIncidentReport(ctx.db)(id, {
+      status: "in_review",
+      severity: "medium",
+      actionsTaken: "Assigned to trustee",
+      riddorRequired: false,
+      safeguardingDiscussed: true,
+      safeguardingNotes: "Reviewed with SGO",
+    });
+
+    const updated = await getIncidentReport(ctx.db)(id);
+    expect(updated?.status).toBe("in_review");
+    expect(updated?.severity).toBe("medium");
+    expect(updated?.actionsTaken).toBe("Assigned to trustee");
+    expect(updated?.riddorRequired).toBe(false);
+    expect(updated?.safeguardingDiscussed).toBe(true);
+    expect(updated?.safeguardingNotes).toBe("Reviewed with SGO");
+
+    // Reporter fields untouched.
+    expect(updated?.reporterName).toBe("Round-trip Tester");
+    expect(updated?.declarationConfirmed).toBe(true);
+  });
+
+  it("riddorRequired accepts null, false and true distinctly", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = createIncidentReportSubmission(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id } = await submit(validSubmission());
+
+    await updateIncidentReport(ctx.db)(id, { riddorRequired: true });
+    expect((await getIncidentReport(ctx.db)(id))?.riddorRequired).toBe(true);
+
+    await updateIncidentReport(ctx.db)(id, { riddorRequired: false });
+    expect((await getIncidentReport(ctx.db)(id))?.riddorRequired).toBe(false);
+
+    await updateIncidentReport(ctx.db)(id, { riddorRequired: null });
+    expect((await getIncidentReport(ctx.db)(id))?.riddorRequired).toBeNull();
+  });
+});

--- a/apps/api/src/features/incident-report/routes.ts
+++ b/apps/api/src/features/incident-report/routes.ts
@@ -1,0 +1,96 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { requireRole } from "../auth/middleware.ts";
+import {
+  incidentReportAdminUpdateSchema,
+  incidentReportDetailSchema,
+  incidentReportIdParamSchema,
+  incidentReportSubmissionResponseSchema,
+  incidentReportSubmissionSchema,
+  listIncidentReportsResponseSchema,
+  listIncidentReportsSchema,
+  successResponseSchema,
+} from "./schemas.ts";
+import {
+  createIncidentReportSubmission,
+  getIncidentReport,
+  listIncidentReports,
+  updateIncidentReport,
+} from "./service.ts";
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const incidentReportRoutes: FastifyPluginAsyncZod = async (app) => {
+  const submit = createIncidentReportSubmission(app.db, {
+    slackWebhookUrl: app.config.SLACK_WEBHOOK_URL,
+    baseUrl: app.config.BASE_URL,
+    send: app.send,
+  });
+  const list = listIncidentReports(app.db);
+  const get = getIncidentReport(app.db);
+  const update = updateIncidentReport(app.db);
+
+  // --- Public ---
+
+  app.post(
+    "/incident-report",
+    {
+      schema: {
+        body: incidentReportSubmissionSchema,
+        response: { 200: incidentReportSubmissionResponseSchema },
+      },
+    },
+    async (request) => {
+      return await submit(request.body);
+    },
+  );
+
+  // --- Admin ---
+
+  app.get(
+    "/admin/incident-reports",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        querystring: listIncidentReportsSchema,
+        response: { 200: listIncidentReportsResponseSchema },
+      },
+    },
+    async (request) => {
+      return await list(request.query);
+    },
+  );
+
+  app.get(
+    "/admin/incident-reports/:id",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: incidentReportIdParamSchema,
+        response: { 200: incidentReportDetailSchema },
+      },
+    },
+    async (request) => {
+      const report = await get(request.params.id);
+      if (!report) {
+        throw Object.assign(new Error("Incident report not found"), {
+          statusCode: 404,
+        });
+      }
+      return report;
+    },
+  );
+
+  app.patch(
+    "/admin/incident-reports/:id",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: incidentReportIdParamSchema,
+        body: incidentReportAdminUpdateSchema,
+        response: { 200: successResponseSchema },
+      },
+    },
+    async (request) => {
+      return await update(request.params.id, request.body);
+    },
+  );
+};

--- a/apps/api/src/features/incident-report/schemas.ts
+++ b/apps/api/src/features/incident-report/schemas.ts
@@ -1,0 +1,196 @@
+import { z } from "zod";
+
+export const incidentStatusSchema = z.enum(["new", "in_review", "done"]);
+export const incidentSeveritySchema = z.enum(["low", "medium", "high"]);
+export const injurySeveritySchema = z.enum(["minor", "serious", "fatal"]);
+export const incidentTypeSchema = z.enum([
+  "injury",
+  "near_miss",
+  "dangerous_occurrence",
+  "ill_health",
+  "property_damage",
+]);
+export const reporterRelationshipSchema = z.enum([
+  "member",
+  "parent_or_guardian",
+  "player",
+  "coach_or_volunteer",
+  "visitor",
+  "other",
+]);
+export const affectedRelationshipSchema = z.enum([
+  "trustee",
+  "member",
+  "volunteer",
+  "visitor",
+  "contractor",
+  "other",
+]);
+
+/**
+ * Public submission schema. The `website` field is a honeypot — humans leave
+ * it blank, bots tend to fill it. The route short-circuits if it has a value.
+ * Mirrors PMCSC form POL006a Section 1.
+ */
+export const incidentReportSubmissionSchema = z.object({
+  // Reporter
+  reporterName: z.string().min(1).max(200),
+  reporterEmail: z.email(),
+  reporterPhone: z.string().max(50).optional(),
+  reporterRelationship: reporterRelationshipSchema,
+  prefersNoContact: z.boolean().default(false),
+
+  // Affected person
+  affectedName: z.string().max(200).optional(),
+  affectedRelationship: affectedRelationshipSchema.optional(),
+  affectedContact: z.string().max(500).optional(),
+  affectedIsMinor: z.boolean().default(false),
+
+  // Incident
+  occurredAt: z.string().min(1),
+  location: z.string().min(1).max(300),
+  activity: z.string().max(300).optional(),
+  incidentType: incidentTypeSchema,
+  description: z.string().min(1).max(5000),
+
+  // Injury / ill health
+  injuryOccurred: z.boolean().default(false),
+  natureOfInjury: z.string().max(1000).optional(),
+  bodyPartsAffected: z.string().max(500).optional(),
+  injurySeverity: injurySeveritySchema.optional(),
+  firstAidGiven: z.boolean().default(false),
+  firstAiderName: z.string().max(200).optional(),
+  firstAidDetails: z.string().max(2000).optional(),
+  medicalTreatmentRequired: z.boolean().default(false),
+
+  // Actions and witnesses
+  immediateActions: z.string().max(2000).optional(),
+  witnesses: z.string().max(2000).optional(),
+
+  // Declaration — must be ticked (true) to submit.
+  declarationConfirmed: z.literal(true),
+
+  // Honeypot — must be empty for real submissions.
+  website: z.string().max(0).optional(),
+});
+
+export type IncidentReportSubmission = z.infer<
+  typeof incidentReportSubmissionSchema
+>;
+
+export const incidentReportSubmissionResponseSchema = z.object({
+  id: z.string(),
+});
+
+export const listIncidentReportsSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+  status: incidentStatusSchema.optional(),
+});
+
+export type ListIncidentReports = z.infer<typeof listIncidentReportsSchema>;
+
+const incidentReportSummarySchema = z.object({
+  id: z.string(),
+  status: incidentStatusSchema,
+  severity: incidentSeveritySchema.nullable(),
+  incidentType: incidentTypeSchema,
+  reporterName: z.string(),
+  affectedIsMinor: z.boolean(),
+  injuryOccurred: z.boolean(),
+  injurySeverity: injurySeveritySchema.nullable(),
+  location: z.string(),
+  occurredAt: z.string(),
+  createdAt: z.string(),
+});
+
+export const listIncidentReportsResponseSchema = z.object({
+  reports: z.array(incidentReportSummarySchema),
+  total: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+
+export const incidentReportIdParamSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const incidentReportDetailSchema = z.object({
+  id: z.string(),
+
+  reporterName: z.string(),
+  reporterEmail: z.string(),
+  reporterPhone: z.string().nullable(),
+  reporterRelationship: z.string(),
+  prefersNoContact: z.boolean(),
+
+  affectedName: z.string().nullable(),
+  affectedRelationship: z.string().nullable(),
+  affectedContact: z.string().nullable(),
+  affectedIsMinor: z.boolean(),
+
+  occurredAt: z.string(),
+  location: z.string(),
+  activity: z.string().nullable(),
+  incidentType: incidentTypeSchema,
+  description: z.string(),
+
+  injuryOccurred: z.boolean(),
+  natureOfInjury: z.string().nullable(),
+  bodyPartsAffected: z.string().nullable(),
+  injurySeverity: injurySeveritySchema.nullable(),
+  firstAidGiven: z.boolean(),
+  firstAiderName: z.string().nullable(),
+  firstAidDetails: z.string().nullable(),
+  medicalTreatmentRequired: z.boolean(),
+
+  immediateActions: z.string().nullable(),
+  witnesses: z.string().nullable(),
+  declarationConfirmed: z.boolean(),
+
+  status: incidentStatusSchema,
+  severity: incidentSeveritySchema.nullable(),
+  ownerUserId: z.string().nullable(),
+  ownerName: z.string().nullable(),
+  actionsTaken: z.string().nullable(),
+  targetCompletionDate: z.string().nullable(),
+  riddorRequired: z.boolean().nullable(),
+  riddorReportedAt: z.string().nullable(),
+  internalNotes: z.string().nullable(),
+  closureReason: z.string().nullable(),
+  closedAt: z.string().nullable(),
+  safeguardingDiscussed: z.boolean(),
+  safeguardingDiscussedAt: z.string().nullable(),
+  safeguardingNotes: z.string().nullable(),
+
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/**
+ * Admin update — every field optional. Pass `null` to clear, omit to leave
+ * unchanged. Date fields accept ISO datetime strings.
+ */
+export const incidentReportAdminUpdateSchema = z.object({
+  status: incidentStatusSchema.optional(),
+  severity: incidentSeveritySchema.nullable().optional(),
+  ownerUserId: z.string().nullable().optional(),
+  actionsTaken: z.string().max(5000).nullable().optional(),
+  targetCompletionDate: z.string().nullable().optional(),
+  riddorRequired: z.boolean().nullable().optional(),
+  riddorReportedAt: z.string().nullable().optional(),
+  internalNotes: z.string().max(5000).nullable().optional(),
+  closureReason: z.string().max(2000).nullable().optional(),
+  closedAt: z.string().nullable().optional(),
+  safeguardingDiscussed: z.boolean().optional(),
+  safeguardingDiscussedAt: z.string().nullable().optional(),
+  safeguardingNotes: z.string().max(2000).nullable().optional(),
+});
+
+export type IncidentReportAdminUpdate = z.infer<
+  typeof incidentReportAdminUpdateSchema
+>;
+
+export const successResponseSchema = z.object({
+  success: z.boolean(),
+});

--- a/apps/api/src/features/incident-report/service.test.ts
+++ b/apps/api/src/features/incident-report/service.test.ts
@@ -1,0 +1,538 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock email package — templates render to empty html, we only assert
+// that `send` is called with the right subject / recipient.
+vi.mock("@percy-main/email", () => ({
+  IncidentReportConfirmation: {
+    subject: "We've received your accident / incident report",
+    component: vi.fn(),
+  },
+}));
+
+vi.mock("@react-email/render", () => ({
+  render: vi.fn().mockResolvedValue("<html></html>"),
+}));
+
+const {
+  mockExecuteTakeFirst,
+  mockExecuteTakeFirstOrThrow,
+  mockExecute,
+  mockQueryBuilder,
+} = vi.hoisted(() => {
+  const mockExecuteTakeFirst = vi.fn();
+  const mockExecuteTakeFirstOrThrow = vi.fn();
+  const mockExecute = vi.fn();
+
+  const mockQueryBuilder: Record<string, unknown> = {
+    selectFrom: vi.fn().mockReturnThis(),
+    updateTable: vi.fn().mockReturnThis(),
+    insertInto: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
+    executeTakeFirst: mockExecuteTakeFirst,
+    executeTakeFirstOrThrow: mockExecuteTakeFirstOrThrow,
+    execute: mockExecute,
+    fn: {
+      countAll: vi.fn().mockReturnValue({
+        as: vi.fn().mockReturnValue("count_expr"),
+      }),
+    },
+  };
+
+  return {
+    mockExecuteTakeFirst,
+    mockExecuteTakeFirstOrThrow,
+    mockExecute,
+    mockQueryBuilder,
+  };
+});
+
+import {
+  incidentReportSubmissionSchema,
+  type IncidentReportSubmission,
+} from "./schemas.ts";
+import {
+  createIncidentReportSubmission,
+  getIncidentReport,
+  listIncidentReports,
+  updateIncidentReport,
+} from "./service.ts";
+
+const db = mockQueryBuilder as unknown as Kysely<DB>;
+
+function validSubmission(
+  overrides: Partial<IncidentReportSubmission> = {},
+): IncidentReportSubmission {
+  return {
+    reporterName: "Jane Doe",
+    reporterEmail: "jane@example.com",
+    reporterRelationship: "member",
+    prefersNoContact: false,
+    affectedIsMinor: false,
+    occurredAt: "2026-04-24T18:30:00.000Z",
+    location: "Main pitch",
+    incidentType: "injury",
+    description: "Twisted ankle in fielding practice.",
+    injuryOccurred: true,
+    firstAidGiven: true,
+    medicalTreatmentRequired: false,
+    declarationConfirmed: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(mockQueryBuilder)) {
+    const val = mockQueryBuilder[key];
+    if (typeof val === "function" && "mockReturnValue" in (val as object)) {
+      (val as ReturnType<typeof vi.fn>).mockReturnValue(mockQueryBuilder);
+    }
+  }
+});
+
+describe("incidentReportSubmissionSchema", () => {
+  it("rejects submissions with declarationConfirmed: false", () => {
+    const result = incidentReportSubmissionSchema.safeParse({
+      ...validSubmission(),
+      declarationConfirmed: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects submissions without declarationConfirmed", () => {
+    const { declarationConfirmed: _unused, ...rest } = validSubmission();
+    void _unused;
+    const result = incidentReportSubmissionSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts submissions with declarationConfirmed: true", () => {
+    const result = incidentReportSubmissionSchema.safeParse(validSubmission());
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid email", () => {
+    const result = incidentReportSubmissionSchema.safeParse({
+      ...validSubmission(),
+      reporterEmail: "not-an-email",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown incidentType", () => {
+    const result = incidentReportSubmissionSchema.safeParse({
+      ...validSubmission(),
+      incidentType: "something_else",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("requires honeypot to be empty", () => {
+    const result = incidentReportSubmissionSchema.safeParse({
+      ...validSubmission(),
+      website: "http://spam.example.com",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("createIncidentReportSubmission", () => {
+  it("persists the report with all required fields and declaration set", async () => {
+    mockExecute.mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue(undefined);
+
+    const result = await createIncidentReportSubmission(db, {
+      baseUrl: "https://percymain.org",
+      send,
+    })(validSubmission());
+
+    expect(result.id).toBeDefined();
+    expect(typeof result.id).toBe("string");
+    expect(mockQueryBuilder.insertInto).toHaveBeenCalledWith(
+      "accident_incident_report",
+    );
+
+    // .values() was called with the insert payload.
+    const valuesMock = mockQueryBuilder.values as ReturnType<typeof vi.fn>;
+    expect(valuesMock).toHaveBeenCalledTimes(1);
+    const insertPayload = valuesMock.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+
+    expect(insertPayload.id).toBe(result.id);
+    expect(insertPayload.reporter_name).toBe("Jane Doe");
+    expect(insertPayload.reporter_email).toBe("jane@example.com");
+    expect(insertPayload.incident_type).toBe("injury");
+    expect(insertPayload.declaration_confirmed).toBe(true);
+    expect(insertPayload.injury_occurred).toBe(true);
+  });
+
+  it("sends a confirmation email to the reporter", async () => {
+    mockExecute.mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue(undefined);
+
+    await createIncidentReportSubmission(db, {
+      baseUrl: "https://percymain.org",
+      send,
+    })(validSubmission({ reporterEmail: "reporter@example.com" }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    const emailArg = send.mock.calls[0][0] as {
+      to: string;
+      subject: string;
+      html: string;
+    };
+    expect(emailArg.to).toBe("reporter@example.com");
+    expect(emailArg.subject).toBe(
+      "We've received your accident / incident report",
+    );
+    expect(typeof emailArg.html).toBe("string");
+  });
+
+  it("still sends a confirmation when the reporter prefers no contact", async () => {
+    mockExecute.mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue(undefined);
+
+    await createIncidentReportSubmission(db, {
+      baseUrl: "https://percymain.org",
+      send,
+    })(validSubmission({ prefersNoContact: true }));
+
+    // Transactional receipt is always sent — see design Q3.
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when email delivery fails", async () => {
+    mockExecute.mockResolvedValue(undefined);
+    const send = vi.fn().mockRejectedValue(new Error("SES down"));
+
+    const result = await createIncidentReportSubmission(db, {
+      baseUrl: "https://percymain.org",
+      send,
+    })(validSubmission());
+
+    expect(typeof result.id).toBe("string");
+    expect(result.id.length).toBeGreaterThan(0);
+  });
+
+  it("fires a Slack notification when a webhook URL is configured", async () => {
+    mockExecute.mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue(undefined);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok"));
+
+    await createIncidentReportSubmission(db, {
+      slackWebhookUrl: "https://hooks.slack.test/XYZ",
+      baseUrl: "https://percymain.org",
+      send,
+    })(validSubmission());
+
+    // Slack fires fire-and-forget; give the microtask queue a tick.
+    await new Promise((r) => setImmediate(r));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const call = fetchSpy.mock.calls[0];
+    expect(call[0]).toBe("https://hooks.slack.test/XYZ");
+    expect(call[1]?.method).toBe("POST");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("skips Slack when no webhook URL is configured", async () => {
+    mockExecute.mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue(undefined);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await createIncidentReportSubmission(db, {
+      baseUrl: "https://percymain.org",
+      send,
+    })(validSubmission());
+
+    await new Promise((r) => setImmediate(r));
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("short-circuits if the honeypot field is populated", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const result = await createIncidentReportSubmission(db, {
+      slackWebhookUrl: "https://hooks.slack.test/XYZ",
+      baseUrl: "https://percymain.org",
+      send,
+    })({
+      // Service receives parsed data; we bypass the schema's maxLength to
+      // simulate the insert-time guard directly.
+      ...validSubmission(),
+      website: "http://spam.example.com",
+    } as IncidentReportSubmission);
+
+    // Fake id returned so the bot can't distinguish success from a drop.
+    expect(result.id).toBeDefined();
+    expect(mockQueryBuilder.insertInto).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+
+    await new Promise((r) => setImmediate(r));
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+});
+
+describe("listIncidentReports", () => {
+  it("applies pagination params to limit/offset", async () => {
+    mockExecute.mockResolvedValue([]);
+    mockExecuteTakeFirstOrThrow.mockResolvedValue({ total: 0 });
+
+    await listIncidentReports(db)({ page: 3, pageSize: 15 });
+
+    expect(mockQueryBuilder.limit).toHaveBeenCalledWith(15);
+    expect(mockQueryBuilder.offset).toHaveBeenCalledWith(30);
+  });
+
+  it("filters by status when supplied", async () => {
+    mockExecute.mockResolvedValue([]);
+    mockExecuteTakeFirstOrThrow.mockResolvedValue({ total: 0 });
+
+    await listIncidentReports(db)({
+      page: 1,
+      pageSize: 20,
+      status: "new",
+    });
+
+    expect(mockQueryBuilder.where).toHaveBeenCalledWith("status", "=", "new");
+  });
+
+  it("does not filter by status when omitted", async () => {
+    mockExecute.mockResolvedValue([]);
+    mockExecuteTakeFirstOrThrow.mockResolvedValue({ total: 0 });
+
+    await listIncidentReports(db)({ page: 1, pageSize: 20 });
+
+    expect(mockQueryBuilder.where).not.toHaveBeenCalled();
+  });
+
+  it("sorts done reports to the bottom and higher severity first among open", async () => {
+    mockExecute.mockResolvedValue([
+      {
+        id: "r-done-high",
+        status: "done",
+        severity: "high",
+        incident_type: "injury",
+        reporter_name: "A",
+        affected_is_minor: false,
+        injury_occurred: false,
+        injury_severity: null,
+        location: "X",
+        occurred_at: new Date("2026-04-01"),
+        created_at: new Date("2026-04-01"),
+      },
+      {
+        id: "r-new-low",
+        status: "new",
+        severity: "low",
+        incident_type: "injury",
+        reporter_name: "B",
+        affected_is_minor: false,
+        injury_occurred: false,
+        injury_severity: null,
+        location: "X",
+        occurred_at: new Date("2026-04-02"),
+        created_at: new Date("2026-04-02"),
+      },
+      {
+        id: "r-new-high",
+        status: "new",
+        severity: "high",
+        incident_type: "injury",
+        reporter_name: "C",
+        affected_is_minor: false,
+        injury_occurred: false,
+        injury_severity: null,
+        location: "X",
+        occurred_at: new Date("2026-04-03"),
+        created_at: new Date("2026-04-03"),
+      },
+      {
+        id: "r-review-unset",
+        status: "in_review",
+        severity: null,
+        incident_type: "injury",
+        reporter_name: "D",
+        affected_is_minor: false,
+        injury_occurred: false,
+        injury_severity: null,
+        location: "X",
+        occurred_at: new Date("2026-04-04"),
+        created_at: new Date("2026-04-04"),
+      },
+    ]);
+    mockExecuteTakeFirstOrThrow.mockResolvedValue({ total: 4 });
+
+    const result = await listIncidentReports(db)({ page: 1, pageSize: 20 });
+    const ids = result.reports.map((r) => r.id);
+
+    expect(ids).toEqual([
+      "r-new-high",
+      "r-new-low",
+      "r-review-unset",
+      "r-done-high",
+    ]);
+  });
+});
+
+describe("getIncidentReport", () => {
+  it("returns null when no row is found", async () => {
+    mockExecuteTakeFirst.mockResolvedValue(undefined);
+
+    const result = await getIncidentReport(db)("missing");
+    expect(result).toBeNull();
+  });
+
+  it("maps snake_case row to camelCase with joined owner name", async () => {
+    mockExecuteTakeFirst.mockResolvedValue({
+      id: "r-1",
+      reporter_name: "Jane",
+      reporter_email: "jane@example.com",
+      reporter_phone: null,
+      reporter_relationship: "member",
+      prefers_no_contact: false,
+      affected_name: null,
+      affected_relationship: null,
+      affected_contact: null,
+      affected_is_minor: false,
+      occurred_at: new Date("2026-04-24T18:30:00Z"),
+      location: "Main pitch",
+      activity: null,
+      incident_type: "injury",
+      description: "Fell over",
+      injury_occurred: true,
+      nature_of_injury: null,
+      body_parts_affected: null,
+      injury_severity: "minor",
+      first_aid_given: false,
+      first_aider_name: null,
+      first_aid_details: null,
+      medical_treatment_required: false,
+      immediate_actions: null,
+      witnesses: null,
+      declaration_confirmed: true,
+      status: "new",
+      severity: null,
+      owner_user_id: "user-1",
+      owner_name: "Admin Alice",
+      actions_taken: null,
+      target_completion_date: null,
+      riddor_required: null,
+      riddor_reported_at: null,
+      internal_notes: null,
+      closure_reason: null,
+      closed_at: null,
+      safeguarding_discussed: false,
+      safeguarding_discussed_at: null,
+      safeguarding_notes: null,
+      created_at: new Date("2026-04-24T18:31:00Z"),
+      updated_at: new Date("2026-04-24T18:31:00Z"),
+    });
+
+    const result = await getIncidentReport(db)("r-1");
+
+    expect(result).toMatchObject({
+      id: "r-1",
+      reporterName: "Jane",
+      incidentType: "injury",
+      injurySeverity: "minor",
+      declarationConfirmed: true,
+      ownerUserId: "user-1",
+      ownerName: "Admin Alice",
+      riddorRequired: null,
+      riddorReportedAt: null,
+    });
+    expect(result?.occurredAt).toBe("2026-04-24T18:30:00.000Z");
+  });
+});
+
+describe("updateIncidentReport", () => {
+  it("only updates the fields provided (plus updated_at)", async () => {
+    mockExecute.mockResolvedValue(undefined);
+
+    await updateIncidentReport(db)("r-1", { status: "in_review" });
+
+    const setMock = mockQueryBuilder.set as ReturnType<typeof vi.fn>;
+    expect(setMock).toHaveBeenCalledTimes(1);
+    const payload = setMock.mock.calls[0][0] as Record<string, unknown>;
+
+    expect(Object.keys(payload).sort()).toEqual(["status", "updated_at"]);
+    expect(payload.status).toBe("in_review");
+    expect(typeof payload.updated_at).toBe("string");
+  });
+
+  it("distinguishes riddorRequired: null from false", async () => {
+    mockExecute.mockResolvedValue(undefined);
+    const setMock = mockQueryBuilder.set as ReturnType<typeof vi.fn>;
+
+    await updateIncidentReport(db)("r-1", { riddorRequired: null });
+    const nullPayload = setMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(nullPayload).toHaveProperty("riddor_required");
+    expect(nullPayload.riddor_required).toBeNull();
+
+    setMock.mockClear();
+
+    await updateIncidentReport(db)("r-1", { riddorRequired: false });
+    const falsePayload = setMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(falsePayload.riddor_required).toBe(false);
+  });
+
+  it("does not touch riddor_required when the caller omits it", async () => {
+    mockExecute.mockResolvedValue(undefined);
+
+    await updateIncidentReport(db)("r-1", { internalNotes: "some note" });
+
+    const setMock = mockQueryBuilder.set as ReturnType<typeof vi.fn>;
+    const payload = setMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("riddor_required");
+    expect(payload.internal_notes).toBe("some note");
+  });
+
+  it("maps camelCase fields to snake_case columns", async () => {
+    mockExecute.mockResolvedValue(undefined);
+
+    await updateIncidentReport(db)("r-1", {
+      targetCompletionDate: "2026-05-01T00:00:00.000Z",
+      safeguardingDiscussed: true,
+      safeguardingNotes: "Discussed with SGO",
+      closureReason: "No further action",
+    });
+
+    const setMock = mockQueryBuilder.set as ReturnType<typeof vi.fn>;
+    const payload = setMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.target_completion_date).toBe("2026-05-01T00:00:00.000Z");
+    expect(payload.safeguarding_discussed).toBe(true);
+    expect(payload.safeguarding_notes).toBe("Discussed with SGO");
+    expect(payload.closure_reason).toBe("No further action");
+  });
+
+  it("bumps updated_at on every call", async () => {
+    mockExecute.mockResolvedValue(undefined);
+
+    await updateIncidentReport(db)("r-1", {});
+
+    const setMock = mockQueryBuilder.set as ReturnType<typeof vi.fn>;
+    const payload = setMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).toHaveProperty("updated_at");
+  });
+});

--- a/apps/api/src/features/incident-report/service.ts
+++ b/apps/api/src/features/incident-report/service.ts
@@ -1,0 +1,401 @@
+import type { DB } from "@percy-main/db";
+import { IncidentReportConfirmation, type Email } from "@percy-main/email";
+import { render } from "@react-email/render";
+import type { Kysely } from "kysely";
+import { createElement } from "react";
+import type {
+  IncidentReportAdminUpdate,
+  IncidentReportSubmission,
+  ListIncidentReports,
+} from "./schemas.ts";
+
+const SEVERITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
+
+function formatOccurredAt(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString("en-GB", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function createSlackNotifier(slackWebhookUrl?: string) {
+  return async (data: {
+    reportId: string;
+    reporterName: string;
+    location: string;
+    occurredAt: string;
+    incidentType: string;
+    affectedIsMinor: boolean;
+    injuryOccurred: boolean;
+    injurySeverity: string | null;
+    description: string;
+    adminUrl: string;
+  }) => {
+    if (!slackWebhookUrl) return;
+
+    const flags: string[] = [];
+    if (data.affectedIsMinor) flags.push("under 18");
+    if (data.injuryOccurred) flags.push("injury reported");
+    if (data.injurySeverity === "fatal") flags.push("FATAL");
+    else if (data.injurySeverity === "serious") flags.push("serious injury");
+    const flagText = flags.length > 0 ? ` (${flags.join(", ")})` : "";
+
+    await fetch(slackWebhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text:
+          `:rotating_light: New accident/incident report${flagText}\n` +
+          `*Type:* ${data.incidentType.replace(/_/g, " ")}\n` +
+          `*From:* ${data.reporterName}\n` +
+          `*When:* ${formatOccurredAt(data.occurredAt)}\n` +
+          `*Where:* ${data.location}\n` +
+          `*Summary:* ${data.description.slice(0, 500)}${data.description.length > 500 ? "…" : ""}\n` +
+          `*Admin:* ${data.adminUrl}`,
+      }),
+    });
+  };
+}
+
+export function createIncidentReportSubmission(
+  db: Kysely<DB>,
+  config: {
+    slackWebhookUrl?: string;
+    baseUrl: string;
+    send: (email: Email) => Promise<void>;
+  },
+) {
+  const sendSlack = createSlackNotifier(config.slackWebhookUrl);
+  const imageBaseUrl = `${config.baseUrl}/images`;
+
+  return async (data: IncidentReportSubmission) => {
+    // Honeypot tripped — silently accept but don't persist or notify.
+    if (data.website && data.website.length > 0) {
+      return { id: crypto.randomUUID() };
+    }
+
+    const id = crypto.randomUUID();
+
+    await db
+      .insertInto("accident_incident_report")
+      .values({
+        id,
+        reporter_name: data.reporterName,
+        reporter_email: data.reporterEmail,
+        reporter_phone: data.reporterPhone ?? null,
+        reporter_relationship: data.reporterRelationship,
+        prefers_no_contact: data.prefersNoContact,
+        affected_name: data.affectedName ?? null,
+        affected_relationship: data.affectedRelationship ?? null,
+        affected_contact: data.affectedContact ?? null,
+        affected_is_minor: data.affectedIsMinor,
+        occurred_at: data.occurredAt,
+        location: data.location,
+        activity: data.activity ?? null,
+        incident_type: data.incidentType,
+        description: data.description,
+        injury_occurred: data.injuryOccurred,
+        nature_of_injury: data.natureOfInjury ?? null,
+        body_parts_affected: data.bodyPartsAffected ?? null,
+        injury_severity: data.injurySeverity ?? null,
+        first_aid_given: data.firstAidGiven,
+        first_aider_name: data.firstAiderName ?? null,
+        first_aid_details: data.firstAidDetails ?? null,
+        medical_treatment_required: data.medicalTreatmentRequired,
+        immediate_actions: data.immediateActions ?? null,
+        witnesses: data.witnesses ?? null,
+        declaration_confirmed: data.declarationConfirmed,
+      })
+      .execute();
+
+    // Confirmation email — always send as a transactional receipt.
+    try {
+      await config.send({
+        to: data.reporterEmail,
+        subject: IncidentReportConfirmation.subject,
+        html: await render(
+          createElement(IncidentReportConfirmation.component, {
+            imageBaseUrl,
+            reporterName: data.reporterName,
+            occurredAt: formatOccurredAt(data.occurredAt),
+            location: data.location,
+            reportId: id,
+          }),
+        ),
+      });
+    } catch {
+      // Don't block submission on email failure.
+    }
+
+    // Fire-and-forget Slack notification.
+    sendSlack({
+      reportId: id,
+      reporterName: data.reporterName,
+      location: data.location,
+      occurredAt: data.occurredAt,
+      incidentType: data.incidentType,
+      affectedIsMinor: data.affectedIsMinor,
+      injuryOccurred: data.injuryOccurred,
+      injurySeverity: data.injurySeverity ?? null,
+      description: data.description,
+      adminUrl: `${config.baseUrl}/admin?tab=incidents`,
+    }).catch(() => {
+      // Silently ignore Slack failures.
+    });
+
+    return { id };
+  };
+}
+
+export function listIncidentReports(db: Kysely<DB>) {
+  return async (params: ListIncidentReports) => {
+    const offset = (params.page - 1) * params.pageSize;
+
+    let baseQuery = db.selectFrom("accident_incident_report");
+    if (params.status) {
+      baseQuery = baseQuery.where("status", "=", params.status);
+    }
+
+    const [countResult, rows] = await Promise.all([
+      baseQuery
+        .select((eb) => eb.fn.countAll<string>().as("total"))
+        .executeTakeFirstOrThrow(),
+      baseQuery
+        .select([
+          "id",
+          "status",
+          "severity",
+          "incident_type",
+          "reporter_name",
+          "affected_is_minor",
+          "injury_occurred",
+          "injury_severity",
+          "location",
+          "occurred_at",
+          "created_at",
+        ])
+        // Open reports first (new, in_review), sorted by recency.
+        .orderBy(
+          (eb) => eb.case().when("status", "=", "done").then(1).else(0).end(),
+          "asc",
+        )
+        .orderBy("created_at", "desc")
+        .limit(params.pageSize)
+        .offset(offset)
+        .execute(),
+    ]);
+
+    const reports = rows
+      .map((r) => ({
+        id: r.id,
+        status: r.status as "new" | "in_review" | "done",
+        severity: r.severity as "low" | "medium" | "high" | null,
+        incidentType: r.incident_type as
+          | "injury"
+          | "near_miss"
+          | "dangerous_occurrence"
+          | "ill_health"
+          | "property_damage",
+        reporterName: r.reporter_name,
+        affectedIsMinor: r.affected_is_minor,
+        injuryOccurred: r.injury_occurred,
+        injurySeverity: r.injury_severity as
+          | "minor"
+          | "serious"
+          | "fatal"
+          | null,
+        location: r.location,
+        occurredAt: toIsoString(r.occurred_at),
+        createdAt: toIsoString(r.created_at),
+      }))
+      // Secondary sort: within open reports, higher severity first.
+      .sort((a, b) => {
+        if (a.status === "done" && b.status !== "done") return 1;
+        if (a.status !== "done" && b.status === "done") return -1;
+        const aSev = a.severity ? SEVERITY_ORDER[a.severity] : 99;
+        const bSev = b.severity ? SEVERITY_ORDER[b.severity] : 99;
+        return aSev - bSev;
+      });
+
+    return {
+      reports,
+      total: Number(countResult.total),
+      page: params.page,
+      pageSize: params.pageSize,
+    };
+  };
+}
+
+function toIsoString(v: unknown): string {
+  return v instanceof Date ? v.toISOString() : String(v);
+}
+
+function toIsoStringNullable(v: unknown): string | null {
+  return v === null || v === undefined ? null : toIsoString(v);
+}
+
+export function getIncidentReport(db: Kysely<DB>) {
+  return async (id: string) => {
+    const row = await db
+      .selectFrom("accident_incident_report")
+      .leftJoin("user", "user.id", "accident_incident_report.owner_user_id")
+      .where("accident_incident_report.id", "=", id)
+      .select([
+        "accident_incident_report.id",
+        "accident_incident_report.reporter_name",
+        "accident_incident_report.reporter_email",
+        "accident_incident_report.reporter_phone",
+        "accident_incident_report.reporter_relationship",
+        "accident_incident_report.prefers_no_contact",
+        "accident_incident_report.affected_name",
+        "accident_incident_report.affected_relationship",
+        "accident_incident_report.affected_contact",
+        "accident_incident_report.affected_is_minor",
+        "accident_incident_report.occurred_at",
+        "accident_incident_report.location",
+        "accident_incident_report.activity",
+        "accident_incident_report.incident_type",
+        "accident_incident_report.description",
+        "accident_incident_report.injury_occurred",
+        "accident_incident_report.nature_of_injury",
+        "accident_incident_report.body_parts_affected",
+        "accident_incident_report.injury_severity",
+        "accident_incident_report.first_aid_given",
+        "accident_incident_report.first_aider_name",
+        "accident_incident_report.first_aid_details",
+        "accident_incident_report.medical_treatment_required",
+        "accident_incident_report.immediate_actions",
+        "accident_incident_report.witnesses",
+        "accident_incident_report.declaration_confirmed",
+        "accident_incident_report.status",
+        "accident_incident_report.severity",
+        "accident_incident_report.owner_user_id",
+        "user.name as owner_name",
+        "accident_incident_report.actions_taken",
+        "accident_incident_report.target_completion_date",
+        "accident_incident_report.riddor_required",
+        "accident_incident_report.riddor_reported_at",
+        "accident_incident_report.internal_notes",
+        "accident_incident_report.closure_reason",
+        "accident_incident_report.closed_at",
+        "accident_incident_report.safeguarding_discussed",
+        "accident_incident_report.safeguarding_discussed_at",
+        "accident_incident_report.safeguarding_notes",
+        "accident_incident_report.created_at",
+        "accident_incident_report.updated_at",
+      ])
+      .executeTakeFirst();
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      reporterName: row.reporter_name,
+      reporterEmail: row.reporter_email,
+      reporterPhone: row.reporter_phone,
+      reporterRelationship: row.reporter_relationship,
+      prefersNoContact: row.prefers_no_contact,
+      affectedName: row.affected_name,
+      affectedRelationship: row.affected_relationship,
+      affectedContact: row.affected_contact,
+      affectedIsMinor: row.affected_is_minor,
+      occurredAt: toIsoString(row.occurred_at),
+      location: row.location,
+      activity: row.activity,
+      incidentType: row.incident_type as
+        | "injury"
+        | "near_miss"
+        | "dangerous_occurrence"
+        | "ill_health"
+        | "property_damage",
+      description: row.description,
+      injuryOccurred: row.injury_occurred,
+      natureOfInjury: row.nature_of_injury,
+      bodyPartsAffected: row.body_parts_affected,
+      injurySeverity: row.injury_severity as
+        | "minor"
+        | "serious"
+        | "fatal"
+        | null,
+      firstAidGiven: row.first_aid_given,
+      firstAiderName: row.first_aider_name,
+      firstAidDetails: row.first_aid_details,
+      medicalTreatmentRequired: row.medical_treatment_required,
+      immediateActions: row.immediate_actions,
+      witnesses: row.witnesses,
+      declarationConfirmed: row.declaration_confirmed,
+      status: row.status as "new" | "in_review" | "done",
+      severity: row.severity as "low" | "medium" | "high" | null,
+      ownerUserId: row.owner_user_id,
+      ownerName: row.owner_name,
+      actionsTaken: row.actions_taken,
+      targetCompletionDate: toIsoStringNullable(row.target_completion_date),
+      riddorRequired: row.riddor_required,
+      riddorReportedAt: toIsoStringNullable(row.riddor_reported_at),
+      internalNotes: row.internal_notes,
+      closureReason: row.closure_reason,
+      closedAt: toIsoStringNullable(row.closed_at),
+      safeguardingDiscussed: row.safeguarding_discussed,
+      safeguardingDiscussedAt: toIsoStringNullable(
+        row.safeguarding_discussed_at,
+      ),
+      safeguardingNotes: row.safeguarding_notes,
+      createdAt: toIsoString(row.created_at),
+      updatedAt: toIsoString(row.updated_at),
+    };
+  };
+}
+
+export function updateIncidentReport(db: Kysely<DB>) {
+  return async (id: string, update: IncidentReportAdminUpdate) => {
+    await db
+      .updateTable("accident_incident_report")
+      .set({
+        updated_at: new Date().toISOString(),
+        ...(update.status !== undefined ? { status: update.status } : {}),
+        ...(update.severity !== undefined ? { severity: update.severity } : {}),
+        ...(update.ownerUserId !== undefined
+          ? { owner_user_id: update.ownerUserId }
+          : {}),
+        ...(update.actionsTaken !== undefined
+          ? { actions_taken: update.actionsTaken }
+          : {}),
+        ...(update.targetCompletionDate !== undefined
+          ? { target_completion_date: update.targetCompletionDate }
+          : {}),
+        ...(update.riddorRequired !== undefined
+          ? { riddor_required: update.riddorRequired }
+          : {}),
+        ...(update.riddorReportedAt !== undefined
+          ? { riddor_reported_at: update.riddorReportedAt }
+          : {}),
+        ...(update.internalNotes !== undefined
+          ? { internal_notes: update.internalNotes }
+          : {}),
+        ...(update.closureReason !== undefined
+          ? { closure_reason: update.closureReason }
+          : {}),
+        ...(update.closedAt !== undefined
+          ? { closed_at: update.closedAt }
+          : {}),
+        ...(update.safeguardingDiscussed !== undefined
+          ? { safeguarding_discussed: update.safeguardingDiscussed }
+          : {}),
+        ...(update.safeguardingDiscussedAt !== undefined
+          ? { safeguarding_discussed_at: update.safeguardingDiscussedAt }
+          : {}),
+        ...(update.safeguardingNotes !== undefined
+          ? { safeguarding_notes: update.safeguardingNotes }
+          : {}),
+      })
+      .where("id", "=", id)
+      .execute();
+
+    return { success: true };
+  };
+}

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -67,6 +67,14 @@ export const SiteFooter: FC = () => {
               </li>
               <li>
                 <Link
+                  to="/report-incident"
+                  className="text-white/80 transition hover:text-white"
+                >
+                  Report an accident or incident
+                </Link>
+              </li>
+              <li>
+                <Link
                   to="/legal/privacy"
                   className="text-white/80 transition hover:text-white"
                 >

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -8895,6 +8895,272 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/incident-report": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        reporterName: string;
+                        /** Format: email */
+                        reporterEmail: string;
+                        reporterPhone?: string;
+                        /** @enum {string} */
+                        reporterRelationship: "member" | "parent_or_guardian" | "player" | "coach_or_volunteer" | "visitor" | "other";
+                        /** @default false */
+                        prefersNoContact?: boolean;
+                        affectedName?: string;
+                        /** @enum {string} */
+                        affectedRelationship?: "trustee" | "member" | "volunteer" | "visitor" | "contractor" | "other";
+                        affectedContact?: string;
+                        /** @default false */
+                        affectedIsMinor?: boolean;
+                        occurredAt: string;
+                        location: string;
+                        activity?: string;
+                        /** @enum {string} */
+                        incidentType: "injury" | "near_miss" | "dangerous_occurrence" | "ill_health" | "property_damage";
+                        description: string;
+                        /** @default false */
+                        injuryOccurred?: boolean;
+                        natureOfInjury?: string;
+                        bodyPartsAffected?: string;
+                        /** @enum {string} */
+                        injurySeverity?: "minor" | "serious" | "fatal";
+                        /** @default false */
+                        firstAidGiven?: boolean;
+                        firstAiderName?: string;
+                        firstAidDetails?: string;
+                        /** @default false */
+                        medicalTreatmentRequired?: boolean;
+                        immediateActions?: string;
+                        witnesses?: string;
+                        /** @enum {boolean} */
+                        declarationConfirmed: true;
+                        website?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/incident-reports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    page?: number;
+                    pageSize?: number;
+                    status?: "new" | "in_review" | "done";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            reports: {
+                                id: string;
+                                /** @enum {string} */
+                                status: "new" | "in_review" | "done";
+                                /** @enum {string|null} */
+                                severity: "low" | "medium" | "high" | null;
+                                /** @enum {string} */
+                                incidentType: "injury" | "near_miss" | "dangerous_occurrence" | "ill_health" | "property_damage";
+                                reporterName: string;
+                                affectedIsMinor: boolean;
+                                injuryOccurred: boolean;
+                                /** @enum {string|null} */
+                                injurySeverity: "minor" | "serious" | "fatal" | null;
+                                location: string;
+                                occurredAt: string;
+                                createdAt: string;
+                            }[];
+                            total: number;
+                            page: number;
+                            pageSize: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/incident-reports/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            reporterName: string;
+                            reporterEmail: string;
+                            reporterPhone: string | null;
+                            reporterRelationship: string;
+                            prefersNoContact: boolean;
+                            affectedName: string | null;
+                            affectedRelationship: string | null;
+                            affectedContact: string | null;
+                            affectedIsMinor: boolean;
+                            occurredAt: string;
+                            location: string;
+                            activity: string | null;
+                            /** @enum {string} */
+                            incidentType: "injury" | "near_miss" | "dangerous_occurrence" | "ill_health" | "property_damage";
+                            description: string;
+                            injuryOccurred: boolean;
+                            natureOfInjury: string | null;
+                            bodyPartsAffected: string | null;
+                            /** @enum {string|null} */
+                            injurySeverity: "minor" | "serious" | "fatal" | null;
+                            firstAidGiven: boolean;
+                            firstAiderName: string | null;
+                            firstAidDetails: string | null;
+                            medicalTreatmentRequired: boolean;
+                            immediateActions: string | null;
+                            witnesses: string | null;
+                            declarationConfirmed: boolean;
+                            /** @enum {string} */
+                            status: "new" | "in_review" | "done";
+                            /** @enum {string|null} */
+                            severity: "low" | "medium" | "high" | null;
+                            ownerUserId: string | null;
+                            ownerName: string | null;
+                            actionsTaken: string | null;
+                            targetCompletionDate: string | null;
+                            riddorRequired: boolean | null;
+                            riddorReportedAt: string | null;
+                            internalNotes: string | null;
+                            closureReason: string | null;
+                            closedAt: string | null;
+                            safeguardingDiscussed: boolean;
+                            safeguardingDiscussedAt: string | null;
+                            safeguardingNotes: string | null;
+                            createdAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        status?: "new" | "in_review" | "done";
+                        /** @enum {string|null} */
+                        severity?: "low" | "medium" | "high" | null;
+                        ownerUserId?: string | null;
+                        actionsTaken?: string | null;
+                        targetCompletionDate?: string | null;
+                        riddorRequired?: boolean | null;
+                        riddorReportedAt?: string | null;
+                        internalNotes?: string | null;
+                        closureReason?: string | null;
+                        closedAt?: string | null;
+                        safeguardingDiscussed?: boolean;
+                        safeguardingDiscussedAt?: string | null;
+                        safeguardingNotes?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/api/stripe/webhook": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -15515,6 +15515,693 @@
         }
       }
     },
+    "/api/incident-report": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reporterName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  },
+                  "reporterEmail": {
+                    "type": "string",
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                  },
+                  "reporterPhone": {
+                    "type": "string",
+                    "maxLength": 50
+                  },
+                  "reporterRelationship": {
+                    "type": "string",
+                    "enum": [
+                      "member",
+                      "parent_or_guardian",
+                      "player",
+                      "coach_or_volunteer",
+                      "visitor",
+                      "other"
+                    ]
+                  },
+                  "prefersNoContact": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "affectedName": {
+                    "type": "string",
+                    "maxLength": 200
+                  },
+                  "affectedRelationship": {
+                    "type": "string",
+                    "enum": [
+                      "trustee",
+                      "member",
+                      "volunteer",
+                      "visitor",
+                      "contractor",
+                      "other"
+                    ]
+                  },
+                  "affectedContact": {
+                    "type": "string",
+                    "maxLength": 500
+                  },
+                  "affectedIsMinor": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "occurredAt": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "location": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "activity": {
+                    "type": "string",
+                    "maxLength": 300
+                  },
+                  "incidentType": {
+                    "type": "string",
+                    "enum": [
+                      "injury",
+                      "near_miss",
+                      "dangerous_occurrence",
+                      "ill_health",
+                      "property_damage"
+                    ]
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 5000
+                  },
+                  "injuryOccurred": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "natureOfInjury": {
+                    "type": "string",
+                    "maxLength": 1000
+                  },
+                  "bodyPartsAffected": {
+                    "type": "string",
+                    "maxLength": 500
+                  },
+                  "injurySeverity": {
+                    "type": "string",
+                    "enum": [
+                      "minor",
+                      "serious",
+                      "fatal"
+                    ]
+                  },
+                  "firstAidGiven": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "firstAiderName": {
+                    "type": "string",
+                    "maxLength": 200
+                  },
+                  "firstAidDetails": {
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "medicalTreatmentRequired": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "immediateActions": {
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "witnesses": {
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "declarationConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  },
+                  "website": {
+                    "type": "string",
+                    "maxLength": 0
+                  }
+                },
+                "required": [
+                  "reporterName",
+                  "reporterEmail",
+                  "reporterRelationship",
+                  "occurredAt",
+                  "location",
+                  "incidentType",
+                  "description",
+                  "declarationConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/incident-reports": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "new",
+                "in_review",
+                "done"
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "reports": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "new",
+                              "in_review",
+                              "done"
+                            ]
+                          },
+                          "severity": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "low",
+                              "medium",
+                              "high"
+                            ]
+                          },
+                          "incidentType": {
+                            "type": "string",
+                            "enum": [
+                              "injury",
+                              "near_miss",
+                              "dangerous_occurrence",
+                              "ill_health",
+                              "property_damage"
+                            ]
+                          },
+                          "reporterName": {
+                            "type": "string"
+                          },
+                          "affectedIsMinor": {
+                            "type": "boolean"
+                          },
+                          "injuryOccurred": {
+                            "type": "boolean"
+                          },
+                          "injurySeverity": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "minor",
+                              "serious",
+                              "fatal"
+                            ]
+                          },
+                          "location": {
+                            "type": "string"
+                          },
+                          "occurredAt": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "status",
+                          "severity",
+                          "incidentType",
+                          "reporterName",
+                          "affectedIsMinor",
+                          "injuryOccurred",
+                          "injurySeverity",
+                          "location",
+                          "occurredAt",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "page": {
+                      "type": "number"
+                    },
+                    "pageSize": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "reports",
+                    "total",
+                    "page",
+                    "pageSize"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/incident-reports/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "reporterName": {
+                      "type": "string"
+                    },
+                    "reporterEmail": {
+                      "type": "string"
+                    },
+                    "reporterPhone": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "reporterRelationship": {
+                      "type": "string"
+                    },
+                    "prefersNoContact": {
+                      "type": "boolean"
+                    },
+                    "affectedName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "affectedRelationship": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "affectedContact": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "affectedIsMinor": {
+                      "type": "boolean"
+                    },
+                    "occurredAt": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "activity": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "incidentType": {
+                      "type": "string",
+                      "enum": [
+                        "injury",
+                        "near_miss",
+                        "dangerous_occurrence",
+                        "ill_health",
+                        "property_damage"
+                      ]
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "injuryOccurred": {
+                      "type": "boolean"
+                    },
+                    "natureOfInjury": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "bodyPartsAffected": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "injurySeverity": {
+                      "nullable": true,
+                      "type": "string",
+                      "enum": [
+                        "minor",
+                        "serious",
+                        "fatal"
+                      ]
+                    },
+                    "firstAidGiven": {
+                      "type": "boolean"
+                    },
+                    "firstAiderName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "firstAidDetails": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "medicalTreatmentRequired": {
+                      "type": "boolean"
+                    },
+                    "immediateActions": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "witnesses": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "declarationConfirmed": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "new",
+                        "in_review",
+                        "done"
+                      ]
+                    },
+                    "severity": {
+                      "nullable": true,
+                      "type": "string",
+                      "enum": [
+                        "low",
+                        "medium",
+                        "high"
+                      ]
+                    },
+                    "ownerUserId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "ownerName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "actionsTaken": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "targetCompletionDate": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "riddorRequired": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "riddorReportedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "internalNotes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "closureReason": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "closedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "safeguardingDiscussed": {
+                      "type": "boolean"
+                    },
+                    "safeguardingDiscussedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "safeguardingNotes": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "reporterName",
+                    "reporterEmail",
+                    "reporterPhone",
+                    "reporterRelationship",
+                    "prefersNoContact",
+                    "affectedName",
+                    "affectedRelationship",
+                    "affectedContact",
+                    "affectedIsMinor",
+                    "occurredAt",
+                    "location",
+                    "activity",
+                    "incidentType",
+                    "description",
+                    "injuryOccurred",
+                    "natureOfInjury",
+                    "bodyPartsAffected",
+                    "injurySeverity",
+                    "firstAidGiven",
+                    "firstAiderName",
+                    "firstAidDetails",
+                    "medicalTreatmentRequired",
+                    "immediateActions",
+                    "witnesses",
+                    "declarationConfirmed",
+                    "status",
+                    "severity",
+                    "ownerUserId",
+                    "ownerName",
+                    "actionsTaken",
+                    "targetCompletionDate",
+                    "riddorRequired",
+                    "riddorReportedAt",
+                    "internalNotes",
+                    "closureReason",
+                    "closedAt",
+                    "safeguardingDiscussed",
+                    "safeguardingDiscussedAt",
+                    "safeguardingNotes",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "new",
+                      "in_review",
+                      "done"
+                    ]
+                  },
+                  "severity": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ]
+                  },
+                  "ownerUserId": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "actionsTaken": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 5000
+                  },
+                  "targetCompletionDate": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "riddorRequired": {
+                    "nullable": true,
+                    "type": "boolean"
+                  },
+                  "riddorReportedAt": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "internalNotes": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 5000
+                  },
+                  "closureReason": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "closedAt": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "safeguardingDiscussed": {
+                    "type": "boolean"
+                  },
+                  "safeguardingDiscussedAt": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "safeguardingNotes": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stripe/webhook": {
       "post": {
         "responses": {

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -9,6 +9,7 @@ import { DuplicatesTab } from "./duplicates-tab";
 import { ExpenseHistoryTab } from "./expense-history-tab";
 import { FantasyTab } from "./fantasy-tab";
 import { GameReportsTab } from "./game-reports-tab";
+import { IncidentsTab } from "./incidents-tab";
 import { JuniorsTab } from "./juniors-tab";
 import { MatchFeesTab } from "./match-fees-tab";
 import { MembersTab } from "./members-tab";
@@ -22,6 +23,7 @@ const TABS = [
   "charges",
   "contacts",
   "sponsorships",
+  "incidents",
   "documents",
   "duplicates",
   "match-fees",
@@ -39,6 +41,7 @@ const ACTIVE_TABS: Tab[] = [
   "charges",
   "contacts",
   "sponsorships",
+  "incidents",
   "documents",
   "duplicates",
   "match-fees",
@@ -89,6 +92,7 @@ export function Component() {
             <TabsTrigger value="charges">Charges</TabsTrigger>
             <TabsTrigger value="contacts">Contacts</TabsTrigger>
             <TabsTrigger value="sponsorships">Sponsorships</TabsTrigger>
+            <TabsTrigger value="incidents">Incidents</TabsTrigger>
             <TabsTrigger value="documents">Documents</TabsTrigger>
             <TabsTrigger value="duplicates">Duplicates</TabsTrigger>
             <TabsTrigger value="match-fees">Match Fees</TabsTrigger>
@@ -113,6 +117,9 @@ export function Component() {
           </TabsContent>
           <TabsContent value="sponsorships">
             <SponsorshipsTab />
+          </TabsContent>
+          <TabsContent value="incidents">
+            <IncidentsTab />
           </TabsContent>
           <TabsContent value="documents">
             <DocumentsTab />

--- a/apps/web/src/pages/admin/incidents-tab.tsx
+++ b/apps/web/src/pages/admin/incidents-tab.tsx
@@ -1,0 +1,713 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { api, callApi } from "@/lib/api-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { formatDate } from "./status-pill";
+
+const PAGE_SIZE = 20;
+
+type Status = "new" | "in_review" | "done";
+type Severity = "low" | "medium" | "high";
+type StatusFilter = "all" | Status;
+type IncidentType =
+  | "injury"
+  | "near_miss"
+  | "dangerous_occurrence"
+  | "ill_health"
+  | "property_damage";
+type InjurySeverity = "minor" | "serious" | "fatal";
+type RiddorState = "unset" | "yes" | "no";
+
+const REPORTER_RELATIONSHIP_LABELS: Record<string, string> = {
+  member: "Member",
+  parent_or_guardian: "Parent / guardian",
+  player: "Player",
+  coach_or_volunteer: "Coach / volunteer",
+  visitor: "Visitor",
+  other: "Other",
+};
+
+const AFFECTED_RELATIONSHIP_LABELS: Record<string, string> = {
+  trustee: "Trustee",
+  member: "Member",
+  volunteer: "Volunteer",
+  visitor: "Visitor",
+  contractor: "Contractor",
+  other: "Other",
+};
+
+const INCIDENT_TYPE_LABELS: Record<IncidentType, string> = {
+  injury: "Injury",
+  near_miss: "Near miss",
+  dangerous_occurrence: "Dangerous occurrence",
+  ill_health: "Ill health",
+  property_damage: "Property damage",
+};
+
+function StatusBadge({ status }: { status: Status }) {
+  if (status === "new") return <Badge variant="warning">New</Badge>;
+  if (status === "in_review") return <Badge variant="info">In review</Badge>;
+  return <Badge variant="success">Done</Badge>;
+}
+
+function SeverityBadge({ severity }: { severity: Severity | null }) {
+  if (!severity) return <Badge variant="outline">Unset</Badge>;
+  if (severity === "high") return <Badge variant="destructive">High</Badge>;
+  if (severity === "medium") return <Badge variant="warning">Medium</Badge>;
+  return <Badge variant="secondary">Low</Badge>;
+}
+
+function InjurySeverityBadge({
+  severity,
+}: {
+  severity: InjurySeverity | null;
+}) {
+  if (!severity) return <>—</>;
+  if (severity === "fatal") return <Badge variant="destructive">Fatal</Badge>;
+  if (severity === "serious")
+    return <Badge variant="destructive">Serious</Badge>;
+  return <Badge variant="secondary">Minor</Badge>;
+}
+
+function toDateTimeLocal(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function fromDateTimeLocal(value: string): string | null {
+  if (!value) return null;
+  const d = new Date(value);
+  if (isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+function toDateInput(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function fromDateInput(value: string): string | null {
+  if (!value) return null;
+  const d = new Date(`${value}T00:00:00`);
+  if (isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+export function IncidentsTab() {
+  const [page, setPage] = useState(1);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const query = useQuery({
+    queryKey: ["admin", "incidentReports", page, PAGE_SIZE, statusFilter],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/incident-reports", {
+          params: {
+            query: {
+              page,
+              pageSize: PAGE_SIZE,
+              ...(statusFilter !== "all" ? { status: statusFilter } : {}),
+            },
+          },
+        }),
+      ),
+  });
+
+  const totalPages = query.data
+    ? Math.max(1, Math.ceil(query.data.total / PAGE_SIZE))
+    : 1;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Label htmlFor="incident-status-filter" className="text-sm">
+          Status
+        </Label>
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => {
+            setStatusFilter(v as StatusFilter);
+            setPage(1);
+          }}
+        >
+          <SelectTrigger id="incident-status-filter" className="w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="new">New</SelectItem>
+            <SelectItem value="in_review">In review</SelectItem>
+            <SelectItem value="done">Done</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {query.isLoading && <p className="text-gray-500">Loading...</p>}
+      {query.isError && (
+        <p className="text-red-600">Failed to load incident reports.</p>
+      )}
+
+      {query.data && (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Reported</TableHead>
+                <TableHead>Occurred</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Location</TableHead>
+                <TableHead>Reporter</TableHead>
+                <TableHead>Flags</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Severity</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {query.data.reports.length === 0 && (
+                <TableRow>
+                  <TableCell
+                    colSpan={8}
+                    className="py-6 text-center text-gray-500"
+                  >
+                    No incident reports found.
+                  </TableCell>
+                </TableRow>
+              )}
+              {query.data.reports.map((r) => (
+                <TableRow
+                  key={r.id}
+                  className="cursor-pointer"
+                  onClick={() => setOpenId(r.id)}
+                >
+                  <TableCell>{formatDate(r.createdAt, true)}</TableCell>
+                  <TableCell>{formatDate(r.occurredAt, true)}</TableCell>
+                  <TableCell>{INCIDENT_TYPE_LABELS[r.incidentType]}</TableCell>
+                  <TableCell>{r.location}</TableCell>
+                  <TableCell>{r.reporterName}</TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {r.affectedIsMinor && (
+                        <Badge variant="destructive">U18</Badge>
+                      )}
+                      {r.injuryOccurred && (
+                        <Badge variant="warning">Injury</Badge>
+                      )}
+                      {r.injurySeverity === "fatal" && (
+                        <Badge variant="destructive">Fatal</Badge>
+                      )}
+                      {r.injurySeverity === "serious" && (
+                        <Badge variant="destructive">Serious</Badge>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge status={r.status} />
+                  </TableCell>
+                  <TableCell>
+                    <SeverityBadge severity={r.severity} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-gray-500">
+              {query.data.total} report{query.data.total !== 1 ? "s" : ""} total
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                Previous
+              </Button>
+              <span className="text-gray-600">
+                Page {page} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+
+      <IncidentDetailDialog id={openId} onClose={() => setOpenId(null)} />
+    </div>
+  );
+}
+
+function IncidentDetailDialog({
+  id,
+  onClose,
+}: {
+  id: string | null;
+  onClose: () => void;
+}) {
+  const open = id !== null;
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Incident report</DialogTitle>
+        </DialogHeader>
+        {id !== null && (
+          <IncidentDetailBody key={id} id={id} onClose={onClose} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type IncidentDetail = NonNullable<
+  Awaited<ReturnType<typeof loadIncidentDetail>>
+>;
+
+async function loadIncidentDetail(id: string) {
+  return await callApi(
+    api.GET("/api/admin/incident-reports/{id}", {
+      params: { path: { id } },
+    }),
+  );
+}
+
+function IncidentDetailBody({
+  id,
+  onClose,
+}: {
+  id: string;
+  onClose: () => void;
+}) {
+  const detail = useQuery({
+    queryKey: ["admin", "incidentReport", id],
+    queryFn: () => loadIncidentDetail(id),
+  });
+
+  if (detail.isLoading) return <p className="text-gray-500">Loading...</p>;
+  if (detail.isError || !detail.data)
+    return <p className="text-red-600">Failed to load report.</p>;
+
+  return <IncidentEditForm id={id} initial={detail.data} onClose={onClose} />;
+}
+
+function IncidentEditForm({
+  id,
+  initial,
+  onClose,
+}: {
+  id: string;
+  initial: IncidentDetail;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+
+  const [status, setStatus] = useState<Status>(initial.status);
+  const [severity, setSeverity] = useState<Severity | "unset">(
+    initial.severity ?? "unset",
+  );
+  const [internalNotes, setInternalNotes] = useState(
+    initial.internalNotes ?? "",
+  );
+  const [actionsTaken, setActionsTaken] = useState(initial.actionsTaken ?? "");
+  const [targetCompletionDate, setTargetCompletionDate] = useState(
+    toDateInput(initial.targetCompletionDate),
+  );
+  const [riddorRequired, setRiddorRequired] = useState<RiddorState>(
+    initial.riddorRequired === true
+      ? "yes"
+      : initial.riddorRequired === false
+        ? "no"
+        : "unset",
+  );
+  const [riddorReportedAt, setRiddorReportedAt] = useState(
+    toDateInput(initial.riddorReportedAt),
+  );
+  const [closureReason, setClosureReason] = useState(
+    initial.closureReason ?? "",
+  );
+  const [closedAt, setClosedAt] = useState(toDateTimeLocal(initial.closedAt));
+  const [safeguardingDiscussed, setSafeguardingDiscussed] = useState(
+    initial.safeguardingDiscussed,
+  );
+  const [safeguardingDiscussedAt, setSafeguardingDiscussedAt] = useState(
+    toDateTimeLocal(initial.safeguardingDiscussedAt),
+  );
+  const [safeguardingNotes, setSafeguardingNotes] = useState(
+    initial.safeguardingNotes ?? "",
+  );
+
+  const save = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.PATCH("/api/admin/incident-reports/{id}", {
+          params: { path: { id } },
+          body: {
+            status,
+            severity: severity === "unset" ? null : severity,
+            actionsTaken: actionsTaken.trim() || null,
+            targetCompletionDate: fromDateInput(targetCompletionDate),
+            riddorRequired:
+              riddorRequired === "unset" ? null : riddorRequired === "yes",
+            riddorReportedAt: fromDateInput(riddorReportedAt),
+            internalNotes: internalNotes.trim() || null,
+            closureReason: closureReason.trim() || null,
+            closedAt: fromDateTimeLocal(closedAt),
+            safeguardingDiscussed,
+            safeguardingDiscussedAt: fromDateTimeLocal(safeguardingDiscussedAt),
+            safeguardingNotes: safeguardingNotes.trim() || null,
+          },
+        }),
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["admin", "incidentReports"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["admin", "incidentReport", id],
+      });
+      onClose();
+    },
+  });
+
+  return (
+    <>
+      <div className="flex flex-col gap-6">
+        <section className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+          <ReadField label="Reported at">
+            {formatDate(initial.createdAt, true)}
+          </ReadField>
+          <ReadField label="Occurred">
+            {formatDate(initial.occurredAt, true)}
+          </ReadField>
+          <ReadField label="Location">{initial.location}</ReadField>
+          <ReadField label="Activity">{initial.activity ?? "—"}</ReadField>
+          <ReadField label="Type">
+            {INCIDENT_TYPE_LABELS[initial.incidentType]}
+          </ReadField>
+        </section>
+
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">Reporter</h3>
+          <div className="grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+            <ReadField label="Name">{initial.reporterName}</ReadField>
+            <ReadField label="Relationship">
+              {REPORTER_RELATIONSHIP_LABELS[initial.reporterRelationship] ??
+                initial.reporterRelationship}
+            </ReadField>
+            <ReadField label="Email">
+              <a
+                className="text-blue-700 underline"
+                href={`mailto:${initial.reporterEmail}`}
+              >
+                {initial.reporterEmail}
+              </a>
+            </ReadField>
+            <ReadField label="Phone">
+              {initial.reporterPhone ? (
+                <a
+                  className="text-blue-700 underline"
+                  href={`tel:${initial.reporterPhone}`}
+                >
+                  {initial.reporterPhone}
+                </a>
+              ) : (
+                "—"
+              )}
+            </ReadField>
+          </div>
+          {initial.prefersNoContact && (
+            <p className="mt-2 text-sm font-medium text-amber-700">
+              ⚠ Reporter prefers not to be contacted about this report.
+            </p>
+          )}
+        </section>
+
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">
+            Injured / affected person
+          </h3>
+          <div className="grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+            <ReadField label="Name">{initial.affectedName ?? "—"}</ReadField>
+            <ReadField label="Role / relationship">
+              {initial.affectedRelationship
+                ? (AFFECTED_RELATIONSHIP_LABELS[initial.affectedRelationship] ??
+                  initial.affectedRelationship)
+                : "—"}
+            </ReadField>
+            <ReadField label="Contact">
+              {initial.affectedContact ?? "—"}
+            </ReadField>
+            <ReadField label="Under 18">
+              {initial.affectedIsMinor ? "Yes" : "No"}
+            </ReadField>
+          </div>
+        </section>
+
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">What happened</h3>
+          <p className="mt-1 text-sm whitespace-pre-wrap">
+            {initial.description}
+          </p>
+        </section>
+
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">Injury / ill health</h3>
+          <div className="grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+            <ReadField label="Injury / ill health occurred">
+              {initial.injuryOccurred ? "Yes" : "No"}
+            </ReadField>
+            <ReadField label="Severity">
+              <InjurySeverityBadge severity={initial.injurySeverity} />
+            </ReadField>
+            <ReadField label="Nature">
+              {initial.natureOfInjury ?? "—"}
+            </ReadField>
+            <ReadField label="Body parts affected">
+              {initial.bodyPartsAffected ?? "—"}
+            </ReadField>
+            <ReadField label="First aid given">
+              {initial.firstAidGiven ? "Yes" : "No"}
+            </ReadField>
+            <ReadField label="First aider">
+              {initial.firstAiderName ?? "—"}
+            </ReadField>
+            <ReadField label="First aid details">
+              {initial.firstAidDetails ?? "—"}
+            </ReadField>
+            <ReadField label="Medical treatment required">
+              {initial.medicalTreatmentRequired ? "Yes" : "No"}
+            </ReadField>
+          </div>
+        </section>
+
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">
+            Actions at the time &amp; witnesses
+          </h3>
+          <div className="grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+            <ReadField label="Immediate actions">
+              {initial.immediateActions ?? "—"}
+            </ReadField>
+            <ReadField label="Witnesses">{initial.witnesses ?? "—"}</ReadField>
+          </div>
+        </section>
+
+        <section className="border-border bg-muted/30 rounded border p-3 text-xs text-gray-600">
+          <strong>Declaration:</strong>{" "}
+          {initial.declarationConfirmed
+            ? "Reporter confirmed the information is true and accurate to the best of their knowledge and belief."
+            : "Not confirmed."}
+        </section>
+
+        <hr />
+
+        <section>
+          <h3 className="mb-3 text-sm font-semibold">Admin review</h3>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <Label className="mb-1 block">Status</Label>
+              <Select
+                value={status}
+                onValueChange={(v) => setStatus(v as Status)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="new">New</SelectItem>
+                  <SelectItem value="in_review">In review</SelectItem>
+                  <SelectItem value="done">Done</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="mb-1 block">Severity</Label>
+              <Select
+                value={severity}
+                onValueChange={(v) => setSeverity(v as Severity | "unset")}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="unset">Unset</SelectItem>
+                  <SelectItem value="low">Low</SelectItem>
+                  <SelectItem value="medium">Medium</SelectItem>
+                  <SelectItem value="high">High</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="md:col-span-2">
+              <Label className="mb-1 block">Actions taken</Label>
+              <Textarea
+                rows={3}
+                value={actionsTaken}
+                onChange={(e) => setActionsTaken(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label className="mb-1 block">Target completion date</Label>
+              <input
+                type="date"
+                className="border-border bg-surface text-dark w-full rounded-md border px-3 py-2 text-sm"
+                value={targetCompletionDate}
+                onChange={(e) => setTargetCompletionDate(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label className="mb-1 block">RIDDOR reporting required?</Label>
+              <Select
+                value={riddorRequired}
+                onValueChange={(v) => setRiddorRequired(v as RiddorState)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="unset">Not decided</SelectItem>
+                  <SelectItem value="no">No</SelectItem>
+                  <SelectItem value="yes">Yes</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {riddorRequired === "yes" && (
+              <div className="md:col-span-2">
+                <Label className="mb-1 block">Date reported to HSE</Label>
+                <input
+                  type="date"
+                  className="border-border bg-surface text-dark w-full rounded-md border px-3 py-2 text-sm"
+                  value={riddorReportedAt}
+                  onChange={(e) => setRiddorReportedAt(e.target.value)}
+                />
+              </div>
+            )}
+            <div className="md:col-span-2">
+              <Label className="mb-1 block">Internal notes</Label>
+              <Textarea
+                rows={3}
+                value={internalNotes}
+                onChange={(e) => setInternalNotes(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label className="mb-1 block">Date closed</Label>
+              <input
+                type="datetime-local"
+                className="border-border bg-surface text-dark w-full rounded-md border px-3 py-2 text-sm"
+                value={closedAt}
+                onChange={(e) => setClosedAt(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label className="mb-1 block">Closure reason</Label>
+              <input
+                type="text"
+                className="border-border bg-surface text-dark w-full rounded-md border px-3 py-2 text-sm"
+                value={closureReason}
+                onChange={(e) => setClosureReason(e.target.value)}
+              />
+            </div>
+            <div className="flex items-center gap-2 md:col-span-2">
+              <Checkbox
+                id="safeguarding-discussed"
+                checked={safeguardingDiscussed}
+                onCheckedChange={(v) => setSafeguardingDiscussed(v === true)}
+              />
+              <Label htmlFor="safeguarding-discussed">
+                Discussed with club safeguarding officer
+              </Label>
+            </div>
+            {safeguardingDiscussed && (
+              <>
+                <div>
+                  <Label className="mb-1 block">Discussion date</Label>
+                  <input
+                    type="datetime-local"
+                    className="border-border bg-surface text-dark w-full rounded-md border px-3 py-2 text-sm"
+                    value={safeguardingDiscussedAt}
+                    onChange={(e) => setSafeguardingDiscussedAt(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label className="mb-1 block">Discussion note</Label>
+                  <input
+                    type="text"
+                    className="border-border bg-surface text-dark w-full rounded-md border px-3 py-2 text-sm"
+                    value={safeguardingNotes}
+                    onChange={(e) => setSafeguardingNotes(e.target.value)}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button onClick={() => save.mutate()} disabled={save.isPending}>
+          {save.isPending ? "Saving..." : "Save changes"}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function ReadField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="text-xs font-medium text-gray-500">{label}</div>
+      <div className="text-sm">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/legal/privacy.tsx
+++ b/apps/web/src/pages/legal/privacy.tsx
@@ -52,6 +52,11 @@ export function Component() {
             </a>
           </li>
           <li>
+            <a className="text-blue-900 underline" href="#incidents">
+              Accident and incident reports
+            </a>
+          </li>
+          <li>
             <a className="text-blue-900 underline" href="#complain">
               How to complain
             </a>
@@ -110,6 +115,30 @@ export function Component() {
           <li>Name</li>
           <li>Contact information</li>
           <li>Health and safety information</li>
+        </ul>
+
+        <p>
+          We collect or use the following personal information to{" "}
+          <strong>
+            record, review and respond to accidents, incidents and safety
+            concerns
+          </strong>
+          :
+        </p>
+        <ul>
+          <li>Names and contact details of the reporter</li>
+          <li>
+            Name and age indication (adult or under 18) of the person affected
+          </li>
+          <li>
+            Details of the incident — date, time, location, activity, and a
+            description of what happened
+          </li>
+          <li>
+            Health-related information where relevant — for example whether an
+            injury occurred and what first aid or emergency care was given
+          </li>
+          <li>Witness details where known</li>
         </ul>
 
         <p>
@@ -373,6 +402,49 @@ export function Component() {
           processing and storage
         </p>
 
+        {/* Accident and incident reports */}
+        <h2 id="incidents" className="scroll-mt-40">
+          Accident and incident reports
+        </h2>
+        <p>
+          The club provides a form for reporting accidents, injuries, near
+          misses and safety concerns at{" "}
+          <a className="text-blue-900 underline" href="/report-incident">
+            /report-incident
+          </a>
+          . Information submitted through this form is used to record, review
+          and respond to the incident, and to demonstrate responsible health and
+          safety governance.
+        </p>
+        <p>
+          Reports may include health-related information (for example details of
+          an injury or first aid given). We treat this information as sensitive
+          and only use it for the purposes set out below.
+        </p>
+        <p>
+          <strong>Who can see accident and incident reports:</strong> access is
+          restricted to authorised club admins. These individuals are DBS
+          checked and safeguarding aware. Reports involving people under 18 are
+          handled with particular care and, where appropriate, discussed with
+          the club&rsquo;s safeguarding officer.
+        </p>
+        <p>
+          <strong>How long we keep them:</strong> accident, incident and health
+          and safety records are retained for as long as is necessary to meet
+          our health and safety, insurance and legal obligations. Where children
+          are involved, records may be kept for longer in line with safeguarding
+          guidance.
+        </p>
+        <p>
+          <strong>Who we may share them with:</strong> where necessary and
+          lawful, we may share information from accident and incident reports
+          with third parties including our insurers, relevant sport governing
+          bodies (for example the England and Wales Cricket Board or the
+          Northumberland &amp; Tyneside Cricket League), emergency services,
+          local authorities, safeguarding agencies and regulators such as the
+          Health and Safety Executive.
+        </p>
+
         {/* How to complain */}
         <h2 id="complain" className="scroll-mt-40">
           How to complain
@@ -414,7 +486,7 @@ export function Component() {
         </p>
 
         <h2>Last updated</h2>
-        <p>10 January 2025</p>
+        <p>24 April 2026</p>
       </div>
     </div>
   );

--- a/apps/web/src/pages/report-incident.tsx
+++ b/apps/web/src/pages/report-incident.tsx
@@ -1,0 +1,601 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useDocumentMeta } from "@/hooks/use-document-meta.js";
+import { api, callApi } from "@/lib/api-client";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { Link } from "react-router";
+
+type ReporterRelationship =
+  | "member"
+  | "parent_or_guardian"
+  | "player"
+  | "coach_or_volunteer"
+  | "visitor"
+  | "other";
+
+type AffectedRelationship =
+  | "trustee"
+  | "member"
+  | "volunteer"
+  | "visitor"
+  | "contractor"
+  | "other";
+
+type IncidentType =
+  | "injury"
+  | "near_miss"
+  | "dangerous_occurrence"
+  | "ill_health"
+  | "property_damage";
+
+type InjurySeverity = "minor" | "serious" | "fatal";
+
+export function Component() {
+  useDocumentMeta(
+    "Report an accident or incident",
+    "Report an accident, injury, near miss or safety concern at Percy Main Community Sports Club.",
+  );
+
+  // Reporter
+  const [reporterName, setReporterName] = useState("");
+  const [reporterEmail, setReporterEmail] = useState("");
+  const [reporterPhone, setReporterPhone] = useState("");
+  const [reporterRelationship, setReporterRelationship] =
+    useState<ReporterRelationship>("member");
+  const [prefersNoContact, setPrefersNoContact] = useState(false);
+
+  // Affected
+  const [affectedName, setAffectedName] = useState("");
+  const [affectedRelationship, setAffectedRelationship] = useState<
+    AffectedRelationship | ""
+  >("");
+  const [affectedContact, setAffectedContact] = useState("");
+  const [affectedIsMinor, setAffectedIsMinor] = useState(false);
+
+  // Incident
+  const [occurredAt, setOccurredAt] = useState("");
+  const [location, setLocation] = useState("");
+  const [activity, setActivity] = useState("");
+  const [incidentType, setIncidentType] = useState<IncidentType>("injury");
+  const [description, setDescription] = useState("");
+
+  // Injury / ill health
+  const [injuryOccurred, setInjuryOccurred] = useState(false);
+  const [natureOfInjury, setNatureOfInjury] = useState("");
+  const [bodyPartsAffected, setBodyPartsAffected] = useState("");
+  const [injurySeverity, setInjurySeverity] = useState<InjurySeverity | "">("");
+  const [firstAidGiven, setFirstAidGiven] = useState(false);
+  const [firstAiderName, setFirstAiderName] = useState("");
+  const [firstAidDetails, setFirstAidDetails] = useState("");
+  const [medicalTreatmentRequired, setMedicalTreatmentRequired] =
+    useState(false);
+
+  // Actions & witnesses
+  const [immediateActions, setImmediateActions] = useState("");
+  const [witnesses, setWitnesses] = useState("");
+
+  // Declaration
+  const [declarationConfirmed, setDeclarationConfirmed] = useState(false);
+
+  // Honeypot — bots tend to fill this, humans leave it blank.
+  const [website, setWebsite] = useState("");
+
+  const submit = useMutation({
+    mutationFn: () => {
+      const occurredIso = occurredAt
+        ? new Date(occurredAt).toISOString()
+        : new Date().toISOString();
+      return callApi(
+        api.POST("/api/incident-report", {
+          body: {
+            reporterName,
+            reporterEmail,
+            ...(reporterPhone ? { reporterPhone } : {}),
+            reporterRelationship,
+            prefersNoContact,
+            ...(affectedName ? { affectedName } : {}),
+            ...(affectedRelationship ? { affectedRelationship } : {}),
+            ...(affectedContact ? { affectedContact } : {}),
+            affectedIsMinor,
+            occurredAt: occurredIso,
+            location,
+            ...(activity ? { activity } : {}),
+            incidentType,
+            description,
+            injuryOccurred,
+            ...(natureOfInjury ? { natureOfInjury } : {}),
+            ...(bodyPartsAffected ? { bodyPartsAffected } : {}),
+            ...(injurySeverity ? { injurySeverity } : {}),
+            firstAidGiven,
+            ...(firstAiderName ? { firstAiderName } : {}),
+            ...(firstAidDetails ? { firstAidDetails } : {}),
+            medicalTreatmentRequired,
+            ...(immediateActions ? { immediateActions } : {}),
+            ...(witnesses ? { witnesses } : {}),
+            declarationConfirmed: true as const,
+            ...(website ? { website } : {}),
+          },
+        }),
+      );
+    },
+  });
+
+  function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    if (!declarationConfirmed) return;
+    submit.mutate();
+  }
+
+  if (submit.isSuccess) {
+    return (
+      <div className="container mx-auto max-w-2xl px-4 py-8">
+        <h1>Thank you</h1>
+        <p className="mt-4">
+          Your report has been received. We&rsquo;ve sent a confirmation to the
+          email address you provided. The club trustees will review it and, if
+          needed, be in touch using the contact details you gave us.
+        </p>
+        <p className="mt-4">
+          <Link className="text-blue-900 underline" to="/">
+            Back to the home page
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <h1>Report an accident or incident</h1>
+
+      <Alert variant="destructive" className="mt-4">
+        <AlertDescription>
+          <strong>If this is an emergency, call 999 first.</strong> Use this
+          form to log accidents, injuries, near misses, or safety concerns after
+          anyone in immediate danger is safe.
+        </AlertDescription>
+      </Alert>
+
+      <p className="mt-4 text-sm text-gray-700">
+        This form is for reporting something that has already happened at, or in
+        connection with, the club. The information you submit will be used by
+        the club to record, review and respond to accidents, incidents and
+        safety concerns. See our{" "}
+        <Link className="text-blue-900 underline" to="/legal/privacy">
+          privacy policy
+        </Link>{" "}
+        for how we handle this information.
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-6">
+        {/* Honeypot — visually hidden, bots tend to fill it. */}
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: "-10000px",
+            top: "auto",
+            width: "1px",
+            height: "1px",
+            overflow: "hidden",
+          }}
+        >
+          <label>
+            Website
+            <input
+              type="text"
+              tabIndex={-1}
+              autoComplete="off"
+              value={website}
+              onChange={(e) => setWebsite(e.target.value)}
+            />
+          </label>
+        </div>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold">About you</h2>
+          <FieldRow>
+            <Field>
+              <Label htmlFor="reporterName">Your name *</Label>
+              <Input
+                id="reporterName"
+                required
+                value={reporterName}
+                onChange={(e) => setReporterName(e.target.value)}
+              />
+            </Field>
+            <Field>
+              <Label htmlFor="reporterRelationship">
+                Your relationship to the club *
+              </Label>
+              <Select
+                value={reporterRelationship}
+                onValueChange={(v) =>
+                  setReporterRelationship(v as ReporterRelationship)
+                }
+              >
+                <SelectTrigger id="reporterRelationship">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="member">Member</SelectItem>
+                  <SelectItem value="parent_or_guardian">
+                    Parent or guardian
+                  </SelectItem>
+                  <SelectItem value="player">Player</SelectItem>
+                  <SelectItem value="coach_or_volunteer">
+                    Coach or volunteer
+                  </SelectItem>
+                  <SelectItem value="visitor">Visitor</SelectItem>
+                  <SelectItem value="other">Other</SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+          </FieldRow>
+          <FieldRow>
+            <Field>
+              <Label htmlFor="reporterEmail">Email *</Label>
+              <Input
+                id="reporterEmail"
+                type="email"
+                required
+                value={reporterEmail}
+                onChange={(e) => setReporterEmail(e.target.value)}
+              />
+            </Field>
+            <Field>
+              <Label htmlFor="reporterPhone">Phone</Label>
+              <Input
+                id="reporterPhone"
+                type="tel"
+                value={reporterPhone}
+                onChange={(e) => setReporterPhone(e.target.value)}
+              />
+            </Field>
+          </FieldRow>
+          <div className="flex items-start gap-2">
+            <Checkbox
+              id="prefersNoContact"
+              className="mt-1"
+              checked={prefersNoContact}
+              onCheckedChange={(v) => setPrefersNoContact(v === true)}
+            />
+            <Label htmlFor="prefersNoContact" className="leading-snug">
+              I&rsquo;d prefer not to be contacted about this report. (We still
+              need your contact details for our records, but we won&rsquo;t
+              reach out unless we have to.)
+            </Label>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold">
+            Details of the injured / affected person
+          </h2>
+          <FieldRow>
+            <Field>
+              <Label htmlFor="affectedName">
+                Full name (if different from you)
+              </Label>
+              <Input
+                id="affectedName"
+                value={affectedName}
+                onChange={(e) => setAffectedName(e.target.value)}
+                placeholder="Leave blank if this was you, or unknown"
+              />
+            </Field>
+            <Field>
+              <Label htmlFor="affectedRelationship">Role / relationship</Label>
+              <Select
+                value={affectedRelationship}
+                onValueChange={(v) =>
+                  setAffectedRelationship(v as AffectedRelationship)
+                }
+              >
+                <SelectTrigger id="affectedRelationship">
+                  <SelectValue placeholder="Select..." />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="trustee">Trustee</SelectItem>
+                  <SelectItem value="member">Member</SelectItem>
+                  <SelectItem value="volunteer">Volunteer</SelectItem>
+                  <SelectItem value="visitor">Visitor</SelectItem>
+                  <SelectItem value="contractor">Contractor</SelectItem>
+                  <SelectItem value="other">Other</SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+          </FieldRow>
+          <Field>
+            <Label htmlFor="affectedContact">Contact details (if known)</Label>
+            <Input
+              id="affectedContact"
+              value={affectedContact}
+              onChange={(e) => setAffectedContact(e.target.value)}
+              placeholder="Email and/or phone number"
+            />
+          </Field>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="affectedIsMinor"
+              checked={affectedIsMinor}
+              onCheckedChange={(v) => setAffectedIsMinor(v === true)}
+            />
+            <Label htmlFor="affectedIsMinor">
+              The person affected is under 18
+            </Label>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold">Accident / incident details</h2>
+          <FieldRow>
+            <Field>
+              <Label htmlFor="occurredAt">When did it happen? *</Label>
+              <Input
+                id="occurredAt"
+                type="datetime-local"
+                required
+                value={occurredAt}
+                onChange={(e) => setOccurredAt(e.target.value)}
+              />
+            </Field>
+            <Field>
+              <Label htmlFor="location">Exact location *</Label>
+              <Input
+                id="location"
+                required
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                placeholder="e.g. Main pitch, clubhouse, nets"
+              />
+            </Field>
+          </FieldRow>
+          <FieldRow>
+            <Field>
+              <Label htmlFor="incidentType">Type of incident *</Label>
+              <Select
+                value={incidentType}
+                onValueChange={(v) => setIncidentType(v as IncidentType)}
+              >
+                <SelectTrigger id="incidentType">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="injury">Injury</SelectItem>
+                  <SelectItem value="near_miss">Near miss</SelectItem>
+                  <SelectItem value="dangerous_occurrence">
+                    Dangerous occurrence
+                  </SelectItem>
+                  <SelectItem value="ill_health">Ill health</SelectItem>
+                  <SelectItem value="property_damage">
+                    Property damage
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field>
+              <Label htmlFor="activity">Activity (if any)</Label>
+              <Input
+                id="activity"
+                value={activity}
+                onChange={(e) => setActivity(e.target.value)}
+                placeholder="e.g. Junior training, match day, maintenance"
+              />
+            </Field>
+          </FieldRow>
+          <Field>
+            <Label htmlFor="description">Describe what happened *</Label>
+            <Textarea
+              id="description"
+              required
+              rows={5}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </Field>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold">
+            Injury or ill health details
+          </h2>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="injuryOccurred"
+              checked={injuryOccurred}
+              onCheckedChange={(v) => setInjuryOccurred(v === true)}
+            />
+            <Label htmlFor="injuryOccurred">
+              Someone was injured or unwell
+            </Label>
+          </div>
+          {injuryOccurred && (
+            <>
+              <Field>
+                <Label htmlFor="natureOfInjury">
+                  Nature of injury or condition
+                </Label>
+                <Textarea
+                  id="natureOfInjury"
+                  rows={2}
+                  value={natureOfInjury}
+                  onChange={(e) => setNatureOfInjury(e.target.value)}
+                  placeholder="e.g. sprained ankle, cut to the head, asthma attack"
+                />
+              </Field>
+              <FieldRow>
+                <Field>
+                  <Label htmlFor="bodyPartsAffected">
+                    Part(s) of body affected
+                  </Label>
+                  <Input
+                    id="bodyPartsAffected"
+                    value={bodyPartsAffected}
+                    onChange={(e) => setBodyPartsAffected(e.target.value)}
+                  />
+                </Field>
+                <Field>
+                  <Label htmlFor="injurySeverity">Severity</Label>
+                  <Select
+                    value={injurySeverity}
+                    onValueChange={(v) =>
+                      setInjurySeverity(v as InjurySeverity)
+                    }
+                  >
+                    <SelectTrigger id="injurySeverity">
+                      <SelectValue placeholder="Select..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="minor">Minor</SelectItem>
+                      <SelectItem value="serious">Serious</SelectItem>
+                      <SelectItem value="fatal">Fatal</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </Field>
+              </FieldRow>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="medicalTreatmentRequired"
+                  checked={medicalTreatmentRequired}
+                  onCheckedChange={(v) =>
+                    setMedicalTreatmentRequired(v === true)
+                  }
+                />
+                <Label htmlFor="medicalTreatmentRequired">
+                  Medical treatment was required
+                </Label>
+              </div>
+            </>
+          )}
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="firstAidGiven"
+              checked={firstAidGiven}
+              onCheckedChange={(v) => setFirstAidGiven(v === true)}
+            />
+            <Label htmlFor="firstAidGiven">First aid was given</Label>
+          </div>
+          {firstAidGiven && (
+            <>
+              <Field>
+                <Label htmlFor="firstAiderName">Given by (name)</Label>
+                <Input
+                  id="firstAiderName"
+                  value={firstAiderName}
+                  onChange={(e) => setFirstAiderName(e.target.value)}
+                />
+              </Field>
+              <Field>
+                <Label htmlFor="firstAidDetails">
+                  First aid details (if any)
+                </Label>
+                <Textarea
+                  id="firstAidDetails"
+                  rows={2}
+                  value={firstAidDetails}
+                  onChange={(e) => setFirstAidDetails(e.target.value)}
+                />
+              </Field>
+            </>
+          )}
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold">
+            Immediate actions and witnesses
+          </h2>
+          <Field>
+            <Label htmlFor="immediateActions">
+              Details of any immediate actions taken
+            </Label>
+            <Textarea
+              id="immediateActions"
+              rows={3}
+              value={immediateActions}
+              onChange={(e) => setImmediateActions(e.target.value)}
+            />
+          </Field>
+          <Field>
+            <Label htmlFor="witnesses">
+              Witnesses — names, relationship and contact details if known
+            </Label>
+            <Textarea
+              id="witnesses"
+              rows={3}
+              value={witnesses}
+              onChange={(e) => setWitnesses(e.target.value)}
+            />
+          </Field>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold">Declaration</h2>
+          <div className="border-border bg-muted/30 flex items-start gap-3 rounded border p-4">
+            <Checkbox
+              id="declarationConfirmed"
+              className="mt-1"
+              checked={declarationConfirmed}
+              onCheckedChange={(v) => setDeclarationConfirmed(v === true)}
+            />
+            <Label
+              htmlFor="declarationConfirmed"
+              className="text-sm leading-relaxed font-normal"
+            >
+              I confirm that the information provided in this accident/incident
+              report is true and accurate to the best of my knowledge and
+              belief. I understand that this record may be used for health and
+              safety management, investigation purposes, insurance, and where
+              necessary to meet statutory reporting requirements under UK health
+              and safety legislation (including RIDDOR 2013). *
+            </Label>
+          </div>
+        </section>
+
+        {submit.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Sorry, something went wrong submitting your report. Please try
+              again, or email the trustees directly at{" "}
+              <a className="underline" href="mailto:trustees@percymain.org">
+                trustees@percymain.org
+              </a>
+              .
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex justify-end">
+          <Button
+            type="submit"
+            disabled={submit.isPending || !declarationConfirmed}
+          >
+            {submit.isPending ? "Submitting..." : "Submit report"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function Field({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-col gap-1">{children}</div>;
+}
+
+function FieldRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">{children}</div>
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -83,6 +83,10 @@ export const router = createBrowserRouter([
         lazy: () => import("./pages/legal/privacy.js"),
       },
       {
+        path: "report-incident",
+        lazy: () => import("./pages/report-incident.js"),
+      },
+      {
         path: "purchase/:priceId",
         lazy: () => import("./pages/purchase/purchase.js"),
       },

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -23,6 +23,50 @@ export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
+export interface AccidentIncidentReport {
+  actions_taken: string | null;
+  activity: string | null;
+  affected_contact: string | null;
+  affected_is_minor: Generated<boolean>;
+  affected_name: string | null;
+  affected_relationship: string | null;
+  body_parts_affected: string | null;
+  closed_at: Timestamp | null;
+  closure_reason: string | null;
+  created_at: Generated<Timestamp>;
+  declaration_confirmed: boolean;
+  description: string;
+  first_aid_details: string | null;
+  first_aid_given: Generated<boolean>;
+  first_aider_name: string | null;
+  id: string;
+  immediate_actions: string | null;
+  incident_type: string;
+  injury_occurred: Generated<boolean>;
+  injury_severity: string | null;
+  internal_notes: string | null;
+  location: string;
+  medical_treatment_required: Generated<boolean>;
+  nature_of_injury: string | null;
+  occurred_at: Timestamp;
+  owner_user_id: string | null;
+  prefers_no_contact: Generated<boolean>;
+  reporter_email: string;
+  reporter_name: string;
+  reporter_phone: string | null;
+  reporter_relationship: string;
+  riddor_reported_at: Timestamp | null;
+  riddor_required: boolean | null;
+  safeguarding_discussed: Generated<boolean>;
+  safeguarding_discussed_at: Timestamp | null;
+  safeguarding_notes: string | null;
+  severity: string | null;
+  status: Generated<string>;
+  target_completion_date: Timestamp | null;
+  updated_at: Generated<Timestamp>;
+  witnesses: string | null;
+}
+
 export interface Account {
   accessToken: string | null;
   accessTokenExpiresAt: Timestamp | null;
@@ -551,6 +595,7 @@ export interface Verification {
 }
 
 export interface DB {
+  accident_incident_report: AccidentIncidentReport;
   account: Account;
   availability_assignment: AvailabilityAssignment;
   availability_fixture: AvailabilityFixture;

--- a/packages/db/src/migrations/2026-04-24T12:41:23.439Z.ts
+++ b/packages/db/src/migrations/2026-04-24T12:41:23.439Z.ts
@@ -1,0 +1,78 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE accident_incident_report (
+      id TEXT PRIMARY KEY,
+
+      -- Reporter (PMCSC form Section 1: Personal Details)
+      reporter_name TEXT NOT NULL,
+      reporter_email TEXT NOT NULL,
+      reporter_phone TEXT,
+      reporter_relationship TEXT NOT NULL,
+      prefers_no_contact BOOLEAN NOT NULL DEFAULT FALSE,
+
+      -- Affected person (Section 1: Details of the Injured / Affected Person)
+      affected_name TEXT,
+      affected_relationship TEXT,
+      affected_contact TEXT,
+      affected_is_minor BOOLEAN NOT NULL DEFAULT FALSE,
+
+      -- Incident details (Section 1: Accident / Incident Details)
+      occurred_at TIMESTAMPTZ NOT NULL,
+      location TEXT NOT NULL,
+      activity TEXT,
+      incident_type TEXT NOT NULL,
+      description TEXT NOT NULL,
+
+      -- Injury / ill health details (Section 1)
+      injury_occurred BOOLEAN NOT NULL DEFAULT FALSE,
+      nature_of_injury TEXT,
+      body_parts_affected TEXT,
+      injury_severity TEXT,
+      first_aid_given BOOLEAN NOT NULL DEFAULT FALSE,
+      first_aider_name TEXT,
+      first_aid_details TEXT,
+      medical_treatment_required BOOLEAN NOT NULL DEFAULT FALSE,
+
+      -- Immediate actions and witnesses (Section 1)
+      immediate_actions TEXT,
+      witnesses TEXT,
+
+      -- Declaration (Section 1): reporter must confirm before submission.
+      declaration_confirmed BOOLEAN NOT NULL,
+
+      -- Admin / responsible person (Section 2)
+      status TEXT NOT NULL DEFAULT 'new',
+      severity TEXT,
+      owner_user_id TEXT REFERENCES "user"(id),
+      actions_taken TEXT,
+      target_completion_date TIMESTAMPTZ,
+      riddor_required BOOLEAN,
+      riddor_reported_at TIMESTAMPTZ,
+      internal_notes TEXT,
+      closure_reason TEXT,
+      closed_at TIMESTAMPTZ,
+      safeguarding_discussed BOOLEAN NOT NULL DEFAULT FALSE,
+      safeguarding_discussed_at TIMESTAMPTZ,
+      safeguarding_notes TEXT,
+
+      created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `.execute(db);
+
+  await sql`
+    CREATE INDEX idx_accident_incident_report_status
+      ON accident_incident_report (status)
+  `.execute(db);
+
+  await sql`
+    CREATE INDEX idx_accident_incident_report_created_at
+      ON accident_incident_report (created_at DESC)
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS accident_incident_report`.execute(db);
+}

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -4,6 +4,7 @@ export { AvailabilityRequest } from "./templates/AvailabilityRequest.tsx";
 export { ChaosWeekAnnouncement } from "./templates/ChaosWeekAnnouncement.tsx";
 export { ChargeNotification } from "./templates/ChargeNotification.tsx";
 export { FantasyReminder } from "./templates/FantasyReminder.tsx";
+export { IncidentReportConfirmation } from "./templates/IncidentReportConfirmation.tsx";
 export { MembershipUpdated } from "./templates/MembershipUpdated.tsx";
 export { PaymentReminder } from "./templates/PaymentReminder.tsx";
 export { PlayerSponsorshipConfirmation } from "./templates/PlayerSponsorshipConfirmation.tsx";

--- a/packages/email/src/templates/IncidentReportConfirmation.tsx
+++ b/packages/email/src/templates/IncidentReportConfirmation.tsx
@@ -1,0 +1,87 @@
+// organize-imports-ignore — React must stay: tsx/esbuild uses classic JSX transform for workspace deps
+import React, { type FC } from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Text,
+} from "@react-email/components";
+import { email } from "../email.ts";
+import * as styles from "../styles.ts";
+
+interface Props {
+  imageBaseUrl: string;
+  reporterName: string;
+  occurredAt: string;
+  location: string;
+  reportId: string;
+}
+
+const Component: FC<Props> = ({
+  imageBaseUrl,
+  reporterName,
+  occurredAt,
+  location,
+  reportId,
+}) => (
+  <Html>
+    <Head />
+    <Preview>
+      We&rsquo;ve received your accident / incident report at Percy Main
+    </Preview>
+    <Body style={styles.main}>
+      <Container style={styles.container}>
+        <Img
+          src={`${imageBaseUrl}/club_logo.png`}
+          width="100"
+          height="100"
+          alt="Percy Main Club Logo"
+          style={styles.logo}
+        />
+        <Text style={styles.paragraph}>Hi {reporterName},</Text>
+        <Text style={styles.paragraph}>
+          Thank you for letting us know. This email confirms that we&rsquo;ve
+          received your report about an incident on {occurredAt} at {location}.
+        </Text>
+        <Text style={styles.paragraph}>
+          Your report has been logged and will be reviewed by the club&rsquo;s
+          trustees. If we need to follow up with you, we&rsquo;ll be in touch
+          using the contact details you provided.
+        </Text>
+        <Text style={styles.paragraph}>
+          If this was a medical emergency and you haven&rsquo;t already, please
+          call 999.
+        </Text>
+        <Text style={styles.paragraph}>
+          Your reference: <strong>{reportId}</strong>
+        </Text>
+        <Text style={styles.paragraph}>
+          Best,
+          <br />
+          The Trustees
+        </Text>
+        <Hr style={styles.hr} />
+        <Text style={styles.footer}>
+          Percy Main Cricket Club, St. Johns Terrace, North Shields, NE29 6HS
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export const IncidentReportConfirmation = email<Props>(
+  "We've received your accident / incident report",
+  {
+    preview: {
+      imageBaseUrl: "http://localhost:5173/images",
+      reporterName: "Jane Smith",
+      occurredAt: "24 April 2026 at 18:30",
+      location: "Main pitch, Percy Main CSC",
+      reportId: "abc-123",
+    },
+  },
+)(Component);


### PR DESCRIPTION
## Summary

Adds a public accident / incident reporting flow and a matching admin review UI. Mirrors the existing PMCSC POL006a paper form (reporter, affected person, incident type, injury details, first aid, witnesses, declaration) so trustees can keep a lightweight but auditable H&S log without a separate paper/digital split.

- Public form at `/report-incident` with a 999 emergency banner, link to the privacy policy, and the exact POL006a declaration as a required tickbox
- Admin tab at `/admin?tab=incidents` — paginated list + modal with editable status (New / In review / Done), severity, owner, actions taken, RIDDOR decision + HSE report date, closure fields, and a safeguarding-discussed checkbox with optional date/note
- Slack notification fires to admins on submission (reuses `SLACK_WEBHOOK_URL`); flags U18 / injury / serious / fatal. Reporter gets a transactional confirmation email even when they tick *prefer not to be contacted*
- Privacy policy extended with an Accident and incident reports section covering collection, authorised-admin access (DBS checked), retention, and external sharing with insurers, governing bodies, emergency services and HSE
- Quick Links footer now includes a link to the form so it's reachable from every page
- Honeypot field for basic bot protection (Sentinel still deferred)

## Design notes

- Admin notification is Slack-only, no admin email (per design discussion)
- Severity defaults to NULL so an admin has to make the call on review rather than inheriting a default
- `riddorRequired` is a nullable boolean — null = not decided, false = decided no, true = decided yes
- Declaration is stored per-row as an audit trail; form submission is blocked client-side and server-side (Zod `literal(true)`) without it

## Tests

- 24 unit tests (`service.test.ts`) covering schema validation, honeypot short-circuit, email + Slack fan-out, failure-swallowing, list sort precedence, and partial-update field isolation
- 5 integration tests (`integration.test.ts`, testcontainers + real migration) covering full / minimal submissions, honeypot drop, submit → list → get → update round-trip, and the riddor null/false/true distinction through the DB

Workspace typecheck + lint + all 291 unit tests + integration tests green on this branch.

## Test plan

- [ ] Submit a report at `/report-incident`; confirm Slack notification fires and reporter receives the confirmation email
- [ ] Submit with the declaration unticked — submit button stays disabled
- [ ] Open the submitted report from `/admin?tab=incidents`, change status / severity / owner / actions, save, reopen — values persist
- [ ] Tick *RIDDOR required → Yes*, set HSE report date, save and confirm it round-trips
- [ ] Tick *Discussed with safeguarding officer* and confirm the date/note fields appear and save
- [ ] Visit `/legal/privacy` and confirm the new Accident and incident reports section renders and the TOC links to it
- [ ] Confirm the footer *Report an accident or incident* link works from the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)