### PR TITLE
Scout: weather tool, inline charts, per-message PDF export

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -77,7 +77,7 @@ const configSchema = z.object({
   SCOUT_MAX_STEPS: z.coerce.number().int().positive().default(20),
   SCOUT_ALLOWED_EMAILS: z
     .string()
-    .default("alex@alexyoung.info")
+    .default("alex@alexyoung.info,steve.knight@percymain.org")
     .transform((v) =>
       v
         .split(",")

--- a/apps/api/src/features/scout/agent.ts
+++ b/apps/api/src/features/scout/agent.ts
@@ -1,13 +1,15 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import type { DB } from "@percy-main/db";
-import type { LanguageModel, ToolSet } from "ai";
+import type { LanguageModel, ToolSet, UIMessageStreamWriter } from "ai";
 import type { Kysely } from "kysely";
 import type { Config } from "../../config.ts";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 import { SCOUT_SYSTEM_PROMPT } from "./system-prompt.ts";
 import { createScoutCache } from "./tools/cache.ts";
+import { createChartTool } from "./tools/chart.ts";
 import { createDbTools } from "./tools/db.ts";
 import { createPlayCricketTools } from "./tools/play-cricket.ts";
+import { createWeatherTools } from "./tools/weather.ts";
 
 /**
  * Scout's agent config — model, system prompt, and the tool dictionary that
@@ -22,6 +24,10 @@ export interface ScoutAgentDeps {
   dbReadonly: Kysely<DB>;
   playCricket: PlayCricketApiClient;
   config: Config;
+  // Stream writer used by chart_render to emit data-chart parts inline with
+  // the assistant's prose. The route wraps streamText in createUIMessageStream
+  // and passes the resulting writer down.
+  writer: UIMessageStreamWriter;
 }
 
 export interface ScoutAgent {
@@ -38,6 +44,8 @@ export function createScoutAgent(deps: ScoutAgentDeps): ScoutAgent {
     cache,
   });
   const dbTools = createDbTools({ dbReadonly: deps.dbReadonly });
+  const weatherTools = createWeatherTools({ cache });
+  const chartTools = createChartTool({ writer: deps.writer });
 
   // Anchor "today" so the model doesn't fall back to its training cutoff
   // when picking a default season AND so it filters past/future matches
@@ -58,7 +66,12 @@ When asked about the "next" or "upcoming" match, filter match_date strictly GREA
   return {
     model: anthropic(deps.config.SCOUT_MODEL_CHAT),
     system: `${SCOUT_SYSTEM_PROMPT}\n\n${todayLine}`,
-    tools: { ...playCricketTools, ...dbTools },
+    tools: {
+      ...playCricketTools,
+      ...dbTools,
+      ...weatherTools,
+      ...chartTools,
+    },
     maxSteps: deps.config.SCOUT_MAX_STEPS,
   };
 }

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -1,5 +1,7 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
+  pipeUIMessageStreamToResponse,
   stepCountIs,
   streamText,
   type UIMessage,
@@ -168,7 +170,8 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
       // Guard: Scout requires the readonly DB client and an Anthropic key.
       // Both are optional in config so non-Scout deployments can boot, but
       // hitting this route without them is a misconfiguration.
-      if (!app.dbReadonly) {
+      const dbReadonly = app.dbReadonly;
+      if (!dbReadonly) {
         throw Object.assign(
           new Error("Scout DB is not configured (set SCOUT_DB_URL)."),
           { statusCode: 503 },
@@ -223,29 +226,86 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
         siteId: app.config.PLAY_CRICKET_SITE_ID,
       });
 
-      const agent = createScoutAgent({
-        db: app.db,
-        dbReadonly: app.dbReadonly,
-        playCricket,
-        config: app.config,
-      });
-
-      const modelMessages = await convertToModelMessages(incoming);
-      const result = streamText({
-        model: agent.model,
-        system: agent.system,
-        tools: agent.tools,
-        messages: modelMessages,
-        stopWhen: stepCountIs(agent.maxSteps),
-        onError: ({ error }) => {
-          app.log.error({ err: error }, "scout streamText error");
-        },
-      });
-
       const firstUserText = lastMessage.parts
         .filter((p): p is { type: "text"; text: string } => p.type === "text")
         .map((p) => p.text)
         .join(" ");
+
+      // Convert messages up front — execute() in createUIMessageStream is
+      // synchronous and can't await, so the conversion has to be done before
+      // the stream is built.
+      const modelMessages = await convertToModelMessages(incoming);
+
+      // Token usage is captured inside execute() and read back in onFinish.
+      // We can't await result.usage from outside because `result` is local to
+      // the stream's execute closure.
+      let usagePromise:
+        | Promise<{
+            inputTokens?: number;
+            outputTokens?: number;
+          }>
+        | undefined;
+
+      const stream = createUIMessageStream({
+        originalMessages: incoming,
+        onFinish: async ({ responseMessage, isAborted }) => {
+          if (isAborted || !responseMessage) return;
+          try {
+            const usage = (await usagePromise) ?? {};
+            await append(threadId, "assistant", responseMessage.parts, {
+              input: usage.inputTokens,
+              output: usage.outputTokens,
+            });
+            await bump(threadId);
+            // Best-effort: rename the thread if it still has the
+            // placeholder title. Failures don't break the chat turn.
+            await generateTitle(threadId, firstUserText);
+          } catch (err) {
+            app.log.error(
+              { err, threadId },
+              "scout: failed to persist assistant message",
+            );
+          }
+        },
+        execute: ({ writer }) => {
+          // The chart tool needs the writer to emit data-chart parts inline.
+          const agent = createScoutAgent({
+            db: app.db,
+            dbReadonly,
+            playCricket,
+            config: app.config,
+            writer,
+          });
+
+          const result = streamText({
+            model: agent.model,
+            system: agent.system,
+            tools: agent.tools,
+            messages: modelMessages,
+            stopWhen: stepCountIs(agent.maxSteps),
+            onError: ({ error }) => {
+              app.log.error(
+                { err: sanitizeError(error) },
+                "scout streamText error",
+              );
+            },
+          });
+          usagePromise = Promise.resolve(result.usage).then((u) => ({
+            inputTokens: u.inputTokens ?? undefined,
+            outputTokens: u.outputTokens ?? undefined,
+          }));
+
+          // sendStart: false because createUIMessageStream emits its own start
+          // chunk; merging streamText's would duplicate.
+          writer.merge(result.toUIMessageStream({ sendStart: false }));
+        },
+        onError: (error) => {
+          app.log.error({ err: sanitizeError(error) }, "scout UI stream error");
+          return error instanceof Error
+            ? error.message
+            : "Scout stream failed.";
+        },
+      });
 
       // CORS (and any other) headers set by Fastify hooks live on the reply
       // object and are flushed to `reply.raw` only when reply.send() runs.
@@ -259,40 +319,37 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
         }
       }
 
-      result.pipeUIMessageStreamToResponse(reply.raw, {
-        originalMessages: incoming,
-        onFinish: async ({ responseMessage, isAborted }) => {
-          if (isAborted || !responseMessage) return;
-          try {
-            const usage = await result.usage;
-            await append(threadId, "assistant", responseMessage.parts, {
-              input: usage.inputTokens ?? undefined,
-              output: usage.outputTokens ?? undefined,
-            });
-            await bump(threadId);
-            // Best-effort: rename the thread if it still has the
-            // placeholder title. Failures don't break the chat turn.
-            await generateTitle(threadId, firstUserText);
-          } catch (err) {
-            app.log.error(
-              { err, threadId },
-              "scout: failed to persist assistant message",
-            );
-          }
-        },
-        onError: (error) => {
-          app.log.error({ err: error }, "scout UI stream error");
-          return error instanceof Error
-            ? error.message
-            : "Scout stream failed.";
-        },
-      });
+      pipeUIMessageStreamToResponse({ stream, response: reply.raw });
 
       // Return the raw reply so Fastify doesn't double-write a body.
       return reply;
     },
   );
 };
+
+// AI SDK errors (most importantly Anthropic's APICallError) carry the entire
+// request body — including the conversation history — as own properties.
+// Logging the raw error via pino spams the stream with full transcripts, so
+// project to a small set of safe fields. The Anthropic request_id is the most
+// useful debug handle when it's present.
+function sanitizeError(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) {
+    return { value: typeof error === "string" ? error : String(error) };
+  }
+  const e = error as Error & {
+    statusCode?: number;
+    responseBody?: string;
+    requestId?: string;
+    data?: { error?: { type?: string; message?: string } };
+  };
+  return {
+    name: e.name,
+    message: e.message,
+    statusCode: e.statusCode,
+    requestId: e.requestId,
+    apiError: e.data?.error,
+  };
+}
 
 // Small inline helper — same shape as the one in auth/middleware.ts but the
 // access route can't use requireAuth (we want a 200 response when not

--- a/apps/api/src/features/scout/system-prompt.ts
+++ b/apps/api/src/features/scout/system-prompt.ts
@@ -41,6 +41,28 @@ When data is thin, say so explicitly and propose what to gather (e.g. "I have 2 
 
 Tactical recommendations: keep them grounded in the dismissal-type and form data you actually have. "Their top-4 are bowled/LBW 6 of 12 times this season — keep it full and straight at the stumps" is fair. "Bowl short to him because he plays through the leg side" is invented and forbidden.
 
+Weather (weather_get / weather_geocode):
+Cricket is the most weather-sensitive of the major team sports. Use weather_get when conditions plausibly bear on the question — toss decisions, post-mortems on a low total, planning bowling rotations, scouting whether an opposition's recent form was inflated by belters or shrunk by green tops. Don't pull weather just because you can.
+
+What to look at, and what it actually means at our level (English club cricket, NTCL):
+- Rain & precipitation_sum: the obvious one. Even after rain stops the outfield is slow; expect 10–15% lower scoring rates on a wet day. Multi-day rain leading up to a match softens the pitch — slower, lower, harder to bat on, helpful for medium-pace seamers.
+- Cloud cover & humidity: the classic English seam-and-swing combination. Overcast morning with 80%+ humidity → ball moves more in the air and off the seam → bowl first if you win the toss is the conventional read. Sunny + dry → batting friendlier, especially after the new-ball spell.
+- Temperature (max & min): hotter days = ball softens faster, batters tire, scoring rates often higher in the back half of an innings; lows below ~12°C make the ball harder to grip and slower to come on. Most Saturday games are in the 10–22°C range.
+- Wind (speed & direction): material when one boundary is short. Six-hitting downwind, holding catches in a cross-wind, slower bowlers preferring to bowl with the breeze.
+- Sunshine duration: proxy for pitch hardness over the preceding days. A dry, sunny week → faster, harder pitch with more bounce. A grey, damp week → slow and low.
+
+Don't invent meteorological causation: "the wind helped him hit sixes" is fine if the wind was 25mph in his hitting direction; "the humidity made him edge it" is a stretch unless your data is more granular than scorecards.
+
+Ground location: every Play Cricket match summary row carries ground_latitude and ground_longitude fields. Use those directly. Only fall back to weather_geocode (then weather_get with the result) when the lat/lng is missing — typically on user-named grounds outside Play Cricket's data.
+
+Charts (chart_render):
+Sometimes a chart is just clearer than prose or a table. Render one when:
+- you have a trend over time (e.g. our average score by month, a player's batting average across consecutive innings) — use type: "line"
+- you have a categorical comparison (dismissals by mode, runs by opposition, points by division) — use type: "bar"
+- you're checking correlation between two numeric variables (innings score vs air temperature, strike rate vs over of dismissal) — use type: "scatter", and put the match label on each point so the user can identify outliers
+
+Don't chart 3 data points; don't chart what reads better as one number. After rendering a chart, still summarise the headline finding in your prose. The chart supplements your analysis, it doesn't replace it. The user sees the chart inline — don't describe what the chart shows axis-by-axis, just call out the takeaway.
+
 Important context:
 - The club is Percy Main CC. The league is the Northumberland and Tyneside Cricket League (NTCL) — never call it the "North East Premier League" or anything else.
 - The user is a club captain. They know cricket. Skip basic explanations of cricket concepts.

--- a/apps/api/src/features/scout/tools/chart.test.ts
+++ b/apps/api/src/features/scout/tools/chart.test.ts
@@ -1,0 +1,74 @@
+import type { UIMessageStreamWriter } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { createChartTool } from "./chart.ts";
+
+const opts = {
+  toolCallId: "test-call",
+  messages: [],
+  abortSignal: undefined,
+} as unknown as Parameters<
+  NonNullable<ReturnType<typeof createChartTool>["chart_render"]["execute"]>
+>[1];
+
+function makeWriter() {
+  return {
+    write: vi.fn(),
+    merge: vi.fn(),
+    onError: undefined,
+  } as unknown as UIMessageStreamWriter & { write: ReturnType<typeof vi.fn> };
+}
+
+async function runChart(spec: unknown) {
+  const writer = makeWriter();
+  const { chart_render } = createChartTool({ writer });
+  const exec = chart_render.execute;
+  if (!exec) throw new Error("no execute");
+  const result = await exec({ chart: spec } as never, opts as never);
+  return { result, writer };
+}
+
+describe("chart_render", () => {
+  it("emits a data-chart part via the writer for a bar chart", async () => {
+    const { result, writer } = await runChart({
+      type: "bar",
+      title: "Average score by month",
+      data: [
+        { x: "May", y: 145 },
+        { x: "Jun", y: 162 },
+      ],
+    });
+
+    expect(writer.write).toHaveBeenCalledTimes(1);
+    const part = (writer.write.mock.calls[0] as unknown[])[0] as {
+      type: string;
+      id: string;
+      data: { type: string };
+    };
+    expect(part.type).toBe("data-chart");
+    expect(part.data.type).toBe("bar");
+    expect(typeof part.id).toBe("string");
+    expect(result).toMatchObject({
+      rendered: true,
+      type: "bar",
+      points: 2,
+    });
+  });
+
+  it("emits a scatter chart with labelled points", async () => {
+    const { writer } = await runChart({
+      type: "scatter",
+      title: "Innings score vs air temp",
+      xLabel: "Air temperature (°C)",
+      yLabel: "Runs",
+      data: [
+        { x: 14, y: 87, label: "vs Tynemouth, 13/05" },
+        { x: 22, y: 168, label: "vs Backworth, 03/06" },
+      ],
+    });
+    const part = (writer.write.mock.calls[0] as unknown[])[0] as {
+      data: { type: string; data: unknown[] };
+    };
+    expect(part.data.type).toBe("scatter");
+    expect(part.data.data).toHaveLength(2);
+  });
+});

--- a/apps/api/src/features/scout/tools/chart.ts
+++ b/apps/api/src/features/scout/tools/chart.ts
@@ -1,0 +1,59 @@
+import { chartSpecSchema, type ChartSpec } from "@percy-main/shared";
+import { tool, type UIMessageStreamWriter } from "ai";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+export interface ChartToolDeps {
+  // The route wraps streamText in a createUIMessageStream; that gives us a
+  // writer the chart tool can use to emit a data-chart part inline with the
+  // assistant's prose. Tools called inside streamText don't get a writer by
+  // default — we close over it here.
+  writer: UIMessageStreamWriter;
+}
+
+// Anthropic's API requires each tool's input_schema to be an OBJECT schema at
+// the top level. A bare z.discriminatedUnion produces { anyOf: [...] }, which
+// the API rejects with "tools.N.custom.input_schema.type: Field required".
+// Wrap the spec in an object so JSON-schema generation emits
+// { type: "object", properties: { chart: {...} } }.
+const chartInputSchema = z.object({
+  chart: chartSpecSchema,
+});
+
+export function createChartTool(deps: ChartToolDeps) {
+  const { writer } = deps;
+
+  return {
+    chart_render: tool({
+      description: `Render a chart inline in the chat. Use when a chart communicates the answer faster than prose or a table — e.g. trend over time, distribution across categories, or a scatter to look for correlation.
+
+Render unsolicited only when the data clearly benefits from it. Don't chart 3 data points; don't chart something better expressed as one number. Common shapes that DO chart well:
+
+- bar: a team's average score by month; dismissals by mode (bowled/lbw/caught/run-out); runs scored against opposition X across seasons.
+- line: a player's batting average across innings of a season; team total over the last 10 matches.
+- scatter: any "does X correlate with Y" question — runs scored vs air temperature, strike rate vs over of dismissal, etc. Include label per point so the user can see which match/innings each point is.
+
+Always still summarise the chart's headline finding in your prose — the chart supplements your analysis, it doesn't replace it.`,
+      inputSchema: chartInputSchema,
+      // eslint-disable-next-line @typescript-eslint/require-await -- AI SDK execute signature is async; this tool has no async work to do.
+      execute: async ({ chart }: { chart: ChartSpec }) => {
+        const id = randomUUID();
+        writer.write({
+          type: "data-chart",
+          id,
+          data: chart,
+        });
+        // The tool result the model sees. Keep it short; the chart payload is
+        // already on its way to the client via the data part above.
+        return {
+          rendered: true,
+          chartId: id,
+          type: chart.type,
+          points: chart.data.length,
+        };
+      },
+    }),
+  };
+}
+
+export type ChartTools = ReturnType<typeof createChartTool>;

--- a/apps/api/src/features/scout/tools/weather.test.ts
+++ b/apps/api/src/features/scout/tools/weather.test.ts
@@ -1,0 +1,160 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import type { ScoutCache } from "./cache.ts";
+import { createWeatherTools } from "./weather.ts";
+
+// Cache that always misses — keeps test focus on the fetch path.
+const passthroughCache: ScoutCache = {
+  getOrSet: async (_tool, _args, _ttl, fetcher) => fetcher(),
+};
+
+const opts = {
+  toolCallId: "test-call",
+  messages: [],
+  abortSignal: undefined,
+} as unknown as Parameters<
+  NonNullable<ReturnType<typeof createWeatherTools>["weather_get"]["execute"]>
+>[1];
+
+const tools = createWeatherTools({ cache: passthroughCache });
+
+async function runWeather(input: {
+  latitude: number;
+  longitude: number;
+  startDate: string;
+  endDate: string;
+  timezone?: string;
+}) {
+  const exec = tools.weather_get.execute;
+  if (!exec) throw new Error("no execute");
+  return exec(
+    { timezone: "Europe/London", ...input },
+    opts as never,
+  ) as Promise<{ source: "forecast" | "archive" }>;
+}
+
+let fetchSpy: MockInstance<typeof fetch>;
+
+beforeEach(() => {
+  fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({ daily: { time: [] } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+describe("weather_get routing", () => {
+  it("uses the forecast endpoint for upcoming dates", async () => {
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    await runWeather({
+      latitude: 55.0167,
+      longitude: -1.45,
+      startDate: tomorrow,
+      endDate: tomorrow,
+    });
+    const url = fetchSpy.mock.calls[0][0] as URL;
+    expect(url.toString()).toContain("api.open-meteo.com/v1/forecast");
+  });
+
+  it("uses the forecast endpoint for recent past (within 90 days)", async () => {
+    const recent = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    await runWeather({
+      latitude: 55.0167,
+      longitude: -1.45,
+      startDate: recent,
+      endDate: recent,
+    });
+    const url = fetchSpy.mock.calls[0][0] as URL;
+    expect(url.toString()).toContain("/v1/forecast");
+  });
+
+  it("uses the archive endpoint for old dates", async () => {
+    await runWeather({
+      latitude: 55.0167,
+      longitude: -1.45,
+      startDate: "2024-07-01",
+      endDate: "2024-07-01",
+    });
+    const url = fetchSpy.mock.calls[0][0] as URL;
+    expect(url.toString()).toContain("archive-api.open-meteo.com/v1/archive");
+  });
+
+  it("passes daily and hourly variables, lat/lng, and timezone", async () => {
+    await runWeather({
+      latitude: 55.0167,
+      longitude: -1.45,
+      startDate: "2024-07-01",
+      endDate: "2024-07-01",
+    });
+    const url = fetchSpy.mock.calls[0][0] as URL;
+    expect(url.searchParams.get("latitude")).toBe("55.0167");
+    expect(url.searchParams.get("longitude")).toBe("-1.45");
+    expect(url.searchParams.get("start_date")).toBe("2024-07-01");
+    expect(url.searchParams.get("end_date")).toBe("2024-07-01");
+    expect(url.searchParams.get("timezone")).toBe("Europe/London");
+    // Sanity-check a few of the variables we always pull.
+    expect(url.searchParams.get("daily")).toContain("precipitation_sum");
+    expect(url.searchParams.get("daily")).toContain("temperature_2m_max");
+    expect(url.searchParams.get("hourly")).toContain("relative_humidity_2m");
+  });
+
+  it("tags the source on the response", async () => {
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const result = await runWeather({
+      latitude: 0,
+      longitude: 0,
+      startDate: tomorrow,
+      endDate: tomorrow,
+    });
+    expect(result.source).toBe("forecast");
+  });
+
+  it("throws on non-2xx response", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("nope", { status: 500 }));
+    await expect(
+      runWeather({
+        latitude: 0,
+        longitude: 0,
+        startDate: "2024-07-01",
+        endDate: "2024-07-01",
+      }),
+    ).rejects.toThrow(/Open-Meteo archive/);
+  });
+});
+
+describe("weather_geocode", () => {
+  function runGeocode(name: string) {
+    const exec = tools.weather_geocode.execute;
+    if (!exec) throw new Error("no execute");
+    return exec({ name }, opts as never);
+  }
+
+  it("calls the geocoding endpoint with the place name", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ results: [] }), { status: 200 }),
+    );
+    await runGeocode("Percy Main");
+    const url = fetchSpy.mock.calls[0][0] as URL;
+    expect(url.toString()).toContain("geocoding-api.open-meteo.com/v1/search");
+    expect(url.searchParams.get("name")).toBe("Percy Main");
+    expect(url.searchParams.get("count")).toBe("5");
+  });
+});

--- a/apps/api/src/features/scout/tools/weather.ts
+++ b/apps/api/src/features/scout/tools/weather.ts
@@ -1,0 +1,174 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { ScoutCache } from "./cache.ts";
+
+// Open-Meteo is free and keyless. Forecast covers ~16 days ahead and up to 92
+// past_days; archive starts ~1940. We split forecast vs archive on a 90-day
+// boundary so recent matches still come from the higher-resolution forecast
+// model (which has past data baked in via past_days). Anything older falls
+// to the long-term archive.
+const FORECAST_BASE = "https://api.open-meteo.com/v1/forecast";
+const ARCHIVE_BASE = "https://archive-api.open-meteo.com/v1/archive";
+const GEOCODING_BASE = "https://geocoding-api.open-meteo.com/v1/search";
+
+// Variables we always pull. Daily aggregates are what cricket actually cares
+// about (max temp, total rain, max wind); hourly is for matchday timing
+// (e.g. did the rain hit during the chase?). Variable names are stable across
+// forecast and archive endpoints.
+const DAILY_VARS = [
+  "weather_code",
+  "temperature_2m_max",
+  "temperature_2m_min",
+  "precipitation_sum",
+  "rain_sum",
+  "windspeed_10m_max",
+  "winddirection_10m_dominant",
+  "shortwave_radiation_sum",
+  "sunshine_duration",
+] as const;
+
+const HOURLY_VARS = [
+  "temperature_2m",
+  "relative_humidity_2m",
+  "precipitation",
+  "cloudcover",
+  "windspeed_10m",
+  "winddirection_10m",
+] as const;
+
+const HOUR = 60 * 60;
+const DAY = 24 * HOUR;
+const NINETY_DAYS_MS = 90 * DAY * 1000;
+
+export interface WeatherToolDeps {
+  cache: ScoutCache;
+}
+
+export function createWeatherTools(deps: WeatherToolDeps) {
+  const { cache } = deps;
+
+  return {
+    weather_get: tool({
+      description: `Fetch weather for a cricket ground on a given date (or date range). Routes to Open-Meteo's forecast API for recent/upcoming dates and the archive API for older dates. Returns daily aggregates (max/min temp, total rain, peak wind, sunshine) and hourly series for the day.
+
+Use this when weather is plausibly relevant: matchday planning (toss decision, bowling plans), post-mortem of a low-scoring innings, or scouting opposition form across conditions.
+
+Prefer passing latitude/longitude when you already have them — every Play Cricket match summary row carries ground_latitude and ground_longitude. Fall back to weather_geocode (then call this tool with the result) if you only have a place name.`,
+      inputSchema: z.object({
+        latitude: z.number().describe("WGS84 latitude, e.g. 55.0167."),
+        longitude: z.number().describe("WGS84 longitude, e.g. -1.45."),
+        startDate: z
+          .string()
+          .regex(/^\d{4}-\d{2}-\d{2}$/, "Use yyyy-mm-dd")
+          .describe(
+            "Start date in yyyy-mm-dd. Use the same value as endDate for a single day.",
+          ),
+        endDate: z
+          .string()
+          .regex(/^\d{4}-\d{2}-\d{2}$/, "Use yyyy-mm-dd")
+          .describe("End date in yyyy-mm-dd. Inclusive."),
+        timezone: z
+          .string()
+          .default("Europe/London")
+          .describe(
+            "IANA timezone for daily aggregation boundaries. Defaults to Europe/London (Percy Main's home timezone).",
+          ),
+      }),
+      execute: async ({ latitude, longitude, startDate, endDate, timezone }) =>
+        cache.getOrSet(
+          "weather_get",
+          { latitude, longitude, startDate, endDate, timezone },
+          24 * HOUR,
+          () =>
+            fetchWeather({ latitude, longitude, startDate, endDate, timezone }),
+        ),
+    }),
+
+    weather_geocode: tool({
+      description: `Look up latitude/longitude for a place by name. Use this only when a Play Cricket match summary row doesn't carry ground_latitude/ground_longitude — most do, so check first. Returns up to 5 candidates; the agent picks the right one (e.g. by country=GB).`,
+      inputSchema: z.object({
+        name: z
+          .string()
+          .min(1)
+          .describe(
+            "Place name to search — ground name, suburb, postcode, or town.",
+          ),
+      }),
+      execute: async ({ name }) =>
+        cache.getOrSet("weather_geocode", { name }, 30 * DAY, () =>
+          fetchGeocode(name),
+        ),
+    }),
+  };
+}
+
+export type WeatherTools = ReturnType<typeof createWeatherTools>;
+
+interface FetchWeatherArgs {
+  latitude: number;
+  longitude: number;
+  startDate: string;
+  endDate: string;
+  timezone: string;
+}
+
+async function fetchWeather(args: FetchWeatherArgs) {
+  const useArchive = isArchiveRange(args.startDate, args.endDate);
+  const base = useArchive ? ARCHIVE_BASE : FORECAST_BASE;
+
+  const url = new URL(base);
+  url.searchParams.set("latitude", String(args.latitude));
+  url.searchParams.set("longitude", String(args.longitude));
+  url.searchParams.set("start_date", args.startDate);
+  url.searchParams.set("end_date", args.endDate);
+  url.searchParams.set("timezone", args.timezone);
+  url.searchParams.set("daily", DAILY_VARS.join(","));
+  url.searchParams.set("hourly", HOURLY_VARS.join(","));
+  url.searchParams.set("wind_speed_unit", "mph");
+  url.searchParams.set("precipitation_unit", "mm");
+
+  const res = await fetch(url);
+  const body = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `Open-Meteo ${useArchive ? "archive" : "forecast"} error (HTTP ${res.status}): ${body.slice(0, 500)}`,
+    );
+  }
+
+  const json = JSON.parse(body) as Record<string, unknown>;
+  return {
+    source: useArchive ? ("archive" as const) : ("forecast" as const),
+    ...json,
+  };
+}
+
+async function fetchGeocode(name: string) {
+  const url = new URL(GEOCODING_BASE);
+  url.searchParams.set("name", name);
+  url.searchParams.set("count", "5");
+  url.searchParams.set("language", "en");
+  url.searchParams.set("format", "json");
+
+  const res = await fetch(url);
+  const body = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `Open-Meteo geocoding error (HTTP ${res.status}): ${body.slice(0, 500)}`,
+    );
+  }
+  return JSON.parse(body) as unknown;
+}
+
+// The forecast endpoint accepts past dates up to ~92 days back; the archive
+// endpoint covers everything older. Using forecast for recent past gives
+// higher-resolution local data, so route on a 90-day boundary.
+function isArchiveRange(start: string, end: string): boolean {
+  const now = Date.now();
+  const earliest = Math.min(parseDateUtc(start), parseDateUtc(end));
+  return now - earliest > NINETY_DAYS_MS;
+}
+
+function parseDateUtc(yyyymmdd: string): number {
+  // yyyy-mm-dd → midnight UTC. Comparison only — no DST nonsense to worry about.
+  return Date.parse(`${yyyymmdd}T00:00:00Z`);
+}

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -331,3 +331,45 @@
 .mdx-content tr:last-child td {
   @apply border-b-0;
 }
+
+/* ── Per-message PDF export (Scout) ──
+   The Export button on an assistant message marks it with
+   data-scout-printing, then calls window.print(). The standard "print one
+   element" pattern: hide all ink with visibility:hidden, re-show only the
+   printing element + its descendants, and pull the printing element to the
+   top-left of the page so nothing else takes layout space. visibility (vs
+   display:none) preserves the DOM tree so the printing element's ancestors
+   keep working — only the painted output is suppressed. */
+@media print {
+  body:has([data-scout-printing]) * {
+    visibility: hidden !important;
+  }
+  body:has([data-scout-printing]) [data-scout-printing],
+  body:has([data-scout-printing]) [data-scout-printing] * {
+    visibility: visible !important;
+  }
+  /* Tool-call cards are debug noise in the exported document. */
+  body:has([data-scout-printing]) [data-scout-printing] [data-scout-tool-card],
+  body:has([data-scout-printing])
+    [data-scout-printing]
+    [data-scout-tool-card]
+    * {
+    visibility: hidden !important;
+  }
+  body:has([data-scout-printing]) [data-scout-printing] [data-scout-tool-card] {
+    display: none !important;
+  }
+  body:has([data-scout-printing]) [data-scout-printing] {
+    position: absolute !important;
+    left: 0 !important;
+    top: 0 !important;
+    width: 100% !important;
+    /* Drop the chat-bubble framing so the message reads like a document. */
+    max-width: none !important;
+    border: none !important;
+    background: white !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    box-shadow: none !important;
+  }
+}

--- a/apps/web/src/pages/scout/message-view.tsx
+++ b/apps/web/src/pages/scout/message-view.tsx
@@ -1,7 +1,9 @@
 import type { UIMessage } from "@ai-sdk/react";
+import type { ChartSpec } from "@percy-main/shared";
 import { useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { ScoutChart } from "./scout-chart.tsx";
 
 const REMARK_PLUGINS = [remarkGfm];
 
@@ -111,8 +113,9 @@ export function MessageView({ message }: MessageViewProps) {
 
   return (
     <div
-      className={`flex ${isUser ? "justify-end" : "justify-start"} my-3`}
+      className={`group flex ${isUser ? "justify-end" : "justify-start"} my-3`}
       data-message-id={message.id}
+      data-scout-message
     >
       <div
         className={`max-w-3xl rounded-lg px-4 py-3 ${
@@ -124,8 +127,44 @@ export function MessageView({ message }: MessageViewProps) {
         {message.parts.map((part, i) => (
           <PartView key={`${message.id}-${i}`} part={part} />
         ))}
+        {!isUser && (
+          <div className="mt-2 flex justify-end opacity-0 transition-opacity group-hover:opacity-100 print:hidden">
+            <ExportMessageButton messageId={message.id} />
+          </div>
+        )}
       </div>
     </div>
+  );
+}
+
+// Triggers the browser's Print → Save as PDF flow, scoped to a single
+// assistant message. The print stylesheet (in scout.tsx) hides everything
+// except the message marked data-scout-printing. We pick that target by
+// message id at click time so unrelated messages stay hidden.
+function ExportMessageButton({ messageId }: { messageId: string }) {
+  function handleExport() {
+    const target = document.querySelector(
+      `[data-message-id="${CSS.escape(messageId)}"]`,
+    );
+    if (!(target instanceof HTMLElement)) return;
+    target.setAttribute("data-scout-printing", "");
+    const cleanup = () => {
+      target.removeAttribute("data-scout-printing");
+      window.removeEventListener("afterprint", cleanup);
+    };
+    window.addEventListener("afterprint", cleanup);
+    window.print();
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      className="rounded border border-gray-200 px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+      title="Save this message as PDF"
+    >
+      Export
+    </button>
   );
 }
 
@@ -152,6 +191,13 @@ function PartView({ part }: { part: Part }) {
         <div className="mt-1 font-mono whitespace-pre-wrap">{part.text}</div>
       </details>
     );
+  }
+
+  if (part.type === "data-chart") {
+    // Charts arrive as data-* parts via the AI SDK's UIMessageStream writer.
+    // The schema is validated server-side (Zod) so the FE trusts the shape.
+    const chartPart = part as { type: "data-chart"; data: ChartSpec };
+    return <ScoutChart spec={chartPart.data} />;
   }
 
   if (part.type.startsWith("tool-")) {
@@ -186,7 +232,10 @@ function ToolPartView({ part }: { part: Part }) {
           : "·";
 
   return (
-    <div className="my-2 rounded border border-gray-200 bg-gray-50 text-xs">
+    <div
+      data-scout-tool-card
+      className="my-2 rounded border border-gray-200 bg-gray-50 text-xs"
+    >
       <button
         type="button"
         className="flex w-full items-center justify-between px-2 py-1 text-left font-mono text-gray-700 hover:bg-gray-100"

--- a/apps/web/src/pages/scout/scout-chart.tsx
+++ b/apps/web/src/pages/scout/scout-chart.tsx
@@ -1,0 +1,194 @@
+import type { ChartSpec } from "@percy-main/shared";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Label,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+
+// Chart colour pool — colour-blind-safe-ish, picked to read fine on both
+// white message-list backgrounds. Keep the count high enough to cover most
+// "by-month" or "by-season" series without repeats.
+const SERIES_COLOURS = [
+  "#1f77b4",
+  "#ff7f0e",
+  "#2ca02c",
+  "#d62728",
+  "#9467bd",
+  "#8c564b",
+  "#e377c2",
+  "#17becf",
+];
+
+const HEIGHT = 260;
+
+export function ScoutChart({ spec }: { spec: ChartSpec }) {
+  return (
+    <figure className="my-3 rounded border border-gray-200 bg-white p-3">
+      <figcaption className="mb-2 text-sm font-semibold text-gray-800">
+        {spec.title}
+      </figcaption>
+      <div style={{ width: "100%", height: HEIGHT }}>
+        <ResponsiveContainer>
+          <ChartBody spec={spec} />
+        </ResponsiveContainer>
+      </div>
+      {spec.caption && (
+        <p className="mt-2 text-xs text-gray-500">{spec.caption}</p>
+      )}
+    </figure>
+  );
+}
+
+function ChartBody({ spec }: { spec: ChartSpec }) {
+  if (spec.type === "bar") {
+    return (
+      <BarChart
+        data={spec.data}
+        margin={{ top: 8, right: 16, bottom: 24, left: 8 }}
+      >
+        <CartesianGrid stroke="#eee" strokeDasharray="3 3" />
+        <XAxis dataKey="x" tick={{ fontSize: 11 }}>
+          {spec.xLabel ? (
+            <Label value={spec.xLabel} position="insideBottom" offset={-12} />
+          ) : null}
+        </XAxis>
+        <YAxis tick={{ fontSize: 11 }}>
+          {spec.yLabel ? (
+            <Label value={spec.yLabel} angle={-90} position="insideLeft" />
+          ) : null}
+        </YAxis>
+        <Tooltip cursor={{ fill: "rgba(0,0,0,0.04)" }} />
+        <Bar dataKey="y" fill={SERIES_COLOURS[0]} />
+      </BarChart>
+    );
+  }
+
+  if (spec.type === "line") {
+    const seriesNames = uniqueSeries(spec.data, "single line");
+    const grouped = groupBy(spec.data, (d) => d.series ?? "single line");
+
+    return (
+      <LineChart margin={{ top: 8, right: 16, bottom: 24, left: 8 }}>
+        <CartesianGrid stroke="#eee" strokeDasharray="3 3" />
+        <XAxis
+          dataKey="x"
+          type="category"
+          allowDuplicatedCategory={false}
+          tick={{ fontSize: 11 }}
+        >
+          {spec.xLabel ? (
+            <Label value={spec.xLabel} position="insideBottom" offset={-12} />
+          ) : null}
+        </XAxis>
+        <YAxis tick={{ fontSize: 11 }}>
+          {spec.yLabel ? (
+            <Label value={spec.yLabel} angle={-90} position="insideLeft" />
+          ) : null}
+        </YAxis>
+        <Tooltip />
+        {seriesNames.length > 1 ? <Legend /> : null}
+        {seriesNames.map((name, i) => (
+          <Line
+            key={name}
+            type="monotone"
+            dataKey="y"
+            data={grouped.get(name)}
+            name={name}
+            stroke={SERIES_COLOURS[i % SERIES_COLOURS.length]}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+          />
+        ))}
+      </LineChart>
+    );
+  }
+
+  // scatter
+  const scatterSeries = uniqueSeries(spec.data, "points");
+  const scatterGroups = groupBy(spec.data, (d) => d.series ?? "points");
+
+  return (
+    <ScatterChart margin={{ top: 8, right: 16, bottom: 24, left: 8 }}>
+      <CartesianGrid stroke="#eee" strokeDasharray="3 3" />
+      <XAxis dataKey="x" type="number" tick={{ fontSize: 11 }}>
+        {spec.xLabel ? (
+          <Label value={spec.xLabel} position="insideBottom" offset={-12} />
+        ) : null}
+      </XAxis>
+      <YAxis dataKey="y" type="number" tick={{ fontSize: 11 }}>
+        {spec.yLabel ? (
+          <Label value={spec.yLabel} angle={-90} position="insideLeft" />
+        ) : null}
+      </YAxis>
+      <ZAxis range={[40, 40]} />
+      <Tooltip
+        cursor={{ strokeDasharray: "3 3" }}
+        content={<ScatterTooltip />}
+      />
+      {scatterSeries.length > 1 ? <Legend /> : null}
+      {scatterSeries.map((name, i) => (
+        <Scatter
+          key={name}
+          name={name}
+          data={scatterGroups.get(name)}
+          fill={SERIES_COLOURS[i % SERIES_COLOURS.length]}
+        />
+      ))}
+    </ScatterChart>
+  );
+}
+
+function uniqueSeries(
+  data: Array<{ series?: string }>,
+  fallback: string,
+): string[] {
+  const set = new Set<string>();
+  for (const d of data) set.add(d.series ?? fallback);
+  return Array.from(set);
+}
+
+function groupBy<T>(data: T[], keyFn: (d: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const d of data) {
+    const k = keyFn(d);
+    const arr = map.get(k);
+    if (arr) arr.push(d);
+    else map.set(k, [d]);
+  }
+  return map;
+}
+
+interface ScatterTooltipPayload {
+  payload?: { x?: number; y?: number; label?: string; series?: string };
+}
+
+function ScatterTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: ScatterTooltipPayload[];
+}) {
+  if (!active || !payload?.length) return null;
+  const p = payload[0]?.payload;
+  if (!p) return null;
+  return (
+    <div className="rounded border border-gray-200 bg-white px-2 py-1 text-xs shadow-sm">
+      {p.label ? <div className="font-medium">{p.label}</div> : null}
+      <div className="text-gray-600">
+        x: {p.x} · y: {p.y}
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,3 +29,5 @@ export {
 export { stripeConfig, type StripeConfig } from "./stripe-config.ts";
 
 export { nameSimilarity, normalizeName } from "./name-similarity.ts";
+
+export { chartSpecSchema, type ChartSpec } from "./scout-chart.ts";

--- a/packages/shared/src/scout-chart.ts
+++ b/packages/shared/src/scout-chart.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+// Chart specs are streamed to the FE as data-chart parts. We keep the surface
+// narrow on purpose: bar / line / scatter cover almost every cricket-stats
+// chart we'd want, and a tight schema means the model rarely produces
+// invalid output. Use a discriminated union (not optional fields) so each
+// chart type has exactly the keys it needs.
+
+const xValueSchema = z.union([z.string(), z.number()]);
+const yValueSchema = z.number();
+
+const barDatumSchema = z.object({
+  x: xValueSchema,
+  y: yValueSchema,
+});
+
+const lineDatumSchema = z.object({
+  x: xValueSchema,
+  y: yValueSchema,
+  series: z.string().optional(),
+});
+
+const scatterDatumSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  label: z.string().optional(),
+  series: z.string().optional(),
+});
+
+const baseFieldsSchema = z.object({
+  title: z.string().min(1).describe("Title shown above the chart."),
+  xLabel: z.string().optional().describe("X-axis label."),
+  yLabel: z.string().optional().describe("Y-axis label."),
+  caption: z
+    .string()
+    .optional()
+    .describe(
+      "Optional one-line caption shown below the chart (sample size, source, etc.).",
+    ),
+});
+
+export const chartSpecSchema = z.discriminatedUnion("type", [
+  baseFieldsSchema.extend({
+    type: z.literal("bar"),
+    data: z
+      .array(barDatumSchema)
+      .min(1)
+      .max(200)
+      .describe("Each datum is one bar: { x, y }."),
+  }),
+  baseFieldsSchema.extend({
+    type: z.literal("line"),
+    data: z
+      .array(lineDatumSchema)
+      .min(2)
+      .max(500)
+      .describe(
+        "Points along one or more lines: { x, y, series? }. If `series` is set on any datum, points are grouped into separate lines.",
+      ),
+  }),
+  baseFieldsSchema.extend({
+    type: z.literal("scatter"),
+    data: z
+      .array(scatterDatumSchema)
+      .min(1)
+      .max(500)
+      .describe(
+        "Points: { x, y, label?, series? }. Both x and y must be numeric. Use scatter when looking for correlation (e.g. innings score vs air temperature).",
+      ),
+  }),
+]);
+
+export type ChartSpec = z.infer<typeof chartSpecSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,10 +52,10 @@ importers:
         version: 3.1022.0
       '@better-auth/infra':
         specifier: ^0.1.13
-        version: 0.1.13(9c70778cc91d7205870d3fa32646111b)
+        version: 0.1.13(c5ed1d55fcb91bfb734ecc8c43af85f6)
       '@better-auth/passkey':
         specifier: ^1.5.4
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
@@ -249,7 +249,7 @@ importers:
         version: 3.0.176(react@19.2.4)(zod@4.3.6)
       '@better-auth/passkey':
         specifier: ^1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -8440,7 +8440,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8535,7 +8535,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8575,10 +8575,10 @@ snapshots:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/infra@0.1.13(9c70778cc91d7205870d3fa32646111b)':
+  '@better-auth/infra@0.1.13(c5ed1d55fcb91bfb734ecc8c43af85f6)':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
-      '@better-auth/sso': 1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1)
+      '@better-auth/sso': 1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
       better-call: 1.3.4(zod@4.3.6)
@@ -8632,9 +8632,9 @@ snapshots:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/sso@1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))':
+  '@better-auth/sso@1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))':
     dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
@@ -12430,6 +12430,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
@@ -14053,7 +14057,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3


### PR DESCRIPTION
## Summary

Three Scout improvements + a couple of fallout fixes from production usage.

### Weather tool
- `weather_get` — daily aggregates + hourly series for any cricket ground. Auto-routes between Open-Meteo's forecast and archive endpoints on a 90-day boundary, so recent past comes from the higher-resolution forecast model and older dates from the long-term archive.
- `weather_geocode` — free-text → lat/lng fallback for grounds Play Cricket doesn't carry coords for. Most match summaries already include `ground_latitude`/`ground_longitude`, so the agent uses those directly when present.
- System prompt now has a *Weather* section (rain, cloud/humidity, temp, wind, sunshine→pitch hardness, framed against English club cricket) and a guardrail: "Don't invent meteorological causation."
- Plain `fetch` to JSON, no SDK. Cached via the existing `ScoutCache` (24h forecast/archive, 30d geocoding).

### Inline charts
- Streaming route now wraps `streamText` in `createUIMessageStream`, exposing a `UIMessageStreamWriter` to tools.
- `chart_render` tool emits `data-chart` parts inline with the assistant's prose. Persisted in `messages.parts` via the existing onFinish flow — charts show up correctly when reloading old threads.
- Spec is a Zod discriminated union by chart type (`bar | line | scatter`). Wrapped in an object to satisfy Anthropic's "tool input_schema must be an object" requirement.
- Spec moved to `packages/shared` so backend Zod and frontend rendering share one source.
- Frontend renders via `recharts` 3.8: bar (single colour), line (multi-series support), scatter (per-point labels in tooltip). Mounted in `MessageView` as a first-class part type.

### Per-message PDF export
- Hover-revealed Export button on assistant messages calls `window.print()` with print CSS scoped to the targeted message.
- Standard `visibility: hidden` everywhere + `visibility: visible` on the printing subtree, target absolutely positioned at top-left so other elements take no layout space. Zero new deps.
- Tool-call cards (`data-scout-tool-card`) hidden in print output.

### Fallout fixes
- **Log-spam fix**: `sanitizeError` in both stream error handlers projects errors down to `{ name, message, statusCode, requestId, apiError }`. AI SDK errors (most importantly Anthropic's `APICallError`) carry the entire request body — including the conversation history — as own properties; logging the raw error via pino was dumping full transcripts.
- **Scout allowlist**: default now includes `steve.knight@percymain.org`.

## Test plan

- [ ] Ask Scout for the weather forecast for an upcoming fixture — should hit `weather_get` and use `forecast` source.
- [ ] Ask Scout for the weather on a match from a previous season — should use `archive` source.
- [ ] Ask Scout to chart something (e.g. "show me our average score by month this season as a bar chart") — chart should render inline, persist on reload.
- [ ] Click Export on an assistant message — system print dialog opens, only that message visible (no chrome, no tool-call cards).
- [ ] Production logs (after deploy) should no longer contain full transcript dumps when a Scout request errors.
- [ ] `steve.knight@percymain.org` should be able to access Scout after the API redeploys.