### PR TITLE
Scout: forbid DB-vetting before fact_record; ban false 'stored' claims

### DIFF
--- a/apps/api/src/features/scout/agent.ts
+++ b/apps/api/src/features/scout/agent.ts
@@ -78,6 +78,9 @@ export function createScoutAgent(deps: ScoutAgentDeps): ScoutAgent {
         // Same writer the chart tool uses — cite_fact emits
         // data-fact-citation parts inline with assistant prose.
         writer: deps.writer,
+        // Used to log raw Voyage error bodies server-side without
+        // surfacing them to the model.
+        logger: deps.logger,
       })
     : {};
 

--- a/apps/api/src/features/scout/facts/voyage.test.ts
+++ b/apps/api/src/features/scout/facts/voyage.test.ts
@@ -3,6 +3,7 @@ import {
   createVoyageClient,
   fromVectorLiteral,
   toVectorLiteral,
+  VoyageError,
 } from "./voyage.ts";
 
 // `vi.fn(async () => ...)` infers Mock<[], Promise<Response>>, which makes
@@ -116,13 +117,32 @@ describe("voyage client", () => {
     });
   });
 
-  it("surfaces non-2xx responses with status + body in the error message", async () => {
+  it("throws a sanitised VoyageError on non-2xx; raw provider body stays on .detail (not in .message)", async () => {
+    // Voyage's 429 body includes billing copy + dashboard URLs we must
+    // not surface to the model or user. The exposed Error.message is a
+    // short vendor-neutral phrase; the raw body is preserved on .detail
+    // for server-side logs only.
+    const billingCopy =
+      '{"detail":"You have not yet added your payment method ... https://dashboard.voyageai.com/"}';
     const fetchImpl = mockFetch(() =>
-      Promise.resolve(new Response("rate limited", { status: 429 })),
+      Promise.resolve(new Response(billingCopy, { status: 429 })),
     );
     const client = createVoyageClient({ apiKey: "k", fetchImpl });
 
-    await expect(client.embed("hi", "query")).rejects.toThrow(/HTTP 429/);
+    let caught: unknown;
+    try {
+      await client.embed("hi", "query");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(VoyageError);
+    const e = caught as VoyageError;
+    expect(e.status).toBe(429);
+    expect(e.endpoint).toBe("embed");
+    expect(e.message).not.toContain("dashboard.voyageai.com");
+    expect(e.message).not.toContain("payment method");
+    expect(e.message).toMatch(/rate-limited/i);
+    expect(e.detail).toContain("dashboard.voyageai.com");
   });
 
   it("short-circuits empty inputs without hitting the wire", async () => {

--- a/apps/api/src/features/scout/facts/voyage.ts
+++ b/apps/api/src/features/scout/facts/voyage.ts
@@ -14,6 +14,51 @@ import { z } from "zod";
 const EMBED_URL = "https://api.voyageai.com/v1/embeddings";
 const RERANK_URL = "https://api.voyageai.com/v1/rerank";
 
+/**
+ * Error thrown for non-2xx Voyage responses. The exposed `message` is
+ * deliberately terse — it gets surfaced as a tool result to Scout and
+ * potentially to the user — so we keep billing copy, dashboard URLs,
+ * and other vendor-specific guidance out of it. The raw response body
+ * is preserved on `.detail` for server-side logs only.
+ */
+export class VoyageError extends Error {
+  readonly status: number;
+  readonly endpoint: "embed" | "rerank";
+  readonly detail: string;
+
+  constructor(opts: {
+    status: number;
+    endpoint: "embed" | "rerank";
+    detail: string;
+  }) {
+    super(buildSanitisedMessage(opts.status, opts.endpoint));
+    this.name = "VoyageError";
+    this.status = opts.status;
+    this.endpoint = opts.endpoint;
+    this.detail = opts.detail;
+  }
+}
+
+function buildSanitisedMessage(
+  status: number,
+  endpoint: "embed" | "rerank",
+): string {
+  // Map common HTTP statuses to short, vendor-neutral phrasing. Anything
+  // unmapped falls back to a generic "service unavailable" so we never
+  // surface raw provider responses (billing URLs, internal hints, etc.)
+  // through the tool result chain.
+  if (status === 429) {
+    return `Fact memory ${endpoint} is rate-limited right now. Try again in a moment.`;
+  }
+  if (status === 401 || status === 403) {
+    return `Fact memory ${endpoint} is misconfigured (auth rejected). Ask the tech lead to check the Voyage API key.`;
+  }
+  if (status >= 500) {
+    return `Fact memory ${endpoint} provider is having an issue (HTTP ${status}). Try again shortly.`;
+  }
+  return `Fact memory ${endpoint} failed (HTTP ${status}).`;
+}
+
 // Voyage rejects requests over their per-call payload caps long before
 // they'd hurt our latency. Keep generous local limits as a safety net.
 const MAX_BATCH = 128;
@@ -111,9 +156,11 @@ export function createVoyageClient(config: VoyageConfig): VoyageClient {
 
     if (!res.ok) {
       const body = await res.text();
-      throw new Error(
-        `Voyage embed failed (HTTP ${res.status}): ${body.slice(0, 500)}`,
-      );
+      throw new VoyageError({
+        status: res.status,
+        endpoint: "embed",
+        detail: body.slice(0, 500),
+      });
     }
 
     const json = embedResponseSchema.parse(await res.json());
@@ -150,9 +197,11 @@ export function createVoyageClient(config: VoyageConfig): VoyageClient {
 
       if (!res.ok) {
         const body = await res.text();
-        throw new Error(
-          `Voyage rerank failed (HTTP ${res.status}): ${body.slice(0, 500)}`,
-        );
+        throw new VoyageError({
+          status: res.status,
+          endpoint: "rerank",
+          detail: body.slice(0, 500),
+        });
       }
 
       const json = rerankResponseSchema.parse(await res.json());

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -277,7 +277,9 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
         } catch (err) {
           // Fact retrieval failure must not break the chat turn. Log and
           // proceed with no injected facts — the agent still has its
-          // tools to recover.
+          // tools to recover. Voyage errors carry structured detail
+          // (status, endpoint, raw body) on the error itself; pino picks
+          // them up automatically from the err field.
           app.log.error(
             { err, threadId },
             "scout: auto-retrieval failed; continuing without fact injection",

--- a/apps/api/src/features/scout/system-prompt.ts
+++ b/apps/api/src/features/scout/system-prompt.ts
@@ -105,16 +105,25 @@ Example: a known fact "[fact:abc12345-...] Mitford CC have no covers (confidence
 
 Don't fabricate factIds. Only cite ids that appear in <known-facts> or in a fact_retrieve result. If you state something that isn't in the corpus, don't cite it — just say it.
 
-When to call fact_record (default scope = club, unless clearly personal):
-- The user states a piece of domain knowledge: "Mitford CC have no covers", "Saturday games start at 1pm", "Swalwell's a massive ground".
-- The user states a personal preference relevant to scouting them: "I hate facing spin", "I open the bowling" — record with scope: "user".
-- You discover a non-obvious data pattern likely to recur: "Smith has been bowled or LBW in 9 of his last 12 dismissals".
-- The user corrects you: record the correction.
+RECORDING FACTS — read this carefully, it's the single most-misbehaved area.
+
+When the user is telling you something to remember, fact_record is the FIRST and ONLY tool you call. Do NOT run db_list_tables, db_run_sql, db_describe_table, or pc_* tools to "verify" the subject exists, look up player ids, or cross-check the DB. The user has authority over the fact — your job is to write it down, not to vet it. Vetting via the DB before storing is wasted tokens and a delay; the "DB-first" rule above is for answering questions, not for recording facts.
+
+Triggers (any of these → call fact_record, then a short reply, no DB lookups):
+- "remember that X", "note that X", "save this: X", "for future reference: X".
+- The user lists facts about people, grounds, opposition, or scheduling: "Oli Robson — medium/slow, gets movement", "Mitford have no covers", "Saturday games start at 1pm".
+- A personal preference relevant to scouting: "I hate facing spin", "I open the bowling" → scope: "user".
+- The user corrects something you got wrong → record the correction.
+- You discover a non-obvious data-derived pattern likely to recur ("Smith has been bowled or LBW in 9 of his last 12 dismissals") — this is the only case where DB lookup precedes fact_record, because the lookup IS the source of the fact.
+
+If the user lists multiple facts in one turn, call fact_record once per fact. Don't batch them into one sentence.
+
+NEVER claim you've recorded a fact unless fact_record was actually called this turn and returned recorded:true. "Got it — saved", "Stored", "Logged", "I'll remember that" without a successful fact_record call is a lie to the user. If fact_record returned an error, say so plainly.
 
 When NOT to call fact_record:
-- Anything derivable from a SQL query (today's score, this season's averages — these live in the DB).
-- Speculation, vibes, or claims you can't ground in the data per the rules above.
-- Restating what's already in <known-facts>.
+- The user is asking a question (DB / Play Cricket / weather lookups).
+- Restating what's already in <known-facts> for this turn.
+- Speculation, vibes, or claims you can't ground.
 
 RECORD THE FACT, NOT YOUR INTERPRETATION. The \`content\` field is the literal statement, as close to what the user said as possible. Don't editorialise, don't extrapolate consequences, don't bolt on tactical reasoning, don't add hedging caveats. If the user says "Mitford have no covers", the fact is "Mitford CC have no covers" — not "Mitford CC have no covers, so wet weather will make their pitch slow and low and favour medium-pace seamers". The downstream analysis is your job at retrieval time, not at storage time. Recording your inferences as facts pollutes the corpus: future you will retrieve that wrapped-up sentence and treat the inference as ground truth.
 

--- a/apps/api/src/features/scout/tools/facts.ts
+++ b/apps/api/src/features/scout/tools/facts.ts
@@ -51,24 +51,28 @@ export function createFactTools(deps: FactToolDeps) {
 
   return {
     fact_record: tool({
-      description: `Record a durable fact you've learned about a club, ground, opposition player, or the user. Facts persist across conversations and are auto-retrieved on every user turn — record anything that would help future analysis avoid the same mistakes or repeat the same insights.
+      description: `Record a durable fact about a club, ground, player, or the user. Facts persist across conversations and are auto-retrieved on every user turn.
+
+CRITICAL — when the user states a fact for you to remember, fact_record is the FIRST and ONLY tool you call. Do not run db_list_tables, db_run_sql, db_describe_table, or pc_* tools to verify the subject exists, look up player ids, or cross-check the DB before writing the fact. The user has authority over the fact; your job is to write it down. After fact_record returns recorded:true, reply briefly to confirm — never claim storage before the call succeeds, and never claim it succeeded if it returned an error.
 
 When to call:
-- The user tells you a piece of domain knowledge ("Mitford CC have no covers", "Saturday games start at 1pm").
-- The user states a personal preference relevant to scouting them ("I hate facing spin", "I open the bowling").
-- You discover a non-obvious pattern from data that's worth keeping ("Smith hasn't faced more than 20 balls vs. left-arm pace in 3 seasons").
-- The user corrects something you got wrong (record the correction, not the mistake).
+- The user tells you a piece of domain knowledge: "Mitford CC have no covers", "Saturday games start at 1pm", "Oli Robson — medium/slow, gets movement".
+- A personal preference relevant to scouting the speaker: "I hate facing spin", "I open the bowling" → scope: "user".
+- The user corrects something you got wrong (record the correction).
+- You discover a non-obvious pattern from data worth keeping ("Smith bowled/LBW in 9 of his last 12 dismissals") — this is the only case where DB lookup may precede fact_record.
+
+If the user lists multiple facts in one turn, call fact_record once per fact — don't batch.
 
 When NOT to call:
 - Transient state ("we won today") — the data is in the DB already.
-- Things the agent can re-derive cheaply from a SQL query.
-- Speculation or unverified claims.
+- Restating what's already in <known-facts> for this turn.
+- Speculation, vibes, or claims you can't ground.
 
-Tags drive retrieval. Use semantic keys: \`team\`, \`venue\`, \`player\`, \`topic\` (e.g. "weather", "scheduling", "kit"), \`season\`. Values can be strings or arrays.
+Tags drive retrieval. Use semantic keys: \`team\`, \`venue\`, \`player\`, \`topic\` (e.g. "weather", "scheduling", "kit", "bowling-style", "batting-style"), \`season\`. Values can be strings or arrays. Keep tag values stable — "Oli Robson" not "Oli", "Mitford CC" not "Mitford" — so retrieval matches across turns.
 
 Scope:
 - "user" — personal to the speaker (preferences, their own form notes). Only retrievable for that user.
-- "club" — shared by everyone with Scout access (ground info, opposition quirks, league rules).
+- "club" — shared by everyone with Scout access (ground info, opposition quirks, league rules, our players' bowling/batting profiles).
 
 Confidence is 1–5: 5 = stated outright by the user as fact; 3 = reasonably solid inference; 1 = guess. Be conservative.`,
       inputSchema: z.object({

--- a/apps/api/src/features/scout/tools/facts.ts
+++ b/apps/api/src/features/scout/tools/facts.ts
@@ -1,5 +1,6 @@
 import type { DB } from "@percy-main/db";
 import { tool, type UIMessageStreamWriter } from "ai";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
@@ -10,7 +11,37 @@ import {
   retrieveFacts,
   type RetrievedFact,
 } from "../facts/service.ts";
-import type { VoyageClient } from "../facts/voyage.ts";
+import { VoyageError, type VoyageClient } from "../facts/voyage.ts";
+
+/**
+ * Wrap a fact-tool execute body so VoyageErrors degrade into a sanitised
+ * tool result instead of bubbling up. The raw provider response (which
+ * contains billing copy, dashboard URLs, account hints) is logged for
+ * the operator but never reaches the model or the user.
+ */
+async function withVoyageGuard<T>(
+  logger: FastifyBaseLogger | undefined,
+  toolName: string,
+  fn: () => Promise<T>,
+): Promise<T | { recorded: false; error: string }> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof VoyageError) {
+      logger?.error(
+        {
+          tool: toolName,
+          status: err.status,
+          endpoint: err.endpoint,
+          detail: err.detail,
+        },
+        "scout fact tool: voyage call failed",
+      );
+      return { recorded: false as const, error: err.message };
+    }
+    throw err;
+  }
+}
 
 /**
  * Scout's fact-RAG tools. Bound to the user_id of the caller so the
@@ -42,10 +73,16 @@ export interface FactToolDeps {
    * tests don't need to wire one.
    */
   writer?: UIMessageStreamWriter;
+  /**
+   * Optional — used to log raw Voyage error bodies server-side. Tool
+   * results stay sanitised regardless; this just controls whether the
+   * raw `detail` lands in pino for operator triage.
+   */
+  logger?: FastifyBaseLogger;
 }
 
 export function createFactTools(deps: FactToolDeps) {
-  const { db, voyage, userId, threadId, writer } = deps;
+  const { db, voyage, userId, threadId, writer, logger } = deps;
   const record = recordFact(db, voyage);
   const retrieve = retrieveFacts(db, voyage);
 
@@ -103,22 +140,23 @@ Confidence is 1–5: 5 = stated outright by the user as fact; 3 = reasonably sol
             "Self-assessed confidence, 1 (guess) to 5 (verbatim user fact).",
           ),
       }),
-      execute: async ({ content, tags, scope, confidence }) => {
-        const result = await record({
-          userId,
-          scope,
-          content,
-          tags,
-          confidence,
-          sourceThreadId: threadId,
-        });
-        return {
-          recorded: true as const,
-          id: result.id,
-          action: result.action,
-          supersededId: result.supersededId,
-        };
-      },
+      execute: ({ content, tags, scope, confidence }) =>
+        withVoyageGuard(logger, "fact_record", async () => {
+          const result = await record({
+            userId,
+            scope,
+            content,
+            tags,
+            confidence,
+            sourceThreadId: threadId,
+          });
+          return {
+            recorded: true as const,
+            id: result.id,
+            action: result.action,
+            supersededId: result.supersededId,
+          };
+        }),
     }),
 
     cite_fact: tool({
@@ -224,14 +262,15 @@ Useful when:
           .default(8)
           .describe("Max number of facts to return (default 8)."),
       }),
-      execute: async ({ query, tags, limit }) => {
-        const facts = await retrieve({ userId, query, tags, topK: limit });
-        return {
-          query,
-          count: facts.length,
-          facts: facts.map(serialiseFact),
-        };
-      },
+      execute: ({ query, tags, limit }) =>
+        withVoyageGuard(logger, "fact_retrieve", async () => {
+          const facts = await retrieve({ userId, query, tags, topK: limit });
+          return {
+            query,
+            count: facts.length,
+            facts: facts.map(serialiseFact),
+          };
+        }),
     }),
   };
 }

