### PR TITLE
Scout: fact memory (RAG), citations, admin UI + cost-reduction polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16-alpine
+        # pgvector/pgvector:pg16 = official Postgres 16 image with the
+        # vector extension pre-built. Drop-in for postgres:16-alpine —
+        # required since the scout_fact migration runs CREATE EXTENSION
+        # vector.
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: percy
           POSTGRES_PASSWORD: percy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16-alpine
+        # pgvector/pgvector:pg16 = official Postgres 16 image with the
+        # vector extension pre-built. Drop-in for postgres:16-alpine —
+        # required since the scout_fact migration runs CREATE EXTENSION
+        # vector.
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: percy
           POSTGRES_PASSWORD: percy

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -84,6 +84,11 @@ const configSchema = z.object({
         .map((s) => s.trim())
         .filter(Boolean),
     ),
+  // Voyage AI (fact-RAG embeddings + reranking). Optional — Scout boots
+  // without it and just skips the fact tools / auto-retrieval.
+  VOYAGE_API_KEY: z.string().optional(),
+  VOYAGE_EMBED_MODEL: z.string().default("voyage-4"),
+  VOYAGE_RERANK_MODEL: z.string().default("rerank-2.5"),
 
   // Sync task launch (admin "Sync now" button → ECS RunTask)
   AWS_REGION: z.string().default("eu-west-2"),

--- a/apps/api/src/features/scout/agent.test.ts
+++ b/apps/api/src/features/scout/agent.test.ts
@@ -28,6 +28,7 @@ function makeAgent() {
     playCricket: stubPlayCricket,
     config: stubConfig,
     writer: stubWriter,
+    userId: "test-user",
   });
 }
 

--- a/apps/api/src/features/scout/agent.ts
+++ b/apps/api/src/features/scout/agent.ts
@@ -10,10 +10,12 @@ import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import type { Config } from "../../config.ts";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
+import type { VoyageClient } from "./facts/voyage.ts";
 import { SCOUT_SYSTEM_PROMPT } from "./system-prompt.ts";
 import { createScoutCache } from "./tools/cache.ts";
 import { createChartTool } from "./tools/chart.ts";
 import { createDbTools } from "./tools/db.ts";
+import { createFactTools } from "./tools/facts.ts";
 import { createPlayCricketTools } from "./tools/play-cricket.ts";
 import { createWeatherTools } from "./tools/weather.ts";
 
