### PR TITLE
Scout: cite_match / cite_player_stats + card-style Sources panel

### DIFF
--- a/apps/api/src/features/scout/agent.ts
+++ b/apps/api/src/features/scout/agent.ts
@@ -16,6 +16,7 @@ import { createScoutCache } from "./tools/cache.ts";
 import { createChartTool } from "./tools/chart.ts";
 import { createDbTools } from "./tools/db.ts";
 import { createFactTools } from "./tools/facts.ts";
+import { createPlayCricketCitationTools } from "./tools/play-cricket-citations.ts";
 import { createPlayCricketTools } from "./tools/play-cricket.ts";
 import { createWeatherTools } from "./tools/weather.ts";
 
@@ -66,6 +67,12 @@ export function createScoutAgent(deps: ScoutAgentDeps): ScoutAgent {
   const dbTools = createDbTools({ dbReadonly: deps.dbReadonly });
   const weatherTools = createWeatherTools({ cache });
   const chartTools = createChartTool({ writer: deps.writer });
+  // Match / player-stats citation tools — companions to cite_fact. They
+  // don't need the DB or any external client, only the writer to stream
+  // data-*-citation parts to the FE alongside the assistant's prose.
+  const playCricketCitationTools = createPlayCricketCitationTools({
+    writer: deps.writer,
+  });
   // Fact tools only register when Voyage is configured. Auto-retrieval in
   // the route also short-circuits in that case, so a deployment without
   // VOYAGE_API_KEY behaves as if the RAG layer doesn't exist.
@@ -109,6 +116,7 @@ When asked about the "next" or "upcoming" match, filter match_date strictly GREA
       ...weatherTools,
       ...chartTools,
       ...factTools,
+      ...playCricketCitationTools,
     },
     maxSteps: deps.config.SCOUT_MAX_STEPS,
     prepareStep: ({ messages }) => ({

--- a/apps/api/src/features/scout/system-prompt.ts
+++ b/apps/api/src/features/scout/system-prompt.ts
@@ -96,10 +96,19 @@ Don't invent meteorological causation: "the wind helped him hit sixes" is fine i
 
 Ground location: every Play Cricket match summary row carries ground_latitude and ground_longitude fields. Use those directly. Only fall back to weather_geocode (then weather_get with the result) when the lat/lng is missing — typically on user-named grounds outside Play Cricket's data.
 
-Fact memory (fact_record / fact_retrieve / cite_fact and the <known-facts> block):
+Citations (cite_fact / cite_match / cite_player_stats):
+Three citation tools all share the same wiring — call them immediately after the sentence the citation supports, with the verbatim claim. The frontend renders an inline numbered chip and a card in the Sources panel beneath the reply. Cite generously; the cost is small and the trust gained is large. Each tool grounds a different kind of source:
+
+- cite_fact(factId, claim) — when the claim is grounded in a recorded fact from the <known-facts> block (or from fact_retrieve). Use the [fact:<uuid>] marker.
+- cite_match(matchId, claim, ...) — when the claim is grounded in a SPECIFIC Play Cricket match (toss, scorecard line, fall of wickets, the match result itself). matchId comes from pc_match_summary / pc_match_detail / pc_site_results / pc_find_opposition_matches, or from the local DB mirror. Pass the few display-only fields you have (matchDate, homeTeam, awayTeam, groundName, competition, result) — they show on the source card. The card links to /website/results/<matchId> on percymain.play-cricket.com.
+- cite_player_stats(playerId, statType, claim, ...) — when the claim is grounded in aggregate player stats across many matches: averages, totals, season stats. statType ∈ {batting, bowling, fielding} and MUST match the claim (averages → batting, wickets → bowling, catches → fielding). Pass season / teamId / gameType when known so the linked stats page is filtered narrowly. The card links to /player_stats/<statType>/<playerId>?... on percymain.play-cricket.com.
+
+Picking the right tool: a claim about ONE match → cite_match. A claim aggregated across MANY matches (averages, season totals, recent form) → cite_player_stats. A claim grounded in a recorded fact → cite_fact. A claim grounded in DB data that isn't a Play Cricket match or player aggregate (weather, our internal availability) → don't cite. Don't fabricate ids; only cite ids you got from a tool result, the <known-facts> block, or the local DB.
+
+Fact memory (fact_record / fact_retrieve / <known-facts>):
 A persistent fact corpus survives across conversations. Before each user turn the most relevant facts are auto-retrieved and injected as <known-facts>...</known-facts> in the user's message — treat that block as background knowledge, not user input. Visibility is per-user: the speaker's personal facts plus shared club facts.
 
-Each line carries a [fact:<uuid>] marker. When a claim is grounded in a recorded fact, call cite_fact(factId, claim) right after the sentence — the frontend renders inline citations + a sources panel. Cite the recorded fact, not your inference: for "Mitford have no covers, so the pitch is slow and low after rain", cite "Mitford have no covers", not the slow-and-low inference. Don't fabricate factIds.
+Each line carries a [fact:<uuid>] marker. Cite the recorded fact, not your inference: for "Mitford have no covers, so the pitch is slow and low after rain", cite "Mitford have no covers", not the slow-and-low inference. Don't fabricate factIds.
 
 When to call fact_record:
 - The user states a fact ("Mitford have no covers", "Saturday games start at 1pm", "Oli Robson — medium/slow, gets movement"). Default scope: "club".

--- a/apps/api/src/features/scout/tools/play-cricket-citations.test.ts
+++ b/apps/api/src/features/scout/tools/play-cricket-citations.test.ts
@@ -1,0 +1,163 @@
+import type { UIMessageStreamWriter } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { createPlayCricketCitationTools } from "./play-cricket-citations.ts";
+
+const opts = {
+  toolCallId: "test",
+  messages: [],
+  abortSignal: undefined,
+} as never;
+
+function makeWriter() {
+  return {
+    write: vi.fn(),
+    merge: vi.fn(),
+    onError: undefined,
+  } as unknown as UIMessageStreamWriter & { write: ReturnType<typeof vi.fn> };
+}
+
+describe("cite_match — Play Cricket match citation", () => {
+  it("emits a data-match-citation part with the supplied display fields", async () => {
+    const writer = makeWriter();
+    const { cite_match } = createPlayCricketCitationTools({ writer });
+    const exec = cite_match.execute;
+    if (!exec) throw new Error("no execute");
+
+    const result = (await exec(
+      {
+        matchId: "7262912",
+        claim: "We beat Backworth by 47 runs.",
+        matchDate: "26/04/2025",
+        homeTeam: "Percy Main CC, 1st XI",
+        awayTeam: "Backworth Hall CC, 1st XI",
+        groundName: "Preston Avenue",
+        competition: "NTCL Premier Division",
+        result: "Percy Main won by 47 runs",
+      } as never,
+      opts,
+    )) as { cited: boolean; matchId: string; citationId: string };
+
+    expect(result.cited).toBe(true);
+    expect(result.matchId).toBe("7262912");
+    expect(typeof result.citationId).toBe("string");
+
+    expect(writer.write).toHaveBeenCalledTimes(1);
+    const part = (writer.write.mock.calls[0] as unknown[])[0] as {
+      type: string;
+      id: string;
+      data: {
+        matchId: string;
+        claim: string;
+        matchDate?: string;
+        homeTeam?: string;
+        awayTeam?: string;
+        groundName?: string;
+        competition?: string;
+        result?: string;
+      };
+    };
+    expect(part.type).toBe("data-match-citation");
+    expect(part.id).toBe(result.citationId);
+    expect(part.data).toMatchObject({
+      matchId: "7262912",
+      claim: "We beat Backworth by 47 runs.",
+      matchDate: "26/04/2025",
+      homeTeam: "Percy Main CC, 1st XI",
+      awayTeam: "Backworth Hall CC, 1st XI",
+      result: "Percy Main won by 47 runs",
+    });
+  });
+
+  it("works with only required fields (matchId + claim) — display fields are optional", async () => {
+    const writer = makeWriter();
+    const { cite_match } = createPlayCricketCitationTools({ writer });
+    const exec = cite_match.execute;
+    if (!exec) throw new Error("no execute");
+
+    const result = (await exec(
+      { matchId: "1234", claim: "Match cited" } as never,
+      opts,
+    )) as { cited: boolean };
+
+    expect(result.cited).toBe(true);
+    expect(writer.write).toHaveBeenCalledTimes(1);
+    const part = (writer.write.mock.calls[0] as unknown[])[0] as {
+      data: { matchId: string };
+    };
+    expect(part.data.matchId).toBe("1234");
+  });
+
+  it("does not throw when no writer is supplied (unit-test mode)", async () => {
+    const { cite_match } = createPlayCricketCitationTools({});
+    const exec = cite_match.execute;
+    if (!exec) throw new Error("no execute");
+    const result = (await exec(
+      { matchId: "1234", claim: "x" } as never,
+      opts,
+    )) as { cited: boolean };
+    expect(result.cited).toBe(true);
+  });
+});
+
+describe("cite_player_stats — Play Cricket player aggregate citation", () => {
+  it("emits a data-player-stats-citation part and stamps the Percy Main club_id by default", async () => {
+    const writer = makeWriter();
+    const { cite_player_stats } = createPlayCricketCitationTools({ writer });
+    const exec = cite_player_stats.execute;
+    if (!exec) throw new Error("no execute");
+
+    const result = (await exec(
+      {
+        playerId: "6577518",
+        playerName: "John Smith",
+        statType: "batting",
+        claim: "Smith averages 12.3 across 18 innings vs us this season.",
+        season: 2025,
+        teamId: "68498",
+        gameType: "League",
+      } as never,
+      opts,
+    )) as { cited: boolean; playerId: string; statType: string };
+
+    expect(result.cited).toBe(true);
+    expect(result.playerId).toBe("6577518");
+    expect(result.statType).toBe("batting");
+
+    expect(writer.write).toHaveBeenCalledTimes(1);
+    const part = (writer.write.mock.calls[0] as unknown[])[0] as {
+      type: string;
+      data: {
+        playerId: string;
+        statType: string;
+        season?: number;
+        teamId?: string;
+        gameType?: string;
+        clubId?: string;
+      };
+    };
+    expect(part.type).toBe("data-player-stats-citation");
+    expect(part.data.playerId).toBe("6577518");
+    expect(part.data.statType).toBe("batting");
+    expect(part.data.season).toBe(2025);
+    expect(part.data.teamId).toBe("68498");
+    expect(part.data.gameType).toBe("League");
+    // Stamped server-side so the FE doesn't have to know our club_id.
+    expect(part.data.clubId).toBe("134");
+  });
+
+  it("accepts each of batting / bowling / fielding", async () => {
+    const writer = makeWriter();
+    const { cite_player_stats } = createPlayCricketCitationTools({ writer });
+    const exec = cite_player_stats.execute;
+    if (!exec) throw new Error("no execute");
+    for (const statType of ["batting", "bowling", "fielding"] as const) {
+      const result = (await exec(
+        { playerId: "1", statType, claim: "x" } as never,
+        opts,
+      )) as { cited: boolean; statType: string };
+      expect(result.cited).toBe(true);
+      expect(result.statType).toBe(statType);
+    }
+    expect(writer.write).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/api/src/features/scout/tools/play-cricket-citations.ts
+++ b/apps/api/src/features/scout/tools/play-cricket-citations.ts
@@ -1,0 +1,189 @@
+import { tool, type UIMessageStreamWriter } from "ai";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+/**
+ * Citation primitives for Play Cricket data — companions to cite_fact.
+ *
+ * cite_match: when a claim is grounded in a specific match (e.g. "we beat
+ * Backworth by 47 runs in the 1st XI fixture on 26 April"), the model calls
+ * cite_match with the Play Cricket match id and a few display-only fields
+ * (date, teams, ground). The FE renders an inline [N] chip and a card in the
+ * Sources panel that deep-links to /website/results/<matchId> on Play Cricket.
+ *
+ * cite_player_stats: when a claim is grounded in aggregate player stats
+ * (e.g. "Smith averages 12.3 across 18 innings against us this season"),
+ * the model calls cite_player_stats with the Play Cricket player id, the
+ * stat type (batting/bowling/fielding), and any narrowing fields it has
+ * (season, team, game type). The FE links to the appropriate
+ * /player_stats/<type>/<playerId>?... page.
+ *
+ * Both tools require a UIMessageStreamWriter — they emit data-* parts the
+ * frontend keys off, the same wiring chart_render and cite_fact use. When
+ * no writer is provided (unit tests), the validation still runs and a
+ * payload is returned, but no part is streamed.
+ */
+
+const PERCY_MAIN_CLUB_ID = "134";
+
+export interface PlayCricketCitationToolDeps {
+  writer?: UIMessageStreamWriter;
+}
+
+const claim = z
+  .string()
+  .min(3)
+  .max(500)
+  .describe(
+    "The verbatim sentence (or short clause) from your reply that the citation grounds. The frontend uses this to highlight the cited span.",
+  );
+
+export function createPlayCricketCitationTools(
+  deps: PlayCricketCitationToolDeps,
+) {
+  const { writer } = deps;
+
+  return {
+    cite_match: tool({
+      description: `Attach a citation to a claim grounded in a specific Play Cricket match — past or upcoming. Call this immediately after the sentence the citation supports, with the matchId you got from pc_match_summary / pc_match_detail / pc_site_results / pc_find_opposition_matches (or from the local DB mirror). The frontend renders an inline [N] chip and a card linking to the match's page on percymain.play-cricket.com.
+
+When to call:
+- You stated something specific about a single match: "We beat Backworth by 47 runs on 26/04/2025" → cite_match with that matchId.
+- You quoted a scorecard line: "Weatherburn 76 (115) in the 2nd XI fixture vs Tynemouth" → cite the match.
+- A claim narrows to one match's events (toss decision, fall of wickets, a bowling spell).
+
+When NOT to call:
+- The claim aggregates across many matches (use cite_player_stats or just the underlying numbers).
+- You don't have the Play Cricket matchId (e.g. weather-only claim, or a fact-corpus claim — use cite_fact).
+- The claim is generic ("the pitch was slow") with no match attached.
+
+One call per cited match. The same matchId can appear multiple times if the response references it more than once.`,
+      inputSchema: z.object({
+        matchId: z
+          .string()
+          .min(1)
+          .describe(
+            "Play Cricket match id, exactly as it appears in pc_match_summary / pc_match_detail (matches[].id or match_details[].id). Numeric string, e.g. '7262912'.",
+          ),
+        claim,
+        matchDate: z
+          .string()
+          .optional()
+          .describe(
+            "Match date in dd/mm/yyyy as Play Cricket emits it. Display-only; the FE shows it on the source card.",
+          ),
+        homeTeam: z
+          .string()
+          .optional()
+          .describe(
+            "Home team display name (e.g. 'Percy Main CC, 1st XI'). Display-only.",
+          ),
+        awayTeam: z
+          .string()
+          .optional()
+          .describe("Away team display name. Display-only."),
+        groundName: z.string().optional(),
+        competition: z
+          .string()
+          .optional()
+          .describe(
+            "League / cup name as it appears on the match summary, e.g. 'NTCL Premier Division'.",
+          ),
+        result: z
+          .string()
+          .optional()
+          .describe("Result line if known, e.g. 'Percy Main won by 47 runs'."),
+      }),
+      // eslint-disable-next-line @typescript-eslint/require-await -- AI SDK execute signature is async; no async work here.
+      execute: async (input) => {
+        const citationId = randomUUID();
+        if (writer) {
+          writer.write({
+            type: "data-match-citation",
+            id: citationId,
+            data: input,
+          });
+        }
+        return {
+          cited: true as const,
+          citationId,
+          matchId: input.matchId,
+        };
+      },
+    }),
+
+    cite_player_stats: tool({
+      description: `Attach a citation to a claim grounded in aggregate player stats from Play Cricket (batting, bowling, or fielding). Call this immediately after the sentence the citation supports. The frontend renders an inline [N] chip and a card linking to /player_stats/<type>/<playerId> on percymain.play-cricket.com (filtered as best we can with the optional fields you pass).
+
+When to call:
+- You quoted a player average / aggregate: "Smith averages 12.3 across 18 innings vs us this season" → cite_player_stats(playerId, "batting", ...).
+- You quoted bowling figures across a season: "5–28 best, 17 wickets at 19.4" → statType "bowling".
+- You quoted catches/run-outs across a season → statType "fielding".
+
+When NOT to call:
+- The claim is about a single match — use cite_match.
+- The claim came from a recorded fact in <known-facts> — use cite_fact.
+- You don't have a Play Cricket player_id (the link target is the playerId page; without it there's nothing to link to).
+
+statType MUST match what you're claiming — picking "batting" for a bowling-figures claim links the user to the wrong stats page.`,
+      inputSchema: z.object({
+        playerId: z
+          .string()
+          .min(1)
+          .describe(
+            "Play Cricket player_id (a.k.a. member_id). Numeric string, e.g. '6577518'. Use pc_list_players if you only have a name.",
+          ),
+        playerName: z
+          .string()
+          .optional()
+          .describe("Display name for the source card."),
+        statType: z
+          .enum(["batting", "bowling", "fielding"])
+          .describe(
+            "Which stats page to link to. Must match the claim — batting averages → 'batting', wickets → 'bowling', catches/run-outs → 'fielding'.",
+          ),
+        claim,
+        season: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            "Season year if the claim is season-bounded (e.g. 2025). Display-only on the card.",
+          ),
+        teamId: z
+          .string()
+          .optional()
+          .describe(
+            "Play Cricket team_id (e.g. our 1st XI). When present, included as ?team_id=… on the link.",
+          ),
+        gameType: z
+          .string()
+          .optional()
+          .describe(
+            "Play Cricket game_type filter, e.g. 'League', 'Cup', 'T20'. When present, included as ?game_type=… on the link.",
+          ),
+      }),
+      // eslint-disable-next-line @typescript-eslint/require-await
+      execute: async (input) => {
+        const citationId = randomUUID();
+        if (writer) {
+          writer.write({
+            type: "data-player-stats-citation",
+            id: citationId,
+            data: { ...input, clubId: PERCY_MAIN_CLUB_ID },
+          });
+        }
+        return {
+          cited: true as const,
+          citationId,
+          playerId: input.playerId,
+          statType: input.statType,
+        };
+      },
+    }),
+  };
+}
+
+export type PlayCricketCitationTools = ReturnType<
+  typeof createPlayCricketCitationTools
+>;

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -58,6 +58,7 @@
 
   /* Animation */
   --animate-caret-blink: caret-blink 1.25s ease-out infinite;
+  --animate-cite-flash: cite-flash 1.6s ease-out 1;
 
   @keyframes caret-blink {
     0%,
@@ -68,6 +69,37 @@
     20%,
     50% {
       opacity: 0;
+    }
+  }
+
+  /* Pulsing border + soft halo on a Source card after the user clicks an
+     inline [N] chip. Two short pulses, then settle back to the card's
+     resting state. Border colour matches blue-500 so it reads as an
+     intentional "selected" pop in both light and dark surfaces. */
+  @keyframes cite-flash {
+    0% {
+      box-shadow:
+        0 0 0 2px rgb(59 130 246 / 0%),
+        0 0 0 6px rgb(59 130 246 / 0%);
+      border-color: rgb(229 231 235);
+    }
+    20% {
+      box-shadow:
+        0 0 0 2px rgb(59 130 246 / 80%),
+        0 0 0 6px rgb(59 130 246 / 25%);
+      border-color: rgb(59 130 246);
+    }
+    60% {
+      box-shadow:
+        0 0 0 2px rgb(59 130 246 / 60%),
+        0 0 0 10px rgb(59 130 246 / 12%);
+      border-color: rgb(59 130 246);
+    }
+    100% {
+      box-shadow:
+        0 0 0 2px rgb(59 130 246 / 0%),
+        0 0 0 6px rgb(59 130 246 / 0%);
+      border-color: rgb(229 231 235);
     }
   }
 }

--- a/apps/web/src/pages/scout/message-view.tsx
+++ b/apps/web/src/pages/scout/message-view.tsx
@@ -7,22 +7,111 @@ import { ScoutChart } from "./scout-chart.tsx";
 
 const REMARK_PLUGINS = [remarkGfm];
 
+// ── Citation model ────────────────────────────────────────────────────────
+//
+// Three citation kinds share one numbering + sources panel: facts (RAG
+// corpus), Play Cricket matches, and Play Cricket player aggregate stats.
+// They use different streaming part types but render through a single
+// per-citation-key map so the inline chips and the sources panel agree on
+// numbering. Keys identify a citation uniquely within a message:
+//   fact          → f:<factId>
+//   match         → m:<matchId>
+//   player_stats  → p:<playerId>:<statType>
+//
+// `[[CITE:<key>]]` markers spliced into text parts get swapped for chips
+// at render time. We keep the marker format permissive (any non-]
+// characters between brackets) so future citation kinds with new key
+// shapes don't need a regex change.
+
+interface FactCitation {
+  kind: "fact";
+  factId: string;
+  claim: string;
+  content: string;
+  tags: Record<string, string | string[]>;
+  scope: "user" | "club";
+  confidence: number;
+}
+
+interface MatchCitation {
+  kind: "match";
+  matchId: string;
+  claim: string;
+  matchDate?: string;
+  homeTeam?: string;
+  awayTeam?: string;
+  groundName?: string;
+  competition?: string;
+  result?: string;
+}
+
+interface PlayerStatsCitation {
+  kind: "player_stats";
+  playerId: string;
+  playerName?: string;
+  statType: "batting" | "bowling" | "fielding";
+  claim: string;
+  season?: number;
+  teamId?: string;
+  gameType?: string;
+  clubId?: string;
+}
+
+type Citation = FactCitation | MatchCitation | PlayerStatsCitation;
+
+const PERCY_MAIN_HOSTNAME = "percymain.play-cricket.com";
+const PERCY_MAIN_CLUB_ID = "134";
+
+function citationKey(c: Citation): string {
+  switch (c.kind) {
+    case "fact":
+      return `f:${c.factId}`;
+    case "match":
+      return `m:${c.matchId}`;
+    case "player_stats":
+      return `p:${c.playerId}:${c.statType}`;
+  }
+}
+
+function citationDomId(c: Citation): string {
+  return `cite-${citationKey(c).replace(/:/g, "-")}`;
+}
+
+function citationDomIdFromKey(key: string): string {
+  return `cite-${key.replace(/:/g, "-")}`;
+}
+
+function buildPlayerStatsUrl(c: PlayerStatsCitation): string {
+  const params = new URLSearchParams();
+  params.set("club_id", c.clubId ?? PERCY_MAIN_CLUB_ID);
+  params.set("tab", c.statType);
+  if (c.teamId) params.set("team_id", c.teamId);
+  if (c.gameType) params.set("game_type", c.gameType);
+  return `https://${PERCY_MAIN_HOSTNAME}/player_stats/${c.statType}/${encodeURIComponent(c.playerId)}?${params.toString()}`;
+}
+
+function buildMatchUrl(c: MatchCitation): string {
+  return `https://${PERCY_MAIN_HOSTNAME}/website/results/${encodeURIComponent(c.matchId)}`;
+}
+
+// ── Markdown component overrides ──────────────────────────────────────────
+
 // Tailwind doesn't ship a typography plugin in this project, so we restyle
 // the elements react-markdown emits ourselves. Tables get the heaviest
 // treatment because Scout uses them constantly.
 //
-// Wrapped in a factory because the inline-element overrides (p, li,
-// table cells) need access to the per-message citationNumberByFactId
-// map so they can swap [[CITE:UUID]] markers in their text children
-// for inline citation chips. Markers are spliced in by renderParts()
-// before this is called.
+// Wrapped in a factory because the inline-element overrides (p, li, td)
+// need access to the per-message numberByKey map so they can swap
+// [[CITE:KEY]] markers for inline chips. Markers are spliced in by
+// renderParts() before this is called.
 function buildMarkdownComponents(
-  citationNumberByFactId: Map<string, number>,
+  numberByKey: Map<string, number>,
+  onChipClick: (key: string) => void,
 ): Components {
   const cite = (children: React.ReactNode) =>
-    citationNumberByFactId.size === 0
+    numberByKey.size === 0
       ? children
-      : injectCitations(children, citationNumberByFactId);
+      : injectCitations(children, numberByKey, onChipClick);
   return {
     table: ({ children, ...rest }) => (
       <div className="my-3 overflow-x-auto">
@@ -46,7 +135,7 @@ function buildMarkdownComponents(
     ),
     td: ({ children, ...rest }) => (
       <td className="border border-gray-200 px-2 py-1 align-top" {...rest}>
-        {children}
+        {cite(children)}
       </td>
     ),
     tr: ({ children, ...rest }) => (
@@ -122,39 +211,68 @@ interface MessageViewProps {
   message: UIMessage;
 }
 
-interface Citation {
-  factId: string;
-  claim: string;
-  content: string;
-  tags: Record<string, string | string[]>;
-  scope: "user" | "club";
-  confidence: number;
-}
-
-// Walk parts once to assign each unique factId a stable citation number
-// (1, 2, 3, ...). Numbers are scoped to a single message — citations
-// don't carry across messages, since the sources panel is per-message.
+// Walk parts once to assign each unique citation key a stable number
+// (1, 2, 3, ...). Numbers are scoped to a single message — citations don't
+// carry across messages, since the sources panel is per-message.
 function buildCitationIndex(parts: UIMessage["parts"]): {
-  numberByFactId: Map<string, number>;
+  numberByKey: Map<string, number>;
   ordered: Citation[];
 } {
-  const numberByFactId = new Map<string, number>();
+  const numberByKey = new Map<string, number>();
   const ordered: Citation[] = [];
   for (const part of parts) {
-    if (part.type !== "data-fact-citation") continue;
-    const data = (part as { data: Citation }).data;
-    if (numberByFactId.has(data.factId)) continue;
-    numberByFactId.set(data.factId, ordered.length + 1);
-    ordered.push(data);
+    const c = partToCitation(part);
+    if (!c) continue;
+    const key = citationKey(c);
+    if (numberByKey.has(key)) continue;
+    numberByKey.set(key, ordered.length + 1);
+    ordered.push(c);
   }
-  return { numberByFactId, ordered };
+  return { numberByKey, ordered };
+}
+
+function partToCitation(part: UIMessage["parts"][number]): Citation | null {
+  if (part.type === "data-fact-citation") {
+    const data = (part as { data: Omit<FactCitation, "kind"> }).data;
+    return { kind: "fact", ...data };
+  }
+  if (part.type === "data-match-citation") {
+    const data = (part as { data: Omit<MatchCitation, "kind"> }).data;
+    return { kind: "match", ...data };
+  }
+  if (part.type === "data-player-stats-citation") {
+    const data = (part as { data: Omit<PlayerStatsCitation, "kind"> }).data;
+    return { kind: "player_stats", ...data };
+  }
+  return null;
 }
 
 export function MessageView({ message }: MessageViewProps) {
   const isUser = message.role === "user";
   const citations = isUser
-    ? { numberByFactId: new Map<string, number>(), ordered: [] as Citation[] }
+    ? { numberByKey: new Map<string, number>(), ordered: [] as Citation[] }
     : buildCitationIndex(message.parts);
+
+  // Track which source card is currently flashing. A click on an inline [N]
+  // chip sets this to the citation key, scrolls the matching card into the
+  // middle of the viewport, and we clear it after the animation completes
+  // so the card returns to its resting state.
+  const [flashingKey, setFlashingKey] = useState<string | null>(null);
+
+  function handleChipClick(key: string) {
+    const id = citationDomIdFromKey(key);
+    const card = document.getElementById(id);
+    if (card) {
+      // block: 'center' is what the user asked for — scroll the card to
+      // roughly the middle of the scroll container (the chat scroll
+      // viewport is the nearest scrollable ancestor).
+      card.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    // Re-trigger the flash even if it was already flashing for this key by
+    // clearing first on the next tick. Same-key clicks should re-pulse.
+    setFlashingKey(null);
+    requestAnimationFrame(() => setFlashingKey(key));
+  }
 
   return (
     <div
@@ -169,15 +287,21 @@ export function MessageView({ message }: MessageViewProps) {
             : "border border-gray-200 bg-white text-gray-900"
         }`}
       >
-        {renderParts(message.parts, citations.numberByFactId).map((part, i) => (
+        {renderParts(message.parts, citations.numberByKey).map((part, i) => (
           <PartView
             key={`${message.id}-${i}`}
             part={part}
-            citationNumberByFactId={citations.numberByFactId}
+            numberByKey={citations.numberByKey}
+            onChipClick={handleChipClick}
           />
         ))}
         {!isUser && citations.ordered.length > 0 && (
-          <SourcesPanel citations={citations.ordered} />
+          <SourcesPanel
+            citations={citations.ordered}
+            numberByKey={citations.numberByKey}
+            flashingKey={flashingKey}
+            onFlashEnd={() => setFlashingKey(null)}
+          />
         )}
         {!isUser && (
           <div className="mt-2 flex justify-end opacity-0 transition-opacity group-hover:opacity-100 print:hidden">
@@ -190,9 +314,8 @@ export function MessageView({ message }: MessageViewProps) {
 }
 
 // Triggers the browser's Print → Save as PDF flow, scoped to a single
-// assistant message. The print stylesheet (in scout.tsx) hides everything
-// except the message marked data-scout-printing. We pick that target by
-// message id at click time so unrelated messages stay hidden.
+// assistant message. The print stylesheet (in app.css) hides everything
+// except the message marked data-scout-printing.
 function ExportMessageButton({ messageId }: { messageId: string }) {
   function handleExport() {
     const target = document.querySelector(
@@ -222,34 +345,39 @@ function ExportMessageButton({ messageId }: { messageId: string }) {
 
 type Part = UIMessage["parts"][number];
 
-// Citation markers we splice into text-part content. Picked to be both
-// markdown-safe (no syntax meaning) and unlikely to collide with prose.
-const CITE_MARKER_RE = /\[\[CITE:([0-9a-f-]+)\]\]/gi;
+const CITE_MARKER_RE = /\[\[CITE:([^\]]+)\]\]/g;
 
 /**
- * Fold each data-fact-citation part into the immediately preceding
- * text part as a `[[CITE:UUID]]` marker. The chip then renders inline
- * (via the `p` markdown override) at the end of the cited sentence
- * instead of as a sibling block on a new line.
+ * Fold each citation data part into the immediately preceding text part as
+ * a `[[CITE:KEY]]` marker. The chip then renders inline (via the markdown
+ * overrides) at the end of the cited sentence instead of as a sibling block
+ * on a new line.
  *
- * Citation parts that don't follow a text part fall through unchanged
- * and render via the regular PartView path; the SourcesPanel reads the
- * raw parts array independently, so dropping citations from this
- * rendered list doesn't lose them from the bibliography.
+ * Citation parts that don't follow a text part fall through unchanged and
+ * render via the regular PartView path; the SourcesPanel reads the raw
+ * parts array independently, so dropping citations from this rendered list
+ * doesn't lose them from the bibliography.
  */
 function renderParts(
   parts: UIMessage["parts"],
-  numberByFactId: Map<string, number>,
+  numberByKey: Map<string, number>,
 ): Part[] {
   const out: Part[] = [];
   for (const part of parts) {
-    // tool-cite_fact has no UI (the citation chip is the UI). Drop it
-    // from the rendered list so the data-fact-citation that follows
-    // can fold into the *text* part that preceded the tool call.
-    if (part.type === "tool-cite_fact") continue;
-    if (part.type === "data-fact-citation") {
-      const data = (part as { data: { factId: string } }).data;
-      if (!numberByFactId.has(data.factId)) continue;
+    // The citation tool calls have no UI of their own (the chip + source
+    // card IS the UI). Drop them so the data-* citation that follows can
+    // fold into the prose that preceded the tool call.
+    if (
+      part.type === "tool-cite_fact" ||
+      part.type === "tool-cite_match" ||
+      part.type === "tool-cite_player_stats"
+    ) {
+      continue;
+    }
+    const citation = partToCitation(part);
+    if (citation) {
+      const key = citationKey(citation);
+      if (!numberByKey.has(key)) continue;
       // Append marker to the most recent text part (skipping over any
       // non-text parts already in `out`, since the AI SDK puts the
       // tool-call in between the text and the citation data part).
@@ -264,13 +392,12 @@ function renderParts(
         const t = out[target] as Part & { type: "text"; text: string };
         out[target] = {
           ...t,
-          text: `${t.text}[[CITE:${data.factId}]]`,
+          text: `${t.text}[[CITE:${key}]]`,
         } as Part;
         continue;
       }
-      // No preceding text — fall through; PartView will render it
-      // standalone (rare; happens only if the model cites before any
-      // prose).
+      // No preceding text — fall through; PartView will render a standalone
+      // chip as a fallback so the citation isn't lost.
       out.push(part);
       continue;
     }
@@ -280,32 +407,37 @@ function renderParts(
 }
 
 interface CitationChipProps {
-  factId: string;
+  citationKey: string;
   number: number;
+  onClick: (key: string) => void;
 }
 
-function CitationChip({ factId, number }: CitationChipProps) {
+function CitationChip({ citationKey, number, onClick }: CitationChipProps) {
   return (
-    <a
-      href={`#fact-${factId}`}
-      className="ml-0.5 inline-flex items-baseline rounded bg-blue-100 px-1 align-super text-[10px] font-semibold text-blue-700 hover:bg-blue-200"
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        onClick(citationKey);
+      }}
+      className="ml-0.5 inline-flex cursor-pointer items-baseline rounded bg-blue-100 px-1 align-super text-[10px] font-semibold text-blue-700 hover:bg-blue-200 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-500"
       title="View source"
     >
       [{number}]
-    </a>
+    </button>
   );
 }
 
 /**
- * Walk the children of a markdown element (typically a `<p>`), scan
- * each string child for `[[CITE:UUID]]` markers, and splice in inline
- * citation chips at marker positions. Non-string children (already
- * rendered React nodes — `<strong>`, `<em>`, etc.) pass through
- * unchanged.
+ * Walk the children of a markdown element (typically a `<p>`), scan each
+ * string child for `[[CITE:KEY]]` markers, and splice in inline citation
+ * chips at marker positions. Non-string children (already rendered React
+ * nodes — `<strong>`, `<em>`, etc.) pass through unchanged.
  */
 function injectCitations(
   children: React.ReactNode,
-  numberByFactId: Map<string, number>,
+  numberByKey: Map<string, number>,
+  onChipClick: (key: string) => void,
 ): React.ReactNode {
   return React.Children.map(children, (child) => {
     if (typeof child !== "string") return child;
@@ -318,14 +450,15 @@ function injectCitations(
       if (match.index > lastIdx) {
         segments.push(child.slice(lastIdx, match.index));
       }
-      const factId = match[1];
-      const number = numberByFactId.get(factId);
+      const key = match[1];
+      const number = numberByKey.get(key);
       if (number) {
         segments.push(
           <CitationChip
-            key={`cite-${match.index}-${factId}`}
-            factId={factId}
+            key={`cite-${match.index}-${key}`}
+            citationKey={key}
             number={number}
+            onClick={onChipClick}
           />,
         );
       }
@@ -338,17 +471,19 @@ function injectCitations(
 
 function PartView({
   part,
-  citationNumberByFactId,
+  numberByKey,
+  onChipClick,
 }: {
   part: Part;
-  citationNumberByFactId: Map<string, number>;
+  numberByKey: Map<string, number>;
+  onChipClick: (key: string) => void;
 }) {
   if (part.type === "text") {
     return (
       <div className="text-sm leading-relaxed text-gray-900">
         <ReactMarkdown
           remarkPlugins={REMARK_PLUGINS}
-          components={buildMarkdownComponents(citationNumberByFactId)}
+          components={buildMarkdownComponents(numberByKey, onChipClick)}
         >
           {part.text}
         </ReactMarkdown>
@@ -372,23 +507,29 @@ function PartView({
     return <ScoutChart spec={chartPart.data} />;
   }
 
-  if (part.type === "data-fact-citation") {
-    // Normal path: renderParts() folded this into the preceding text
-    // part as a [[CITE:UUID]] marker, and the markdown override emits
-    // the inline chip. We only get here when there was no preceding
-    // text — render a standalone chip as a fallback so the citation
-    // isn't lost.
-    const data = (part as { data: { factId: string } }).data;
-    const number = citationNumberByFactId.get(data.factId);
+  // Citation data parts that didn't get folded into a preceding text part
+  // (rare — only when the model cites before any prose). Render a standalone
+  // chip so the citation isn't lost.
+  const citation = partToCitation(part);
+  if (citation) {
+    const key = citationKey(citation);
+    const number = numberByKey.get(key);
     if (!number) return null;
-    return <CitationChip factId={data.factId} number={number} />;
+    return (
+      <CitationChip citationKey={key} number={number} onClick={onChipClick} />
+    );
   }
 
   if (part.type.startsWith("tool-")) {
-    // cite_fact has its own inline rendering (the [N] chip + Sources
-    // panel below). Hide the generic tool-call box for it — it adds
-    // visual noise alongside the citation it produced.
-    if (part.type === "tool-cite_fact") return null;
+    // Citation tool calls render as the inline [N] chip + the Sources card,
+    // not the generic tool-call box.
+    if (
+      part.type === "tool-cite_fact" ||
+      part.type === "tool-cite_match" ||
+      part.type === "tool-cite_player_stats"
+    ) {
+      return null;
+    }
     return <ToolPartView part={part} />;
   }
 
@@ -396,35 +537,212 @@ function PartView({
   return null;
 }
 
-function SourcesPanel({ citations }: { citations: Citation[] }) {
+// ── Sources panel + cards ─────────────────────────────────────────────────
+
+interface SourcesPanelProps {
+  citations: Citation[];
+  numberByKey: Map<string, number>;
+  flashingKey: string | null;
+  onFlashEnd: () => void;
+}
+
+function SourcesPanel({
+  citations,
+  numberByKey,
+  flashingKey,
+  onFlashEnd,
+}: SourcesPanelProps) {
   return (
-    <div className="mt-3 border-t border-gray-200 pt-2 text-xs text-gray-700">
-      <div className="mb-1 font-semibold text-gray-600">Sources</div>
-      <ol className="list-decimal space-y-1 pl-5">
-        {citations.map((c, idx) => {
-          const tagPairs = Object.entries(c.tags)
-            .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(" / ") : v}`)
-            .join(" · ");
+    <div className="mt-3 border-t border-gray-200 pt-3">
+      <div className="mb-2 text-xs font-semibold tracking-wide text-gray-600 uppercase">
+        Sources
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {citations.map((c) => {
+          const key = citationKey(c);
+          const number = numberByKey.get(key) ?? 0;
           return (
-            <li key={c.factId} id={`fact-${c.factId}`} className="leading-snug">
-              <span className="font-medium">{c.content}</span>
-              <span className="ml-2 text-gray-500">
-                {c.scope === "user" ? "personal" : "club"}
-                {" · "}confidence {c.confidence}/5
-                {tagPairs ? ` · ${tagPairs}` : ""}
-              </span>
-              {
-                c.claim && idx === 0
-                  ? null
-                  : null /* claim is captured per cite; not shown in panel to keep it compact */
-              }
-            </li>
+            <SourceCard
+              key={key}
+              citation={c}
+              number={number}
+              flashing={flashingKey === key}
+              onFlashEnd={onFlashEnd}
+            />
           );
         })}
-      </ol>
+      </div>
     </div>
   );
 }
+
+interface SourceCardProps {
+  citation: Citation;
+  number: number;
+  flashing: boolean;
+  onFlashEnd: () => void;
+}
+
+function SourceCard({
+  citation,
+  number,
+  flashing,
+  onFlashEnd,
+}: SourceCardProps) {
+  const baseClass =
+    "relative rounded-lg border border-gray-200 bg-white p-3 text-xs shadow-sm transition-colors";
+  // animate-cite-flash is registered in app.css's @theme block. We toggle it
+  // by adding the class only when this card is the flashing target; the
+  // animationend handler clears the parent state so the class drops off.
+  const flashClass = flashing ? "animate-cite-flash" : "";
+
+  return (
+    <div
+      id={citationDomId(citation)}
+      data-cite-key={citationKey(citation)}
+      className={`${baseClass} ${flashClass}`}
+      onAnimationEnd={() => {
+        if (flashing) onFlashEnd();
+      }}
+    >
+      <div className="absolute -top-2 -left-2 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-blue-600 px-1.5 text-[10px] font-semibold text-white shadow">
+        {number}
+      </div>
+      {citation.kind === "fact" && <FactCardBody citation={citation} />}
+      {citation.kind === "match" && <MatchCardBody citation={citation} />}
+      {citation.kind === "player_stats" && (
+        <PlayerStatsCardBody citation={citation} />
+      )}
+    </div>
+  );
+}
+
+function FactCardBody({ citation: c }: { citation: FactCitation }) {
+  const tagPairs = Object.entries(c.tags)
+    .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(" / ") : v}`)
+    .join(" · ");
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-1.5">
+        <Pill tone="green">Fact</Pill>
+        <span className="text-[10px] text-gray-500">
+          {c.scope === "user" ? "personal" : "club"} · confidence {c.confidence}
+          /5
+        </span>
+      </div>
+      <div className="font-medium text-gray-900">{c.content}</div>
+      {tagPairs && (
+        <div className="mt-1 text-[10px] text-gray-500">{tagPairs}</div>
+      )}
+    </div>
+  );
+}
+
+function MatchCardBody({ citation: c }: { citation: MatchCitation }) {
+  const teams =
+    c.homeTeam && c.awayTeam
+      ? `${c.homeTeam} v ${c.awayTeam}`
+      : (c.homeTeam ?? c.awayTeam ?? `Match ${c.matchId}`);
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-1.5">
+        <Pill tone="blue">Match</Pill>
+        {c.matchDate && (
+          <span className="text-[10px] text-gray-500">{c.matchDate}</span>
+        )}
+      </div>
+      <a
+        href={buildMatchUrl(c)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium text-gray-900 hover:text-blue-700 hover:underline"
+      >
+        {teams}
+      </a>
+      {c.competition && (
+        <div className="mt-0.5 text-[10px] text-gray-500">{c.competition}</div>
+      )}
+      {c.groundName && (
+        <div className="text-[10px] text-gray-500">{c.groundName}</div>
+      )}
+      {c.result && (
+        <div className="mt-1 text-[11px] font-medium text-gray-700">
+          {c.result}
+        </div>
+      )}
+      <div className="mt-1 truncate text-[10px] text-blue-700">
+        play-cricket.com →
+      </div>
+    </div>
+  );
+}
+
+function PlayerStatsCardBody({
+  citation: c,
+}: {
+  citation: PlayerStatsCitation;
+}) {
+  const label = c.playerName ?? `Player ${c.playerId}`;
+  const filters = [
+    c.season ? String(c.season) : null,
+    c.gameType ?? null,
+    c.teamId ? `Team ${c.teamId}` : null,
+  ].filter(Boolean) as string[];
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-1.5">
+        <Pill tone="purple">{capitalise(c.statType)} stats</Pill>
+        {c.season && (
+          <span className="text-[10px] text-gray-500">{c.season}</span>
+        )}
+      </div>
+      <a
+        href={buildPlayerStatsUrl(c)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium text-gray-900 hover:text-blue-700 hover:underline"
+      >
+        {label}
+      </a>
+      {filters.length > 0 && (
+        <div className="mt-0.5 text-[10px] text-gray-500">
+          {filters.join(" · ")}
+        </div>
+      )}
+      <div className="mt-1 truncate text-[10px] text-blue-700">
+        play-cricket.com →
+      </div>
+    </div>
+  );
+}
+
+function Pill({
+  tone,
+  children,
+}: {
+  tone: "green" | "blue" | "purple";
+  children: React.ReactNode;
+}) {
+  const toneClass =
+    tone === "green"
+      ? "bg-green-100 text-green-800"
+      : tone === "blue"
+        ? "bg-blue-100 text-blue-800"
+        : "bg-purple-100 text-purple-800";
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${toneClass}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function capitalise(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+// ── Tool-call card (debug view for non-citation tools) ────────────────────
 
 interface ToolPart {
   type: string;


### PR DESCRIPTION
## Summary
- Adds two new citation tools — `cite_match` (single-match claims, links to `/website/results/<matchId>`) and `cite_player_stats` (aggregate batting/bowling/fielding stats, links to `/player_stats/<type>/<playerId>?club_id=134&tab=…&team_id=…&game_type=…`) — alongside the existing `cite_fact`.
- Refactors the FE citation index to a string-keyed map so all three kinds share inline numbering and a card-based Sources panel (one card per kind, with a coloured pill and a deep-link to play-cricket.com for matches/player stats).
- Inline `[N]` chip becomes a button: click scrolls the matching source card to viewport centre and pulses a temporary border highlight (`cite-flash` keyframe).
- System prompt updated with a unified Citations section so the model picks the right tool (single match → `cite_match`, season aggregates → `cite_player_stats`, recorded fact → `cite_fact`).

## Notes
- Player-stats URL builder uses a conservative param set (`club_id=134`, `tab`, plus `team_id` / `game_type` when known). Did not include `rule_type_id` / `team_category_id` / `sub_tab` since the agent has no reliable way to populate them — easy to add later if needed.

## Test plan
- [x] `pnpm --filter api lint` clean
- [x] `pnpm --filter api typecheck` clean
- [x] `pnpm --filter api test` — 386 tests pass (including new `play-cricket-citations.test.ts`)
- [x] `pnpm --filter web lint` clean
- [x] `pnpm --filter web typecheck` clean
- [x] `pnpm --filter web build` clean
- [ ] Manual: ask Scout about a recent match, verify the `[N]` chip in the reply links to a Source card with a working play-cricket.com URL and that clicking the chip scrolls + pulses
- [ ] Manual: ask Scout about a player's season stats, verify the player-stats card links through to the correct `/player_stats/<type>/<playerId>` page with sensible filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)