### PR TITLE
Scout: post-match debrief mode + fact permanence

### DIFF
--- a/apps/api/src/features/scout/agent.test.ts
+++ b/apps/api/src/features/scout/agent.test.ts
@@ -11,7 +11,7 @@ import { createScoutAgent } from "./agent.ts";
 // this regresses, every multi-step Scout turn pays full input rate again
 // for the accumulated tool results — the exact bug we shipped this for.
 
-function makeAgent() {
+function makeAgent(mode: "scouting" | "debrief" = "scouting") {
   // The agent only reaches its DB / writer during tool invocation; for
   // prepareStep tests we never invoke a tool, so empty stubs are safe.
   const stubDb = {} as Kysely<DB>;
@@ -29,6 +29,7 @@ function makeAgent() {
     config: stubConfig,
     writer: stubWriter,
     userId: "test-user",
+    mode,
   });
 }
 
@@ -87,5 +88,22 @@ describe("agent.prepareStep — cache-control breakpoint", () => {
     const agent = makeAgent();
     const { messages: out } = agent.prepareStep({ messages: [] });
     expect(out).toEqual([]);
+  });
+});
+
+describe("agent — mode-driven prompt + tool surface", () => {
+  it("uses the scouting prompt and registers chart_render but not ask_question", () => {
+    const agent = makeAgent("scouting");
+    expect(agent.system).toContain("ALWAYS try to answer from the local DB");
+    expect(agent.system).not.toContain("running a post-match DEBRIEF");
+    expect(agent.tools.chart_render).toBeDefined();
+    expect(agent.tools.ask_question).toBeUndefined();
+  });
+
+  it("uses the debrief prompt and registers ask_question but not chart_render", () => {
+    const agent = makeAgent("debrief");
+    expect(agent.system).toContain("running a post-match DEBRIEF");
+    expect(agent.tools.ask_question).toBeDefined();
+    expect(agent.tools.chart_render).toBeUndefined();
   });
 });

--- a/apps/api/src/features/scout/agent.ts
+++ b/apps/api/src/features/scout/agent.ts
@@ -11,7 +11,12 @@ import type { Kysely } from "kysely";
 import type { Config } from "../../config.ts";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 import type { VoyageClient } from "./facts/voyage.ts";
-import { SCOUT_SYSTEM_PROMPT } from "./system-prompt.ts";
+import type { ScoutMode } from "./schemas.ts";
+import {
+  SCOUT_DEBRIEF_SYSTEM_PROMPT,
+  SCOUT_SYSTEM_PROMPT,
+} from "./system-prompt.ts";
+import { createAskQuestionTool } from "./tools/ask-question.ts";
 import { createScoutCache } from "./tools/cache.ts";
 import { createChartTool } from "./tools/chart.ts";
 import { createDbTools } from "./tools/db.ts";
@@ -45,6 +50,10 @@ export interface ScoutAgentDeps {
   voyage?: VoyageClient;
   userId: string;
   threadId?: string;
+  // Interaction mode — fixed at thread creation. Picks system prompt and
+  // toggles the ask_question / chart_render tool surface (debrief uses
+  // ask_question and skips charts; scouting is the inverse).
+  mode: ScoutMode;
 }
 
 export interface ScoutAgent {
@@ -66,7 +75,16 @@ export function createScoutAgent(deps: ScoutAgentDeps): ScoutAgent {
   });
   const dbTools = createDbTools({ dbReadonly: deps.dbReadonly });
   const weatherTools = createWeatherTools({ cache });
-  const chartTools = createChartTool({ writer: deps.writer });
+  // Charts are useful in scouting answers but out of place in a debrief
+  // interview — register chart_render only when in scouting mode.
+  const chartTools =
+    deps.mode === "scouting" ? createChartTool({ writer: deps.writer }) : {};
+  // ask_question is the inverse: only in debrief, where the agent walks
+  // the captain through structured prompts via inline button cards.
+  const askQuestionTools =
+    deps.mode === "debrief"
+      ? createAskQuestionTool({ writer: deps.writer })
+      : {};
   // Match / player-stats citation tools — companions to cite_fact. They
   // don't need the DB or any external client, only the writer to stream
   // data-*-citation parts to the FE alongside the assistant's prose.