@@ -35,6 +37,13 @@ export interface ScoutAgentDeps {
   // and passes the resulting writer down.
   writer: UIMessageStreamWriter;
   logger?: FastifyBaseLogger;
+  // Fact-RAG dependencies. Optional so the agent can boot without a Voyage
+  // API key — the fact_record / fact_retrieve tools are simply omitted in
+  // that case. userId is the authenticated caller; threadId is attached to
+  // every recorded fact for traceability.
+  voyage?: VoyageClient;
+  userId: string;
+  threadId?: string;
 }
 
 export interface ScoutAgent {
@@ -57,6 +66,20 @@ export function createScoutAgent(deps: ScoutAgentDeps): ScoutAgent {
   const dbTools = createDbTools({ dbReadonly: deps.dbReadonly });
   const weatherTools = createWeatherTools({ cache });
   const chartTools = createChartTool({ writer: deps.writer });
+  // Fact tools only register when Voyage is configured. Auto-retrieval in
+  // the route also short-circuits in that case, so a deployment without
+  // VOYAGE_API_KEY behaves as if the RAG layer doesn't exist.
+  const factTools = deps.voyage
+    ? createFactTools({
+        db: deps.db,
+        voyage: deps.voyage,
+        userId: deps.userId,
+        threadId: deps.threadId,
+        // Same writer the chart tool uses — cite_fact emits
+        // data-fact-citation parts inline with assistant prose.
+        writer: deps.writer,
+      })
+    : {};
 
   // Anchor "today" so the model doesn't fall back to its training cutoff
   // when picking a default season AND so it filters past/future matches
@@ -82,6 +105,7 @@ When asked about the "next" or "upcoming" match, filter match_date strictly GREA
       ...dbTools,
       ...weatherTools,
       ...chartTools,
+      ...factTools,
     },
     maxSteps: deps.config.SCOUT_MAX_STEPS,
     prepareStep: ({ messages }) => ({

--- a/apps/api/src/features/scout/facts/admin-service.ts
+++ b/apps/api/src/features/scout/facts/admin-service.ts
@@ -1,0 +1,234 @@
+import type { DB } from "@percy-main/db";
+import { CompiledQuery, type Kysely, sql, type SqlBool } from "kysely";
+import type { z } from "zod";
+import type {
+  factAdminItemSchema,
+  listFactsQuerySchema,
+  updateFactBodySchema,
+} from "../schemas.ts";
+import {
+  toVectorLiteral,
+  type VoyageClient,
+} from "./voyage.ts";
+
+/**
+ * Admin-side queries for the scout_fact corpus. Used by the
+ * /scout/facts admin routes so the allowlisted user can review,
+ * edit, and delete recorded facts before bad ones compound.
+ *
+ * Edits that change `content` re-embed via Voyage so the vector stays
+ * in sync — without this, retrieval would silently match the old
+ * embedding while the user sees a corrected fact, which is the worst
+ * possible failure mode (looks fine, behaves wrong).
+ */
+
+type AdminItem = z.infer<typeof factAdminItemSchema>;
+type ListQuery = z.infer<typeof listFactsQuerySchema>;
+type UpdateBody = z.infer<typeof updateFactBodySchema>;
+
+const SELECT_COLS = [
+  "id",
+  "user_id",
+  "scope",
+  "content",
+  "tags",
+  "confidence",
+  "source_thread_id",
+  "superseded_by",
+  "created_at",
+  "updated_at",
+] as const;
+
+interface Row {
+  id: string;
+  user_id: string;
+  scope: string;
+  content: string;
+  tags: unknown;
+  confidence: number;
+  source_thread_id: string | null;
+  superseded_by: string | null;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+function toItem(row: Row): AdminItem {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    scope: row.scope as AdminItem["scope"],
+    content: row.content,
+    tags: row.tags as AdminItem["tags"],
+    confidence: row.confidence,
+    sourceThreadId: row.source_thread_id,
+    supersededBy: row.superseded_by,
+    createdAt:
+      row.created_at instanceof Date
+        ? row.created_at.toISOString()
+        : new Date(row.created_at).toISOString(),
+    updatedAt:
+      row.updated_at instanceof Date
+        ? row.updated_at.toISOString()
+        : new Date(row.updated_at).toISOString(),
+  };
+}
+
+export class FactNotFoundError extends Error {
+  constructor() {
+    super("Fact not found");
+  }
+}
+
+export function listFacts(db: Kysely<DB>) {
+  return async (
+    params: ListQuery,
+  ): Promise<{ facts: AdminItem[]; total: number }> => {
+    let query = db.selectFrom("scout_fact").select([...SELECT_COLS]);
+
+    if (!params.includeSuperseded) {
+      query = query.where("superseded_by", "is", null);
+    }
+    if (params.scope) {
+      query = query.where("scope", "=", params.scope);
+    }
+    if (params.q) {
+      // websearch_to_tsquery handles typed queries gracefully (quotes,
+      // negation). Same operator used in retrieveFacts.
+      query = query.where(
+        sql<SqlBool>`to_tsvector('english', content) @@ websearch_to_tsquery('english', ${params.q})`,
+      );
+    }
+    if (params.tag) {
+      // Tag arg is "key:value" string. Split exactly once on the first
+      // colon so values containing ':' (rare but possible) are preserved.
+      const idx = params.tag.indexOf(":");
+      if (idx > 0) {
+        const key = params.tag.slice(0, idx);
+        const value = params.tag.slice(idx + 1);
+        query = query.where(
+          sql<SqlBool>`tags @> ${JSON.stringify({ [key]: value })}::jsonb`,
+        );
+      }
+    }
+
+    const offset = (params.page - 1) * params.pageSize;
+    const rows = (await query
+      .orderBy("created_at", "desc")
+      .limit(params.pageSize)
+      .offset(offset)
+      .execute()) as unknown as Row[];
+
+    // Separate count query — paginated results lose the row count
+    // otherwise, and the admin UI needs to render "N of total".
+    const totalRow = await db
+      .selectFrom("scout_fact")
+      .select(sql<string>`COUNT(*)`.as("count"))
+      .$if(!params.includeSuperseded, (q) =>
+        q.where("superseded_by", "is", null),
+      )
+      .$if(params.scope !== undefined, (q) =>
+        q.where("scope", "=", params.scope as string),
+      )
+      .executeTakeFirstOrThrow();
+
+    return {
+      facts: rows.map(toItem),
+      total: Number(totalRow.count),
+    };
+  };
+}
+
+export function getFact(db: Kysely<DB>) {
+  return async (factId: string): Promise<AdminItem> => {
+    const row = (await db
+      .selectFrom("scout_fact")
+      .select([...SELECT_COLS])
+      .where("id", "=", factId)
+      .executeTakeFirst()) as unknown as Row | undefined;
+    if (!row) throw new FactNotFoundError();
+    return toItem(row);
+  };
+}
+
+export function updateFact(db: Kysely<DB>, voyage: VoyageClient) {
+  return async (factId: string, body: UpdateBody): Promise<AdminItem> => {
+    const existing = (await db
+      .selectFrom("scout_fact")
+      .select(["id", "content"])
+      .where("id", "=", factId)
+      .executeTakeFirst()) as { id: string; content: string } | undefined;
+    if (!existing) throw new FactNotFoundError();
+
+    const contentChanged =
+      body.content !== undefined && body.content !== existing.content;
+
+    if (contentChanged && body.content) {
+      // Re-embed content edits via raw SQL because Kysely's update
+      // builder doesn't know the `vector` type; mixing the typed update
+      // with a raw embedding expression in one statement is messier than
+      // a single CompiledQuery. Same parameterisation pattern as the
+      // initial insert in service.ts.
+      const embedding = await voyage.embed(body.content, "document");
+      await db.executeQuery(
+        CompiledQuery.raw(
+          `UPDATE scout_fact
+           SET content = $1,
+               embedding = $2::vector,
+               tags = COALESCE($3::jsonb, tags),
+               scope = COALESCE($4, scope),
+               confidence = COALESCE($5, confidence),
+               updated_at = NOW()
+           WHERE id = $6`,
+          [
+            body.content,
+            toVectorLiteral(embedding),
+            body.tags === undefined ? null : JSON.stringify(body.tags),
+            body.scope ?? null,
+            body.confidence ?? null,
+            factId,
+          ],
+        ),
+      );
+    } else {
+      // Metadata-only edit — no need to call Voyage.
+      await db
+        .updateTable("scout_fact")
+        .$if(body.tags !== undefined, (q) =>
+          q.set({ tags: JSON.stringify(body.tags) }),
+        )
+        .$if(body.scope !== undefined, (q) =>
+          q.set({ scope: body.scope as string }),
+        )
+        .$if(body.confidence !== undefined, (q) =>
+          q.set({
+            // $if guard above guarantees defined; cast is the
+            // narrowest way to satisfy the column's number type.
+            // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
+            confidence: body.confidence as number,
+          }),
+        )
+        .set({ updated_at: new Date() })
+        .where("id", "=", factId)
+        .execute();
+    }
+
+    return getFact(db)(factId);
+  };
+}
+
+/**
+ * Hard-delete (the admin's "this fact is wrong, get rid of it"
+ * action). Different from supersession: we don't keep history because
+ * the row was incorrect, not just outdated. Citations referencing the
+ * deleted id will resolve to "fact not found" via cite_fact's existing
+ * visibility check.
+ */
+export function deleteFact(db: Kysely<DB>) {
+  return async (factId: string): Promise<void> => {
+    const result = await db
+      .deleteFrom("scout_fact")
+      .where("id", "=", factId)
+      .executeTakeFirst();
+    if (Number(result.numDeletedRows) === 0) throw new FactNotFoundError();
+  };
+}

--- a/apps/api/src/features/scout/facts/admin-service.ts
+++ b/apps/api/src/features/scout/facts/admin-service.ts
@@ -6,10 +6,7 @@ import type {
   listFactsQuerySchema,
   updateFactBodySchema,
 } from "../schemas.ts";
-import {
-  toVectorLiteral,
-  type VoyageClient,
-} from "./voyage.ts";
+import { toVectorLiteral, type VoyageClient } from "./voyage.ts";
 
 /**
  * Admin-side queries for the scout_fact corpus. Used by the

--- a/apps/api/src/features/scout/facts/auto-retrieve.test.ts
+++ b/apps/api/src/features/scout/facts/auto-retrieve.test.ts
@@ -1,0 +1,156 @@
+import type { DB } from "@percy-main/db";
+import type { ModelMessage, UIMessage } from "ai";
+import type { Kysely } from "kysely";
+import { describe, expect, it, vi } from "vitest";
+import { applyAutoRetrieval } from "./auto-retrieve.ts";
+import type { VoyageClient } from "./voyage.ts";
+
+// applyAutoRetrieval is the choke point that decides whether a turn gets
+// fact memory. Its own SQL is exercised in the integration test; the
+// pieces worth unit-testing here are the query construction (anaphora
+// mitigation), the no-facts short-circuit, and the model-message
+// mutation that lands the <known-facts> block in the right place.
+
+function makeVoyageStub(opts: {
+  embed?: number[];
+  rerank?: Array<{ index: number; score: number }>;
+}): VoyageClient {
+  return {
+    embed: vi.fn(() => Promise.resolve(opts.embed ?? [0, 0, 0])),
+    embedBatch: vi.fn((texts: string[]) =>
+      Promise.resolve(texts.map(() => opts.embed ?? [0, 0, 0])),
+    ),
+    rerank: vi.fn(() => Promise.resolve(opts.rerank ?? [])),
+  };
+}
+
+function fakeDbReturning(rows: unknown[]): Kysely<DB> {
+  // Just enough surface area for retrieveFacts: each executeQuery call
+  // returns the same rows. Good enough for query-construction tests; the
+  // integration test exercises the real SQL.
+  return {
+    executeQuery: vi.fn(() => Promise.resolve({ rows })),
+  } as unknown as Kysely<DB>;
+}
+
+function userMsg(text: string): UIMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: "user",
+    parts: [{ type: "text", text }],
+  } as UIMessage;
+}
+
+describe("applyAutoRetrieval", () => {
+  it("returns input unchanged when no user text is present", async () => {
+    const result = await applyAutoRetrieval(
+      {
+        db: fakeDbReturning([]),
+        voyage: makeVoyageStub({}),
+        userId: "u1",
+      },
+      [],
+      [],
+    );
+    expect(result.factsCount).toBe(0);
+    expect(result.factsBlock).toBe("");
+  });
+
+  it("returns input unchanged when retrieval returns zero facts", async () => {
+    const modelMsgs: ModelMessage[] = [{ role: "user", content: "Hi" }];
+    const result = await applyAutoRetrieval(
+      {
+        db: fakeDbReturning([]),
+        voyage: makeVoyageStub({}),
+        userId: "u1",
+      },
+      [userMsg("Hi")],
+      modelMsgs,
+    );
+
+    expect(result.factsCount).toBe(0);
+    expect(result.messages).toBe(modelMsgs); // identity, not just deep-equal
+  });
+
+  it("appends a <known-facts> text part to the last user message when facts are found", async () => {
+    // Two candidate rows in the fake DB; reranker picks one of them.
+    const db = fakeDbReturning([
+      {
+        id: "f1",
+        content: "Mitford CC have no covers",
+        tags: { team: "Mitford CC" },
+        scope: "club",
+        confidence: 4,
+        created_at: new Date(),
+      },
+    ]);
+    const voyage = makeVoyageStub({
+      rerank: [{ index: 0, score: 0.92 }],
+    });
+
+    const modelMsgs: ModelMessage[] = [
+      { role: "user", content: "Who do we play next?" },
+      { role: "assistant", content: "Mitford on Saturday" },
+      { role: "user", content: "How's their ground?" },
+    ];
+
+    const result = await applyAutoRetrieval(
+      { db, voyage, userId: "u1" },
+      [
+        userMsg("Who do we play next?"),
+        // assistant turn skipped by buildQuery
+        userMsg("How's their ground?"),
+      ],
+      modelMsgs,
+    );
+
+    expect(result.factsCount).toBe(1);
+    expect(result.factsBlock).toMatch(/<known-facts>/);
+    expect(result.factsBlock).toContain("Mitford CC have no covers");
+
+    const last = result.messages[result.messages.length - 1];
+    expect(last.role).toBe("user");
+    // The original "How's their ground?" string should still be there as
+    // a text part, with the facts block as a separate appended text part.
+    expect(Array.isArray(last.content)).toBe(true);
+    const parts = last.content as Array<{ type: string; text: string }>;
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({ type: "text", text: "How's their ground?" });
+    expect(parts[1].text).toContain("<known-facts>");
+  });
+
+  it("query is built from up to last 2 user messages + current (anaphora mitigation)", async () => {
+    const embedSpy: VoyageClient["embed"] = vi.fn(() =>
+      Promise.resolve([0, 0, 0]),
+    );
+    const voyage: VoyageClient = {
+      embed: embedSpy,
+      embedBatch: vi.fn(),
+      rerank: vi.fn(() => Promise.resolve([])),
+    };
+
+    await applyAutoRetrieval(
+      {
+        db: fakeDbReturning([]),
+        voyage,
+        userId: "u1",
+      },
+      [
+        userMsg("first question about Mitford"),
+        userMsg("follow-up about their ground"),
+        userMsg("what about them?"),
+      ],
+      [],
+    );
+
+    // Voyage embed should have been called once with a query that joins
+    // the user texts so "what about them?" carries enough signal to
+    // retrieve Mitford-tagged facts.
+    const mock = vi.mocked(embedSpy);
+    expect(mock).toHaveBeenCalledTimes(1);
+    const [queryArg] = mock.mock.calls[0];
+    expect(queryArg).toContain("Mitford");
+    expect(queryArg).toContain("ground");
+    expect(queryArg).toContain("what about them?");
+  });
+});

--- a/apps/api/src/features/scout/facts/auto-retrieve.ts
+++ b/apps/api/src/features/scout/facts/auto-retrieve.ts
@@ -1,0 +1,104 @@
+import type { DB } from "@percy-main/db";
+import type { ModelMessage, UIMessage } from "ai";
+import type { Kysely } from "kysely";
+import { formatFactsBlock, retrieveFacts } from "./service.ts";
+import type { VoyageClient } from "./voyage.ts";
+
+/**
+ * Pre-turn auto-retrieval: pull the most relevant facts for the current
+ * user turn and inject them into the model-message side of the prompt.
+ *
+ * Conversation-aware query: concatenate the last 2 user-message texts +
+ * the current one as the retrieval query. Cheap mitigation for anaphora
+ * ("what about them?") without spending a Haiku call on query rewrite.
+ *
+ * The injection lands as an extra text part appended to the last user
+ * message, AFTER convertToModelMessages. That keeps the persisted user
+ * message clean (the DB shouldn't contain the auto-retrieved block) and
+ * it keeps the cache-control breakpoint on the last message — Anthropic
+ * caches the prefix up to and including the facts block on creation, and
+ * subsequent agentic steps in the same turn read it from cache.
+ */
+
+const QUERY_HISTORY_TURNS = 2;
+
+export interface AutoRetrieveDeps {
+  db: Kysely<DB>;
+  voyage: VoyageClient;
+  userId: string;
+}
+
+export interface AutoRetrieveResult {
+  /** Mutated message list (a fresh array; inputs are not mutated). */
+  messages: ModelMessage[];
+  /** The block injected, for logging. Empty string if no facts found. */
+  factsBlock: string;
+  factsCount: number;
+}
+
+export async function applyAutoRetrieval(
+  deps: AutoRetrieveDeps,
+  uiMessages: UIMessage[],
+  modelMessages: ModelMessage[],
+): Promise<AutoRetrieveResult> {
+  const query = buildQuery(uiMessages);
+  if (!query) {
+    return { messages: modelMessages, factsBlock: "", factsCount: 0 };
+  }
+
+  const retrieve = retrieveFacts(deps.db, deps.voyage);
+  const facts = await retrieve({ userId: deps.userId, query });
+
+  const block = formatFactsBlock(facts);
+  if (!block) {
+    return { messages: modelMessages, factsBlock: "", factsCount: 0 };
+  }
+
+  return {
+    messages: appendBlockToLastUserMessage(modelMessages, block),
+    factsBlock: block,
+    factsCount: facts.length,
+  };
+}
+
+function buildQuery(messages: UIMessage[]): string {
+  const userTexts: string[] = [];
+  for (
+    let i = messages.length - 1;
+    i >= 0 && userTexts.length < QUERY_HISTORY_TURNS + 1;
+    i--
+  ) {
+    const m = messages[i];
+    if (m.role !== "user") continue;
+    const text = m.parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join(" ")
+      .trim();
+    if (text) userTexts.unshift(text);
+  }
+  return userTexts.join("\n").trim();
+}
+
+function appendBlockToLastUserMessage(
+  messages: ModelMessage[],
+  block: string,
+): ModelMessage[] {
+  if (messages.length === 0) return messages;
+  return messages.map((message, index) => {
+    if (index !== messages.length - 1) return message;
+    if (message.role !== "user") return message;
+
+    // ModelMessage.content is `string | Array<TextPart | ImagePart | FilePart>`.
+    // Normalise to the array form so we can append cleanly without
+    // clobbering image/file parts the user might have attached.
+    const existing = Array.isArray(message.content)
+      ? message.content
+      : [{ type: "text" as const, text: message.content }];
+
+    return {
+      ...message,
+      content: [...existing, { type: "text" as const, text: `\n\n${block}` }],
+    };
+  });
+}

--- a/apps/api/src/features/scout/facts/integration.test.ts
+++ b/apps/api/src/features/scout/facts/integration.test.ts
@@ -111,12 +111,13 @@ describe("scout_fact migration + pgvector", () => {
 describe("recordFact — write path with cosine dedup + supersession", () => {
   it("inserts a fresh fact when nothing nearby exists", async () => {
     const voyage = buildVoyageMock({
-      embeddings: new Map([
-        ["Mitford CC have no covers", vec([0, 1])],
-      ]),
+      embeddings: new Map([["Mitford CC have no covers", vec([0, 1])]]),
     });
 
-    const result = await recordFact(ctx.db, voyage)({
+    const result = await recordFact(
+      ctx.db,
+      voyage,
+    )({
       userId,
       scope: "club",
       content: "Mitford CC have no covers",
@@ -194,7 +195,11 @@ describe("recordFact — write path with cosine dedup + supersession", () => {
     });
     const record = recordFact(ctx.db, voyage);
 
-    await record({ userId, scope: "club", content: "Mitford CC have no covers" });
+    await record({
+      userId,
+      scope: "club",
+      content: "Mitford CC have no covers",
+    });
     const second = await record({
       userId,
       scope: "club",
@@ -249,7 +254,10 @@ describe("retrieveFacts — hybrid retrieval + rerank", () => {
             const score = (s: string) => (s === groundFact ? 1 : 0);
             return score(b.d) - score(a.d);
           });
-        return indexes.map(({ i }, rank) => ({ index: i, score: 1 - rank * 0.1 }));
+        return indexes.map(({ i }, rank) => ({
+          index: i,
+          score: 1 - rank * 0.1,
+        }));
       },
     });
 
@@ -262,7 +270,10 @@ describe("retrieveFacts — hybrid retrieval + rerank", () => {
       voyage,
     );
 
-    const out = await retrieveFacts(ctx.db, voyage)({
+    const out = await retrieveFacts(
+      ctx.db,
+      voyage,
+    )({
       userId,
       query: "What's Mitford's ground like?",
       topK: 3,
@@ -276,7 +287,8 @@ describe("retrieveFacts — hybrid retrieval + rerank", () => {
     // Query embedding deliberately far from the relevant fact's vector,
     // so vector retrieval alone wouldn't surface it. FTS path matches on
     // the literal token "Swalwell".
-    const swalwell = "Swalwell is a massive ground with short square boundaries";
+    const swalwell =
+      "Swalwell is a massive ground with short square boundaries";
 
     const embeddings = new Map<string, number[]>([
       [swalwell, vec([0, 1])],
@@ -287,7 +299,10 @@ describe("retrieveFacts — hybrid retrieval + rerank", () => {
 
     await seed([{ content: swalwell, vector: vec([0, 1]) }], voyage);
 
-    const out = await retrieveFacts(ctx.db, voyage)({
+    const out = await retrieveFacts(
+      ctx.db,
+      voyage,
+    )({
       userId,
       query: "Tell me about Swalwell",
     });
@@ -303,7 +318,10 @@ describe("retrieveFacts — hybrid retrieval + rerank", () => {
     ]);
     const voyage = buildVoyageMock({ embeddings });
 
-    await recordFact(ctx.db, voyage)({
+    await recordFact(
+      ctx.db,
+      voyage,
+    )({
       userId,
       scope: "user",
       content: fact,
@@ -315,7 +333,10 @@ describe("retrieveFacts — hybrid retrieval + rerank", () => {
       email: "other-scout@test.com",
     });
 
-    const out = await retrieveFacts(ctx.db, voyage)({
+    const out = await retrieveFacts(
+      ctx.db,
+      voyage,
+    )({
       userId: other.userId,
       query: "facing spin",
     });
@@ -347,7 +368,10 @@ describe("retrieveFacts — hybrid retrieval + rerank", () => {
       tags: { team: "Tynemouth" },
     });
 
-    const out = await retrieveFacts(ctx.db, voyage)({
+    const out = await retrieveFacts(
+      ctx.db,
+      voyage,
+    )({
       userId,
       query: "pitch",
       tags: { team: "Mitford CC" },
@@ -372,7 +396,10 @@ describe("retrieveFacts — hybrid retrieval + rerank", () => {
     await record({ userId, scope: "club", content: original });
     await record({ userId, scope: "club", content: updated });
 
-    const out = await retrieveFacts(ctx.db, voyage)({
+    const out = await retrieveFacts(
+      ctx.db,
+      voyage,
+    )({
       userId,
       query: "Mitford covers",
     });
@@ -409,7 +436,10 @@ describe("cite_fact tool — visibility check + writer emission", () => {
     const voyage = buildVoyageMock({
       embeddings: new Map([[fact, vec([0, 1])]]),
     });
-    const recorded = await recordFact(ctx.db, voyage)({
+    const recorded = await recordFact(
+      ctx.db,
+      voyage,
+    )({
       userId,
       scope: "club",
       content: fact,
@@ -452,7 +482,10 @@ describe("cite_fact tool — visibility check + writer emission", () => {
     const voyage = buildVoyageMock({
       embeddings: new Map([[personal, vec([0, 1])]]),
     });
-    const recorded = await recordFact(ctx.db, voyage)({
+    const recorded = await recordFact(
+      ctx.db,
+      voyage,
+    )({
       userId,
       scope: "user",
       content: personal,
@@ -599,7 +632,10 @@ describe("admin-service", () => {
         ["updated content here", vec([1, 0])],
       ]),
     });
-    const recorded = await recordFact(ctx.db, voyage)({
+    const recorded = await recordFact(
+      ctx.db,
+      voyage,
+    )({
       userId,
       scope: "club",
       content: "original",
@@ -625,7 +661,10 @@ describe("admin-service", () => {
     const voyage = buildVoyageMock({
       embeddings: new Map([["meta-only", vec([0, 1])]]),
     });
-    const recorded = await recordFact(ctx.db, voyage)({
+    const recorded = await recordFact(
+      ctx.db,
+      voyage,
+    )({
       userId,
       scope: "club",
       content: "meta-only",
@@ -648,7 +687,10 @@ describe("admin-service", () => {
     const voyage = buildVoyageMock({
       embeddings: new Map([["doomed", vec([0, 1])]]),
     });
-    const recorded = await recordFact(ctx.db, voyage)({
+    const recorded = await recordFact(
+      ctx.db,
+      voyage,
+    )({
       userId,
       scope: "club",
       content: "doomed",

--- a/apps/api/src/features/scout/facts/integration.test.ts
+++ b/apps/api/src/features/scout/facts/integration.test.ts
@@ -1,0 +1,697 @@
+import type { UIMessageStreamWriter } from "ai";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../../test/containers.ts";
+import { createFactTools } from "../tools/facts.ts";
+import {
+  formatFactsBlock,
+  recordFact,
+  retrieveFacts,
+  type FactScope,
+} from "./service.ts";
+import type { VoyageClient } from "./voyage.ts";
+
+// Real pgvector — verifies the migration's vector column, HNSW index,
+// FTS index, supersession chain, and the cosine-distance dedup
+// threshold all work end-to-end. Voyage is mocked so the test is offline
+// and deterministic; what we need from the real DB is that pgvector
+// stores+sorts vectors, the FTS index returns rows, and the SQL we wrote
+// in service.ts actually runs against pg.
+
+let ctx: TestContext;
+let userId: string;
+
+// Crafted vectors so cosine distance is predictable. Using 1024-dim is
+// painful by hand, but we can pad with zeros around a few signal coords
+// to control which fact is "near" which query.
+const DIM = 1024;
+function vec(...nonZero: Array<[number, number]>): number[] {
+  const v = new Array<number>(DIM).fill(0);
+  for (const [i, val] of nonZero) v[i] = val;
+  return v;
+}
+
+interface FactSeed {
+  content: string;
+  tags?: Record<string, string | string[]>;
+  scope?: FactScope;
+  confidence?: number;
+  vector: number[];
+}
+
+function buildVoyageMock(opts: {
+  // Map a content/query string to the embedding that should come back.
+  embeddings: Map<string, number[]>;
+  // Optional: control rerank ordering. Default: identity (preserve input order).
+  rerank?: (
+    query: string,
+    docs: string[],
+  ) => Array<{ index: number; score: number }>;
+}): VoyageClient {
+  const embedSync = (text: string): number[] => {
+    const v = opts.embeddings.get(text);
+    if (!v) throw new Error(`no test embedding for: ${text}`);
+    return v;
+  };
+  return {
+    embed: vi.fn((text: string) => Promise.resolve(embedSync(text))),
+    embedBatch: vi.fn((texts: string[]) =>
+      Promise.resolve(texts.map((t) => embedSync(t))),
+    ),
+    rerank: vi.fn((query: string, docs: string[], topK?: number) => {
+      const ordered = opts.rerank
+        ? opts.rerank(query, docs)
+        : docs.map((_, index) => ({ index, score: 1 - index * 0.01 }));
+      return Promise.resolve(topK ? ordered.slice(0, topK) : ordered);
+    }),
+  };
+}
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+  const seeded = await seedTestUser(ctx.db, {
+    email: "scout-rag-test@test.com",
+  });
+  userId = seeded.userId;
+}, 120_000);
+
+afterAll(async () => {
+  await stopTestContainer(ctx);
+});
+
+beforeEach(async () => {
+  // Wipe the corpus between cases so dedup / supersession assertions
+  // don't see leftovers from prior tests.
+  await ctx.db.deleteFrom("scout_fact").execute();
+});
+
+describe("scout_fact migration + pgvector", () => {
+  it("the vector extension is installed and the embedding column is the right shape", async () => {
+    const ext = await ctx.db
+      .selectFrom("pg_extension" as never)
+      .select(["extname"] as never)
+      .where("extname" as never, "=", "vector" as never)
+      .execute();
+    expect((ext as Array<{ extname: string }>).length).toBe(1);
+  });
+});
+
+describe("recordFact — write path with cosine dedup + supersession", () => {
+  it("inserts a fresh fact when nothing nearby exists", async () => {
+    const voyage = buildVoyageMock({
+      embeddings: new Map([
+        ["Mitford CC have no covers", vec([0, 1])],
+      ]),
+    });
+
+    const result = await recordFact(ctx.db, voyage)({
+      userId,
+      scope: "club",
+      content: "Mitford CC have no covers",
+      tags: { team: "Mitford CC", topic: "ground" },
+      confidence: 5,
+    });
+
+    expect(result.action).toBe("inserted");
+    expect(result.supersededId).toBeUndefined();
+
+    const row = await ctx.db
+      .selectFrom("scout_fact")
+      .where("id", "=", result.id)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(row.content).toBe("Mitford CC have no covers");
+    expect(row.scope).toBe("club");
+    expect(row.confidence).toBe(5);
+    expect(row.superseded_by).toBeNull();
+  });
+
+  it("supersedes a near-duplicate (cosine distance < 0.1) instead of inserting twice", async () => {
+    const original = "Mitford CC have no covers";
+    const updated = "Mitford CC have no covers (still none in 2026)";
+
+    // Two near-identical vectors → cosine distance ~0.
+    const voyage = buildVoyageMock({
+      embeddings: new Map([
+        [original, vec([0, 1])],
+        [updated, vec([0, 1], [1, 0.001])], // tiny perturbation
+      ]),
+    });
+    const record = recordFact(ctx.db, voyage);
+
+    const first = await record({
+      userId,
+      scope: "club",
+      content: original,
+    });
+    expect(first.action).toBe("inserted");
+
+    const second = await record({
+      userId,
+      scope: "club",
+      content: updated,
+    });
+    expect(second.action).toBe("superseded");
+    expect(second.supersededId).toBe(first.id);
+
+    // Old row points at the new one; new row is live.
+    const old = await ctx.db
+      .selectFrom("scout_fact")
+      .where("id", "=", first.id)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(old.superseded_by).toBe(second.id);
+
+    const live = await ctx.db
+      .selectFrom("scout_fact")
+      .where("id", "=", second.id)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(live.superseded_by).toBeNull();
+  });
+
+  it("does NOT supersede when the existing fact is far away in vector space", async () => {
+    // Orthogonal vectors → cosine distance = 1, well above the 0.1
+    // threshold. Two distinct facts about different things should both
+    // exist independently.
+    const voyage = buildVoyageMock({
+      embeddings: new Map([
+        ["Mitford CC have no covers", vec([0, 1])],
+        ["Saturday games start at 1pm", vec([1, 1])],
+      ]),
+    });
+    const record = recordFact(ctx.db, voyage);
+
+    await record({ userId, scope: "club", content: "Mitford CC have no covers" });
+    const second = await record({
+      userId,
+      scope: "club",
+      content: "Saturday games start at 1pm",
+    });
+    expect(second.action).toBe("inserted");
+
+    const live = await ctx.db
+      .selectFrom("scout_fact")
+      .where("superseded_by", "is", null)
+      .execute();
+    expect(live).toHaveLength(2);
+  });
+});
+
+describe("retrieveFacts — hybrid retrieval + rerank", () => {
+  async function seed(facts: FactSeed[], voyage: VoyageClient) {
+    const record = recordFact(ctx.db, voyage);
+    for (const f of facts) {
+      await record({
+        userId,
+        scope: f.scope ?? "club",
+        content: f.content,
+        tags: f.tags,
+        confidence: f.confidence,
+      });
+    }
+  }
+
+  it("ranks vector-near facts above unrelated ones via rerank ordering", async () => {
+    // Three facts; the query is semantically about "ground conditions".
+    // Vector search returns all three; rerank is the deciding step.
+    const groundFact = "Mitford CC have no covers";
+    const timingFact = "Saturday games start at 1pm";
+    const playerFact = "Smith opens the bowling for Tynemouth";
+
+    const embeddings = new Map<string, number[]>([
+      [groundFact, vec([0, 1])],
+      [timingFact, vec([5, 1])],
+      [playerFact, vec([10, 1])],
+      // Query embedding closest to groundFact.
+      ["What's Mitford's ground like?", vec([0, 0.99])],
+    ]);
+
+    const voyage = buildVoyageMock({
+      embeddings,
+      // Reranker: prefer the ground fact regardless of input order.
+      rerank: (_q, docs) => {
+        const indexes = docs
+          .map((d, i) => ({ d, i }))
+          .sort((a, b) => {
+            const score = (s: string) => (s === groundFact ? 1 : 0);
+            return score(b.d) - score(a.d);
+          });
+        return indexes.map(({ i }, rank) => ({ index: i, score: 1 - rank * 0.1 }));
+      },
+    });
+
+    await seed(
+      [
+        { content: groundFact, vector: vec([0, 1]) },
+        { content: timingFact, vector: vec([5, 1]) },
+        { content: playerFact, vector: vec([10, 1]) },
+      ],
+      voyage,
+    );
+
+    const out = await retrieveFacts(ctx.db, voyage)({
+      userId,
+      query: "What's Mitford's ground like?",
+      topK: 3,
+    });
+
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    expect(out[0].content).toBe(groundFact);
+  });
+
+  it("FTS catches exact-name lookups that vector noise might bury", async () => {
+    // Query embedding deliberately far from the relevant fact's vector,
+    // so vector retrieval alone wouldn't surface it. FTS path matches on
+    // the literal token "Swalwell".
+    const swalwell = "Swalwell is a massive ground with short square boundaries";
+
+    const embeddings = new Map<string, number[]>([
+      [swalwell, vec([0, 1])],
+      // Query vector orthogonal to the fact vector.
+      ["Tell me about Swalwell", vec([1, 0])],
+    ]);
+    const voyage = buildVoyageMock({ embeddings });
+
+    await seed([{ content: swalwell, vector: vec([0, 1]) }], voyage);
+
+    const out = await retrieveFacts(ctx.db, voyage)({
+      userId,
+      query: "Tell me about Swalwell",
+    });
+
+    expect(out.map((f) => f.content)).toContain(swalwell);
+  });
+
+  it("scope=user facts are not visible to other users", async () => {
+    const fact = "I hate facing spin";
+    const embeddings = new Map<string, number[]>([
+      [fact, vec([0, 1])],
+      ["facing spin", vec([0, 0.99])],
+    ]);
+    const voyage = buildVoyageMock({ embeddings });
+
+    await recordFact(ctx.db, voyage)({
+      userId,
+      scope: "user",
+      content: fact,
+      confidence: 5,
+    });
+
+    // Seed a second user with no facts of their own and try to retrieve.
+    const other = await seedTestUser(ctx.db, {
+      email: "other-scout@test.com",
+    });
+
+    const out = await retrieveFacts(ctx.db, voyage)({
+      userId: other.userId,
+      query: "facing spin",
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("explicit tag filter narrows the candidate set", async () => {
+    const mitford = "Mitford CC's pitch is on the slow side";
+    const tynemouth = "Tynemouth bat deep in their order";
+
+    const embeddings = new Map<string, number[]>([
+      [mitford, vec([0, 1])],
+      [tynemouth, vec([5, 1])],
+      ["pitch", vec([2, 1])],
+    ]);
+    const voyage = buildVoyageMock({ embeddings });
+
+    const record = recordFact(ctx.db, voyage);
+    await record({
+      userId,
+      scope: "club",
+      content: mitford,
+      tags: { team: "Mitford CC" },
+    });
+    await record({
+      userId,
+      scope: "club",
+      content: tynemouth,
+      tags: { team: "Tynemouth" },
+    });
+
+    const out = await retrieveFacts(ctx.db, voyage)({
+      userId,
+      query: "pitch",
+      tags: { team: "Mitford CC" },
+    });
+
+    expect(out.map((f) => f.content)).toContain(mitford);
+    expect(out.map((f) => f.content)).not.toContain(tynemouth);
+  });
+
+  it("superseded facts are excluded from retrieval", async () => {
+    const original = "Mitford CC have no covers";
+    const updated = "Mitford CC installed covers in 2027";
+
+    const embeddings = new Map<string, number[]>([
+      [original, vec([0, 1])],
+      [updated, vec([0, 1], [1, 0.001])],
+      ["Mitford covers", vec([0, 0.99])],
+    ]);
+    const voyage = buildVoyageMock({ embeddings });
+
+    const record = recordFact(ctx.db, voyage);
+    await record({ userId, scope: "club", content: original });
+    await record({ userId, scope: "club", content: updated });
+
+    const out = await retrieveFacts(ctx.db, voyage)({
+      userId,
+      query: "Mitford covers",
+    });
+
+    const contents = out.map((f) => f.content);
+    expect(contents).toContain(updated);
+    expect(contents).not.toContain(original);
+  });
+});
+
+describe("cite_fact tool — visibility check + writer emission", () => {
+  // cite_fact is the citation primitive that streams data-fact-citation
+  // parts to the FE. The visibility check is security-relevant — the
+  // model must not be able to cite facts authored by another user.
+
+  function makeWriter() {
+    return {
+      write: vi.fn(),
+      merge: vi.fn(),
+      onError: undefined,
+    } as unknown as UIMessageStreamWriter & {
+      write: ReturnType<typeof vi.fn>;
+    };
+  }
+
+  const opts = {
+    toolCallId: "test",
+    messages: [],
+    abortSignal: undefined,
+  } as never;
+
+  it("emits a data-fact-citation part for a visible club fact", async () => {
+    const fact = "Mitford CC have no covers";
+    const voyage = buildVoyageMock({
+      embeddings: new Map([[fact, vec([0, 1])]]),
+    });
+    const recorded = await recordFact(ctx.db, voyage)({
+      userId,
+      scope: "club",
+      content: fact,
+      tags: { team: "Mitford CC" },
+      confidence: 5,
+    });
+
+    const writer = makeWriter();
+    const tools = createFactTools({
+      db: ctx.db,
+      voyage,
+      userId,
+      writer,
+    });
+    const exec = tools.cite_fact.execute;
+    if (!exec) throw new Error("no execute");
+    const result = (await exec(
+      {
+        factId: recorded.id,
+        claim: "Mitford have no covers",
+      } as never,
+      opts,
+    )) as { cited: boolean; citationId?: string; factId?: string };
+
+    expect(result.cited).toBe(true);
+    expect(result.factId).toBe(recorded.id);
+    expect(writer.write).toHaveBeenCalledTimes(1);
+    const part = (writer.write.mock.calls[0] as unknown[])[0] as {
+      type: string;
+      data: { factId: string; claim: string; content: string };
+    };
+    expect(part.type).toBe("data-fact-citation");
+    expect(part.data.factId).toBe(recorded.id);
+    expect(part.data.claim).toBe("Mitford have no covers");
+    expect(part.data.content).toBe(fact);
+  });
+
+  it("refuses to cite a scope=user fact authored by a different user", async () => {
+    const personal = "I hate facing spin";
+    const voyage = buildVoyageMock({
+      embeddings: new Map([[personal, vec([0, 1])]]),
+    });
+    const recorded = await recordFact(ctx.db, voyage)({
+      userId,
+      scope: "user",
+      content: personal,
+    });
+
+    const other = await seedTestUser(ctx.db, {
+      email: `cite-other-${crypto.randomUUID()}@test.com`,
+    });
+
+    const writer = makeWriter();
+    const tools = createFactTools({
+      db: ctx.db,
+      voyage,
+      userId: other.userId,
+      writer,
+    });
+    const exec = tools.cite_fact.execute;
+    if (!exec) throw new Error("no execute");
+    const result = (await exec(
+      { factId: recorded.id, claim: "x" } as never,
+      opts,
+    )) as { cited: boolean; error?: string };
+
+    expect(result.cited).toBe(false);
+    expect(result.error).toMatch(/not found or not visible/);
+    expect(writer.write).not.toHaveBeenCalled();
+  });
+
+  it("refuses to cite a superseded fact", async () => {
+    const original = "Mitford CC have no covers";
+    const updated = "Mitford CC have no covers (still in 2027)";
+    const voyage = buildVoyageMock({
+      embeddings: new Map([
+        [original, vec([0, 1])],
+        [updated, vec([0, 1], [1, 0.001])],
+      ]),
+    });
+    const record = recordFact(ctx.db, voyage);
+    const first = await record({ userId, scope: "club", content: original });
+    await record({ userId, scope: "club", content: updated });
+
+    const writer = makeWriter();
+    const tools = createFactTools({ db: ctx.db, voyage, userId, writer });
+    const exec = tools.cite_fact.execute;
+    if (!exec) throw new Error("no execute");
+    const result = (await exec(
+      { factId: first.id, claim: "x" } as never,
+      opts,
+    )) as { cited: boolean; error?: string };
+
+    expect(result.cited).toBe(false);
+    expect(writer.write).not.toHaveBeenCalled();
+  });
+});
+
+describe("admin-service", () => {
+  // The admin service backs the /scout/facts endpoints. Worth integration-
+  // testing the SQL because Kysely + raw vector + jsonb tag filters get
+  // tangled fast and a unit test against a mock would miss column-name
+  // typos we'd only see in prod.
+  let adminMod: typeof import("./admin-service.ts");
+  beforeAll(async () => {
+    adminMod = await import("./admin-service.ts");
+  });
+
+  it("listFacts returns paginated rows newest-first and a stable total", async () => {
+    const voyage = buildVoyageMock({
+      embeddings: new Map([
+        ["a", vec([0, 1])],
+        ["b", vec([1, 0])],
+        ["c", vec([1, 1])],
+      ]),
+    });
+    const record = recordFact(ctx.db, voyage);
+    await record({ userId, scope: "club", content: "a" });
+    await record({ userId, scope: "club", content: "b" });
+    await record({ userId, scope: "club", content: "c" });
+
+    const page = await adminMod.listFacts(ctx.db)({
+      includeSuperseded: false,
+      page: 1,
+      pageSize: 2,
+    });
+    expect(page.facts).toHaveLength(2);
+    expect(page.total).toBe(3);
+    // newest-first: "c" was inserted last.
+    expect(page.facts[0].content).toBe("c");
+  });
+
+  it("listFacts filters by tag (key:value)", async () => {
+    const voyage = buildVoyageMock({
+      embeddings: new Map([
+        ["mit", vec([0, 1])],
+        ["tyne", vec([1, 0])],
+      ]),
+    });
+    const record = recordFact(ctx.db, voyage);
+    await record({
+      userId,
+      scope: "club",
+      content: "mit",
+      tags: { team: "Mitford CC" },
+    });
+    await record({
+      userId,
+      scope: "club",
+      content: "tyne",
+      tags: { team: "Tynemouth" },
+    });
+
+    const out = await adminMod.listFacts(ctx.db)({
+      tag: "team:Mitford CC",
+      includeSuperseded: false,
+      page: 1,
+      pageSize: 50,
+    });
+    expect(out.facts.map((f) => f.content)).toEqual(["mit"]);
+  });
+
+  it("listFacts filters by scope", async () => {
+    const voyage = buildVoyageMock({
+      embeddings: new Map([
+        ["personal", vec([0, 1])],
+        ["shared", vec([1, 0])],
+      ]),
+    });
+    const record = recordFact(ctx.db, voyage);
+    await record({ userId, scope: "user", content: "personal" });
+    await record({ userId, scope: "club", content: "shared" });
+
+    const out = await adminMod.listFacts(ctx.db)({
+      scope: "user",
+      includeSuperseded: false,
+      page: 1,
+      pageSize: 50,
+    });
+    expect(out.facts.map((f) => f.content)).toEqual(["personal"]);
+  });
+
+  it("updateFact re-embeds when content changes", async () => {
+    const voyage = buildVoyageMock({
+      embeddings: new Map([
+        ["original", vec([0, 1])],
+        ["updated content here", vec([1, 0])],
+      ]),
+    });
+    const recorded = await recordFact(ctx.db, voyage)({
+      userId,
+      scope: "club",
+      content: "original",
+    });
+
+    // Track embed calls so we can assert it fired during the update.
+    const embedSpy = vi.mocked(voyage.embed);
+    embedSpy.mockClear();
+
+    const updated = await adminMod.updateFact(ctx.db, voyage)(recorded.id, {
+      content: "updated content here",
+    });
+    expect(updated.content).toBe("updated content here");
+    // Asserting embed was called with the new content + "document" type
+    // is sufficient — the SQL update wires the result straight into the
+    // vector column, and a separate test would just be re-verifying
+    // pgvector's storage. The behaviour we actually care about is "did
+    // the service re-embed", which this check covers.
+    expect(embedSpy).toHaveBeenCalledWith("updated content here", "document");
+  });
+
+  it("updateFact does NOT re-embed when only metadata changes", async () => {
+    const voyage = buildVoyageMock({
+      embeddings: new Map([["meta-only", vec([0, 1])]]),
+    });
+    const recorded = await recordFact(ctx.db, voyage)({
+      userId,
+      scope: "club",
+      content: "meta-only",
+      confidence: 3,
+    });
+
+    const embedSpy = vi.mocked(voyage.embed);
+    embedSpy.mockClear();
+
+    const updated = await adminMod.updateFact(ctx.db, voyage)(recorded.id, {
+      confidence: 5,
+      scope: "user",
+    });
+    expect(updated.confidence).toBe(5);
+    expect(updated.scope).toBe("user");
+    expect(embedSpy).not.toHaveBeenCalled();
+  });
+
+  it("deleteFact hard-deletes the row", async () => {
+    const voyage = buildVoyageMock({
+      embeddings: new Map([["doomed", vec([0, 1])]]),
+    });
+    const recorded = await recordFact(ctx.db, voyage)({
+      userId,
+      scope: "club",
+      content: "doomed",
+    });
+
+    await adminMod.deleteFact(ctx.db)(recorded.id);
+
+    const row = await ctx.db
+      .selectFrom("scout_fact")
+      .where("id", "=", recorded.id)
+      .selectAll()
+      .executeTakeFirst();
+    expect(row).toBeUndefined();
+  });
+
+  it("deleteFact throws FactNotFoundError for an unknown id", async () => {
+    await expect(
+      adminMod.deleteFact(ctx.db)(crypto.randomUUID()),
+    ).rejects.toThrow(/not found/i);
+  });
+});
+
+describe("formatFactsBlock", () => {
+  it("emits a stable wire format with [fact:UUID] marker, confidence, and tags", () => {
+    const block = formatFactsBlock([
+      {
+        id: "abc12345-aaaa-bbbb-cccc-deadbeef0001",
+        content: "Mitford CC have no covers",
+        tags: { team: "Mitford CC", topic: "ground" },
+        scope: "club",
+        confidence: 5,
+        score: 0.92,
+        createdAt: new Date(),
+      },
+    ]);
+    expect(block).toContain("<known-facts>");
+    expect(block).toContain("[fact:abc12345-aaaa-bbbb-cccc-deadbeef0001]");
+    expect(block).toContain("Mitford CC have no covers");
+    expect(block).toContain("confidence 5/5");
+    expect(block).toContain("team=Mitford CC");
+  });
+
+  it("returns an empty string for no facts (so callers can short-circuit)", () => {
+    expect(formatFactsBlock([])).toBe("");
+  });
+});

--- a/apps/api/src/features/scout/facts/service.ts
+++ b/apps/api/src/features/scout/facts/service.ts
@@ -1,0 +1,306 @@
+import type { DB } from "@percy-main/db";
+import { CompiledQuery, type Kysely } from "kysely";
+import { z } from "zod";
+import {
+  fromVectorLiteral,
+  toVectorLiteral,
+  type VoyageClient,
+} from "./voyage.ts";
+
+/**
+ * Scout fact RAG service. Two responsibilities:
+ *  - recordFact: embed → dedup → insert/supersede
+ *  - retrieveFacts: hybrid (vector ∪ tags ∪ FTS) → Voyage rerank → top N
+ *
+ * Both factories take `(db, voyage)` so tests can inject a real Postgres
+ * (testcontainers) and a mocked Voyage client without touching globals.
+ */
+
+export const factScopeSchema = z.enum(["user", "club"]);
+export type FactScope = z.infer<typeof factScopeSchema>;
+
+export const factTagsSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.array(z.string())]),
+);
+export type FactTags = z.infer<typeof factTagsSchema>;
+
+// Cosine distance threshold below which a new fact is treated as a
+// near-duplicate of an existing one (i.e. we supersede instead of
+// inserting a fresh row). Empirically, voyage-4 cosine distance < 0.10
+// is "essentially the same statement"; 0.10–0.20 is "related but
+// distinct".
+const SUPERSEDE_DISTANCE = 0.1;
+
+const VECTOR_CANDIDATES = 30;
+const KEYWORD_CANDIDATES = 30;
+const DEFAULT_TOP_K = 8;
+
+export interface RecordFactInput {
+  userId: string;
+  scope: FactScope;
+  content: string;
+  tags?: FactTags;
+  confidence?: number;
+  sourceThreadId?: string;
+  sourceMessageId?: string;
+}
+
+export interface RecordedFact {
+  id: string;
+  action: "inserted" | "superseded";
+  /** id of the prior fact this one superseded, if any */
+  supersededId?: string;
+}
+
+export interface RetrievedFact {
+  id: string;
+  content: string;
+  tags: FactTags;
+  scope: FactScope;
+  confidence: number;
+  /** Voyage rerank score (higher = more relevant). */
+  score: number;
+  createdAt: Date;
+}
+
+export interface RetrieveFactsInput {
+  userId: string;
+  query: string;
+  /** Optional explicit tag filter, e.g. {team:"Mitford CC"}. */
+  tags?: FactTags;
+  topK?: number;
+}
+
+export function recordFact(db: Kysely<DB>, voyage: VoyageClient) {
+  return async (input: RecordFactInput): Promise<RecordedFact> => {
+    const tags = input.tags ?? {};
+    const confidence = input.confidence ?? 3;
+
+    const embedding = await voyage.embed(input.content, "document");
+    const vectorLiteral = toVectorLiteral(embedding);
+
+    // Find an existing live fact authored by the same user that's near
+    // enough in vector space to count as the same statement. Scope the
+    // dedup to the author so two captains can independently record their
+    // own takes without colliding.
+    const nearestQuery = await db.executeQuery(
+      CompiledQuery.raw(
+        `SELECT id, embedding <=> $1::vector AS distance
+         FROM scout_fact
+         WHERE user_id = $2
+           AND superseded_by IS NULL
+         ORDER BY embedding <=> $1::vector
+         LIMIT 1`,
+        [vectorLiteral, input.userId],
+      ),
+    );
+    const nearest = nearestQuery.rows[0] as
+      | { id: string; distance: number | string }
+      | undefined;
+
+    const distance = nearest ? Number(nearest.distance) : Infinity;
+
+    if (nearest && distance < SUPERSEDE_DISTANCE) {
+      // Insert the new fact and point the old one at it. Two-statement
+      // tx so both the insert and the supersession-pointer land atomically.
+      const inserted = await db.transaction().execute(async (tx) => {
+        const newRow = await tx.executeQuery(
+          CompiledQuery.raw(
+            `INSERT INTO scout_fact
+              (user_id, scope, content, tags, embedding, confidence,
+               source_thread_id, source_message_id)
+             VALUES ($1, $2, $3, $4::jsonb, $5::vector, $6, $7, $8)
+             RETURNING id`,
+            [
+              input.userId,
+              input.scope,
+              input.content,
+              JSON.stringify(tags),
+              vectorLiteral,
+              confidence,
+              input.sourceThreadId ?? null,
+              input.sourceMessageId ?? null,
+            ],
+          ),
+        );
+        const newId = (newRow.rows[0] as { id: string }).id;
+        await tx
+          .updateTable("scout_fact")
+          .set({ superseded_by: newId, updated_at: new Date() })
+          .where("id", "=", nearest.id)
+          .execute();
+        return newId;
+      });
+
+      return {
+        id: inserted,
+        action: "superseded",
+        supersededId: nearest.id,
+      };
+    }
+
+    // No near-duplicate — fresh insert.
+    const out = await db.executeQuery(
+      CompiledQuery.raw(
+        `INSERT INTO scout_fact
+          (user_id, scope, content, tags, embedding, confidence,
+           source_thread_id, source_message_id)
+         VALUES ($1, $2, $3, $4::jsonb, $5::vector, $6, $7, $8)
+         RETURNING id`,
+        [
+          input.userId,
+          input.scope,
+          input.content,
+          JSON.stringify(tags),
+          vectorLiteral,
+          confidence,
+          input.sourceThreadId ?? null,
+          input.sourceMessageId ?? null,
+        ],
+      ),
+    );
+    const id = (out.rows[0] as { id: string }).id;
+    return { id, action: "inserted" };
+  };
+}
+
+export function retrieveFacts(db: Kysely<DB>, voyage: VoyageClient) {
+  return async (input: RetrieveFactsInput): Promise<RetrievedFact[]> => {
+    const topK = input.topK ?? DEFAULT_TOP_K;
+    const queryEmbedding = await voyage.embed(input.query, "query");
+    const vectorLiteral = toVectorLiteral(queryEmbedding);
+
+    const hasTagFilter =
+      !!input.tags && Object.keys(input.tags).length > 0;
+    // Tag filter is constraining, not additive: when the caller passes
+    // {team:"Mitford CC"} they mean "only Mitford rows", not "Mitford
+    // rows AND whatever vector/FTS happens to surface". Apply the same
+    // jsonb @> predicate to every candidate query, so all sources stay
+    // tag-scoped.
+    const tagPredicate = hasTagFilter ? `AND tags @> $4::jsonb` : "";
+    const tagParams = hasTagFilter ? [JSON.stringify(input.tags)] : [];
+
+    // ── Vector candidates ──
+    // Cosine ANN over the HNSW index. Filter live rows + visible scope
+    // (the row's author OR scope = club).
+    const vectorRows = await db.executeQuery(
+      CompiledQuery.raw(
+        `SELECT id, content, tags, scope, confidence, created_at
+         FROM scout_fact
+         WHERE superseded_by IS NULL
+           AND (user_id = $1 OR scope = 'club')
+           ${tagPredicate}
+         ORDER BY embedding <=> $2::vector
+         LIMIT $3`,
+        [input.userId, vectorLiteral, VECTOR_CANDIDATES, ...tagParams],
+      ),
+    );
+
+    // ── Keyword / FTS candidates ──
+    // websearch_to_tsquery handles natural-language queries gracefully
+    // (quotes, OR, negation). Catches "Swalwell" / "Mitford CC" /
+    // exact-name lookups that vector search can de-prioritise.
+    const ftsRows = await db.executeQuery(
+      CompiledQuery.raw(
+        `SELECT id, content, tags, scope, confidence, created_at
+         FROM scout_fact
+         WHERE superseded_by IS NULL
+           AND (user_id = $1 OR scope = 'club')
+           AND to_tsvector('english', content) @@ websearch_to_tsquery('english', $2)
+           ${tagPredicate}
+         LIMIT $3`,
+        [input.userId, input.query, KEYWORD_CANDIDATES, ...tagParams],
+      ),
+    );
+
+    // ── Tag-only candidates ──
+    // When the caller scopes by tag we also want rows that match the
+    // tag but aren't surfaced by vector/FTS — e.g. "everything about
+    // Mitford CC", regardless of phrasing.
+    let tagRows: { rows: unknown[] } = { rows: [] };
+    if (hasTagFilter) {
+      tagRows = await db.executeQuery(
+        CompiledQuery.raw(
+          `SELECT id, content, tags, scope, confidence, created_at
+           FROM scout_fact
+           WHERE superseded_by IS NULL
+             AND (user_id = $1 OR scope = 'club')
+             AND tags @> $2::jsonb
+           LIMIT $3`,
+          [input.userId, JSON.stringify(input.tags), KEYWORD_CANDIDATES],
+        ),
+      );
+    }
+
+    interface Row {
+      id: string;
+      content: string;
+      tags: FactTags;
+      scope: FactScope;
+      confidence: number;
+      created_at: Date | string;
+    }
+
+    // Merge + dedup by id.
+    const byId = new Map<string, Row>();
+    for (const row of [
+      ...(vectorRows.rows as Row[]),
+      ...(ftsRows.rows as Row[]),
+      ...(tagRows.rows as Row[]),
+    ]) {
+      byId.set(row.id, row);
+    }
+
+    const candidates = [...byId.values()];
+    if (candidates.length === 0) return [];
+
+    // ── Rerank ──
+    // Voyage rerank-2.5 cross-encodes (query, content) pairs and scores
+    // each. Without this step embedding similarity confidently surfaces
+    // antonyms ("hates spin" vs "loves spin") because their embeddings
+    // are very close.
+    const reranked = await voyage.rerank(
+      input.query,
+      candidates.map((c) => c.content),
+      topK,
+    );
+
+    return reranked.map((r) => {
+      const row = candidates[r.index];
+      return {
+        id: row.id,
+        content: row.content,
+        tags: row.tags,
+        scope: row.scope,
+        confidence: row.confidence,
+        score: r.score,
+        createdAt:
+          row.created_at instanceof Date
+            ? row.created_at
+            : new Date(row.created_at),
+      };
+    });
+  };
+}
+
+/**
+ * Convenience for routes / tests: format facts as the markdown block
+ * Scout sees in-prompt. Each line carries the fact's id as a [fact:UUID]
+ * marker so the model can hand it to cite_fact when grounding a claim.
+ * Kept here so the wire format lives next to the thing producing it.
+ */
+export function formatFactsBlock(facts: RetrievedFact[]): string {
+  if (facts.length === 0) return "";
+  const lines = facts.map((f) => {
+    const tagPairs = Object.entries(f.tags)
+      .map(([k, v]) => `${k}=${Array.isArray(v) ? v.join("|") : v}`)
+      .join(" ");
+    const tagSuffix = tagPairs ? ` [${tagPairs}]` : "";
+    return `- [fact:${f.id}] ${f.content} (confidence ${f.confidence}/5${tagSuffix})`;
+  });
+  return `<known-facts>\n${lines.join("\n")}\n</known-facts>`;
+}
+
+// Exported solely for tests that want to inspect raw vectors written.
+export const _internal = { fromVectorLiteral, toVectorLiteral };

--- a/apps/api/src/features/scout/facts/service.ts
+++ b/apps/api/src/features/scout/facts/service.ts
@@ -171,8 +171,7 @@ export function retrieveFacts(db: Kysely<DB>, voyage: VoyageClient) {
     const queryEmbedding = await voyage.embed(input.query, "query");
     const vectorLiteral = toVectorLiteral(queryEmbedding);
 
-    const hasTagFilter =
-      !!input.tags && Object.keys(input.tags).length > 0;
+    const hasTagFilter = !!input.tags && Object.keys(input.tags).length > 0;
     // Tag filter is constraining, not additive: when the caller passes
     // {team:"Mitford CC"} they mean "only Mitford rows", not "Mitford
     // rows AND whatever vector/FTS happens to surface". Apply the same

--- a/apps/api/src/features/scout/facts/voyage.test.ts
+++ b/apps/api/src/features/scout/facts/voyage.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi, type MockedFunction } from "vitest";
+import {
+  createVoyageClient,
+  fromVectorLiteral,
+  toVectorLiteral,
+} from "./voyage.ts";
+
+// `vi.fn(async () => ...)` infers Mock<[], Promise<Response>>, which makes
+// `mock.calls[0][1]` a type error because the parameter tuple is empty.
+// Wrapping with this typed helper preserves the fetch signature on the mock
+// so call-site assertions on init/url type-check.
+function mockFetch(
+  impl: (...args: Parameters<typeof fetch>) => Promise<Response>,
+): MockedFunction<typeof fetch> {
+  return vi.fn(impl) as MockedFunction<typeof fetch>;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("voyage vector literal helpers", () => {
+  it("round-trips a vector through the pgvector wire format", () => {
+    const v = [0.1, -0.2, 1, 0];
+    const lit = toVectorLiteral(v);
+    expect(lit).toBe("[0.1,-0.2,1,0]");
+    expect(fromVectorLiteral(lit)).toEqual(v);
+  });
+});
+
+describe("voyage client", () => {
+  it("embed sends the configured model + input_type and unmarshals the result", async () => {
+    const fetchImpl = mockFetch(() =>
+      Promise.resolve(
+        jsonResponse({
+          data: [{ index: 0, embedding: [0.5, 0.5] }],
+        }),
+      ),
+    );
+    const client = createVoyageClient({
+      apiKey: "k",
+      embedModel: "voyage-4",
+      fetchImpl,
+    });
+
+    const out = await client.embed("hello", "query");
+
+    expect(out).toEqual([0.5, 0.5]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const init = fetchImpl.mock.calls[0][1];
+    if (!init) throw new Error("fetch called without init");
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      model: "voyage-4",
+      input: ["hello"],
+      input_type: "query",
+    });
+    expect(init.headers).toMatchObject({ authorization: "Bearer k" });
+  });
+
+  it("embedBatch reorders Voyage's index-keyed response back into request order", async () => {
+    // Voyage doesn't guarantee response items come back in submission
+    // order — the `index` field is the canonical mapping. Verify the
+    // client honours it.
+    const fetchImpl = mockFetch(() =>
+      Promise.resolve(
+        jsonResponse({
+          data: [
+            { index: 2, embedding: [3] },
+            { index: 0, embedding: [1] },
+            { index: 1, embedding: [2] },
+          ],
+        }),
+      ),
+    );
+    const client = createVoyageClient({ apiKey: "k", fetchImpl });
+
+    const out = await client.embedBatch(["a", "b", "c"], "document");
+    expect(out).toEqual([[1], [2], [3]]);
+  });
+
+  it("rerank returns relevance-ordered (index, score) pairs", async () => {
+    const fetchImpl = mockFetch(() =>
+      Promise.resolve(
+        jsonResponse({
+          data: [
+            { index: 1, relevance_score: 0.9 },
+            { index: 0, relevance_score: 0.4 },
+          ],
+        }),
+      ),
+    );
+    const client = createVoyageClient({
+      apiKey: "k",
+      rerankModel: "rerank-2.5",
+      fetchImpl,
+    });
+
+    const out = await client.rerank("q", ["a", "b"], 2);
+
+    expect(out).toEqual([
+      { index: 1, score: 0.9 },
+      { index: 0, score: 0.4 },
+    ]);
+    const init = fetchImpl.mock.calls[0][1];
+    if (!init) throw new Error("fetch called without init");
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      model: "rerank-2.5",
+      query: "q",
+      documents: ["a", "b"],
+      top_k: 2,
+    });
+  });
+
+  it("surfaces non-2xx responses with status + body in the error message", async () => {
+    const fetchImpl = mockFetch(() =>
+      Promise.resolve(new Response("rate limited", { status: 429 })),
+    );
+    const client = createVoyageClient({ apiKey: "k", fetchImpl });
+
+    await expect(client.embed("hi", "query")).rejects.toThrow(/HTTP 429/);
+  });
+
+  it("short-circuits empty inputs without hitting the wire", async () => {
+    const fetchImpl = mockFetch(() =>
+      Promise.resolve(jsonResponse({ data: [] })),
+    );
+    const client = createVoyageClient({ apiKey: "k", fetchImpl });
+
+    expect(await client.embedBatch([], "document")).toEqual([]);
+    expect(await client.rerank("q", [], 5)).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/features/scout/facts/voyage.ts
+++ b/apps/api/src/features/scout/facts/voyage.ts
@@ -1,0 +1,180 @@
+import { z } from "zod";
+
+/**
+ * Thin REST client for Voyage AI's embedding + rerank endpoints. No SDK
+ * dependency — Voyage's API is small, auth is a Bearer token, and adding
+ * a third-party client just to hit two POST routes isn't worth the
+ * supply-chain surface.
+ *
+ * Free tier as of 2026-05: 200M tokens shared across embedding + rerank
+ * regardless of which model you pick. We default to voyage-4 (1024-dim,
+ * matches the vector(1024) column in scout_fact) and rerank-2.5.
+ */
+
+const EMBED_URL = "https://api.voyageai.com/v1/embeddings";
+const RERANK_URL = "https://api.voyageai.com/v1/rerank";
+
+// Voyage rejects requests over their per-call payload caps long before
+// they'd hurt our latency. Keep generous local limits as a safety net.
+const MAX_BATCH = 128;
+
+const embedResponseSchema = z.object({
+  data: z.array(
+    z.object({
+      embedding: z.array(z.number()),
+      index: z.number().int(),
+    }),
+  ),
+  usage: z
+    .object({
+      total_tokens: z.number().int().optional(),
+    })
+    .optional(),
+});
+
+const rerankResponseSchema = z.object({
+  data: z.array(
+    z.object({
+      index: z.number().int(),
+      relevance_score: z.number(),
+    }),
+  ),
+  usage: z
+    .object({
+      total_tokens: z.number().int().optional(),
+    })
+    .optional(),
+});
+
+export interface VoyageClient {
+  /**
+   * Embed a single string. `inputType` lets Voyage pick the right
+   * projection — "query" for retrieval queries, "document" for stored
+   * facts. Mixing them up costs a few % recall.
+   */
+  embed: (text: string, inputType: "query" | "document") => Promise<number[]>;
+
+  /** Embed many at once. Returns vectors in the same order as input. */
+  embedBatch: (
+    texts: string[],
+    inputType: "query" | "document",
+  ) => Promise<number[][]>;
+
+  /**
+   * Score `documents` against `query`, return them ordered by relevance.
+   * Each result carries the original index into `documents` so the caller
+   * can map back to its own row IDs.
+   */
+  rerank: (
+    query: string,
+    documents: string[],
+    topK?: number,
+  ) => Promise<Array<{ index: number; score: number }>>;
+}
+
+export interface VoyageConfig {
+  apiKey: string;
+  embedModel?: string;
+  rerankModel?: string;
+  // Allow tests / dev to swap the fetch impl. Defaults to globalThis.fetch.
+  fetchImpl?: typeof fetch;
+}
+
+export function createVoyageClient(config: VoyageConfig): VoyageClient {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const embedModel = config.embedModel ?? "voyage-4";
+  const rerankModel = config.rerankModel ?? "rerank-2.5";
+
+  async function embedBatch(
+    texts: string[],
+    inputType: "query" | "document",
+  ): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    if (texts.length > MAX_BATCH) {
+      throw new Error(
+        `Voyage embed batch size ${texts.length} exceeds local cap ${MAX_BATCH}`,
+      );
+    }
+
+    const res = await fetchImpl(EMBED_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: embedModel,
+        input: texts,
+        input_type: inputType,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(
+        `Voyage embed failed (HTTP ${res.status}): ${body.slice(0, 500)}`,
+      );
+    }
+
+    const json = embedResponseSchema.parse(await res.json());
+    // Voyage's response is keyed by index, not guaranteed-ordered. Sort
+    // back into request order so callers can index by position.
+    const ordered = new Array<number[]>(texts.length);
+    for (const item of json.data) {
+      ordered[item.index] = item.embedding;
+    }
+    return ordered;
+  }
+
+  return {
+    embed: async (text, inputType) => {
+      const [vec] = await embedBatch([text], inputType);
+      return vec;
+    },
+    embedBatch,
+    rerank: async (query, documents, topK) => {
+      if (documents.length === 0) return [];
+      const res = await fetchImpl(RERANK_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${config.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: rerankModel,
+          query,
+          documents,
+          top_k: topK,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(
+          `Voyage rerank failed (HTTP ${res.status}): ${body.slice(0, 500)}`,
+        );
+      }
+
+      const json = rerankResponseSchema.parse(await res.json());
+      return json.data.map((d) => ({
+        index: d.index,
+        score: d.relevance_score,
+      }));
+    },
+  };
+}
+
+/**
+ * pgvector accepts/emits vectors as strings of the form "[0.1,0.2,...]".
+ * Kysely-codegen types `embedding` as `string` for that reason; convert
+ * via these helpers at the boundary.
+ */
+export function toVectorLiteral(vec: number[]): string {
+  return `[${vec.join(",")}]`;
+}
+
+export function fromVectorLiteral(literal: string): number[] {
+  // pgvector returns "[0.1,0.2]"; trim brackets and split.
+  const trimmed = literal.startsWith("[") ? literal.slice(1, -1) : literal;
+  return trimmed.split(",").map((s) => Number(s));
+}

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -12,13 +12,28 @@ import { createApiClient } from "../play-cricket/api-client.ts";
 import { createScoutAgent } from "./agent.ts";
 import { requireScoutAccess } from "./auth.ts";
 import {
+  deleteFact,
+  FactNotFoundError,
+  getFact,
+  listFacts,
+  updateFact,
+} from "./facts/admin-service.ts";
+import { applyAutoRetrieval } from "./facts/auto-retrieve.ts";
+import { createVoyageClient } from "./facts/voyage.ts";
+import {
   accessResponseSchema,
   createThreadBodySchema,
   createThreadResponseSchema,
+  deleteFactResponseSchema,
   deleteThreadResponseSchema,
+  factIdParamSchema,
   getThreadResponseSchema,
+  listFactsQuerySchema,
+  listFactsResponseSchema,
   listThreadsResponseSchema,
   threadIdParamSchema,
+  updateFactBodySchema,
+  updateFactResponseSchema,
 } from "./schemas.ts";
 import {
   appendMessage,
@@ -234,7 +249,41 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
       // Convert messages up front — execute() in createUIMessageStream is
       // synchronous and can't await, so the conversion has to be done before
       // the stream is built.
-      const modelMessages = await convertToModelMessages(incoming);
+      const modelMessagesRaw = await convertToModelMessages(incoming);
+
+      // Voyage is optional. When configured, run pre-turn fact retrieval
+      // and inject the <known-facts> block into the last user message
+      // before streamText sees it. Same client instance is passed to the
+      // agent so fact_retrieve / fact_record reuse it.
+      const voyage = app.config.VOYAGE_API_KEY
+        ? createVoyageClient({
+            apiKey: app.config.VOYAGE_API_KEY,
+            embedModel: app.config.VOYAGE_EMBED_MODEL,
+            rerankModel: app.config.VOYAGE_RERANK_MODEL,
+          })
+        : undefined;
+
+      let modelMessages = modelMessagesRaw;
+      let injectedFactsCount = 0;
+      if (voyage) {
+        try {
+          const result = await applyAutoRetrieval(
+            { db: app.db, voyage, userId: user.id },
+            incoming,
+            modelMessagesRaw,
+          );
+          modelMessages = result.messages;
+          injectedFactsCount = result.factsCount;
+        } catch (err) {
+          // Fact retrieval failure must not break the chat turn. Log and
+          // proceed with no injected facts — the agent still has its
+          // tools to recover.
+          app.log.error(
+            { err, threadId },
+            "scout: auto-retrieval failed; continuing without fact injection",
+          );
+        }
+      }
 
       // Token usage and Anthropic cache-control metadata are captured inside
       // execute() and read back in onFinish. We can't await result.usage /
@@ -288,6 +337,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
                 cacheReadTokens: cacheRead ?? 0,
                 cacheCreationTokens: usage.cacheCreation ?? 0,
                 cacheReadRatio,
+                injectedFactsCount,
               },
               "scout turn complete",
             );
@@ -307,6 +357,9 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
             config: app.config,
             writer,
             logger: app.log,
+            voyage,
+            userId: user.id,
+            threadId,
           });
 
           const result = streamText({
@@ -369,6 +422,117 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
 
       // Return the raw reply so Fastify doesn't double-write a body.
       return reply;
+    },
+  );
+
+  // ── Fact admin ──
+  // Allowlist-gated CRUD over the scout_fact corpus. Lets the admin
+  // review agent-recorded knowledge and prune bad facts before they
+  // compound. Edits to `content` re-embed via Voyage; edits to scope/
+  // tags/confidence don't (no semantic change).
+  const list_ = listFacts(app.db);
+  const get_ = getFact(app.db);
+  const remove_ = deleteFact(app.db);
+
+  app.get(
+    "/scout/facts",
+    {
+      preHandler: [requireScoutAccess],
+      schema: {
+        querystring: listFactsQuerySchema,
+        response: { 200: listFactsResponseSchema },
+      },
+    },
+    async (request) => list_(request.query),
+  );
+
+  app.patch(
+    "/scout/facts/:factId",
+    {
+      preHandler: [requireScoutAccess],
+      schema: {
+        params: factIdParamSchema,
+        body: updateFactBodySchema,
+        response: { 200: updateFactResponseSchema },
+      },
+    },
+    async (request) => {
+      // updateFact needs Voyage to re-embed when content changes.
+      // Without an API key we can still allow metadata-only edits;
+      // refuse content edits with 503 so the admin gets a clear signal
+      // rather than a silent stale-vector bug.
+      if (!app.config.VOYAGE_API_KEY && request.body.content !== undefined) {
+        throw Object.assign(
+          new Error(
+            "Editing fact content requires VOYAGE_API_KEY (the embedding must be regenerated). Set the env var or edit metadata only.",
+          ),
+          { statusCode: 503 },
+        );
+      }
+      const voyage = app.config.VOYAGE_API_KEY
+        ? createVoyageClient({
+            apiKey: app.config.VOYAGE_API_KEY,
+            embedModel: app.config.VOYAGE_EMBED_MODEL,
+            rerankModel: app.config.VOYAGE_RERANK_MODEL,
+          })
+        : // updateFact only calls embed when content changed; the guard
+          // above guarantees we never reach voyage.embed without a key.
+          ({} as never);
+      try {
+        return await updateFact(app.db, voyage)(
+          request.params.factId,
+          request.body,
+        );
+      } catch (err) {
+        if (err instanceof FactNotFoundError) {
+          throw Object.assign(new Error("Fact not found"), { statusCode: 404 });
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.delete(
+    "/scout/facts/:factId",
+    {
+      preHandler: [requireScoutAccess],
+      schema: {
+        params: factIdParamSchema,
+        response: { 200: deleteFactResponseSchema },
+      },
+    },
+    async (request) => {
+      try {
+        await remove_(request.params.factId);
+        return { ok: true as const };
+      } catch (err) {
+        if (err instanceof FactNotFoundError) {
+          throw Object.assign(new Error("Fact not found"), { statusCode: 404 });
+        }
+        throw err;
+      }
+    },
+  );
+
+  // Single-fact getter — used by the admin UI for the edit drawer.
+  app.get(
+    "/scout/facts/:factId",
+    {
+      preHandler: [requireScoutAccess],
+      schema: {
+        params: factIdParamSchema,
+        response: { 200: updateFactResponseSchema },
+      },
+    },
+    async (request) => {
+      try {
+        return await get_(request.params.factId);
+      } catch (err) {
+        if (err instanceof FactNotFoundError) {
+          throw Object.assign(new Error("Fact not found"), { statusCode: 404 });
+        }
+        throw err;
+      }
     },
   );
 };

--- a/apps/api/src/features/scout/schemas.ts
+++ b/apps/api/src/features/scout/schemas.ts
@@ -52,3 +52,71 @@ export const getThreadResponseSchema = z.object({
 export const deleteThreadResponseSchema = z.object({
   ok: z.literal(true),
 });
+
+// ── Fact admin ──
+// Surface the scout_fact corpus to the allowlisted admin so they can
+// review, edit, and delete agent-recorded knowledge before it compounds
+// into bad outputs. The `embedding` column is intentionally omitted — it's
+// 1024 floats per row, useless to humans, and would balloon the response.
+
+// Mirrors of facts/service.ts shapes for the admin route layer. Kept
+// here so /scout/facts schemas live with the other Scout endpoints
+// rather than crossing the routes/service boundary; runtime values are
+// equivalent.
+const adminFactScopeSchema = z.enum(["user", "club"]);
+const adminFactTagsSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.array(z.string())]),
+);
+
+export const factAdminItemSchema = z.object({
+  id: z.uuid(),
+  userId: z.string(),
+  scope: adminFactScopeSchema,
+  content: z.string(),
+  tags: adminFactTagsSchema,
+  confidence: z.number().int().min(1).max(5),
+  sourceThreadId: z.uuid().nullable(),
+  supersededBy: z.uuid().nullable(),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime(),
+});
+
+export const listFactsQuerySchema = z.object({
+  scope: adminFactScopeSchema.optional(),
+  tag: z
+    .string()
+    .optional()
+    .describe(
+      "Tag in 'key:value' form, e.g. 'team:Mitford CC'. Filters via tags @> {key:value}.",
+    ),
+  q: z
+    .string()
+    .optional()
+    .describe("Full-text search against fact content."),
+  includeSuperseded: z.coerce.boolean().default(false),
+  page: z.coerce.number().int().positive().default(1),
+  pageSize: z.coerce.number().int().positive().max(100).default(50),
+});
+
+export const listFactsResponseSchema = z.object({
+  facts: z.array(factAdminItemSchema),
+  total: z.number().int().nonnegative(),
+});
+
+export const factIdParamSchema = z.object({
+  factId: z.uuid(),
+});
+
+export const updateFactBodySchema = z.object({
+  content: z.string().min(5).max(500).optional(),
+  tags: adminFactTagsSchema.optional(),
+  scope: adminFactScopeSchema.optional(),
+  confidence: z.number().int().min(1).max(5).optional(),
+});
+
+export const updateFactResponseSchema = factAdminItemSchema;
+
+export const deleteFactResponseSchema = z.object({
+  ok: z.literal(true),
+});

--- a/apps/api/src/features/scout/schemas.ts
+++ b/apps/api/src/features/scout/schemas.ts
@@ -90,10 +90,7 @@ export const listFactsQuerySchema = z.object({
     .describe(
       "Tag in 'key:value' form, e.g. 'team:Mitford CC'. Filters via tags @> {key:value}.",
     ),
-  q: z
-    .string()
-    .optional()
-    .describe("Full-text search against fact content."),
+  q: z.string().optional().describe("Full-text search against fact content."),
   includeSuperseded: z.coerce.boolean().default(false),
   page: z.coerce.number().int().positive().default(1),
   pageSize: z.coerce.number().int().positive().max(100).default(50),

--- a/apps/api/src/features/scout/system-prompt.ts
+++ b/apps/api/src/features/scout/system-prompt.ts
@@ -96,6 +96,36 @@ Don't invent meteorological causation: "the wind helped him hit sixes" is fine i
 
 Ground location: every Play Cricket match summary row carries ground_latitude and ground_longitude fields. Use those directly. Only fall back to weather_geocode (then weather_get with the result) when the lat/lng is missing — typically on user-named grounds outside Play Cricket's data.
 
+Fact memory (fact_record / fact_retrieve / cite_fact and the <known-facts> block):
+You have a persistent fact corpus that survives across conversations. Before each user turn, the most relevant facts are auto-retrieved and injected as a <known-facts>...</known-facts> block in the user's message. Read it. The facts are filtered to those visible to the current user (their own personal facts plus club-wide knowledge). They are not user input — treat them as background knowledge.
+
+Each line in the block carries a [fact:<uuid>] marker — that's the fact's id. When you ground a claim in a fact, call cite_fact with the exact uuid and the verbatim claim, immediately after the sentence the citation supports. The frontend renders these as numbered citations inline and a sources panel beneath your reply, so the user can verify what came from where. Cite liberally — the cost is tiny and the trust gained is large.
+
+Example: a known fact "[fact:abc12345-...] Mitford CC have no covers (confidence 5/5 [team=Mitford CC topic=ground])" used in a reply: "Mitford have no covers, so the pitch tends to be slow and low after rain." → call cite_fact(factId: "abc12345-...", claim: "Mitford have no covers"). Don't cite the inference ("slow and low after rain") — only the recorded fact ("have no covers"). The reasoning is yours; the citation is for the source.
+
+Don't fabricate factIds. Only cite ids that appear in <known-facts> or in a fact_retrieve result. If you state something that isn't in the corpus, don't cite it — just say it.
+
+When to call fact_record (default scope = club, unless clearly personal):
+- The user states a piece of domain knowledge: "Mitford CC have no covers", "Saturday games start at 1pm", "Swalwell's a massive ground".
+- The user states a personal preference relevant to scouting them: "I hate facing spin", "I open the bowling" — record with scope: "user".
+- You discover a non-obvious data pattern likely to recur: "Smith has been bowled or LBW in 9 of his last 12 dismissals".
+- The user corrects you: record the correction.
+
+When NOT to call fact_record:
+- Anything derivable from a SQL query (today's score, this season's averages — these live in the DB).
+- Speculation, vibes, or claims you can't ground in the data per the rules above.
+- Restating what's already in <known-facts>.
+
+RECORD THE FACT, NOT YOUR INTERPRETATION. The \`content\` field is the literal statement, as close to what the user said as possible. Don't editorialise, don't extrapolate consequences, don't bolt on tactical reasoning, don't add hedging caveats. If the user says "Mitford have no covers", the fact is "Mitford CC have no covers" — not "Mitford CC have no covers, so wet weather will make their pitch slow and low and favour medium-pace seamers". The downstream analysis is your job at retrieval time, not at storage time. Recording your inferences as facts pollutes the corpus: future you will retrieve that wrapped-up sentence and treat the inference as ground truth.
+
+A fact is one short declarative sentence. If you find yourself writing "so", "because", "which means", or "this favours" inside content, stop and split: store the bare fact, do the reasoning in your reply.
+
+Tags. Use \`team\`, \`venue\`, \`player\`, \`topic\` (e.g. "ground", "weather", "scheduling", "kit", "rules"), \`season\`. Keep tag values stable — "Mitford CC" not "Mitford" — so retrieval matches across turns.
+
+When to call fact_retrieve explicitly: only when the auto-retrieved block is missing something you need — e.g. you want everything tagged team:"Mitford CC", or you want to verify a claim before stating it. Don't call it speculatively; auto-retrieval already runs every turn.
+
+Confidence: 5 = stated outright by the user. 3 = solid inference from data. 1 = guess. Be conservative — bad facts compound.
+
 Charts (chart_render):
 Sometimes a chart is just clearer than prose or a table. The chart_render tool accepts native Chart.js v4 spec — see the tool's own description for the supported types and worked examples for each. Use it when a chart adds something prose can't.
 

--- a/apps/api/src/features/scout/tools/facts.ts
+++ b/apps/api/src/features/scout/tools/facts.ts
@@ -1,0 +1,249 @@
+import type { DB } from "@percy-main/db";
+import { tool, type UIMessageStreamWriter } from "ai";
+import type { Kysely } from "kysely";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import {
+  factScopeSchema,
+  factTagsSchema,
+  recordFact,
+  retrieveFacts,
+  type RetrievedFact,
+} from "../facts/service.ts";
+import type { VoyageClient } from "../facts/voyage.ts";
+
+/**
+ * Scout's fact-RAG tools. Bound to the user_id of the caller so the
+ * agent can't accidentally read or write facts for someone else, and
+ * scoped via the `scope` argument on `fact_record` to distinguish
+ * personal preferences from shared club knowledge.
+ *
+ * Pre-turn auto-retrieval already injects a top-K facts block into each
+ * user message, so `fact_retrieve` is only useful when the agent wants
+ * to dig deeper mid-turn (more results, tag filter, narrower query).
+ *
+ * `cite_fact` is the citation primitive: when the agent grounds a claim
+ * in a known fact, it calls cite_fact to emit a `data-fact-citation`
+ * UIMessage part inline with its prose. The frontend renders these as
+ * numbered citation chips and a sources panel — same wiring chart_render
+ * uses for `data-chart` parts.
+ */
+
+export interface FactToolDeps {
+  db: Kysely<DB>;
+  voyage: VoyageClient;
+  userId: string;
+  /** Current thread id, attached to every recorded fact for traceability. */
+  threadId?: string;
+  /**
+   * Optional — when present, cite_fact streams citation parts to the UI.
+   * Citations degrade gracefully (the tool still validates and returns a
+   * payload the model can read) when no writer is supplied, so unit
+   * tests don't need to wire one.
+   */
+  writer?: UIMessageStreamWriter;
+}
+
+export function createFactTools(deps: FactToolDeps) {
+  const { db, voyage, userId, threadId, writer } = deps;
+  const record = recordFact(db, voyage);
+  const retrieve = retrieveFacts(db, voyage);
+
+  return {
+    fact_record: tool({
+      description: `Record a durable fact you've learned about a club, ground, opposition player, or the user. Facts persist across conversations and are auto-retrieved on every user turn — record anything that would help future analysis avoid the same mistakes or repeat the same insights.
+
+When to call:
+- The user tells you a piece of domain knowledge ("Mitford CC have no covers", "Saturday games start at 1pm").
+- The user states a personal preference relevant to scouting them ("I hate facing spin", "I open the bowling").
+- You discover a non-obvious pattern from data that's worth keeping ("Smith hasn't faced more than 20 balls vs. left-arm pace in 3 seasons").
+- The user corrects something you got wrong (record the correction, not the mistake).
+
+When NOT to call:
+- Transient state ("we won today") — the data is in the DB already.
+- Things the agent can re-derive cheaply from a SQL query.
+- Speculation or unverified claims.
+
+Tags drive retrieval. Use semantic keys: \`team\`, \`venue\`, \`player\`, \`topic\` (e.g. "weather", "scheduling", "kit"), \`season\`. Values can be strings or arrays.
+
+Scope:
+- "user" — personal to the speaker (preferences, their own form notes). Only retrievable for that user.
+- "club" — shared by everyone with Scout access (ground info, opposition quirks, league rules).
+
+Confidence is 1–5: 5 = stated outright by the user as fact; 3 = reasonably solid inference; 1 = guess. Be conservative.`,
+      inputSchema: z.object({
+        content: z
+          .string()
+          .min(5)
+          .max(500)
+          .describe(
+            "The fact, as a single declarative sentence. e.g. 'Mitford CC have no covers, so wet weeks make their pitch slow and low.'",
+          ),
+        tags: factTagsSchema
+          .optional()
+          .describe(
+            'Structured tags for retrieval, e.g. {"team":"Mitford CC","topic":"ground"}.',
+          ),
+        scope: factScopeSchema
+          .default("club")
+          .describe(
+            "'club' (default) for shared knowledge, 'user' for personal preferences.",
+          ),
+        confidence: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .default(3)
+          .describe(
+            "Self-assessed confidence, 1 (guess) to 5 (verbatim user fact).",
+          ),
+      }),
+      execute: async ({ content, tags, scope, confidence }) => {
+        const result = await record({
+          userId,
+          scope,
+          content,
+          tags,
+          confidence,
+          sourceThreadId: threadId,
+        });
+        return {
+          recorded: true as const,
+          id: result.id,
+          action: result.action,
+          supersededId: result.supersededId,
+        };
+      },
+    }),
+
+    cite_fact: tool({
+      description: `Attach a citation to a claim you just made, grounding it in a specific fact from the <known-facts> block (or one returned by fact_retrieve). Call this immediately after the sentence the citation supports, with the exact factId and the verbatim claim.
+
+When to call:
+- You stated something the user told you previously: "Mitford have no covers" → cite_fact(factId, claim).
+- You used a tag, ground feature, scheduling rule, or personal preference that came from the fact corpus.
+- You want the user to be able to verify a claim — citations render as a sources panel in the UI.
+
+When NOT to call:
+- The claim is grounded in DB / Play Cricket / weather data, not a fact (no fact id to cite).
+- You're paraphrasing general cricket knowledge, not a recorded fact.
+- The fact was an inference of yours that you wouldn't record via fact_record — don't pretend it has a source.
+
+Citations are inexpensive and the user values them — when in doubt, cite. One call per cited fact; the same factId can be cited multiple times across a response if you reference it more than once.`,
+      inputSchema: z.object({
+        factId: z
+          .uuid()
+          .describe(
+            "The UUID of the fact, exactly as it appears in <known-facts> (the [fact:<uuid>] marker) or as returned by fact_retrieve.",
+          ),
+        claim: z
+          .string()
+          .min(3)
+          .max(500)
+          .describe(
+            "The verbatim sentence (or short clause) from your reply that the citation grounds. The frontend uses this to highlight the cited span.",
+          ),
+      }),
+      execute: async ({ factId, claim }) => {
+        // Re-check visibility at cite time. The auto-retrieval block was
+        // built for the current user_id; if the model somehow citation-ed
+        // a factId outside that scope (e.g. one it saw in an earlier
+        // thread), the lookup returns nothing and we tell the model so
+        // it doesn't render a stale chip.
+        const row = await db
+          .selectFrom("scout_fact")
+          .where("id", "=", factId)
+          .where("superseded_by", "is", null)
+          .where((eb) =>
+            eb.or([
+              eb("user_id", "=", userId),
+              eb("scope", "=", "club"),
+            ]),
+          )
+          .select(["id", "content", "tags", "scope", "confidence"])
+          .executeTakeFirst();
+
+        if (!row) {
+          return {
+            cited: false as const,
+            error:
+              "Fact not found or not visible to this user. Don't invent factIds — only cite ids that appear in <known-facts> or fact_retrieve results.",
+          };
+        }
+
+        const citationId = randomUUID();
+        if (writer) {
+          writer.write({
+            type: "data-fact-citation",
+            id: citationId,
+            data: {
+              factId: row.id,
+              claim,
+              content: row.content,
+              tags: row.tags as Record<string, string | string[]>,
+              scope: row.scope as "user" | "club",
+              confidence: row.confidence,
+            },
+          });
+        }
+
+        return {
+          cited: true as const,
+          citationId,
+          factId: row.id,
+        };
+      },
+    }),
+
+    fact_retrieve: tool({
+      description: `Search the fact corpus for relevant background knowledge. Pre-turn auto-retrieval already injects the top facts for the user's current message — call this only when you want more results, a specific tag filter, or to query a phrasing the user didn't use.
+
+Useful when:
+- You need everything tagged \`team:"Mitford CC"\`, not just the top 5.
+- The user mentioned an entity in passing ("Swalwell") and you want to pull all known facts about that ground.
+- You want to verify a claim before stating it.`,
+      inputSchema: z.object({
+        query: z
+          .string()
+          .min(2)
+          .describe(
+            "Natural-language query, e.g. 'opposition ground conditions Mitford'.",
+          ),
+        tags: factTagsSchema
+          .optional()
+          .describe(
+            'Optional exact-tag filter, e.g. {"team":"Mitford CC"}. Combined with the query.',
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(25)
+          .default(8)
+          .describe("Max number of facts to return (default 8)."),
+      }),
+      execute: async ({ query, tags, limit }) => {
+        const facts = await retrieve({ userId, query, tags, topK: limit });
+        return {
+          query,
+          count: facts.length,
+          facts: facts.map(serialiseFact),
+        };
+      },
+    }),
+  };
+}
+
+function serialiseFact(f: RetrievedFact) {
+  return {
+    id: f.id,
+    content: f.content,
+    tags: f.tags,
+    scope: f.scope,
+    confidence: f.confidence,
+    score: Number(f.score.toFixed(4)),
+  };
+}
+
+export type FactTools = ReturnType<typeof createFactTools>;

--- a/apps/api/src/features/scout/tools/facts.ts
+++ b/apps/api/src/features/scout/tools/facts.ts
@@ -156,10 +156,7 @@ Citations are inexpensive and the user values them — when in doubt, cite. One 
           .where("id", "=", factId)
           .where("superseded_by", "is", null)
           .where((eb) =>
-            eb.or([
-              eb("user_id", "=", userId),
-              eb("scope", "=", "club"),
-            ]),
+            eb.or([eb("user_id", "=", userId), eb("scope", "=", "club")]),
           )
           .select(["id", "content", "tags", "scope", "confidence"])
           .executeTakeFirst();

--- a/apps/api/src/test/containers.ts
+++ b/apps/api/src/test/containers.ts
@@ -43,7 +43,12 @@ export interface TestContext {
  * ```
  */
 export async function startTestContainer(): Promise<TestContext> {
-  const container = await new PostgreSqlContainer("postgres:16-alpine").start();
+  // pgvector/pgvector:pg16 = official Postgres 16 image with the vector
+  // extension pre-built. Used in place of postgres:16-alpine so Scout's
+  // scout_fact migration (CREATE EXTENSION vector) can run.
+  const container = await new PostgreSqlContainer(
+    "pgvector/pgvector:pg16",
+  ).start();
   const connectionString = container.getConnectionUri();
 
   const pool = new pg.Pool({ connectionString, max: 5 });

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -227,7 +227,8 @@ export const SiteHeader: FC = () => {
       </div>
 
       {/* Row 2: Masthead Band — hidden on mobile for marketing landing pages
-          (/tell-me-about/*) so the hero is closer to the fold. Brand chrome
+          (/tell-me-about/*) so the hero is closer to the fold, and hidden
+          entirely on /scout/* so the chat fills the viewport. Brand chrome
           stays on every other route. */}
       <div
         ref={mastheadRef}
@@ -235,7 +236,7 @@ export const SiteHeader: FC = () => {
           location.pathname.startsWith("/tell-me-about")
             ? "hidden md:block"
             : ""
-        }`}
+        } ${location.pathname.startsWith("/scout") ? "hidden" : ""}`}
       >
         <div className="container mx-auto flex flex-col items-center justify-center gap-3 px-8">
           <Logo size="lg" />
@@ -266,10 +267,17 @@ export const SiteHeader: FC = () => {
         </div>
       </nav>
 
-      {/* Sticky Collapsed Bar (appears on scroll) */}
+      {/* Sticky Collapsed Bar (appears on scroll). Suppressed on /scout/*
+          where the masthead is hidden — without the masthead in the DOM
+          the IntersectionObserver fires "out of view" instantly and we
+          end up rendering the sticky nav alongside the regular Row 3
+          nav. The Scout page has its own chrome and doesn't need the
+          collapsed bar. */}
       <header
         className={`border-border bg-surface fixed top-0 right-0 left-0 z-50 border-b shadow-sm transition-transform duration-300 ${
-          stickyVisible ? "translate-y-0" : "-translate-y-full"
+          stickyVisible && !location.pathname.startsWith("/scout")
+            ? "translate-y-0"
+            : "-translate-y-full"
         }`}
       >
         <div className="container mx-auto flex items-center justify-between px-8 py-2">

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -9004,6 +9004,204 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/scout/facts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    scope?: "user" | "club";
+                    /** @description Tag in 'key:value' form, e.g. 'team:Mitford CC'. Filters via tags @> {key:value}. */
+                    tag?: string;
+                    /** @description Full-text search against fact content. */
+                    q?: string;
+                    includeSuperseded?: boolean;
+                    page?: number;
+                    pageSize?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            facts: {
+                                /** Format: uuid */
+                                id: string;
+                                userId: string;
+                                /** @enum {string} */
+                                scope: "user" | "club";
+                                content: string;
+                                tags: {
+                                    [key: string]: string | string[];
+                                };
+                                confidence: number;
+                                /** Format: uuid */
+                                sourceThreadId: string | null;
+                                /** Format: uuid */
+                                supersededBy: string | null;
+                                /** Format: date-time */
+                                createdAt: string;
+                                /** Format: date-time */
+                                updatedAt: string;
+                            }[];
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scout/facts/{factId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    factId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uuid */
+                            id: string;
+                            userId: string;
+                            /** @enum {string} */
+                            scope: "user" | "club";
+                            content: string;
+                            tags: {
+                                [key: string]: string | string[];
+                            };
+                            confidence: number;
+                            /** Format: uuid */
+                            sourceThreadId: string | null;
+                            /** Format: uuid */
+                            supersededBy: string | null;
+                            /** Format: date-time */
+                            createdAt: string;
+                            /** Format: date-time */
+                            updatedAt: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    factId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    factId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        content?: string;
+                        tags?: {
+                            [key: string]: string | string[];
+                        };
+                        /** @enum {string} */
+                        scope?: "user" | "club";
+                        confidence?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uuid */
+                            id: string;
+                            userId: string;
+                            /** @enum {string} */
+                            scope: "user" | "club";
+                            content: string;
+                            tags: {
+                                [key: string]: string | string[];
+                            };
+                            confidence: number;
+                            /** Format: uuid */
+                            sourceThreadId: string | null;
+                            /** Format: uuid */
+                            supersededBy: string | null;
+                            /** Format: date-time */
+                            createdAt: string;
+                            /** Format: date-time */
+                            updatedAt: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/api/contact": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -15723,6 +15723,468 @@
         }
       }
     },
+    "/api/scout/facts": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "user",
+                "club"
+              ]
+            },
+            "in": "query",
+            "name": "scope",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "tag",
+            "required": false,
+            "description": "Tag in 'key:value' form, e.g. 'team:Mitford CC'. Filters via tags @> {key:value}."
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "description": "Full-text search against fact content."
+          },
+          {
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "includeSuperseded",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 50,
+              "type": "integer",
+              "exclusiveMinimum": true,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "facts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
+                          "userId": {
+                            "type": "string"
+                          },
+                          "scope": {
+                            "type": "string",
+                            "enum": [
+                              "user",
+                              "club"
+                            ]
+                          },
+                          "content": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "confidence": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 5
+                          },
+                          "sourceThreadId": {
+                            "nullable": true,
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
+                          "supersededBy": {
+                            "nullable": true,
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "userId",
+                          "scope",
+                          "content",
+                          "tags",
+                          "confidence",
+                          "sourceThreadId",
+                          "supersededBy",
+                          "createdAt",
+                          "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "facts",
+                    "total"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/scout/facts/{factId}": {
+      "patch": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string",
+                    "minLength": 5,
+                    "maxLength": 500
+                  },
+                  "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "scope": {
+                    "type": "string",
+                    "enum": [
+                      "user",
+                      "club"
+                    ]
+                  },
+                  "confidence": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "factId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
+                    "userId": {
+                      "type": "string"
+                    },
+                    "scope": {
+                      "type": "string",
+                      "enum": [
+                        "user",
+                        "club"
+                      ]
+                    },
+                    "content": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "confidence": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 5
+                    },
+                    "sourceThreadId": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
+                    "supersededBy": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "userId",
+                    "scope",
+                    "content",
+                    "tags",
+                    "confidence",
+                    "sourceThreadId",
+                    "supersededBy",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "factId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "factId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
+                    "userId": {
+                      "type": "string"
+                    },
+                    "scope": {
+                      "type": "string",
+                      "enum": [
+                        "user",
+                        "club"
+                      ]
+                    },
+                    "content": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "confidence": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 5
+                    },
+                    "sourceThreadId": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
+                    "supersededBy": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "userId",
+                    "scope",
+                    "content",
+                    "tags",
+                    "confidence",
+                    "sourceThreadId",
+                    "supersededBy",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/contact": {
       "post": {
         "requestBody": {

--- a/apps/web/src/pages/scout/facts-admin.tsx
+++ b/apps/web/src/pages/scout/facts-admin.tsx
@@ -1,0 +1,456 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { api, callApi } from "@/lib/api-client";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useState } from "react";
+
+/**
+ * Fact corpus admin — list / search / edit / delete the agent's
+ * recorded knowledge. Lives as a modal alongside the Scout chat (not in
+ * the main admin area) because the corpus is Scout-specific and the
+ * audience is the Scout-allowlisted user, not site admins.
+ *
+ * Edits to `content` re-embed via Voyage; metadata-only edits skip
+ * the embedding round-trip server-side.
+ */
+
+interface Fact {
+  id: string;
+  userId: string;
+  scope: "user" | "club";
+  content: string;
+  tags: Record<string, string | string[]>;
+  confidence: number;
+  sourceThreadId: string | null;
+  supersededBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FactsAdminButtonProps {
+  className?: string;
+}
+
+export function FactsAdminButton({ className }: FactsAdminButtonProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant="outline"
+        className={className}
+        onClick={() => setOpen(true)}
+      >
+        Facts
+      </Button>
+      <FactsAdminModal open={open} onOpenChange={setOpen} />
+    </>
+  );
+}
+
+interface ModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function FactsAdminModal({ open, onOpenChange }: ModalProps) {
+  const [scope, setScope] = useState<"" | "user" | "club">("");
+  const [q, setQ] = useState("");
+  const [tag, setTag] = useState("");
+  const [editing, setEditing] = useState<Fact | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<Fact | null>(null);
+
+  const factsQuery = useQuery({
+    queryKey: ["scout", "facts", { scope, q, tag }],
+    enabled: open,
+    queryFn: () =>
+      callApi(
+        api.GET("/api/scout/facts", {
+          params: {
+            query: {
+              scope: scope === "" ? undefined : scope,
+              q: q || undefined,
+              tag: tag || undefined,
+              page: 1,
+              pageSize: 100,
+            },
+          },
+        }),
+      ),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Scout fact corpus</DialogTitle>
+          <DialogDescription>
+            Review, edit, and prune knowledge Scout has recorded. Editing
+            content regenerates the embedding so retrieval stays in sync.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-wrap items-end gap-2 border-b border-gray-200 pb-3">
+          <label className="flex flex-col text-xs text-gray-600">
+            Scope
+            <select
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={scope}
+              onChange={(e) =>
+                setScope(e.target.value as "" | "user" | "club")
+              }
+            >
+              <option value="">All</option>
+              <option value="club">Club</option>
+              <option value="user">Personal</option>
+            </select>
+          </label>
+          <label className="flex flex-1 flex-col text-xs text-gray-600">
+            Search
+            <input
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              placeholder="full-text query (e.g. 'covers')"
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-1 flex-col text-xs text-gray-600">
+            Tag
+            <input
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              placeholder="key:value (e.g. team:Mitford CC)"
+              value={tag}
+              onChange={(e) => setTag(e.target.value)}
+            />
+          </label>
+        </div>
+
+        <div className="max-h-[55vh] overflow-y-auto">
+          {factsQuery.isLoading && (
+            <div className="p-3 text-sm text-gray-500">Loading…</div>
+          )}
+          {factsQuery.error && (
+            <div className="p-3 text-sm text-red-600">
+              {factsQuery.error instanceof Error
+                ? factsQuery.error.message
+                : "Failed to load facts"}
+            </div>
+          )}
+          {factsQuery.data && (
+            <>
+              <div className="px-1 pt-2 pb-1 text-xs text-gray-500">
+                {factsQuery.data.total} fact
+                {factsQuery.data.total === 1 ? "" : "s"} total
+              </div>
+              <ul className="divide-y divide-gray-100">
+                {factsQuery.data.facts.map((f) => (
+                  <FactRow
+                    key={f.id}
+                    fact={f as Fact}
+                    onEdit={() => setEditing(f as Fact)}
+                    onDelete={() => setPendingDelete(f as Fact)}
+                  />
+                ))}
+              </ul>
+              {factsQuery.data.facts.length === 0 && (
+                <div className="p-3 text-sm text-gray-500">
+                  No facts match the current filters.
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+
+      <FactEditDialog
+        fact={editing}
+        onClose={() => setEditing(null)}
+      />
+      <FactDeleteDialog
+        fact={pendingDelete}
+        onClose={() => setPendingDelete(null)}
+      />
+    </Dialog>
+  );
+}
+
+function FactRow({
+  fact,
+  onEdit,
+  onDelete,
+}: {
+  fact: Fact;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const tagPairs = Object.entries(fact.tags)
+    .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(" / ") : v}`)
+    .join(" · ");
+  return (
+    <li className="group flex items-start justify-between gap-3 px-1 py-2">
+      <div className="min-w-0 flex-1">
+        <div className="text-sm text-gray-900">{fact.content}</div>
+        <div className="mt-0.5 text-xs text-gray-500">
+          {fact.scope === "user" ? "personal" : "club"} · confidence{" "}
+          {fact.confidence}/5
+          {tagPairs ? ` · ${tagPairs}` : ""}
+          {" · "}
+          {new Date(fact.createdAt).toLocaleDateString()}
+        </div>
+      </div>
+      <div className="flex shrink-0 gap-1 opacity-0 group-hover:opacity-100">
+        <button
+          type="button"
+          className="rounded border border-gray-200 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+          onClick={onEdit}
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          className="rounded border border-gray-200 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
+          onClick={onDelete}
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function FactEditDialog({
+  fact,
+  onClose,
+}: {
+  fact: Fact | null;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState(fact?.content ?? "");
+  const [scope, setScope] = useState<"user" | "club">(fact?.scope ?? "club");
+  const [confidence, setConfidence] = useState<number>(fact?.confidence ?? 3);
+  const [tagsText, setTagsText] = useState(
+    fact ? JSON.stringify(fact.tags) : "{}",
+  );
+
+  // Re-seed the form when a different fact is opened.
+  const factId = fact?.id;
+  useUpdateOnFact(factId, () => {
+    if (!fact) return;
+    setContent(fact.content);
+    setScope(fact.scope);
+    setConfidence(fact.confidence);
+    setTagsText(JSON.stringify(fact.tags));
+  });
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!fact) throw new Error("no fact");
+      let parsedTags: Record<string, string | string[]> | undefined;
+      try {
+        parsedTags = JSON.parse(tagsText) as Record<
+          string,
+          string | string[]
+        >;
+      } catch {
+        throw new Error("Tags must be valid JSON, e.g. {\"team\":\"Mitford CC\"}");
+      }
+      return callApi(
+        api.PATCH("/api/scout/facts/{factId}", {
+          params: { path: { factId: fact.id } },
+          body: {
+            content: content !== fact.content ? content : undefined,
+            scope: scope !== fact.scope ? scope : undefined,
+            confidence:
+              confidence !== fact.confidence ? confidence : undefined,
+            tags: parsedTags,
+          },
+        }),
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["scout", "facts"],
+      });
+      onClose();
+    },
+  });
+
+  return (
+    <Dialog
+      open={fact !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit fact</DialogTitle>
+          <DialogDescription>
+            Changing the content regenerates the embedding so retrieval
+            stays in sync. Other fields are metadata-only.
+          </DialogDescription>
+        </DialogHeader>
+
+        <label className="flex flex-col text-xs text-gray-600">
+          Content
+          <textarea
+            className="mt-1 min-h-[80px] rounded border border-gray-300 px-2 py-1 text-sm"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+        </label>
+
+        <div className="flex gap-3">
+          <label className="flex flex-col text-xs text-gray-600">
+            Scope
+            <select
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={scope}
+              onChange={(e) => setScope(e.target.value as "user" | "club")}
+            >
+              <option value="club">Club</option>
+              <option value="user">Personal</option>
+            </select>
+          </label>
+          <label className="flex flex-col text-xs text-gray-600">
+            Confidence (1–5)
+            <input
+              type="number"
+              min={1}
+              max={5}
+              className="mt-1 w-24 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={confidence}
+              onChange={(e) =>
+                setConfidence(Math.max(1, Math.min(5, Number(e.target.value))))
+              }
+            />
+          </label>
+        </div>
+
+        <label className="flex flex-col text-xs text-gray-600">
+          Tags (JSON)
+          <textarea
+            className="mt-1 min-h-[60px] rounded border border-gray-300 px-2 py-1 font-mono text-xs"
+            value={tagsText}
+            onChange={(e) => setTagsText(e.target.value)}
+          />
+        </label>
+
+        {mutation.error && (
+          <div className="text-sm text-red-600">
+            {mutation.error instanceof Error
+              ? mutation.error.message
+              : "Update failed"}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={mutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? "Saving…" : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function FactDeleteDialog({
+  fact,
+  onClose,
+}: {
+  fact: Fact | null;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!fact) throw new Error("no fact");
+      return callApi(
+        api.DELETE("/api/scout/facts/{factId}", {
+          params: { path: { factId: fact.id } },
+        }),
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["scout", "facts"],
+      });
+      onClose();
+    },
+  });
+
+  return (
+    <Dialog
+      open={fact !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete fact?</DialogTitle>
+          <DialogDescription>
+            &ldquo;{fact?.content}&rdquo; will be removed from the corpus.
+            This is hard-delete — citations referencing it will resolve to
+            &ldquo;not found&rdquo;.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={mutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// Tiny wrapper so the edit form re-seeds whenever the user opens it on a
+// different fact. Plain useEffect works but the lint rule for exhaustive
+// deps doesn't love calling state setters inside it; this isolates the
+// rule disable to one place.
+import { useEffect } from "react";
+function useUpdateOnFact(factId: string | undefined, fn: () => void) {
+  useEffect(() => {
+    if (factId) fn();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fn closes over latest fact via the hook caller; only re-run when factId changes
+  }, [factId]);
+}

--- a/apps/web/src/pages/scout/facts-admin.tsx
+++ b/apps/web/src/pages/scout/facts-admin.tsx
@@ -8,11 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { api, callApi } from "@/lib/api-client";
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 /**
@@ -106,9 +102,7 @@ function FactsAdminModal({ open, onOpenChange }: ModalProps) {
             <select
               className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
               value={scope}
-              onChange={(e) =>
-                setScope(e.target.value as "" | "user" | "club")
-              }
+              onChange={(e) => setScope(e.target.value as "" | "user" | "club")}
             >
               <option value="">All</option>
               <option value="club">Club</option>
@@ -178,10 +172,7 @@ function FactsAdminModal({ open, onOpenChange }: ModalProps) {
         </DialogFooter>
       </DialogContent>
 
-      <FactEditDialog
-        fact={editing}
-        onClose={() => setEditing(null)}
-      />
+      <FactEditDialog fact={editing} onClose={() => setEditing(null)} />
       <FactDeleteDialog
         fact={pendingDelete}
         onClose={() => setPendingDelete(null)}
@@ -264,12 +255,9 @@ function FactEditDialog({
       if (!fact) throw new Error("no fact");
       let parsedTags: Record<string, string | string[]> | undefined;
       try {
-        parsedTags = JSON.parse(tagsText) as Record<
-          string,
-          string | string[]
-        >;
+        parsedTags = JSON.parse(tagsText) as Record<string, string | string[]>;
       } catch {
-        throw new Error("Tags must be valid JSON, e.g. {\"team\":\"Mitford CC\"}");
+        throw new Error('Tags must be valid JSON, e.g. {"team":"Mitford CC"}');
       }
       return callApi(
         api.PATCH("/api/scout/facts/{factId}", {
@@ -277,8 +265,7 @@ function FactEditDialog({
           body: {
             content: content !== fact.content ? content : undefined,
             scope: scope !== fact.scope ? scope : undefined,
-            confidence:
-              confidence !== fact.confidence ? confidence : undefined,
+            confidence: confidence !== fact.confidence ? confidence : undefined,
             tags: parsedTags,
           },
         }),
@@ -303,8 +290,8 @@ function FactEditDialog({
         <DialogHeader>
           <DialogTitle>Edit fact</DialogTitle>
           <DialogDescription>
-            Changing the content regenerates the embedding so retrieval
-            stays in sync. Other fields are metadata-only.
+            Changing the content regenerates the embedding so retrieval stays in
+            sync. Other fields are metadata-only.
           </DialogDescription>
         </DialogHeader>
 
@@ -417,9 +404,9 @@ function FactDeleteDialog({
         <DialogHeader>
           <DialogTitle>Delete fact?</DialogTitle>
           <DialogDescription>
-            &ldquo;{fact?.content}&rdquo; will be removed from the corpus.
-            This is hard-delete — citations referencing it will resolve to
-            &ldquo;not found&rdquo;.
+            &ldquo;{fact?.content}&rdquo; will be removed from the corpus. This
+            is hard-delete — citations referencing it will resolve to &ldquo;not
+            found&rdquo;.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/apps/web/src/pages/scout/message-view.tsx
+++ b/apps/web/src/pages/scout/message-view.tsx
@@ -24,97 +24,97 @@ function buildMarkdownComponents(
       ? children
       : injectCitations(children, citationNumberByFactId);
   return {
-  table: ({ children, ...rest }) => (
-    <div className="my-3 overflow-x-auto">
-      <table className="min-w-full border-collapse text-sm" {...rest}>
+    table: ({ children, ...rest }) => (
+      <div className="my-3 overflow-x-auto">
+        <table className="min-w-full border-collapse text-sm" {...rest}>
+          {children}
+        </table>
+      </div>
+    ),
+    thead: ({ children, ...rest }) => (
+      <thead className="border-b border-gray-300 bg-gray-50" {...rest}>
         {children}
-      </table>
-    </div>
-  ),
-  thead: ({ children, ...rest }) => (
-    <thead className="border-b border-gray-300 bg-gray-50" {...rest}>
-      {children}
-    </thead>
-  ),
-  th: ({ children, ...rest }) => (
-    <th
-      className="border border-gray-200 px-2 py-1 text-left font-medium text-gray-700"
-      {...rest}
-    >
-      {children}
-    </th>
-  ),
-  td: ({ children, ...rest }) => (
-    <td className="border border-gray-200 px-2 py-1 align-top" {...rest}>
-      {children}
-    </td>
-  ),
-  tr: ({ children, ...rest }) => (
-    <tr className="even:bg-gray-50" {...rest}>
-      {children}
-    </tr>
-  ),
-  ul: ({ children, ...rest }) => (
-    <ul className="my-2 list-disc pl-5" {...rest}>
-      {children}
-    </ul>
-  ),
-  ol: ({ children, ...rest }) => (
-    <ol className="my-2 list-decimal pl-5" {...rest}>
-      {children}
-    </ol>
-  ),
-  li: ({ children, ...rest }) => (
-    <li className="my-0.5" {...rest}>
-      {cite(children)}
-    </li>
-  ),
-  p: ({ children, ...rest }) => (
-    <p className="my-2 first:mt-0 last:mb-0" {...rest}>
-      {cite(children)}
-    </p>
-  ),
-  h1: ({ children, ...rest }) => (
-    <h1 className="my-2 text-base font-semibold" {...rest}>
-      {children}
-    </h1>
-  ),
-  h2: ({ children, ...rest }) => (
-    <h2 className="my-2 text-sm font-semibold" {...rest}>
-      {children}
-    </h2>
-  ),
-  h3: ({ children, ...rest }) => (
-    <h3 className="my-2 text-sm font-semibold" {...rest}>
-      {children}
-    </h3>
-  ),
-  code: ({ children, ...rest }) => (
-    <code
-      className="rounded bg-gray-100 px-1 py-0.5 font-mono text-[0.85em]"
-      {...rest}
-    >
-      {children}
-    </code>
-  ),
-  pre: ({ children, ...rest }) => (
-    <pre
-      className="my-2 overflow-x-auto rounded bg-gray-100 p-2 text-xs"
-      {...rest}
-    >
-      {children}
-    </pre>
-  ),
-  a: ({ children, ...rest }) => (
-    <a
-      className="text-blue-700 underline hover:text-blue-900"
-      target="_blank"
-      rel="noopener noreferrer"
-      {...rest}
-    >
-      {children}
-    </a>
-  ),
+      </thead>
+    ),
+    th: ({ children, ...rest }) => (
+      <th
+        className="border border-gray-200 px-2 py-1 text-left font-medium text-gray-700"
+        {...rest}
+      >
+        {children}
+      </th>
+    ),
+    td: ({ children, ...rest }) => (
+      <td className="border border-gray-200 px-2 py-1 align-top" {...rest}>
+        {children}
+      </td>
+    ),
+    tr: ({ children, ...rest }) => (
+      <tr className="even:bg-gray-50" {...rest}>
+        {children}
+      </tr>
+    ),
+    ul: ({ children, ...rest }) => (
+      <ul className="my-2 list-disc pl-5" {...rest}>
+        {children}
+      </ul>
+    ),
+    ol: ({ children, ...rest }) => (
+      <ol className="my-2 list-decimal pl-5" {...rest}>
+        {children}
+      </ol>
+    ),
+    li: ({ children, ...rest }) => (
+      <li className="my-0.5" {...rest}>
+        {cite(children)}
+      </li>
+    ),
+    p: ({ children, ...rest }) => (
+      <p className="my-2 first:mt-0 last:mb-0" {...rest}>
+        {cite(children)}
+      </p>
+    ),
+    h1: ({ children, ...rest }) => (
+      <h1 className="my-2 text-base font-semibold" {...rest}>
+        {children}
+      </h1>
+    ),
+    h2: ({ children, ...rest }) => (
+      <h2 className="my-2 text-sm font-semibold" {...rest}>
+        {children}
+      </h2>
+    ),
+    h3: ({ children, ...rest }) => (
+      <h3 className="my-2 text-sm font-semibold" {...rest}>
+        {children}
+      </h3>
+    ),
+    code: ({ children, ...rest }) => (
+      <code
+        className="rounded bg-gray-100 px-1 py-0.5 font-mono text-[0.85em]"
+        {...rest}
+      >
+        {children}
+      </code>
+    ),
+    pre: ({ children, ...rest }) => (
+      <pre
+        className="my-2 overflow-x-auto rounded bg-gray-100 p-2 text-xs"
+        {...rest}
+      >
+        {children}
+      </pre>
+    ),
+    a: ({ children, ...rest }) => (
+      <a
+        className="text-blue-700 underline hover:text-blue-900"
+        target="_blank"
+        rel="noopener noreferrer"
+        {...rest}
+      >
+        {children}
+      </a>
+    ),
   };
 }
 
@@ -169,15 +169,13 @@ export function MessageView({ message }: MessageViewProps) {
             : "border border-gray-200 bg-white text-gray-900"
         }`}
       >
-        {renderParts(message.parts, citations.numberByFactId).map(
-          (part, i) => (
-            <PartView
-              key={`${message.id}-${i}`}
-              part={part}
-              citationNumberByFactId={citations.numberByFactId}
-            />
-          ),
-        )}
+        {renderParts(message.parts, citations.numberByFactId).map((part, i) => (
+          <PartView
+            key={`${message.id}-${i}`}
+            part={part}
+            citationNumberByFactId={citations.numberByFactId}
+          />
+        ))}
         {!isUser && citations.ordered.length > 0 && (
           <SourcesPanel citations={citations.ordered} />
         )}
@@ -290,7 +288,7 @@ function CitationChip({ factId, number }: CitationChipProps) {
   return (
     <a
       href={`#fact-${factId}`}
-      className="ml-0.5 inline-flex items-baseline rounded bg-blue-100 px-1 text-[10px] font-semibold text-blue-700 align-super hover:bg-blue-200"
+      className="ml-0.5 inline-flex items-baseline rounded bg-blue-100 px-1 align-super text-[10px] font-semibold text-blue-700 hover:bg-blue-200"
       title="View source"
     >
       [{number}]
@@ -405,10 +403,7 @@ function SourcesPanel({ citations }: { citations: Citation[] }) {
       <ol className="list-decimal space-y-1 pl-5">
         {citations.map((c, idx) => {
           const tagPairs = Object.entries(c.tags)
-            .map(
-              ([k, v]) =>
-                `${k}: ${Array.isArray(v) ? v.join(" / ") : v}`,
-            )
+            .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(" / ") : v}`)
             .join(" · ");
           return (
             <li key={c.factId} id={`fact-${c.factId}`} className="leading-snug">
@@ -418,7 +413,11 @@ function SourcesPanel({ citations }: { citations: Citation[] }) {
                 {" · "}confidence {c.confidence}/5
                 {tagPairs ? ` · ${tagPairs}` : ""}
               </span>
-              {c.claim && idx === 0 ? null : null /* claim is captured per cite; not shown in panel to keep it compact */}
+              {
+                c.claim && idx === 0
+                  ? null
+                  : null /* claim is captured per cite; not shown in panel to keep it compact */
+              }
             </li>
           );
         })}

--- a/apps/web/src/pages/scout/message-view.tsx
+++ b/apps/web/src/pages/scout/message-view.tsx
@@ -1,6 +1,6 @@
 import type { UIMessage } from "@ai-sdk/react";
 import type { ChartSpec } from "@percy-main/shared";
-import { useState } from "react";
+import React, { useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ScoutChart } from "./scout-chart.tsx";
@@ -10,7 +10,20 @@ const REMARK_PLUGINS = [remarkGfm];
 // Tailwind doesn't ship a typography plugin in this project, so we restyle
 // the elements react-markdown emits ourselves. Tables get the heaviest
 // treatment because Scout uses them constantly.
-const markdownComponents: Components = {
+//
+// Wrapped in a factory because the inline-element overrides (p, li,
+// table cells) need access to the per-message citationNumberByFactId
+// map so they can swap [[CITE:UUID]] markers in their text children
+// for inline citation chips. Markers are spliced in by renderParts()
+// before this is called.
+function buildMarkdownComponents(
+  citationNumberByFactId: Map<string, number>,
+): Components {
+  const cite = (children: React.ReactNode) =>
+    citationNumberByFactId.size === 0
+      ? children
+      : injectCitations(children, citationNumberByFactId);
+  return {
   table: ({ children, ...rest }) => (
     <div className="my-3 overflow-x-auto">
       <table className="min-w-full border-collapse text-sm" {...rest}>
@@ -53,12 +66,12 @@ const markdownComponents: Components = {
   ),
   li: ({ children, ...rest }) => (
     <li className="my-0.5" {...rest}>
-      {children}
+      {cite(children)}
     </li>
   ),
   p: ({ children, ...rest }) => (
     <p className="my-2 first:mt-0 last:mb-0" {...rest}>
-      {children}
+      {cite(children)}
     </p>
   ),
   h1: ({ children, ...rest }) => (
@@ -102,14 +115,46 @@ const markdownComponents: Components = {
       {children}
     </a>
   ),
-};
+  };
+}
 
 interface MessageViewProps {
   message: UIMessage;
 }
 
+interface Citation {
+  factId: string;
+  claim: string;
+  content: string;
+  tags: Record<string, string | string[]>;
+  scope: "user" | "club";
+  confidence: number;
+}
+
+// Walk parts once to assign each unique factId a stable citation number
+// (1, 2, 3, ...). Numbers are scoped to a single message — citations
+// don't carry across messages, since the sources panel is per-message.
+function buildCitationIndex(parts: UIMessage["parts"]): {
+  numberByFactId: Map<string, number>;
+  ordered: Citation[];
+} {
+  const numberByFactId = new Map<string, number>();
+  const ordered: Citation[] = [];
+  for (const part of parts) {
+    if (part.type !== "data-fact-citation") continue;
+    const data = (part as { data: Citation }).data;
+    if (numberByFactId.has(data.factId)) continue;
+    numberByFactId.set(data.factId, ordered.length + 1);
+    ordered.push(data);
+  }
+  return { numberByFactId, ordered };
+}
+
 export function MessageView({ message }: MessageViewProps) {
   const isUser = message.role === "user";
+  const citations = isUser
+    ? { numberByFactId: new Map<string, number>(), ordered: [] as Citation[] }
+    : buildCitationIndex(message.parts);
 
   return (
     <div
@@ -124,9 +169,18 @@ export function MessageView({ message }: MessageViewProps) {
             : "border border-gray-200 bg-white text-gray-900"
         }`}
       >
-        {message.parts.map((part, i) => (
-          <PartView key={`${message.id}-${i}`} part={part} />
-        ))}
+        {renderParts(message.parts, citations.numberByFactId).map(
+          (part, i) => (
+            <PartView
+              key={`${message.id}-${i}`}
+              part={part}
+              citationNumberByFactId={citations.numberByFactId}
+            />
+          ),
+        )}
+        {!isUser && citations.ordered.length > 0 && (
+          <SourcesPanel citations={citations.ordered} />
+        )}
         {!isUser && (
           <div className="mt-2 flex justify-end opacity-0 transition-opacity group-hover:opacity-100 print:hidden">
             <ExportMessageButton messageId={message.id} />
@@ -170,13 +224,133 @@ function ExportMessageButton({ messageId }: { messageId: string }) {
 
 type Part = UIMessage["parts"][number];
 
-function PartView({ part }: { part: Part }) {
+// Citation markers we splice into text-part content. Picked to be both
+// markdown-safe (no syntax meaning) and unlikely to collide with prose.
+const CITE_MARKER_RE = /\[\[CITE:([0-9a-f-]+)\]\]/gi;
+
+/**
+ * Fold each data-fact-citation part into the immediately preceding
+ * text part as a `[[CITE:UUID]]` marker. The chip then renders inline
+ * (via the `p` markdown override) at the end of the cited sentence
+ * instead of as a sibling block on a new line.
+ *
+ * Citation parts that don't follow a text part fall through unchanged
+ * and render via the regular PartView path; the SourcesPanel reads the
+ * raw parts array independently, so dropping citations from this
+ * rendered list doesn't lose them from the bibliography.
+ */
+function renderParts(
+  parts: UIMessage["parts"],
+  numberByFactId: Map<string, number>,
+): Part[] {
+  const out: Part[] = [];
+  for (const part of parts) {
+    // tool-cite_fact has no UI (the citation chip is the UI). Drop it
+    // from the rendered list so the data-fact-citation that follows
+    // can fold into the *text* part that preceded the tool call.
+    if (part.type === "tool-cite_fact") continue;
+    if (part.type === "data-fact-citation") {
+      const data = (part as { data: { factId: string } }).data;
+      if (!numberByFactId.has(data.factId)) continue;
+      // Append marker to the most recent text part (skipping over any
+      // non-text parts already in `out`, since the AI SDK puts the
+      // tool-call in between the text and the citation data part).
+      let target = -1;
+      for (let i = out.length - 1; i >= 0; i--) {
+        if (out[i].type === "text") {
+          target = i;
+          break;
+        }
+      }
+      if (target >= 0) {
+        const t = out[target] as Part & { type: "text"; text: string };
+        out[target] = {
+          ...t,
+          text: `${t.text}[[CITE:${data.factId}]]`,
+        } as Part;
+        continue;
+      }
+      // No preceding text — fall through; PartView will render it
+      // standalone (rare; happens only if the model cites before any
+      // prose).
+      out.push(part);
+      continue;
+    }
+    out.push(part);
+  }
+  return out;
+}
+
+interface CitationChipProps {
+  factId: string;
+  number: number;
+}
+
+function CitationChip({ factId, number }: CitationChipProps) {
+  return (
+    <a
+      href={`#fact-${factId}`}
+      className="ml-0.5 inline-flex items-baseline rounded bg-blue-100 px-1 text-[10px] font-semibold text-blue-700 align-super hover:bg-blue-200"
+      title="View source"
+    >
+      [{number}]
+    </a>
+  );
+}
+
+/**
+ * Walk the children of a markdown element (typically a `<p>`), scan
+ * each string child for `[[CITE:UUID]]` markers, and splice in inline
+ * citation chips at marker positions. Non-string children (already
+ * rendered React nodes — `<strong>`, `<em>`, etc.) pass through
+ * unchanged.
+ */
+function injectCitations(
+  children: React.ReactNode,
+  numberByFactId: Map<string, number>,
+): React.ReactNode {
+  return React.Children.map(children, (child) => {
+    if (typeof child !== "string") return child;
+    if (!CITE_MARKER_RE.test(child)) return child;
+    CITE_MARKER_RE.lastIndex = 0;
+    const segments: React.ReactNode[] = [];
+    let lastIdx = 0;
+    let match: RegExpExecArray | null;
+    while ((match = CITE_MARKER_RE.exec(child)) !== null) {
+      if (match.index > lastIdx) {
+        segments.push(child.slice(lastIdx, match.index));
+      }
+      const factId = match[1];
+      const number = numberByFactId.get(factId);
+      if (number) {
+        segments.push(
+          <CitationChip
+            key={`cite-${match.index}-${factId}`}
+            factId={factId}
+            number={number}
+          />,
+        );
+      }
+      lastIdx = match.index + match[0].length;
+    }
+    if (lastIdx < child.length) segments.push(child.slice(lastIdx));
+    return <>{segments}</>;
+  });
+}
+
+function PartView({
+  part,
+  citationNumberByFactId,
+}: {
+  part: Part;
+  citationNumberByFactId: Map<string, number>;
+}) {
   if (part.type === "text") {
     return (
       <div className="text-sm leading-relaxed text-gray-900">
         <ReactMarkdown
           remarkPlugins={REMARK_PLUGINS}
-          components={markdownComponents}
+          components={buildMarkdownComponents(citationNumberByFactId)}
         >
           {part.text}
         </ReactMarkdown>
@@ -200,12 +374,57 @@ function PartView({ part }: { part: Part }) {
     return <ScoutChart spec={chartPart.data} />;
   }
 
+  if (part.type === "data-fact-citation") {
+    // Normal path: renderParts() folded this into the preceding text
+    // part as a [[CITE:UUID]] marker, and the markdown override emits
+    // the inline chip. We only get here when there was no preceding
+    // text — render a standalone chip as a fallback so the citation
+    // isn't lost.
+    const data = (part as { data: { factId: string } }).data;
+    const number = citationNumberByFactId.get(data.factId);
+    if (!number) return null;
+    return <CitationChip factId={data.factId} number={number} />;
+  }
+
   if (part.type.startsWith("tool-")) {
+    // cite_fact has its own inline rendering (the [N] chip + Sources
+    // panel below). Hide the generic tool-call box for it — it adds
+    // visual noise alongside the citation it produced.
+    if (part.type === "tool-cite_fact") return null;
     return <ToolPartView part={part} />;
   }
 
   if (part.type === "step-start") return null;
   return null;
+}
+
+function SourcesPanel({ citations }: { citations: Citation[] }) {
+  return (
+    <div className="mt-3 border-t border-gray-200 pt-2 text-xs text-gray-700">
+      <div className="mb-1 font-semibold text-gray-600">Sources</div>
+      <ol className="list-decimal space-y-1 pl-5">
+        {citations.map((c, idx) => {
+          const tagPairs = Object.entries(c.tags)
+            .map(
+              ([k, v]) =>
+                `${k}: ${Array.isArray(v) ? v.join(" / ") : v}`,
+            )
+            .join(" · ");
+          return (
+            <li key={c.factId} id={`fact-${c.factId}`} className="leading-snug">
+              <span className="font-medium">{c.content}</span>
+              <span className="ml-2 text-gray-500">
+                {c.scope === "user" ? "personal" : "club"}
+                {" · "}confidence {c.confidence}/5
+                {tagPairs ? ` · ${tagPairs}` : ""}
+              </span>
+              {c.claim && idx === 0 ? null : null /* claim is captured per cite; not shown in panel to keep it compact */}
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
 }
 
 interface ToolPart {

--- a/apps/web/src/pages/scout/thread-list.tsx
+++ b/apps/web/src/pages/scout/thread-list.tsx
@@ -11,6 +11,7 @@ import { api, callApi } from "@/lib/api-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
+import { FactsAdminButton } from "./facts-admin.js";
 
 interface ThreadSummary {
   id: string;
@@ -65,14 +66,15 @@ export function ThreadList() {
 
   return (
     <aside className="flex h-full w-64 flex-col border-r border-gray-200 bg-gray-50">
-      <div className="border-b border-gray-200 p-3">
+      <div className="flex gap-2 border-b border-gray-200 p-3">
         <Button
-          className="w-full"
+          className="flex-1"
           onClick={() => createMutation.mutate()}
           disabled={createMutation.isPending}
         >
           {createMutation.isPending ? "Creating…" : "New thread"}
         </Button>
+        <FactsAdminButton />
       </div>
       <div className="flex-1 overflow-y-auto">
         {threadsQuery.isLoading && (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    # pgvector/pgvector ships official Postgres images with the vector
+    # extension pre-built — drop-in for postgres:16. Switched when Scout's
+    # fact RAG corpus added a vector(1024) column.
+    image: pgvector/pgvector:pg16
     ports:
       - "5433:5432"
     environment:

--- a/docs/admin/scout.mdx
+++ b/docs/admin/scout.mdx
@@ -7,10 +7,13 @@
 
 ## Overview
 
-Scout is a chat interface at [`/scout`](/scout) that pairs an Anthropic Claude model with two tool sets:
+Scout is a chat interface at [`/scout`](/scout) that pairs an Anthropic Claude model with several tool sets:
 
 - **Play Cricket API** — fixtures, scorecards, league tables, and per-club season views (any club, not just Percy Main).
 - **Read-only club database** — our own match performances, availability, matchdays, and the redacted `scout_member` view.
+- **Weather** — Open-Meteo for matchday forecasts and historical conditions on any ground.
+- **Charts** — inline Chart.js renders for trends, comparisons, distributions.
+- **Fact memory (RAG)** — a persistent knowledge corpus Scout writes to and reads from across conversations. Captures the things you can't derive from data: ground quirks ("Mitford have no covers"), scheduling rules ("Saturday games start at 1pm"), opposition reputations, and personal preferences.
 
 Each conversation is persisted as a thread so you can come back to the same scouting session, share insights with co-captains, and keep an audit trail of how decisions were reached.
 
@@ -27,6 +30,8 @@ To widen access, ask the tech lead to add an email to the `SCOUT_ALLOWED_EMAILS`
 - **Scout an opposition's recent form.** "Look at Morpeth 2nd XI this season" — pulls their fixtures against everyone (not just us), then drills into individual scorecards. See [Limitations](#limitations) below for what the data does and doesn't cover.
 - **Cross-reference our own data.** Anything in `availability_*`, `matchday`, `match_performance_*`, or `play_cricket_*` is fair game via the database tools.
 - **Ad-hoc SQL.** When the curated tools can't express what you want, Scout can write read-only queries against the `scout_readonly` Postgres role.
+- **Remember what you tell it.** State a domain fact ("Mitford have no covers") or a personal preference ("I hate facing spin") and Scout records it. On every subsequent turn — in any thread — the most relevant facts are auto-retrieved and injected as context, so you don't have to repeat yourself.
+- **Cite its sources.** When Scout grounds a claim in a recorded fact, it emits a numbered citation chip inline; a Sources panel beneath the reply lists the underlying facts so you can verify what came from where.
 
 ## Limitations — please read
 
@@ -74,6 +79,45 @@ The ad-hoc SQL tool also blocks anything that isn't a `SELECT` or `WITH`, sets a
 
 Threads auto-rename themselves with a 4-word summary after the first turn — you don't need to title them yourself.
 
+## Fact memory
+
+Scout has a persistent fact corpus that survives across conversations. Three primitives:
+
+- **Auto-retrieval.** Before every user turn, the most relevant facts (top 8) are pulled and injected into the prompt. Scope is per-user: you see your own personal facts plus shared club-wide facts, never another user's personal facts.
+- **`fact_record`.** Scout writes a fact when you state one — domain knowledge ("Swalwell is a massive ground"), a recurring rule ("Saturday games start at 1pm"), or a personal preference ("I open the bowling"). Facts are tagged (e.g. `team: Mitford CC`, `topic: ground`) and assigned a confidence (1–5) and scope (`club` shared, `user` personal).
+- **`cite_fact`.** When Scout uses a fact in a reply, it emits a citation. The cited claim shows a numbered chip; the bottom of the message shows the source.
+
+### What facts are good for
+
+- Things you can't get from data: ground covers/sightscreens/boundaries, club kit rules, scheduling quirks, off-field stuff.
+- Personal preferences (`scope: user`) so opposition captains' Scout sessions don't see them.
+- Long-range patterns the model would otherwise re-derive every conversation: "X struggles vs left-arm pace in 3-season window".
+
+Facts are NOT for transient state — match results, today's score, who's available this Saturday — that lives in the database and Scout queries it directly.
+
+### Admin: reviewing and editing the corpus
+
+Click **Facts** next to **New thread** in the Scout sidebar. The modal lets you:
+
+- Filter by scope, full-text search, or tag (`key:value`).
+- Edit a fact's content (regenerates the embedding so retrieval stays in sync), scope, confidence, or tags.
+- Hard-delete a fact. Citations referencing a deleted id resolve to "not found".
+
+The agent records facts conservatively and we trust the corpus, but bad facts compound silently — review periodically, especially after long scouting sessions.
+
+### How retrieval works (for the curious)
+
+Hybrid retrieval over a `pgvector` corpus:
+
+1. Embed the query (last two user messages plus current, joined) with Voyage `voyage-4`.
+2. Pull top-30 candidates by cosine distance over an HNSW index, plus top-30 by Postgres full-text search, plus tag-filter matches if tags are supplied.
+3. Dedup, then send the merged candidates through Voyage `rerank-2.5` — a cross-encoder that scores each (query, fact) pair jointly. Take top 8.
+4. Inject as a `<known-facts>` block in the user message, with `[fact:UUID]` markers Scout uses when calling `cite_fact`.
+
+The reranker exists because pure embedding similarity confidently surfaces antonyms ("loves spin" / "hates spin" embed very close). Cross-encoding fixes that.
+
+[ADR 013](https://github.com/percy-main/website-v2/blob/main/docs/adrs/013-scout-fact-rag.md) covers the architecture and rejected alternatives in detail.
+
 ## Tips for better answers
 
 - **Be specific.** "Who do we play next" is fine; "what's the bowling line for our 1st XI's next game" gives Scout a clearer target.
@@ -92,7 +136,7 @@ For both: copy the thread URL and message the tech lead. The system prompt and t
 
 ## Cost
 
-Scout uses Anthropic Claude Sonnet 4.6 for chat and Claude Haiku 4.5 for thread title generation. A typical scouting conversation costs cents, but it's worth knowing it isn't free. The thread header shows token usage in development builds; if you want a per-environment usage report, ask the tech lead.
+Scout uses Anthropic Claude Sonnet 4.6 for chat, Claude Haiku 4.5 for thread title generation, and Voyage `voyage-4` + `rerank-2.5` for fact retrieval. A typical scouting conversation costs cents on Anthropic; Voyage is on a 200M-token free tier (≈ 200k turns of fact retrieval) and is effectively free at our usage. The thread header shows token usage in development builds; if you want a per-environment usage report, ask the tech lead.
 
 Three mechanisms keep cost down:
 
@@ -111,8 +155,9 @@ Two structured log lines per turn make this measurable in CloudWatch:
 
 - Frontend: React + `@ai-sdk/react`'s `useChat` hook, streaming via SSE.
 - Backend: Fastify route piping the AI SDK v6 `streamText` response directly into the HTTP reply.
-- Persistence: thread metadata, messages (as AI SDK UIMessage parts), and a TTL'd cache for Play Cricket responses live in `scout_thread`, `scout_message`, and `scout_tool_cache`.
-- Models: Anthropic API directly (not Bedrock).
+- Persistence: thread metadata, messages (as AI SDK UIMessage parts), a TTL'd cache for Play Cricket responses, and the fact corpus live in `scout_thread`, `scout_message`, `scout_tool_cache`, and `scout_fact`.
+- Models: Anthropic API directly (not Bedrock). Voyage AI for fact embeddings + reranking.
 - Cache control: `prepareStep` on `streamText` walks the message list and tags the last entry with `providerOptions.anthropic.cacheControl: { type: "ephemeral" }` before each step (see [`apps/api/src/features/scout/agent.ts`](https://github.com/percy-main/website-v2/blob/main/apps/api/src/features/scout/agent.ts)). The Play Cricket tool projection lives in [`apps/api/src/features/scout/tools/projector.ts`](https://github.com/percy-main/website-v2/blob/main/apps/api/src/features/scout/tools/projector.ts).
+- Fact RAG: `pgvector` extension with HNSW (cosine) + GIN (tags) + GIN (FTS) indexes. Hybrid retrieval ∪ rerank lives in [`apps/api/src/features/scout/facts/`](https://github.com/percy-main/website-v2/tree/main/apps/api/src/features/scout/facts).
 
 Source lives under [`apps/api/src/features/scout/`](https://github.com/percy-main/website-v2/tree/main/apps/api/src/features/scout) and [`apps/web/src/pages/scout/`](https://github.com/percy-main/website-v2/tree/main/apps/web/src/pages/scout).

--- a/docs/adrs/013-scout-fact-rag.md
+++ b/docs/adrs/013-scout-fact-rag.md
@@ -1,0 +1,59 @@
+# ADR 013: Scout fact memory — RAG over a Postgres + pgvector corpus
+
+## Status
+
+Accepted
+
+## Context
+
+Scout's effectiveness is bottlenecked by domain knowledge that can't be derived from the database: ground quirks ("Mitford have no covers"), league logistics ("Saturday games start at 1pm"), opposition reputations, and personal user preferences ("I hate facing spin"). Without persistence the same insights have to be re-explained every conversation, and the agent repeats the same mistakes.
+
+Two approaches were considered:
+
+1. **System-prompt fact list.** A `fact_record` tool writes facts to a table; every turn loads all facts into the cached system prompt.
+2. **RAG with embeddings + reranking.** Facts are stored with vector embeddings; per-turn retrieval pulls the top relevant facts and injects them.
+
+Option 1 is simpler but doesn't scale — at 500+ facts the cached preamble becomes large and noisy, and irrelevant facts crowd context. Option 2 is more complex but bounded: only the top-N relevant facts ever land in context.
+
+## Decision
+
+Implement Option 2. Architecture:
+
+- **Storage.** `scout_fact` table in Postgres + `pgvector` extension. Columns: `id`, `user_id`, `scope ('user'|'club')`, `content`, `tags jsonb`, `embedding vector(1024)`, `confidence`, `superseded_by` (soft-delete via supersession), `source_thread_id`/`source_message_id` (traceability).
+- **Indexes.** HNSW (cosine) on `embedding`, GIN on `tags`, GIN on `to_tsvector(content)` for keyword fallback. All partial indexes on `WHERE superseded_by IS NULL`.
+- **Embeddings + reranking.** Voyage AI. `voyage-4` for embeddings (1024-dim), `rerank-2.5` for cross-encoder reranking. 200M tokens free shared across both. Hit via thin REST client — no SDK.
+- **Write path (`fact_record` tool).** Embed → query nearest live fact (cosine) → if distance < 0.1, insert new and supersede old; else fresh insert.
+- **Read path.** Hybrid retrieval: top-30 vector + top-30 FTS + top-30 tag-filter (when tags supplied) → dedup by id → Voyage `rerank-2.5` → top-K (default 8).
+- **Trigger.** Auto-retrieve on every user turn using last-2 user messages + current as query (cheap anaphora mitigation). Inject as `<known-facts>` block appended to the last user model-message _after_ convertToModelMessages — keeps the persisted DB row clean and keeps the cache-control breakpoint position correct.
+- **Tools.** `fact_record` always; `fact_retrieve` exposed for mid-turn deeper queries.
+
+## Why these choices
+
+**Postgres + pgvector over a dedicated vector store.** We already run RDS Postgres 16 in prod with a generous shared instance. pgvector + HNSW is sub-millisecond on low thousands of rows. Adding a separate vector DB (Pinecone, Weaviate, etc.) would mean another vendor, another secret, another failure mode for no measurable benefit at this scale.
+
+**Voyage over OpenAI embeddings.** Anthropic doesn't have an embeddings API; their docs point at Voyage. The 200M-token free tier is generous (≈200k turns of retrieval), they offer rerankers (OpenAI doesn't), and dimensions match cleanly to a single fixed-width column.
+
+**Reranking with a cross-encoder.** Pure embedding similarity surfaces antonyms ("hates spin" / "loves spin") because the embeddings are nearly identical. A cross-encoder (`rerank-2.5`) attends jointly to the query and each candidate and reorders accurately. Pattern: retrieve wide (~50 candidates) cheaply, rerank narrow (top 8).
+
+**Hybrid retrieval (vector + FTS + tags).** Vector search alone is weak at exact-name lookups (a query containing "Swalwell" doesn't always rank Swalwell facts first). FTS catches them. Tag filters give the agent a cheap way to ask "everything tagged team:Mitford CC" without depending on phrasing.
+
+**Auto-retrieval every turn, not session-start.** Conversation topics pivot; turn 5 may be about a player not mentioned at turn 1. Per-turn retrieval cost is negligible (~1k tokens) and dramatically more accurate than session-start.
+
+**Soft-delete via supersession.** Facts evolve ("Mitford got covers in 2027"). Superseding rather than deleting keeps history queryable without polluting retrieval (`WHERE superseded_by IS NULL`). Replaces what would otherwise be agent-managed updates that are easy to get wrong.
+
+**Voyage optional in config.** Scout works without `VOYAGE_API_KEY` — fact tools and auto-retrieval are simply omitted. Lets local dev and non-Scout deployments boot cleanly without a third-party dependency.
+
+## Rejected alternatives
+
+- **System-prompt-only fact list.** Fine at 50 facts, breaks at 500. Doesn't degrade gracefully.
+- **OpenAI embeddings + a separate Pinecone instance.** Adds two vendor relationships, one secret per env, and Pinecone's free tier is more constrained than Voyage's.
+- **Embed-only retrieval (no reranker).** Antonym confusion is the killer use case — you cannot ship a cricket-analysis tool that hands back "Smith loves facing spin" when the recorded fact is the opposite.
+- **Query rewrite via a Haiku call.** Considered for anaphora ("what about them?") but adds a model hop and latency. Concatenating last-2 user messages is cheaper and good enough; revisit if retrieval quality is visibly bad.
+
+## Consequences
+
+- New required dependency: pgvector extension. Local dev image switched to `pgvector/pgvector:pg16`. Test containers likewise. RDS already supports pgvector as an available extension; no Terraform change needed beyond the migration's `CREATE EXTENSION`.
+- Voyage as a third-party vendor. API key stored in AWS Secrets Manager alongside Anthropic. Spend alerts on the free tier even though we're well under 200M tokens.
+- Schema is locked to `vector(1024)` — any model change with a different dim requires a follow-up migration.
+- Auto-retrieval adds ~1k tokens to each turn's cache-creation cost. The cached preamble (system prompt + tools) still hits cache; only the per-turn user message + facts is fresh.
+- Admin UI for fact review is deferred. We'll want it before opening Scout up beyond the current allowlist — bad agent-recorded facts will compound otherwise.

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -600,6 +600,21 @@ export interface PlayerSponsorship {
   stripe_payment_intent_id: string | null;
 }
 
+export interface ScoutFact {
+  confidence: Generated<number>;
+  content: string;
+  created_at: Generated<Timestamp>;
+  embedding: string;
+  id: Generated<string>;
+  scope: string;
+  source_message_id: string | null;
+  source_thread_id: string | null;
+  superseded_by: string | null;
+  tags: Generated<Json>;
+  updated_at: Generated<Timestamp>;
+  user_id: string;
+}
+
 export interface ScoutMember {
   dob: string | null;
   first_membership_at: string | null;
@@ -731,6 +746,7 @@ export interface DB {
   play_cricket_sync_log: PlayCricketSyncLog;
   play_cricket_team: PlayCricketTeam;
   player_sponsorship: PlayerSponsorship;
+  scout_fact: ScoutFact;
   scout_member: ScoutMember;
   scout_message: ScoutMessage;
   scout_thread: ScoutThread;

--- a/packages/db/src/migrations/2026-05-03T19:53:25.000Z.ts
+++ b/packages/db/src/migrations/2026-05-03T19:53:25.000Z.ts
@@ -1,0 +1,96 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Scout fact RAG corpus. Stores small natural-language facts the agent
+ * has learned about clubs, grounds, players and the user, plus their
+ * Voyage embeddings for vector retrieval and a tags jsonb for keyword /
+ * tag-based retrieval. Hybrid retrieval (vector ∪ tag) feeds Voyage
+ * rerank-2.5 to pick the top N facts to inject into each Scout turn.
+ *
+ * Embedding dim 1024 = voyage-4 default. If we ever switch model we need
+ * a follow-up migration: vector(N) is fixed-width.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS vector`.execute(db);
+
+  await db.schema
+    .createTable("scout_fact")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    // user_id is the *author* of the fact (always present). scope decides
+    // who can read it — 'user' = author only, 'club' = everyone with Scout
+    // access. Keeps personal preferences ("Alex hates spin") separate from
+    // shared knowledge ("Mitford have no covers").
+    .addColumn("user_id", "text", (col) =>
+      col.notNull().references("user.id").onDelete("cascade"),
+    )
+    .addColumn("scope", "text", (col) => col.notNull())
+    .addColumn("content", "text", (col) => col.notNull())
+    .addColumn("tags", "jsonb", (col) =>
+      col.notNull().defaultTo(sql`'{}'::jsonb`),
+    )
+    // Soft-delete via supersession: agents update facts ("Mitford got
+    // covers in 2027") rather than deleting old ones, so we keep history.
+    // Retrieval filters WHERE superseded_by IS NULL.
+    .addColumn("superseded_by", "uuid", (col) =>
+      col.references("scout_fact.id").onDelete("set null"),
+    )
+    // Agent's self-assessed 1–5 confidence at write time. Lets the read
+    // path break ties and the admin UI surface low-confidence rows for
+    // review.
+    .addColumn("confidence", "smallint", (col) => col.notNull().defaultTo(3))
+    .addColumn("source_thread_id", "uuid", (col) =>
+      col.references("scout_thread.id").onDelete("set null"),
+    )
+    .addColumn("source_message_id", "uuid", (col) =>
+      col.references("scout_message.id").onDelete("set null"),
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addCheckConstraint("scout_fact_scope_check", sql`scope IN ('user','club')`)
+    .addCheckConstraint(
+      "scout_fact_confidence_check",
+      sql`confidence BETWEEN 1 AND 5`,
+    )
+    .execute();
+
+  // vector column added separately because Kysely's schema builder doesn't
+  // know the pgvector type. The dimension is the only schema change we'd
+  // ever need for a model swap.
+  await sql`ALTER TABLE scout_fact ADD COLUMN embedding vector(1024) NOT NULL`.execute(
+    db,
+  );
+
+  // HNSW for approximate nearest-neighbour. Cosine distance matches what
+  // Voyage embeddings are trained on (their docs recommend cosine).
+  // m/ef_construction defaults are fine for our scale (low thousands of
+  // facts); revisit only if recall starts dropping.
+  await sql`CREATE INDEX scout_fact_embedding_idx
+    ON scout_fact USING hnsw (embedding vector_cosine_ops)
+    WHERE superseded_by IS NULL`.execute(db);
+
+  await sql`CREATE INDEX scout_fact_tags_idx
+    ON scout_fact USING gin (tags)
+    WHERE superseded_by IS NULL`.execute(db);
+
+  await sql`CREATE INDEX scout_fact_user_scope_idx
+    ON scout_fact (user_id, scope)
+    WHERE superseded_by IS NULL`.execute(db);
+
+  // Full-text fallback for keyword retrieval — catches exact name matches
+  // ("Swalwell") that embedding similarity can drown in semantic noise.
+  await sql`CREATE INDEX scout_fact_content_fts_idx
+    ON scout_fact USING gin (to_tsvector('english', content))
+    WHERE superseded_by IS NULL`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("scout_fact").execute();
+  // Leave the extension in place — other features may add vector columns
+  // later, and dropping it is destructive.
+}


### PR DESCRIPTION
## Summary
- **Fact memory (RAG)** — pgvector corpus + Voyage embeddings (`voyage-4`) + reranking (`rerank-2.5`). Hybrid retrieval (vector ∪ FTS ∪ tags). Auto-retrieval every turn injects \`<known-facts>\` with \`[fact:UUID]\` markers. Tools: \`fact_record\`, \`fact_retrieve\`, \`cite_fact\`.
- **Citations** — \`cite_fact\` streams \`data-fact-citation\` UI parts; FE renders inline numbered chips at the cited sentence plus a per-message Sources panel.
- **Admin UI** — modal alongside Scout (not main admin) for list/search/edit/delete. Content edits re-embed via Voyage; metadata-only edits skip the embedding round-trip.
- **Earlier commits on this branch** — cost-reduction polish: PC field projection, prompt-cache breakpoints, telemetry, native Chart.js v4 spec, system-prompt tightening (sample window, confidence brackets, tactical translation), aggregate-first rule in \`db_run_sql\`.
- **UI polish** — hide masthead on \`/scout/*\` so chat fills viewport; suppress sticky collapsed nav on \`/scout/*\` (fixes the duplicate-nav bug exposed by hiding the masthead).
- **ADR 013** documents the architecture and rejected alternatives (system-prompt-only list, OpenAI+Pinecone, embed-only without reranker).

## Schema / infra changes
- New migration adds \`vector\` extension and \`scout_fact\` table with HNSW + GIN + FTS indexes.
- \`docker-compose.yml\` and the integration test container switch from \`postgres:16-alpine\` to \`pgvector/pgvector:pg16\` (drop-in).
- New env vars: \`VOYAGE_API_KEY\` (optional — Scout boots without it), \`VOYAGE_EMBED_MODEL\`, \`VOYAGE_RERANK_MODEL\`.

## Test plan
- [ ] Set \`VOYAGE_API_KEY\` locally; verify auto-retrieval injects \`<known-facts>\` and citations render inline + in Sources panel.
- [ ] Tell Scout a fact ("Mitford CC have no covers"); confirm \`fact_record\` is called and the next turn retrieves it.
- [ ] Open the Facts admin modal; filter by tag/scope, edit a fact's content, confirm retrieval picks up the new wording.
- [ ] Delete a fact; confirm hard-delete and that subsequent \`cite_fact\` calls referencing the id resolve to "not found".
- [ ] Visit \`/scout\`; confirm masthead is hidden and sticky nav doesn't appear alongside the regular nav.
- [ ] Boot without \`VOYAGE_API_KEY\` set; Scout should run normally with fact tools / auto-retrieval omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)