--- a/apps/web/src/pages/scout/facts-admin.tsx
+++ b/apps/web/src/pages/scout/facts-admin.tsx
@@ -43,6 +43,7 @@ export function FactsAdminButton({ className }: FactsAdminButtonProps) {
   return (
     <>
       <Button
+        size="sm"
         variant="outline"
         className={className}
         onClick={() => setOpen(true)}

--- a/apps/web/src/pages/scout/scout.tsx
+++ b/apps/web/src/pages/scout/scout.tsx
@@ -134,8 +134,8 @@ function ChatView({ threadId, loaded }: ChatViewProps) {
 
   return (
     <>
-      <header className="flex items-center justify-between border-b border-gray-200 px-4 py-2">
-        <h2 className="truncate text-sm font-medium text-gray-700">
+      <header className="flex h-12 shrink-0 items-center justify-between border-b border-gray-200 px-4">
+        <h2 className="my-0 truncate text-sm font-medium text-gray-700">
           {loaded.thread.title}
         </h2>
         <span className="text-xs text-gray-400">

--- a/apps/web/src/pages/scout/thread-list.tsx
+++ b/apps/web/src/pages/scout/thread-list.tsx
@@ -66,8 +66,13 @@ export function ThreadList() {
 
   return (
     <aside className="flex h-full w-64 flex-col border-r border-gray-200 bg-gray-50">
-      <div className="flex gap-2 border-b border-gray-200 p-3">
+      {/* h-12 matches ChatView's header (also h-12). Same fixed height
+          on both sides keeps the border-bottom divider continuous across
+          the sidebar/main split, regardless of the natural size of the
+          contents on either side. */}
+      <div className="flex h-12 shrink-0 items-center gap-2 border-b border-gray-200 px-3">
         <Button
+          size="sm"
           className="flex-1"
           onClick={() => createMutation.mutate()}
           disabled={createMutation.isPending}


### PR DESCRIPTION
## Summary
Prod conversation showed Scout failing on a multi-fact recall ask. User said:

> Oli Robson - medium/slow pace. Gets lots of movement.
> Akakhel Mashal - medium/fast. Big inswing. Gets lots of wickets bowled.
> James Dance - Quickest of our bowlers...

Scout's response: \`db_list_tables\` → 3× \`db_run_sql\` to "confirm" the players exist, then replied "Saving all three facts" / "All confirmed. Here's what I've stored" — without ever calling \`fact_record\`. Hallucinated success.

Two bugs:
1. **Wrong tool order.** The "DB-first" rule for answering questions was bleeding into fact-recording. The model was vetting the subject of every fact against the local DB before storing.
2. **False success claim.** The model said "stored" / "saved" without the tool ever firing.

## Fix
Both the system prompt's fact section AND the \`fact_record\` tool description now make it explicit:
- When the user states a fact, \`fact_record\` is the FIRST and ONLY tool — no \`db_*\`/\`pc_*\` lookups to vet the subject.
- Multiple facts in one turn → one \`fact_record\` call per fact (no batching).
- Never claim \`recorded:true\` unless the tool actually returned it. Phrases like "saved", "stored", "logged", "I'll remember that" are forbidden without a successful call this turn.

The DB-first rule still applies to answering questions; only fact-recording is exempted.

## Test plan
- [ ] Tell Scout three facts about players in one message; confirm three \`fact_record\` calls and zero \`db_*\` calls before them.
- [ ] Tell Scout a fact about a non-existent player ("Steve Bloggs is left-arm seam"); confirm Scout records it without trying to look him up.
- [ ] Make \`fact_record\` fail (temporarily break the API key); confirm Scout reports the failure plainly instead of claiming success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)