@@ -107,14 +125,18 @@ export function createScoutAgent(deps: ScoutAgentDeps): ScoutAgent {
 
 When asked about the "next" or "upcoming" match, filter match_date strictly GREATER THAN ${ddmmyyyy} — anything on or before today has already been played (or is being played now). Don't trust your gut on what day-of-week a date falls on; always compare against the iso date above.`;
 
+  const basePrompt =
+    deps.mode === "debrief" ? SCOUT_DEBRIEF_SYSTEM_PROMPT : SCOUT_SYSTEM_PROMPT;
+
   return {
     model: anthropic(deps.config.SCOUT_MODEL_CHAT),
-    system: `${SCOUT_SYSTEM_PROMPT}\n\n${todayLine}`,
+    system: `${basePrompt}\n\n${todayLine}`,
     tools: {
       ...playCricketTools,
       ...dbTools,
       ...weatherTools,
       ...chartTools,
+      ...askQuestionTools,
       ...factTools,
       ...playCricketCitationTools,
     },

--- a/apps/api/src/features/scout/facts/admin-service.ts
+++ b/apps/api/src/features/scout/facts/admin-service.ts
@@ -30,6 +30,7 @@ const SELECT_COLS = [
   "content",
   "tags",
   "confidence",
+  "permanence",
   "source_thread_id",
   "superseded_by",
   "created_at",
@@ -43,6 +44,7 @@ interface Row {
   content: string;
   tags: unknown;
   confidence: number;
+  permanence: string | null;
   source_thread_id: string | null;
   superseded_by: string | null;
   created_at: Date | string;
@@ -57,6 +59,7 @@ function toItem(row: Row): AdminItem {
     content: row.content,
     tags: row.tags as AdminItem["tags"],
     confidence: row.confidence,
+    permanence: row.permanence as AdminItem["permanence"],
     sourceThreadId: row.source_thread_id,
     supersededBy: row.superseded_by,
     createdAt:
@@ -165,7 +168,14 @@ export function updateFact(db: Kysely<DB>, voyage: VoyageClient) {
       // with a raw embedding expression in one statement is messier than
       // a single CompiledQuery. Same parameterisation pattern as the
       // initial insert in service.ts.
+      //
+      // For COALESCE on permanence we use a sentinel string ('__keep__')
+      // because NULL is a meaningful value here ("clear permanence to
+      // unknown") and can't be distinguished from "leave alone" via
+      // COALESCE alone.
       const embedding = await voyage.embed(body.content, "document");
+      const permanenceParam =
+        body.permanence === undefined ? "__keep__" : body.permanence;
       await db.executeQuery(
         CompiledQuery.raw(
           `UPDATE scout_fact
@@ -174,14 +184,16 @@ export function updateFact(db: Kysely<DB>, voyage: VoyageClient) {
                tags = COALESCE($3::jsonb, tags),
                scope = COALESCE($4, scope),
                confidence = COALESCE($5, confidence),
+               permanence = CASE WHEN $6 = '__keep__' THEN permanence ELSE NULLIF($6, '__null__') END,
                updated_at = NOW()
-           WHERE id = $6`,
+           WHERE id = $7`,
           [
             body.content,
             toVectorLiteral(embedding),
             body.tags === undefined ? null : JSON.stringify(body.tags),
             body.scope ?? null,
             body.confidence ?? null,
+            permanenceParam ?? "__null__",
             factId,
           ],
         ),
@@ -203,6 +215,11 @@ export function updateFact(db: Kysely<DB>, voyage: VoyageClient) {
             // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
             confidence: body.confidence as number,
           }),
+        )
+        .$if(body.permanence !== undefined, (q) =>
+          // body.permanence may be null (clear back to unknown) — both
+          // valid update values, distinct from `undefined` (leave alone).
+          q.set({ permanence: body.permanence as string | null }),
         )
         .set({ updated_at: new Date() })
         .where("id", "=", factId)

--- a/apps/api/src/features/scout/facts/integration.test.ts
+++ b/apps/api/src/features/scout/facts/integration.test.ts
@@ -137,6 +137,56 @@ describe("recordFact — write path with cosine dedup + supersession", () => {
     expect(row.scope).toBe("club");
     expect(row.confidence).toBe(5);
     expect(row.superseded_by).toBeNull();
+    // topic="ground" maps to permanence=seasonal; the inference fires
+    // when permanence isn't supplied explicitly.
+    expect(row.permanence).toBe("seasonal");
+  });
+
+  it("leaves permanence NULL when the topic isn't in the inference table", async () => {
+    const voyage = buildVoyageMock({
+      embeddings: new Map([["Random unclassified note", vec([0, 1])]]),
+    });
+    const result = await recordFact(
+      ctx.db,
+      voyage,
+    )({
+      userId,
+      scope: "club",
+      content: "Random unclassified note",
+      tags: { topic: "something-else" },
+    });
+    const row = await ctx.db
+      .selectFrom("scout_fact")
+      .where("id", "=", result.id)
+      .select("permanence")
+      .executeTakeFirstOrThrow();
+    expect(row.permanence).toBeNull();
+  });
+
+  it("respects an explicit permanence override over the topic-inferred default", async () => {
+    const voyage = buildVoyageMock({
+      embeddings: new Map([
+        ["Sightscreens at both ends at Mitford", vec([0, 1])],
+      ]),
+    });
+    const result = await recordFact(
+      ctx.db,
+      voyage,
+    )({
+      userId,
+      scope: "club",
+      // topic=ground would normally infer "seasonal" — caller forcing
+      // "permanent" wins.
+      content: "Sightscreens at both ends at Mitford",
+      tags: { topic: "ground" },
+      permanence: "permanent",
+    });
+    const row = await ctx.db
+      .selectFrom("scout_fact")
+      .where("id", "=", result.id)
+      .select("permanence")
+      .executeTakeFirstOrThrow();
+    expect(row.permanence).toBe("permanent");
   });
 
   it("supersedes a near-duplicate (cosine distance < 0.1) instead of inserting twice", async () => {
@@ -722,6 +772,7 @@ describe("formatFactsBlock", () => {
         tags: { team: "Mitford CC", topic: "ground" },
         scope: "club",
         confidence: 5,
+        permanence: "seasonal",
         score: 0.92,
         createdAt: new Date(),
       },

--- a/apps/api/src/features/scout/facts/service.ts
+++ b/apps/api/src/features/scout/facts/service.ts
@@ -25,6 +25,34 @@ export const factTagsSchema = z.record(
 );
 export type FactTags = z.infer<typeof factTagsSchema>;
 
+export type FactPermanence = "permanent" | "seasonal" | "ephemeral";
+
+/**
+ * Infer permanence from a fact's `topic` tag when the caller didn't set
+ * it explicitly. Conservative: anything not in the table stays NULL so
+ * the auto-retrieve "skip if known" rule won't suppress questions for
+ * facts whose shelf-life we don't know.
+ */
+const PERMANENCE_BY_TOPIC: Readonly<Record<string, FactPermanence>> = {
+  handedness: "permanent",
+  "bowling-style": "permanent",
+  position: "permanent",
+  ground: "seasonal",
+  scheduling: "seasonal",
+  rules: "seasonal",
+  kit: "seasonal",
+  weather: "ephemeral",
+  form: "ephemeral",
+  injury: "ephemeral",
+};
+
+export function inferPermanence(tags: FactTags): FactPermanence | null {
+  const raw = tags.topic;
+  const topic = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof topic !== "string") return null;
+  return PERMANENCE_BY_TOPIC[topic] ?? null;
+}
+
 // Cosine distance threshold below which a new fact is treated as a
 // near-duplicate of an existing one (i.e. we supersede instead of
 // inserting a fresh row). Empirically, voyage-4 cosine distance < 0.10
@@ -42,6 +70,13 @@ export interface RecordFactInput {
   content: string;
   tags?: FactTags;
   confidence?: number;
+  /**
+   * How long this fact stays useful. When omitted we infer from
+   * `tags.topic`; when no rule matches we leave it NULL so the agent
+   * doesn't silently skip a re-confirmation question on a fact whose
+   * decay rate we haven't classified.
+   */
+  permanence?: FactPermanence | null;
   sourceThreadId?: string;
   sourceMessageId?: string;
 }
@@ -59,6 +94,7 @@ export interface RetrievedFact {
   tags: FactTags;
   scope: FactScope;
   confidence: number;
+  permanence: FactPermanence | null;
   /** Voyage rerank score (higher = more relevant). */
   score: number;
   createdAt: Date;
@@ -76,6 +112,10 @@ export function recordFact(db: Kysely<DB>, voyage: VoyageClient) {
   return async (input: RecordFactInput): Promise<RecordedFact> => {
     const tags = input.tags ?? {};
     const confidence = input.confidence ?? 3;
+    // Explicit override (including explicit null to clear) wins; otherwise
+    // infer from tags.topic.
+    const permanence =
+      input.permanence === undefined ? inferPermanence(tags) : input.permanence;
 
     const embedding = await voyage.embed(input.content, "document");
     const vectorLiteral = toVectorLiteral(embedding);
@@ -109,8 +149,8 @@ export function recordFact(db: Kysely<DB>, voyage: VoyageClient) {
           CompiledQuery.raw(
             `INSERT INTO scout_fact
               (user_id, scope, content, tags, embedding, confidence,
-               source_thread_id, source_message_id)
-             VALUES ($1, $2, $3, $4::jsonb, $5::vector, $6, $7, $8)
+               permanence, source_thread_id, source_message_id)
+             VALUES ($1, $2, $3, $4::jsonb, $5::vector, $6, $7, $8, $9)
              RETURNING id`,
             [
               input.userId,
@@ -119,6 +159,7 @@ export function recordFact(db: Kysely<DB>, voyage: VoyageClient) {
               JSON.stringify(tags),
               vectorLiteral,
               confidence,
+              permanence,
               input.sourceThreadId ?? null,
               input.sourceMessageId ?? null,
             ],
@@ -145,8 +186,8 @@ export function recordFact(db: Kysely<DB>, voyage: VoyageClient) {
       CompiledQuery.raw(
         `INSERT INTO scout_fact
           (user_id, scope, content, tags, embedding, confidence,
-           source_thread_id, source_message_id)
-         VALUES ($1, $2, $3, $4::jsonb, $5::vector, $6, $7, $8)
+           permanence, source_thread_id, source_message_id)
+         VALUES ($1, $2, $3, $4::jsonb, $5::vector, $6, $7, $8, $9)
          RETURNING id`,
         [
           input.userId,
@@ -155,6 +196,7 @@ export function recordFact(db: Kysely<DB>, voyage: VoyageClient) {
           JSON.stringify(tags),
           vectorLiteral,
           confidence,
+          permanence,
           input.sourceThreadId ?? null,
           input.sourceMessageId ?? null,
         ],
@@ -185,7 +227,7 @@ export function retrieveFacts(db: Kysely<DB>, voyage: VoyageClient) {
     // (the row's author OR scope = club).
     const vectorRows = await db.executeQuery(
       CompiledQuery.raw(
-        `SELECT id, content, tags, scope, confidence, created_at
+        `SELECT id, content, tags, scope, confidence, permanence, created_at
          FROM scout_fact
          WHERE superseded_by IS NULL
            AND (user_id = $1 OR scope = 'club')
@@ -202,7 +244,7 @@ export function retrieveFacts(db: Kysely<DB>, voyage: VoyageClient) {
     // exact-name lookups that vector search can de-prioritise.
     const ftsRows = await db.executeQuery(
       CompiledQuery.raw(
-        `SELECT id, content, tags, scope, confidence, created_at
+        `SELECT id, content, tags, scope, confidence, permanence, created_at
          FROM scout_fact
          WHERE superseded_by IS NULL
            AND (user_id = $1 OR scope = 'club')
@@ -221,7 +263,7 @@ export function retrieveFacts(db: Kysely<DB>, voyage: VoyageClient) {
     if (hasTagFilter) {
       tagRows = await db.executeQuery(
         CompiledQuery.raw(
-          `SELECT id, content, tags, scope, confidence, created_at
+          `SELECT id, content, tags, scope, confidence, permanence, created_at
            FROM scout_fact
            WHERE superseded_by IS NULL
              AND (user_id = $1 OR scope = 'club')
@@ -238,6 +280,7 @@ export function retrieveFacts(db: Kysely<DB>, voyage: VoyageClient) {
       tags: FactTags;
       scope: FactScope;
       confidence: number;
+      permanence: FactPermanence | null;
       created_at: Date | string;
     }
 
@@ -273,6 +316,7 @@ export function retrieveFacts(db: Kysely<DB>, voyage: VoyageClient) {
         tags: row.tags,
         scope: row.scope,
         confidence: row.confidence,
+        permanence: row.permanence,
         score: r.score,
         createdAt:
           row.created_at instanceof Date
@@ -286,19 +330,41 @@ export function retrieveFacts(db: Kysely<DB>, voyage: VoyageClient) {
 /**
  * Convenience for routes / tests: format facts as the markdown block
  * Scout sees in-prompt. Each line carries the fact's id as a [fact:UUID]
- * marker so the model can hand it to cite_fact when grounding a claim.
+ * marker so the model can hand it to cite_fact when grounding a claim,
+ * plus the fact's permanence and age so the debrief flow can decide
+ * whether a recorded fact is still fresh enough to skip re-asking.
  * Kept here so the wire format lives next to the thing producing it.
+ *
+ * `now` is injectable so tests get deterministic age strings.
  */
-export function formatFactsBlock(facts: RetrievedFact[]): string {
+export function formatFactsBlock(
+  facts: RetrievedFact[],
+  now: Date = new Date(),
+): string {
   if (facts.length === 0) return "";
   const lines = facts.map((f) => {
     const tagPairs = Object.entries(f.tags)
       .map(([k, v]) => `${k}=${Array.isArray(v) ? v.join("|") : v}`)
       .join(" ");
     const tagSuffix = tagPairs ? ` [${tagPairs}]` : "";
-    return `- [fact:${f.id}] ${f.content} (confidence ${f.confidence}/5${tagSuffix})`;
+    const meta: string[] = [`confidence ${f.confidence}/5`];
+    if (f.permanence) {
+      meta.push(`${f.permanence} · ${formatAge(f.createdAt, now)} old`);
+    }
+    return `- [fact:${f.id}] ${f.content} (${meta.join(" · ")}${tagSuffix})`;
   });
   return `<known-facts>\n${lines.join("\n")}\n</known-facts>`;
+}
+
+function formatAge(createdAt: Date, now: Date): string {
+  const ms = Math.max(0, now.getTime() - createdAt.getTime());
+  const days = Math.floor(ms / 86_400_000);
+  if (days < 1) return "<1d";
+  if (days < 30) return `${days}d`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo`;
+  const years = Math.floor(months / 12);
+  return `${years}y`;
 }
 
 // Exported solely for tests that want to inspect raw vectors written.

--- a/apps/api/src/features/scout/integration.test.ts
+++ b/apps/api/src/features/scout/integration.test.ts
@@ -14,6 +14,7 @@ import {
   createThread,
   deleteThread,
   getThread,
+  listRecentDebriefMatches,
   listThreads,
   ThreadNotFoundError,
 } from "./service.ts";
@@ -296,8 +297,134 @@ describe("scout thread service (integration)", () => {
       ThreadNotFoundError,
     );
 
-    // Alice can still access her own
-    await expect(assertOwned(alice, aliceThread.id)).resolves.toBeUndefined();
+    // Alice can still access her own — assertThreadOwnership returns the
+    // mode so the streaming route can pick the right system prompt.
+    await expect(assertOwned(alice, aliceThread.id)).resolves.toEqual({
+      mode: "scouting",
+    });
+  });
+
+  it("persists mode on thread creation and surfaces it via list / get / assertOwnership", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    const create = createThread(ctx.db);
+    const list = listThreads(ctx.db);
+    const get = getThread(ctx.db);
+    const assertOwned = assertThreadOwnership(ctx.db);
+
+    const debrief = await create(userId, "Debrief vs Mitford", "debrief");
+    const scouting = await create(userId, "Scout Tynemouth");
+
+    expect(debrief.mode).toBe("debrief");
+    expect(scouting.mode).toBe("scouting");
+
+    const threads = await list(userId);
+    expect(threads.find((t) => t.id === debrief.id)?.mode).toBe("debrief");
+    expect(threads.find((t) => t.id === scouting.id)?.mode).toBe("scouting");
+
+    const loaded = await get(userId, debrief.id);
+    expect(loaded.thread.mode).toBe("debrief");
+
+    await expect(assertOwned(userId, debrief.id)).resolves.toEqual({
+      mode: "debrief",
+    });
+  });
+});
+
+describe("listRecentDebriefMatches (integration)", () => {
+  it("returns Percy Main matches in the last 14 days, descending, with home/away derived from team-name prefix", async () => {
+    const now = new Date("2026-05-04T12:00:00Z");
+    const within = "2026-05-01"; // 3 days before now
+    const oldest = "2026-04-22"; // 12 days before now (in window)
+    const stale = "2026-04-15"; // 19 days before now (outside)
+
+    // Wipe + seed match_result rows directly. We don't need every column
+    // realistic — just enough for the listRecentDebriefMatches query +
+    // mapping to exercise its branches (home, away, oldest, stale-cutoff,
+    // non-Percy-Main row).
+    await ctx.db.deleteFrom("match_result").execute();
+    await ctx.db
+      .insertInto("match_result")
+      .values([
+        {
+          id: crypto.randomUUID(),
+          match_id: "1001",
+          match_date: within,
+          home_team_id: "h1",
+          away_team_id: "a1",
+          home_team_name: "Percy Main 1st XI",
+          away_team_name: "Mitford CC 1st XI",
+          result: "won",
+          result_description: "Won by 5 wickets",
+          result_applied_to: "h1",
+          competition_type: "League",
+          season: 2026,
+        },
+        {
+          id: crypto.randomUUID(),
+          match_id: "1002",
+          match_date: oldest,
+          home_team_id: "h2",
+          away_team_id: "a2",
+          home_team_name: "Tynemouth CC 2nd XI",
+          away_team_name: "Percy Main 2nd XI",
+          result: "lost",
+          result_description: "Lost by 30 runs",
+          result_applied_to: "h2",
+          competition_type: "League",
+          season: 2026,
+        },
+        {
+          id: crypto.randomUUID(),
+          match_id: "1003",
+          match_date: stale,
+          home_team_id: "h3",
+          away_team_id: "a3",
+          home_team_name: "Percy Main 1st XI",
+          away_team_name: "Northumberland CC",
+          result: "won",
+          result_description: "Won",
+          result_applied_to: "h3",
+          competition_type: "League",
+          season: 2026,
+        },
+        {
+          id: crypto.randomUUID(),
+          match_id: "1004",
+          match_date: within,
+          home_team_id: "h4",
+          away_team_id: "a4",
+          home_team_name: "Tynemouth CC 1st XI",
+          away_team_name: "Mitford CC 1st XI",
+          result: "won",
+          result_description: "Won by 50 runs",
+          result_applied_to: "h4",
+          competition_type: "League",
+          season: 2026,
+        },
+      ])
+      .execute();
+
+    const out = await listRecentDebriefMatches(ctx.db)(14, now);
+
+    // Two in-window Percy Main rows; the stale one and the non-Percy-Main
+    // row are excluded. Most-recent first.
+    expect(out.map((m) => m.id)).toEqual(["1001", "1002"]);
+
+    expect(out[0]).toMatchObject({
+      id: "1001",
+      matchDate: within,
+      opposition: "Mitford CC 1st XI",
+      homeAway: "home",
+      ourTeam: "Percy Main 1st XI",
+      result: "Won by 5 wickets",
+    });
+    expect(out[1]).toMatchObject({
+      id: "1002",
+      matchDate: oldest,
+      opposition: "Tynemouth CC 2nd XI",
+      homeAway: "away",
+      ourTeam: "Percy Main 2nd XI",
+    });
   });
 });
 

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -31,6 +31,7 @@ import {
   listFactsQuerySchema,
   listFactsResponseSchema,
   listThreadsResponseSchema,
+  recentDebriefMatchesResponseSchema,
   threadIdParamSchema,
   updateFactBodySchema,
   updateFactResponseSchema,
@@ -42,6 +43,7 @@ import {
   createThread,
   deleteThread,
   getThread,
+  listRecentDebriefMatches,
   listThreads,
   ThreadNotFoundError,
 } from "./service.ts";
@@ -56,6 +58,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
   const append = appendMessage(app.db);
   const bump = bumpThreadUpdatedAt(app.db);
   const assertOwned = assertThreadOwnership(app.db);
+  const recentMatches = listRecentDebriefMatches(app.db);
   const generateTitle = maybeGenerateTitle({
     db: app.db,
     modelId: app.config.SCOUT_MODEL_SUBAGENT,
@@ -112,8 +115,23 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request) => {
       const { user } = getAuthSession(request);
-      return await create(user.id, request.body.title);
+      return await create(user.id, request.body.title, request.body.mode);
     },
+  );
+
+  // ── Debrief launcher ──
+  // Recent Percy Main matches (last 14d) so the FE can offer them as
+  // clickable cards when the captain starts a debrief thread. The
+  // free-text/URL fallback in the FE bypasses this entirely.
+  app.get(
+    "/scout/debrief/recent-matches",
+    {
+      preHandler: [requireScoutAccess],
+      schema: {
+        response: { 200: recentDebriefMatchesResponseSchema },
+      },
+    },
+    async () => ({ matches: await recentMatches() }),
   );
 
   app.get(
@@ -206,8 +224,10 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
         });
       }
 
+      let threadMode: "scouting" | "debrief";
       try {
-        await assertOwned(user.id, threadId);
+        const owned = await assertOwned(user.id, threadId);
+        threadMode = owned.mode;
       } catch (err) {
         if (err instanceof ThreadNotFoundError) {
           throw Object.assign(new Error("Thread not found"), {
@@ -362,6 +382,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
             voyage,
             userId: user.id,
             threadId,
+            mode: threadMode,
           });
 
           const result = streamText({

--- a/apps/api/src/features/scout/schemas.ts
+++ b/apps/api/src/features/scout/schemas.ts
@@ -9,9 +9,13 @@ export const threadIdParamSchema = z.object({
   threadId: z.uuid(),
 });
 
+export const scoutModeSchema = z.enum(["scouting", "debrief"]);
+export type ScoutMode = z.infer<typeof scoutModeSchema>;
+
 export const threadSummarySchema = z.object({
   id: z.uuid(),
   title: z.string(),
+  mode: scoutModeSchema,
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime(),
 });
@@ -22,6 +26,7 @@ export const listThreadsResponseSchema = z.object({
 
 export const createThreadBodySchema = z.object({
   title: z.string().min(1).max(200).default("New thread"),
+  mode: scoutModeSchema.default("scouting"),
 });
 
 export const createThreadResponseSchema = threadSummarySchema;
@@ -69,6 +74,11 @@ const adminFactTagsSchema = z.record(
   z.union([z.string(), z.array(z.string())]),
 );
 
+export const factPermanenceSchema = z
+  .enum(["permanent", "seasonal", "ephemeral"])
+  .nullable();
+export type FactPermanence = z.infer<typeof factPermanenceSchema>;
+
 export const factAdminItemSchema = z.object({
   id: z.uuid(),
   userId: z.string(),
@@ -76,6 +86,7 @@ export const factAdminItemSchema = z.object({
   content: z.string(),
   tags: adminFactTagsSchema,
   confidence: z.number().int().min(1).max(5),
+  permanence: factPermanenceSchema,
   sourceThreadId: z.uuid().nullable(),
   supersededBy: z.uuid().nullable(),
   createdAt: z.iso.datetime(),
@@ -110,10 +121,30 @@ export const updateFactBodySchema = z.object({
   tags: adminFactTagsSchema.optional(),
   scope: adminFactScopeSchema.optional(),
   confidence: z.number().int().min(1).max(5).optional(),
+  // Allow explicit null to clear permanence back to "unknown"; omit the
+  // field entirely to leave it untouched.
+  permanence: factPermanenceSchema.optional(),
 });
 
 export const updateFactResponseSchema = factAdminItemSchema;
 
 export const deleteFactResponseSchema = z.object({
   ok: z.literal(true),
+});
+
+// ── Debrief mode ──
+// Recent Percy Main matches surfaced as launcher options when starting a
+// debrief thread. Last 14 days, descending. The FE renders these as
+// clickable cards alongside a free-text/URL fallback.
+export const recentDebriefMatchSchema = z.object({
+  id: z.string(),
+  matchDate: z.iso.date(),
+  opposition: z.string(),
+  homeAway: z.enum(["home", "away"]),
+  ourTeam: z.string(),
+  result: z.string().nullable(),
+});
+
+export const recentDebriefMatchesResponseSchema = z.object({
+  matches: z.array(recentDebriefMatchSchema),
 });

--- a/apps/api/src/features/scout/service.ts
+++ b/apps/api/src/features/scout/service.ts
@@ -1,9 +1,11 @@
 import type { DB } from "@percy-main/db";
 import type { Kysely } from "kysely";
+import type { ScoutMode } from "./schemas.ts";
 
 export interface ThreadSummary {
   id: string;
   title: string;
+  mode: ScoutMode;
   createdAt: string;
   updatedAt: string;
 }
@@ -29,13 +31,14 @@ export function listThreads(db: Kysely<DB>) {
     const rows = await db
       .selectFrom("scout_thread")
       .where("user_id", "=", userId)
-      .select(["id", "title", "created_at", "updated_at"])
+      .select(["id", "title", "mode", "created_at", "updated_at"])
       .orderBy("updated_at", "desc")
       .execute();
 
     return rows.map((r) => ({
       id: r.id,
       title: r.title,
+      mode: r.mode as ScoutMode,
       createdAt: toIso(r.created_at),
       updatedAt: toIso(r.updated_at),
     }));
@@ -43,16 +46,21 @@ export function listThreads(db: Kysely<DB>) {
 }
 
 export function createThread(db: Kysely<DB>) {
-  return async (userId: string, title: string): Promise<ThreadSummary> => {
+  return async (
+    userId: string,
+    title: string,
+    mode: ScoutMode = "scouting",
+  ): Promise<ThreadSummary> => {
     const row = await db
       .insertInto("scout_thread")
-      .values({ user_id: userId, title })
-      .returning(["id", "title", "created_at", "updated_at"])
+      .values({ user_id: userId, title, mode })
+      .returning(["id", "title", "mode", "created_at", "updated_at"])
       .executeTakeFirstOrThrow();
 
     return {
       id: row.id,
       title: row.title,
+      mode: row.mode as ScoutMode,
       createdAt: toIso(row.created_at),
       updatedAt: toIso(row.updated_at),
     };
@@ -79,7 +87,7 @@ export function getThread(db: Kysely<DB>) {
       .selectFrom("scout_thread")
       .where("id", "=", threadId)
       .where("user_id", "=", userId)
-      .select(["id", "title", "created_at", "updated_at"])
+      .select(["id", "title", "mode", "created_at", "updated_at"])
       .executeTakeFirst();
 
     if (!thread) throw new ThreadNotFoundError();
@@ -115,6 +123,7 @@ export function getThread(db: Kysely<DB>) {
       thread: {
         id: thread.id,
         title: thread.title,
+        mode: thread.mode as ScoutMode,
         createdAt: toIso(thread.created_at),
         updatedAt: toIso(thread.updated_at),
       },
@@ -193,19 +202,84 @@ export function bumpThreadUpdatedAt(db: Kysely<DB>) {
   };
 }
 
+export interface RecentDebriefMatch {
+  id: string;
+  matchDate: string;
+  opposition: string;
+  homeAway: "home" | "away";
+  ourTeam: string;
+  result: string | null;
+}
+
 /**
- * Verify a thread exists and is owned by the user. Used by the streaming
- * route, which can't use getThread (we don't want to load all messages just
- * to check ownership).
+ * Recent Percy Main matches (last 14 days, descending) used to populate
+ * the debrief launcher. We match by team-name prefix because the local
+ * MatchResult mirror doesn't carry club_ids — every Percy Main team
+ * starts with "Percy Main" (e.g. "Percy Main 1st XI", "Percy Main 2nd XI").
+ */
+export function listRecentDebriefMatches(db: Kysely<DB>) {
+  return async (
+    days = 14,
+    now: Date = new Date(),
+  ): Promise<RecentDebriefMatch[]> => {
+    const cutoff = new Date(now.getTime() - days * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const today = now.toISOString().slice(0, 10);
+
+    const rows = await db
+      .selectFrom("match_result")
+      .select([
+        "match_id",
+        "match_date",
+        "home_team_name",
+        "away_team_name",
+        "result",
+        "result_description",
+      ])
+      .where("match_date", ">=", cutoff)
+      .where("match_date", "<=", today)
+      .where((eb) =>
+        eb.or([
+          eb("home_team_name", "like", "Percy Main%"),
+          eb("away_team_name", "like", "Percy Main%"),
+        ]),
+      )
+      .orderBy("match_date", "desc")
+      .execute();
+
+    return rows.map((r) => {
+      const isHome = r.home_team_name.startsWith("Percy Main");
+      return {
+        id: r.match_id,
+        matchDate: r.match_date,
+        opposition: isHome ? r.away_team_name : r.home_team_name,
+        homeAway: isHome ? ("home" as const) : ("away" as const),
+        ourTeam: isHome ? r.home_team_name : r.away_team_name,
+        result: r.result_description || r.result || null,
+      };
+    });
+  };
+}
+
+/**
+ * Verify a thread exists and is owned by the user, returning its mode.
+ * Used by the streaming route, which can't use getThread (we don't want
+ * to load all messages just to check ownership) but does need the mode
+ * to pick the right system prompt + tool surface.
  */
 export function assertThreadOwnership(db: Kysely<DB>) {
-  return async (userId: string, threadId: string): Promise<void> => {
+  return async (
+    userId: string,
+    threadId: string,
+  ): Promise<{ mode: ScoutMode }> => {
     const row = await db
       .selectFrom("scout_thread")
       .where("id", "=", threadId)
       .where("user_id", "=", userId)
-      .select("id")
+      .select(["id", "mode"])
       .executeTakeFirst();
     if (!row) throw new ThreadNotFoundError();
+    return { mode: row.mode as ScoutMode };
   };
 }

--- a/apps/api/src/features/scout/system-prompt.ts
+++ b/apps/api/src/features/scout/system-prompt.ts
@@ -140,3 +140,51 @@ Important context:
 If a tool returns nothing or the relevant sample is empty, say so plainly. Don't estimate, don't extrapolate, don't quietly switch to generic advice and present it as data-led scouting. A useful fallback: "I don't have scorecard data for them in the local DB. I can give a generic plan — start straight, protect boundaries early, reassess after the first two overs — but I wouldn't dress it up as scouting."
 
 Tone: concise, analytical, slightly informal. Lead with the recommendation, then the evidence. No filler ("Great question!", "Let me help you with that"). No bullet-point soup when prose is clearer.`;
+
+export const SCOUT_DEBRIEF_SYSTEM_PROMPT = `You are Scout, running a post-match DEBRIEF for a captain of Percy Main CC.
+
+The aim of debrief is to grow the fact corpus that future scouting reports will draw on. The captain has just played a match; you walk them through a small number of structured questions, record each answer as a fact, and stop. You are NOT producing a long analysis here — debrief is a focused interview, not a report.
+
+How a debrief turn works:
+1. The captain's first message is "Debriefing match <id> ...". Pull that match with pc_match_detail. Use a narrow projection that gets the scorecard, fall-of-wickets, and ground.
+2. Pick 3–5 INTERESTING candidates to talk about — don't walk through all 22 players. Good candidates:
+   - Opposition top scorers (50+, or the highest 2 of the innings)
+   - Opposition bowlers who took 3+ wickets against us
+   - Our players whose scorecard line undersells what happened (e.g. dropped catches off their bowling, run-out at the non-striker's end)
+   - The ground itself if we played away
+3. Tell the captain in one short sentence who/what you want to talk about and why. Then ask the FIRST question via ask_question.
+4. After each answer, call fact_record once with the captain's wording (one fact per answer; pick scope, tags including a topic, and confidence — the system infers permanence from topic). Confirm in one short line, then ask the next question via ask_question.
+5. When you've finished the candidates you proposed, ask via ask_question whether they want to dig into anyone else (options: a couple of named players + "no, we're done"). If they pick a player, repeat from step 3 for that player.
+6. When they say done, summarise in 2–3 lines what was recorded and stop.
+
+ask_question is the right tool for almost every prompt in debrief — yes/no, batting hand, bowling action, ground features, etc. Keep options ≤ 6 and phrase \`value\` as a complete answer so the recorded fact reads naturally. After calling ask_question, STOP — do not continue with prose or other tools, just wait for the reply.
+
+Question categories worth asking about (only the ones the data points at — don't read down a checklist):
+- Bowlers: action/style (RA-medium, LA-orthodox spin, etc.), pace, did they swing/seam, when in the innings did they bowl
+- Batters: handedness, where their runs went (mostly leg/off, square/straight), did they look in control, were there dropped catches off them
+- Ground (away only): covers (yes/no), sightscreens (both ends/one/none), boundary size, slope, square cut to today's pitch
+- Our side: dropped catches (count + off whose bowling), unlucky dismissals (good ball / run-out at the bowler's end / freak), notable contributions not on the scorecard
+
+SKIP-IF-KNOWN — non-negotiable.
+
+The <known-facts> block injected into the user's message annotates each fact with permanence and age:
+  - permanent (handedness, bowling style, position) — never expires
+  - seasonal (ground covers, sightscreens, scheduling) — re-confirm if older than 12 months
+  - ephemeral (weather, recent form, injuries) — re-confirm if older than 7 days
+  - no annotation — treat as "decay rate unknown", and ask if it's relevant
+
+Before asking ANY question, check <known-facts>. If a recent enough fact answers it (using the rule above), DO NOT ask. Instead, briefly state the known fact ("You've previously said Mitford have no covers — sticking with that?") and either accept silently or use ask_question with options like "Yes that's still right" / "No, this has changed". Wasting a captain's time re-asking permanent facts is the single biggest mistake to avoid.
+
+Cite-and-record discipline:
+- Record the captain's literal words, not your interpretation. "Their no.4 was tucking everything off the pads" — record that as the content; don't reduce it to "leg-side strong".
+- One fact_record per piece of information. Don't batch.
+- Tag every fact with a stable \`topic\` (handedness | bowling-style | position | ground | scheduling | rules | kit | weather | form | injury). The system uses topic to set permanence automatically.
+- For team/player facts also tag \`team:"<Club CC>"\` and/or \`player:"<Full Name>"\`.
+- Confidence: 5 if the captain stated it directly; 3 for "I think so"; 1 for guesswork.
+- Only claim a fact was recorded if fact_record returned recorded:true.
+
+Hard rules carried over from scouting mode:
+- Never invent shot patterns / lines / lengths / footwork etc. that the data doesn't support — if the captain didn't say it, don't record it.
+- Never call a player "opener", "death bowler", "spinner" etc. unless they said so.
+- Charts are out of place in debrief — don't use chart_render here.
+- Tone: tight, friendly, one short sentence between questions. Skip filler ("great", "let me help"). The captain wants to be in and out fast.`;

--- a/apps/api/src/features/scout/tools/ask-question.ts
+++ b/apps/api/src/features/scout/tools/ask-question.ts
@@ -1,0 +1,91 @@
+import { tool, type UIMessageStreamWriter } from "ai";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+export interface AskQuestionToolDeps {
+  writer: UIMessageStreamWriter;
+}
+
+const askQuestionInputSchema = z.object({
+  question: z
+    .string()
+    .min(3)
+    .max(280)
+    .describe("The question to ask the user, in plain English."),
+  options: z
+    .array(
+      z.object({
+        label: z
+          .string()
+          .min(1)
+          .max(80)
+          .describe("Button label shown to the user."),
+        value: z
+          .string()
+          .min(1)
+          .max(280)
+          .describe(
+            "Text submitted as the user reply when this option is picked. Make it a complete answer (e.g. 'Yes — covers' rather than 'Yes') so the recorded fact reads naturally.",
+          ),
+      }),
+    )
+    .min(2)
+    .max(6)
+    .describe(
+      "Two to six button options. Cover the realistic outcomes; the user can always type a free-text answer instead.",
+    ),
+  allowFreeText: z
+    .boolean()
+    .default(true)
+    .describe(
+      "Whether to render a free-text input alongside the buttons. Default true — never trap the user in multiple choice.",
+    ),
+});
+
+/**
+ * ask_question lets the agent surface a yes/no/multi-choice prompt as
+ * inline UI rather than asking in prose and waiting for a typed reply.
+ * The frontend renders a card with option buttons; clicking a button
+ * sends the option's `value` as a normal user message, so the agent
+ * picks up the answer through the standard chat loop.
+ *
+ * The tool emits a `data-question` UI part via the stream writer (same
+ * pattern as chart_render / cite_match) and returns a small confirmation
+ * to the model. The system prompt is responsible for telling the model
+ * to STOP its step after asking — there's no further work to do until
+ * the user replies.
+ */
+export function createAskQuestionTool(deps: AskQuestionToolDeps) {
+  const { writer } = deps;
+
+  return {
+    ask_question: tool({
+      description: `Ask the user a single question with clickable options. Use this in debrief mode whenever you need a small piece of information that has a small set of likely answers (yes/no, a category from a short list, etc.). The frontend renders a card with buttons; the user picks one or types a free-text answer.
+
+Rules:
+- One question per call. Don't try to ask multiple things in one prompt.
+- Provide 2–6 options. Cover the realistic outcomes; the free-text input handles edge cases.
+- Each option's \`value\` is the literal text submitted as the user's reply. Phrase it as a complete answer ("Yes — covers", "No covers", "Some matting only") so the next \`fact_record\` you make reads naturally.
+- After calling ask_question, STOP this step. Do not continue with prose or other tool calls; wait for the user's reply in the next turn.
+
+Don't use ask_question for open-ended questions (their feedback on a player's footwork, ground notes that don't fit a small option set) — ask in prose for those.`,
+      inputSchema: askQuestionInputSchema,
+      // eslint-disable-next-line @typescript-eslint/require-await -- AI SDK execute signature is async; this tool only writes a data part.
+      execute: async ({
+        question,
+        options,
+        allowFreeText,
+      }: z.infer<typeof askQuestionInputSchema>) => {
+        const id = randomUUID();
+        writer.write({
+          type: "data-question",
+          id,
+          data: { question, options, allowFreeText },
+        });
+        return { asked: true, questionId: id };
+      },
+    }),
+  };
+}
+
+export type AskQuestionTools = ReturnType<typeof createAskQuestionTool>;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -8866,6 +8866,8 @@ export interface paths {
                                 /** Format: uuid */
                                 id: string;
                                 title: string;
+                                /** @enum {string} */
+                                mode: "scouting" | "debrief";
                                 /** Format: date-time */
                                 createdAt: string;
                                 /** Format: date-time */
@@ -8889,6 +8891,11 @@ export interface paths {
                     "application/json": {
                         /** @default New thread */
                         title?: string;
+                        /**
+                         * @default scouting
+                         * @enum {string}
+                         */
+                        mode?: "scouting" | "debrief";
                     };
                 };
             };
@@ -8903,6 +8910,8 @@ export interface paths {
                             /** Format: uuid */
                             id: string;
                             title: string;
+                            /** @enum {string} */
+                            mode: "scouting" | "debrief";
                             /** Format: date-time */
                             createdAt: string;
                             /** Format: date-time */
@@ -8912,6 +8921,52 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scout/debrief/recent-matches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            matches: {
+                                id: string;
+                                /** Format: date */
+                                matchDate: string;
+                                opposition: string;
+                                /** @enum {string} */
+                                homeAway: "home" | "away";
+                                ourTeam: string;
+                                result: string | null;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -8947,6 +9002,8 @@ export interface paths {
                                 /** Format: uuid */
                                 id: string;
                                 title: string;
+                                /** @enum {string} */
+                                mode: "scouting" | "debrief";
                                 /** Format: date-time */
                                 createdAt: string;
                                 /** Format: date-time */
@@ -9047,6 +9104,8 @@ export interface paths {
                                     [key: string]: string | string[];
                                 };
                                 confidence: number;
+                                /** @enum {string|null} */
+                                permanence: "permanent" | "seasonal" | "ephemeral" | null;
                                 /** Format: uuid */
                                 sourceThreadId: string | null;
                                 /** Format: uuid */
@@ -9105,6 +9164,8 @@ export interface paths {
                                 [key: string]: string | string[];
                             };
                             confidence: number;
+                            /** @enum {string|null} */
+                            permanence: "permanent" | "seasonal" | "ephemeral" | null;
                             /** Format: uuid */
                             sourceThreadId: string | null;
                             /** Format: uuid */
@@ -9166,6 +9227,8 @@ export interface paths {
                         /** @enum {string} */
                         scope?: "user" | "club";
                         confidence?: number;
+                        /** @enum {string|null} */
+                        permanence?: "permanent" | "seasonal" | "ephemeral" | null;
                     };
                 };
             };
@@ -9187,6 +9250,8 @@ export interface paths {
                                 [key: string]: string | string[];
                             };
                             confidence: number;
+                            /** @enum {string|null} */
+                            permanence: "permanent" | "seasonal" | "ephemeral" | null;
                             /** Format: uuid */
                             sourceThreadId: string | null;
                             /** Format: uuid */

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -15458,6 +15458,13 @@
                           "title": {
                             "type": "string"
                           },
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "scouting",
+                              "debrief"
+                            ]
+                          },
                           "createdAt": {
                             "type": "string",
                             "format": "date-time",
@@ -15472,6 +15479,7 @@
                         "required": [
                           "id",
                           "title",
+                          "mode",
                           "createdAt",
                           "updatedAt"
                         ],
@@ -15502,6 +15510,14 @@
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 200
+                  },
+                  "mode": {
+                    "default": "scouting",
+                    "type": "string",
+                    "enum": [
+                      "scouting",
+                      "debrief"
+                    ]
                   }
                 }
               }
@@ -15524,6 +15540,13 @@
                     "title": {
                       "type": "string"
                     },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "scouting",
+                        "debrief"
+                      ]
+                    },
                     "createdAt": {
                       "type": "string",
                       "format": "date-time",
@@ -15538,8 +15561,73 @@
                   "required": [
                     "id",
                     "title",
+                    "mode",
                     "createdAt",
                     "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/scout/debrief/recent-matches": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "matches": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "matchDate": {
+                            "type": "string",
+                            "format": "date",
+                            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))$"
+                          },
+                          "opposition": {
+                            "type": "string"
+                          },
+                          "homeAway": {
+                            "type": "string",
+                            "enum": [
+                              "home",
+                              "away"
+                            ]
+                          },
+                          "ourTeam": {
+                            "type": "string"
+                          },
+                          "result": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "matchDate",
+                          "opposition",
+                          "homeAway",
+                          "ourTeam",
+                          "result"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "matches"
                   ],
                   "additionalProperties": false
                 }
@@ -15582,6 +15670,13 @@
                         "title": {
                           "type": "string"
                         },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "scouting",
+                            "debrief"
+                          ]
+                        },
                         "createdAt": {
                           "type": "string",
                           "format": "date-time",
@@ -15596,6 +15691,7 @@
                       "required": [
                         "id",
                         "title",
+                        "mode",
                         "createdAt",
                         "updatedAt"
                       ],
@@ -15840,6 +15936,15 @@
                             "minimum": 1,
                             "maximum": 5
                           },
+                          "permanence": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "permanent",
+                              "seasonal",
+                              "ephemeral"
+                            ]
+                          },
                           "sourceThreadId": {
                             "nullable": true,
                             "type": "string",
@@ -15870,6 +15975,7 @@
                           "content",
                           "tags",
                           "confidence",
+                          "permanence",
                           "sourceThreadId",
                           "supersededBy",
                           "createdAt",
@@ -15937,6 +16043,15 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 5
+                  },
+                  "permanence": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": [
+                      "permanent",
+                      "seasonal",
+                      "ephemeral"
+                    ]
                   }
                 }
               }
@@ -16002,6 +16117,15 @@
                       "minimum": 1,
                       "maximum": 5
                     },
+                    "permanence": {
+                      "nullable": true,
+                      "type": "string",
+                      "enum": [
+                        "permanent",
+                        "seasonal",
+                        "ephemeral"
+                      ]
+                    },
                     "sourceThreadId": {
                       "nullable": true,
                       "type": "string",
@@ -16032,6 +16156,7 @@
                     "content",
                     "tags",
                     "confidence",
+                    "permanence",
                     "sourceThreadId",
                     "supersededBy",
                     "createdAt",
@@ -16142,6 +16267,15 @@
                       "minimum": 1,
                       "maximum": 5
                     },
+                    "permanence": {
+                      "nullable": true,
+                      "type": "string",
+                      "enum": [
+                        "permanent",
+                        "seasonal",
+                        "ephemeral"
+                      ]
+                    },
                     "sourceThreadId": {
                       "nullable": true,
                       "type": "string",
@@ -16172,6 +16306,7 @@
                     "content",
                     "tags",
                     "confidence",
+                    "permanence",
                     "sourceThreadId",
                     "supersededBy",
                     "createdAt",

--- a/apps/web/src/pages/scout/debrief-launcher.tsx
+++ b/apps/web/src/pages/scout/debrief-launcher.tsx
@@ -1,0 +1,115 @@
+import { Button } from "@/components/ui/button";
+import { api, callApi } from "@/lib/api-client";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+interface DebriefLauncherProps {
+  /** Send a user message into the chat. The launcher hands the agent a
+   *  one-line prompt that names the match (id + opposition + date) so the
+   *  debrief system prompt can pull pc_match_detail for it. */
+  onLaunch: (text: string) => void;
+}
+
+/**
+ * Initial card shown for an empty debrief thread. Lists Percy Main matches
+ * from the last 14 days as clickable options + offers a free-text/URL
+ * fallback. Picking any option fires the first user message; the agent's
+ * system prompt takes it from there.
+ */
+export function DebriefLauncher({ onLaunch }: DebriefLauncherProps) {
+  const recentQuery = useQuery({
+    queryKey: ["scout", "debrief", "recent-matches"],
+    queryFn: () => callApi(api.GET("/api/scout/debrief/recent-matches")),
+  });
+
+  const [freeText, setFreeText] = useState("");
+
+  const submit = (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    onLaunch(trimmed);
+  };
+
+  return (
+    <div className="mx-auto my-6 max-w-xl rounded-lg border border-amber-200 bg-amber-50 p-4">
+      <h3 className="my-0 text-sm font-semibold text-amber-900">
+        Post-match debrief
+      </h3>
+      <p className="mt-1 text-sm text-amber-900/80">
+        Pick a recent match to walk through, or paste a Play Cricket scorecard
+        URL.
+      </p>
+
+      <div className="mt-3">
+        {recentQuery.isLoading && (
+          <div className="text-xs text-amber-900/60">Loading matches…</div>
+        )}
+        {recentQuery.error && (
+          <div className="text-xs text-red-700">
+            {recentQuery.error instanceof Error
+              ? recentQuery.error.message
+              : "Failed to load recent matches"}
+          </div>
+        )}
+        {recentQuery.data?.matches.length === 0 && (
+          <div className="text-xs text-amber-900/60">
+            No Percy Main matches in the last 14 days.
+          </div>
+        )}
+        <ul className="space-y-1.5">
+          {recentQuery.data?.matches.map((m) => (
+            <li key={m.id}>
+              <button
+                type="button"
+                onClick={() =>
+                  submit(
+                    `Debriefing match ${m.id} — ${m.ourTeam} ${
+                      m.homeAway === "home" ? "vs" : "at"
+                    } ${m.opposition} on ${m.matchDate}.`,
+                  )
+                }
+                className="block w-full rounded border border-amber-200 bg-white px-3 py-2 text-left text-sm text-gray-900 shadow-sm hover:border-amber-400 hover:bg-amber-100"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate font-medium">
+                    {m.ourTeam}{" "}
+                    <span className="text-gray-500">
+                      {m.homeAway === "home" ? "vs" : "at"}
+                    </span>{" "}
+                    {m.opposition}
+                  </span>
+                  <span className="shrink-0 text-xs text-gray-500">
+                    {m.matchDate}
+                  </span>
+                </div>
+                {m.result && (
+                  <div className="mt-0.5 text-xs text-gray-600">{m.result}</div>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <form
+        className="mt-3 flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit(freeText);
+          setFreeText("");
+        }}
+      >
+        <input
+          type="text"
+          value={freeText}
+          onChange={(e) => setFreeText(e.target.value)}
+          placeholder="Or paste a Play Cricket scorecard URL"
+          className="flex-1 rounded border border-amber-200 bg-white px-2 py-1.5 text-sm focus:border-amber-500 focus:outline-none"
+        />
+        <Button type="submit" size="sm" disabled={!freeText.trim()}>
+          Start
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/pages/scout/facts-admin.tsx
+++ b/apps/web/src/pages/scout/facts-admin.tsx
@@ -21,6 +21,8 @@ import { useState } from "react";
  * the embedding round-trip server-side.
  */
 
+type Permanence = "permanent" | "seasonal" | "ephemeral" | null;
+
 interface Fact {
   id: string;
   userId: string;
@@ -28,6 +30,7 @@ interface Fact {
   content: string;
   tags: Record<string, string | string[]>;
   confidence: number;
+  permanence: Permanence;
   sourceThreadId: string | null;
   supersededBy: string | null;
   createdAt: string;
@@ -200,7 +203,10 @@ function FactRow({
         <div className="text-sm text-gray-900">{fact.content}</div>
         <div className="mt-0.5 text-xs text-gray-500">
           {fact.scope === "user" ? "personal" : "club"} · confidence{" "}
-          {fact.confidence}/5
+          {fact.confidence}/5 ·{" "}
+          <span className="font-medium">
+            {fact.permanence ?? "permanence?"}
+          </span>
           {tagPairs ? ` · ${tagPairs}` : ""}
           {" · "}
           {new Date(fact.createdAt).toLocaleDateString()}
@@ -237,6 +243,9 @@ function FactEditDialog({
   const [content, setContent] = useState(fact?.content ?? "");
   const [scope, setScope] = useState<"user" | "club">(fact?.scope ?? "club");
   const [confidence, setConfidence] = useState<number>(fact?.confidence ?? 3);
+  const [permanence, setPermanence] = useState<Permanence>(
+    fact?.permanence ?? null,
+  );
   const [tagsText, setTagsText] = useState(
     fact ? JSON.stringify(fact.tags) : "{}",
   );
@@ -248,6 +257,7 @@ function FactEditDialog({
     setContent(fact.content);
     setScope(fact.scope);
     setConfidence(fact.confidence);
+    setPermanence(fact.permanence);
     setTagsText(JSON.stringify(fact.tags));
   });
 
@@ -267,6 +277,7 @@ function FactEditDialog({
             content: content !== fact.content ? content : undefined,
             scope: scope !== fact.scope ? scope : undefined,
             confidence: confidence !== fact.confidence ? confidence : undefined,
+            permanence: permanence !== fact.permanence ? permanence : undefined,
             tags: parsedTags,
           },
         }),
@@ -329,6 +340,22 @@ function FactEditDialog({
                 setConfidence(Math.max(1, Math.min(5, Number(e.target.value))))
               }
             />
+          </label>
+          <label className="flex flex-col text-xs text-gray-600">
+            Permanence
+            <select
+              className="mt-1 rounded border border-gray-300 px-2 py-1 text-sm"
+              value={permanence ?? ""}
+              onChange={(e) => {
+                const v = e.target.value;
+                setPermanence(v === "" ? null : (v as Permanence));
+              }}
+            >
+              <option value="">Unknown</option>
+              <option value="permanent">Permanent</option>
+              <option value="seasonal">Seasonal</option>
+              <option value="ephemeral">Ephemeral</option>
+            </select>
           </label>
         </div>
 

--- a/apps/web/src/pages/scout/message-view.tsx
+++ b/apps/web/src/pages/scout/message-view.tsx
@@ -209,6 +209,20 @@ function buildMarkdownComponents(
 
 interface MessageViewProps {
   message: UIMessage;
+  /** Submit a reply on the user's behalf — used by the inline question
+   *  card (data-question parts) when the user picks an option or types a
+   *  free-text answer. Optional so user-message renders don't need to
+   *  pass it. */
+  onAnswerQuestion?: (text: string) => void;
+  /** Disables the question card while a stream is in flight, so old
+   *  questions don't fire double answers. */
+  isStreaming?: boolean;
+}
+
+interface QuestionData {
+  question: string;
+  options: Array<{ label: string; value: string }>;
+  allowFreeText: boolean;
 }
 
 // Walk parts once to assign each unique citation key a stable number
@@ -247,7 +261,11 @@ function partToCitation(part: UIMessage["parts"][number]): Citation | null {
   return null;
 }
 
-export function MessageView({ message }: MessageViewProps) {
+export function MessageView({
+  message,
+  onAnswerQuestion,
+  isStreaming,
+}: MessageViewProps) {
   const isUser = message.role === "user";
   const citations = isUser
     ? { numberByKey: new Map<string, number>(), ordered: [] as Citation[] }
@@ -293,6 +311,8 @@ export function MessageView({ message }: MessageViewProps) {
             part={part}
             numberByKey={citations.numberByKey}
             onChipClick={handleChipClick}
+            onAnswerQuestion={onAnswerQuestion}
+            isStreaming={isStreaming}
           />
         ))}
         {!isUser && citations.ordered.length > 0 && (
@@ -370,7 +390,8 @@ function renderParts(
     if (
       part.type === "tool-cite_fact" ||
       part.type === "tool-cite_match" ||
-      part.type === "tool-cite_player_stats"
+      part.type === "tool-cite_player_stats" ||
+      part.type === "tool-ask_question"
     ) {
       continue;
     }
@@ -473,10 +494,14 @@ function PartView({
   part,
   numberByKey,
   onChipClick,
+  onAnswerQuestion,
+  isStreaming,
 }: {
   part: Part;
   numberByKey: Map<string, number>;
   onChipClick: (key: string) => void;
+  onAnswerQuestion?: (text: string) => void;
+  isStreaming?: boolean;
 }) {
   if (part.type === "text") {
     return (
@@ -507,6 +532,17 @@ function PartView({
     return <ScoutChart spec={chartPart.data} />;
   }
 
+  if (part.type === "data-question") {
+    const qPart = part as { type: "data-question"; data: QuestionData };
+    return (
+      <QuestionCard
+        data={qPart.data}
+        onAnswer={onAnswerQuestion}
+        disabled={isStreaming}
+      />
+    );
+  }
+
   // Citation data parts that didn't get folded into a preceding text part
   // (rare — only when the model cites before any prose). Render a standalone
   // chip so the citation isn't lost.
@@ -526,7 +562,8 @@ function PartView({
     if (
       part.type === "tool-cite_fact" ||
       part.type === "tool-cite_match" ||
-      part.type === "tool-cite_player_stats"
+      part.type === "tool-cite_player_stats" ||
+      part.type === "tool-ask_question"
     ) {
       return null;
     }
@@ -740,6 +777,86 @@ function Pill({
 
 function capitalise(s: string): string {
   return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+// ── Inline question card (data-question) ─────────────────────────────────
+
+function QuestionCard({
+  data,
+  onAnswer,
+  disabled,
+}: {
+  data: QuestionData;
+  onAnswer?: (text: string) => void;
+  disabled?: boolean;
+}) {
+  // Lock the card once the user has answered, so a re-render driven by
+  // streaming a later message doesn't let them click twice.
+  const [answered, setAnswered] = useState<string | null>(null);
+  const [freeText, setFreeText] = useState("");
+
+  const submit = (text: string) => {
+    if (!onAnswer || disabled || answered !== null) return;
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setAnswered(trimmed);
+    onAnswer(trimmed);
+  };
+
+  const isInteractive =
+    onAnswer !== undefined && !disabled && answered === null;
+
+  return (
+    <div className="my-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
+      <div className="text-sm font-medium text-amber-900">{data.question}</div>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {data.options.map((opt) => {
+          const picked = answered === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => submit(opt.value)}
+              disabled={!isInteractive}
+              className={
+                picked
+                  ? "rounded border border-amber-500 bg-amber-200 px-2.5 py-1 text-xs font-medium text-amber-900"
+                  : "rounded border border-amber-300 bg-white px-2.5 py-1 text-xs text-gray-800 hover:border-amber-500 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-amber-300 disabled:hover:bg-white"
+              }
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+      {data.allowFreeText && answered === null && (
+        <form
+          className="mt-2 flex gap-1.5"
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit(freeText);
+            setFreeText("");
+          }}
+        >
+          <input
+            type="text"
+            value={freeText}
+            onChange={(e) => setFreeText(e.target.value)}
+            disabled={!isInteractive}
+            placeholder="Or type an answer"
+            className="flex-1 rounded border border-amber-300 bg-white px-2 py-1 text-xs focus:border-amber-500 focus:outline-none disabled:opacity-60"
+          />
+          <button
+            type="submit"
+            disabled={!isInteractive || !freeText.trim()}
+            className="rounded bg-amber-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Send
+          </button>
+        </form>
+      )}
+    </div>
+  );
 }
 
 // ── Tool-call card (debug view for non-citation tools) ────────────────────

--- a/apps/web/src/pages/scout/scout.tsx
+++ b/apps/web/src/pages/scout/scout.tsx
@@ -5,9 +5,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { Composer } from "./composer.js";
+import { DebriefLauncher } from "./debrief-launcher.js";
 import { MessageView } from "./message-view.js";
 import { ThreadList } from "./thread-list.js";
 import { useScoutChat } from "./use-scout-chat.js";
+
+type ScoutMode = "scouting" | "debrief";
 
 export function Component() {
   useDocumentMeta("Scout");
@@ -33,8 +36,9 @@ function EmptyState() {
           Pick a thread, or start a new one.
         </div>
         <div>
-          Scout helps you scout opposition and plan dismissals using Play
-          Cricket data + our match history.
+          <strong>New scout</strong> for free-form opposition research, or{" "}
+          <strong>Debrief</strong> to walk through a recent match and grow the
+          fact corpus.
         </div>
       </div>
     </div>
@@ -76,7 +80,7 @@ function ActiveThread({ threadId }: { threadId: string }) {
 interface ChatViewProps {
   threadId: string;
   loaded: {
-    thread: { id: string; title: string };
+    thread: { id: string; title: string; mode: ScoutMode };
     messages: Array<{
       id: string;
       role: "user" | "assistant" | "tool" | "system";
@@ -131,12 +135,18 @@ function ChatView({ threadId, loaded }: ChatViewProps) {
   }, [messages, status]);
 
   const isStreaming = status === "submitted" || status === "streaming";
+  const isDebrief = loaded.thread.mode === "debrief";
 
   return (
     <>
       <header className="flex h-12 shrink-0 items-center justify-between border-b border-gray-200 px-4">
-        <h2 className="my-0 truncate text-sm font-medium text-gray-700">
-          {loaded.thread.title}
+        <h2 className="my-0 flex items-center gap-2 truncate text-sm font-medium text-gray-700">
+          {isDebrief && (
+            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-amber-800 uppercase">
+              Debrief
+            </span>
+          )}
+          <span className="truncate">{loaded.thread.title}</span>
         </h2>
         <span className="text-xs text-gray-400">
           {messages.length} message{messages.length === 1 ? "" : "s"}
@@ -150,13 +160,27 @@ function ChatView({ threadId, loaded }: ChatViewProps) {
         </span>
       </header>
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-2">
-        {messages.length === 0 && (
-          <div className="mt-8 text-center text-sm text-gray-400">
-            New thread. Ask a question to get started.
-          </div>
-        )}
+        {messages.length === 0 &&
+          (isDebrief ? (
+            <DebriefLauncher
+              onLaunch={(text) => {
+                void sendMessage({ text });
+              }}
+            />
+          ) : (
+            <div className="mt-8 text-center text-sm text-gray-400">
+              New thread. Ask a question to get started.
+            </div>
+          ))}
         {messages.map((m) => (
-          <MessageView key={m.id} message={m} />
+          <MessageView
+            key={m.id}
+            message={m}
+            onAnswerQuestion={(text) => {
+              void sendMessage({ text });
+            }}
+            isStreaming={isStreaming}
+          />
         ))}
         {error && (
           <div className="my-3 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">

--- a/apps/web/src/pages/scout/thread-list.tsx
+++ b/apps/web/src/pages/scout/thread-list.tsx
@@ -13,9 +13,12 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { FactsAdminButton } from "./facts-admin.js";
 
+type ScoutMode = "scouting" | "debrief";
+
 interface ThreadSummary {
   id: string;
   title: string;
+  mode: ScoutMode;
   updatedAt: string;
 }
 
@@ -34,10 +37,13 @@ export function ThreadList() {
   });
 
   const createMutation = useMutation({
-    mutationFn: () =>
+    mutationFn: (mode: ScoutMode) =>
       callApi(
         api.POST("/api/scout/threads", {
-          body: { title: "New thread" },
+          body: {
+            title: mode === "debrief" ? "Match debrief" : "New thread",
+            mode,
+          },
         }),
       ),
     onSuccess: async (thread) => {
@@ -74,10 +80,20 @@ export function ThreadList() {
         <Button
           size="sm"
           className="flex-1"
-          onClick={() => createMutation.mutate()}
+          onClick={() => createMutation.mutate("scouting")}
           disabled={createMutation.isPending}
+          title="Free-form scouting chat"
         >
-          {createMutation.isPending ? "Creating…" : "New thread"}
+          {createMutation.isPending ? "Creating…" : "New scout"}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => createMutation.mutate("debrief")}
+          disabled={createMutation.isPending}
+          title="Guided post-match debrief"
+        >
+          Debrief
         </Button>
         <FactsAdminButton />
       </div>
@@ -110,7 +126,14 @@ export function ThreadList() {
                       : "text-gray-700"
                   }`}
                 >
-                  <div className="truncate">{t.title}</div>
+                  <div className="flex items-center gap-1.5">
+                    {t.mode === "debrief" && (
+                      <span className="rounded bg-amber-100 px-1 py-0.5 text-[9px] font-semibold tracking-wide text-amber-800 uppercase">
+                        Debrief
+                      </span>
+                    )}
+                    <span className="truncate">{t.title}</span>
+                  </div>
                   <div className="truncate text-xs text-gray-400">
                     {new Date(t.updatedAt).toLocaleString()}
                   </div>

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -606,6 +606,7 @@ export interface ScoutFact {
   created_at: Generated<Timestamp>;
   embedding: string;
   id: Generated<string>;
+  permanence: string | null;
   scope: string;
   source_message_id: string | null;
   source_thread_id: string | null;
@@ -642,6 +643,7 @@ export interface ScoutMessage {
 export interface ScoutThread {
   created_at: Generated<Timestamp>;
   id: Generated<string>;
+  mode: Generated<string>;
   title: string;
   updated_at: Generated<Timestamp>;
   user_id: string;

--- a/packages/db/src/migrations/2026-05-04T07:52:20.000Z.ts
+++ b/packages/db/src/migrations/2026-05-04T07:52:20.000Z.ts
@@ -1,0 +1,28 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Scout interaction modes. `scouting` is the default free-form chat;
+ * `debrief` is a guided post-match flow where the agent walks through
+ * structured questions (bowler styles, batter weaknesses, ground
+ * conditions, our players' uncredited contributions) to grow the fact
+ * corpus. Mode is fixed at thread creation — the agent picks system
+ * prompt + tool surface from this column.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("scout_thread")
+    .addColumn("mode", "text", (col) => col.notNull().defaultTo("scouting"))
+    .execute();
+
+  await sql`ALTER TABLE scout_thread
+    ADD CONSTRAINT scout_thread_mode_check
+    CHECK (mode IN ('scouting','debrief'))`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("scout_thread")
+    .dropConstraint("scout_thread_mode_check")
+    .execute();
+  await db.schema.alterTable("scout_thread").dropColumn("mode").execute();
+}

--- a/packages/db/src/migrations/2026-05-04T07:52:21.000Z.ts
+++ b/packages/db/src/migrations/2026-05-04T07:52:21.000Z.ts
@@ -1,0 +1,33 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Permanence is how long a fact stays useful before it should be
+ * re-confirmed:
+ *   permanent  — handedness, bowling style, position; never expires.
+ *   seasonal   — ground covers/sightscreens, scheduling; revisit yearly.
+ *   ephemeral  — weather, recent form, injuries; revisit weekly.
+ *
+ * NULL = unknown / not yet classified. Auto-retrieval annotates each
+ * injected fact with its permanence + age so the debrief flow can decide
+ * whether to skip a question that's already answered.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("scout_fact")
+    .addColumn("permanence", "text")
+    .execute();
+
+  await sql`ALTER TABLE scout_fact
+    ADD CONSTRAINT scout_fact_permanence_check
+    CHECK (permanence IS NULL OR permanence IN ('permanent','seasonal','ephemeral'))`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("scout_fact")
+    .dropConstraint("scout_fact_permanence_check")
+    .execute();
+  await db.schema.alterTable("scout_fact").dropColumn("permanence").execute();
+}


### PR DESCRIPTION
## Summary
- Adds a `debrief` interaction mode to Scout: a guided post-match interview that grows the fact corpus rather than producing a report. Mode is fixed at thread creation (`scout_thread.mode`); the agent picks system prompt + tool surface from it.
- New `ask_question` tool streams a `data-question` UI part — the FE renders an inline card with option buttons and a free-text fallback. Registered only in debrief; `chart_render` is registered only in scouting.
- Introduces `scout_fact.permanence` (`permanent` | `seasonal` | `ephemeral` | NULL) to drive a skip-if-known rule. `recordFact` infers permanence from `tags.topic` when not set; admin UI lets you override or clear.
- `<known-facts>` block now annotates each fact with `permanence · age` so the debrief flow can decide whether to re-ask.
- New `GET /scout/debrief/recent-matches` powers a launcher card listing Percy Main's last 14 days of matches; free-text / Play Cricket URL fallback for everything else.
- Frontend: thread-list gets "New scout" / "Debrief" buttons and a mode badge; chat header shows the badge; facts admin shows + edits permanence.

## Test plan
- [x] `pnpm --filter api test` (388 unit tests pass; agent test asserts mode-driven prompt + tool surface)
- [x] `pnpm --filter api test:integration --run scout/integration` (mode persists through create/list/get/assertOwnership; recent-matches filters by 14d window + Percy Main team prefix; home/away derived correctly)
- [x] `pnpm --filter api test:integration --run scout/facts` (permanence inferred from `topic`; explicit override wins; unknown topic stays NULL; format block includes `permanence · age`)
- [x] `pnpm --filter web build` and typechecks across api / web / db
- [x] `pnpm --filter api lint` / `pnpm --filter web lint`
- [ ] Manual: create a debrief thread, pick a recent match, walk through a couple of `ask_question` prompts, confirm facts land in the corpus with the inferred permanence
- [ ] Manual: verify the skip-if-known rule fires on a thread where a `topic:handedness` fact already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)