### PR TITLE
Scout: store match_date as ISO; fix debrief 14-day filter

### DIFF
--- a/apps/api/src/features/fantasy/calculate-scores.ts
+++ b/apps/api/src/features/fantasy/calculate-scores.ts
@@ -32,24 +32,7 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Parse a match date string into a UTC Date object.
- * Handles both DD/MM/YYYY (Play-Cricket API format stored by sync) and
- * YYYY-MM-DD (ISO format used in tests and manual inserts).
- */
 function parseMatchDate(dateStr: string): Date {
-  if (dateStr.includes("/")) {
-    // DD/MM/YYYY format (from Play-Cricket sync)
-    const [dd, mm, yyyy] = dateStr.split("/");
-    return new Date(
-      Date.UTC(
-        parseInt(yyyy ?? "0"),
-        parseInt(mm ?? "1") - 1,
-        parseInt(dd ?? "1"),
-      ),
-    );
-  }
-  // YYYY-MM-DD format (ISO)
   const [yyyy, mm, dd] = dateStr.split("-");
   return new Date(
     Date.UTC(

--- a/apps/api/src/features/fantasy/service.ts
+++ b/apps/api/src/features/fantasy/service.ts
@@ -787,21 +787,7 @@ async function getOwnershipData(
  * Used as a fallback when fantasy_player_score has no data (e.g. pre-season).
  * Matches v1's calculateSeasonPoints().
  */
-/**
- * Parse a match date string into a Date for gameweek filtering.
- * Handles DD/MM/YYYY (Play-Cricket sync format) and YYYY-MM-DD (ISO).
- */
 function parseMatchDateForFilter(dateStr: string): Date | null {
-  if (dateStr.includes("/")) {
-    const [dd, mm, yyyy] = dateStr.split("/");
-    return new Date(
-      Date.UTC(
-        parseInt(yyyy ?? "0"),
-        parseInt(mm ?? "1") - 1,
-        parseInt(dd ?? "1"),
-      ),
-    );
-  }
   const d = new Date(dateStr);
   return isNaN(d.getTime()) ? null : d;
 }

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -558,7 +558,9 @@ describe("play-cricket sync (integration)", () => {
   it("skips already-processed matches outside the resync window", async () => {
     const matchId = 55500 + Math.floor(Math.random() * 1000);
     // Dated well in the past so it falls outside the 7-day resync window.
-    const oldDate = "01/07/2024";
+    // The DB stores ISO; the API summary still emits dd/mm/yyyy.
+    const oldDateIso = "2024-07-01";
+    const oldDatePc = "01/07/2024";
 
     await ctx.db
       .insertInto("match_result")
@@ -569,7 +571,7 @@ describe("play-cricket sync (integration)", () => {
         away_team_id: OPPONENT_TEAM_ID,
         home_team_name: "Percy Main 1st XI",
         away_team_name: "Opposition 1st XI",
-        match_date: oldDate,
+        match_date: oldDateIso,
         season: 2024,
       })
       .execute();
@@ -577,7 +579,7 @@ describe("play-cricket sync (integration)", () => {
     const api = createMockApi({
       getMatchesSummary: vi
         .fn()
-        .mockResolvedValue({ matches: [makeMatchSummary(matchId, oldDate)] }),
+        .mockResolvedValue({ matches: [makeMatchSummary(matchId, oldDatePc)] }),
     });
 
     const sync = runSync(ctx.db, api);

--- a/apps/api/src/features/play-cricket/service.ts
+++ b/apps/api/src/features/play-cricket/service.ts
@@ -25,7 +25,18 @@ export function getMatchDetail(db: Kysely<DB>) {
 
     if (data === undefined) {
       data = await apiClient.getMatchDetail(matchId);
-      const dataRecord = data as Record<string, unknown>;
+
+      // The date lives on match_details[0] in the API response, not the
+      // top level. Normalise DD/MM/YYYY (Play Cricket's wire format) to
+      // ISO so this column matches the rest of our schema.
+      const detail = (data as { match_details?: { match_date?: unknown }[] })
+        .match_details?.[0];
+      const rawDate =
+        typeof detail?.match_date === "string" ? detail.match_date : null;
+      const matchDateIso =
+        rawDate && /^\d{2}\/\d{2}\/\d{4}$/.test(rawDate)
+          ? `${rawDate.slice(6, 10)}-${rawDate.slice(3, 5)}-${rawDate.slice(0, 2)}`
+          : (rawDate ?? new Date().toISOString().split("T")[0]);
 
       // Upsert cache with raw Play Cricket response — enrichment happens
       // after this so member slug changes are picked up on the next read.
@@ -34,21 +45,12 @@ export function getMatchDetail(db: Kysely<DB>) {
           .updateTable("play_cricket_match_cache")
           .set({
             data: JSON.stringify(data),
+            match_date: matchDateIso,
             fetched_at: new Date().toISOString(),
           })
           .where("match_id", "=", matchId)
           .execute();
       } else {
-        // Normalise to ISO YYYY-MM-DD; Play Cricket emits DD/MM/YYYY but the
-        // rest of our schema (and ORDER BY semantics on TEXT) wants ISO.
-        const rawDate =
-          typeof dataRecord.match_date === "string"
-            ? dataRecord.match_date
-            : null;
-        const matchDateIso =
-          rawDate && /^\d{2}\/\d{2}\/\d{4}$/.test(rawDate)
-            ? `${rawDate.slice(6, 10)}-${rawDate.slice(3, 5)}-${rawDate.slice(0, 2)}`
-            : (rawDate ?? new Date().toISOString().split("T")[0]);
         await db
           .insertInto("play_cricket_match_cache")
           .values({

--- a/apps/api/src/features/play-cricket/service.ts
+++ b/apps/api/src/features/play-cricket/service.ts
@@ -29,8 +29,9 @@ export function getMatchDetail(db: Kysely<DB>) {
       // The date lives on match_details[0] in the API response, not the
       // top level. Normalise DD/MM/YYYY (Play Cricket's wire format) to
       // ISO so this column matches the rest of our schema.
-      const detail = (data as { match_details?: { match_date?: unknown }[] })
-        .match_details?.[0];
+      const detail = (
+        data as { match_details?: Array<{ match_date?: unknown }> }
+      ).match_details?.[0];
       const rawDate =
         typeof detail?.match_date === "string" ? detail.match_date : null;
       const matchDateIso =

--- a/apps/api/src/features/play-cricket/service.ts
+++ b/apps/api/src/features/play-cricket/service.ts
@@ -39,15 +39,22 @@ export function getMatchDetail(db: Kysely<DB>) {
           .where("match_id", "=", matchId)
           .execute();
       } else {
+        // Normalise to ISO YYYY-MM-DD; Play Cricket emits DD/MM/YYYY but the
+        // rest of our schema (and ORDER BY semantics on TEXT) wants ISO.
+        const rawDate =
+          typeof dataRecord.match_date === "string"
+            ? dataRecord.match_date
+            : null;
+        const matchDateIso =
+          rawDate && /^\d{2}\/\d{2}\/\d{4}$/.test(rawDate)
+            ? `${rawDate.slice(6, 10)}-${rawDate.slice(3, 5)}-${rawDate.slice(0, 2)}`
+            : (rawDate ?? new Date().toISOString().split("T")[0]);
         await db
           .insertInto("play_cricket_match_cache")
           .values({
             match_id: matchId,
             data: JSON.stringify(data),
-            match_date:
-              (typeof dataRecord.match_date === "string"
-                ? dataRecord.match_date
-                : null) ?? new Date().toISOString().split("T")[0],
+            match_date: matchDateIso,
             fetched_at: new Date().toISOString(),
           })
           .execute();

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -404,6 +404,10 @@ async function syncMatches(
         parseInt(mm) - 1,
         parseInt(dd),
       );
+      // Store as ISO YYYY-MM-DD so it sorts and compares correctly as text.
+      // The Play Cricket API emits DD/MM/YYYY which we don't keep on disk —
+      // every consumer downstream wants ISO.
+      const matchDateIso = `${yyyy}-${mm}-${dd}`;
 
       // Skip already-processed matches only when they're past the resync
       // window. Inside the window, re-fetch — all writes are idempotent
@@ -472,7 +476,7 @@ async function syncMatches(
             matchId,
             battingTeamId,
             match.competition_type ?? "",
-            match.match_date,
+            matchDateIso,
             season,
           );
         }
@@ -484,7 +488,7 @@ async function syncMatches(
             matchId,
             fieldingTeamId,
             match.competition_type ?? "",
-            match.match_date,
+            matchDateIso,
             season,
           );
 
@@ -498,7 +502,7 @@ async function syncMatches(
             matchId,
             fieldingTeamId,
             match.competition_type ?? "",
-            match.match_date,
+            matchDateIso,
             season,
           );
         }
@@ -523,7 +527,7 @@ async function syncMatches(
             result_description: detail.result_description ?? "",
             result_applied_to: detail.result_applied_to ?? "",
             competition_type: match.competition_type ?? "",
-            match_date: match.match_date,
+            match_date: matchDateIso,
             season,
           })
           .onConflict((oc) =>

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -237,6 +237,7 @@ async function storeBattingPerformances(
       .onConflict((oc) =>
         oc.columns(["match_id", "player_id"]).doUpdateSet({
           player_name: bat.batsman_name,
+          match_date: matchDate,
           runs: parseInt(bat.runs) || 0,
           balls: parseInt(bat.balls) || 0,
           fours: parseInt(bat.fours) || 0,
@@ -289,6 +290,7 @@ async function storeBowlingPerformances(
       .onConflict((oc) =>
         oc.columns(["match_id", "player_id"]).doUpdateSet({
           player_name: bowl.bowler_name,
+          match_date: matchDate,
           overs: bowl.overs,
           maidens: parseInt(bowl.maidens) || 0,
           runs: parseInt(bowl.runs) || 0,
@@ -330,6 +332,7 @@ async function storeFieldingPerformances(
       .onConflict((oc) =>
         oc.columns(["match_id", "player_id"]).doUpdateSet({
           player_name: agg.playerName,
+          match_date: matchDate,
           catches: agg.catches,
           run_outs: agg.runOuts,
           stumpings: agg.stumpings,
@@ -535,6 +538,7 @@ async function syncMatches(
               result: matchResult,
               result_description: detail.result_description ?? "",
               result_applied_to: detail.result_applied_to ?? "",
+              match_date: matchDateIso,
             }),
           )
           .execute();

--- a/apps/api/src/features/scout/agent.ts
+++ b/apps/api/src/features/scout/agent.ts
@@ -175,9 +175,13 @@ export function createScoutAgent(deps: ScoutAgentDeps): ScoutAgent {
     year: "numeric",
   });
 
-  const todayLine = `Today is ${dayName} ${iso} (${ddmmyyyy} in dd/mm/yyyy, the format Play Cricket uses). The current season is ${today.getFullYear()}; default to it when the user doesn't specify a year.
+  const todayLine = `Today is ${dayName} ${iso}. The current season is ${today.getFullYear()}; default to it when the user doesn't specify a year.
 
-When asked about the "next" or "upcoming" match, filter match_date strictly GREATER THAN ${ddmmyyyy} — anything on or before today has already been played (or is being played now). Don't trust your gut on what day-of-week a date falls on; always compare against the iso date above.`;
+Date formats are split between sources:
+- The Play Cricket *API* (pc_* tools) emits dd/mm/yyyy — today is ${ddmmyyyy} in that format. Compare API match_date against ${ddmmyyyy} (string compare won't sort correctly across years/months, so for the API tools, just use exact-match or pass the value through unchanged).
+- Our *database* (db_run_sql, ask-db, debrief queries) stores match_date as ISO ${iso}-style. Lex order = chronological order; compare and order on the plain text.
+
+When asked about the "next" or "upcoming" match via the database, filter match_date > '${iso}' — anything on or before today has already been played (or is being played now). Don't trust your gut on what day-of-week a date falls on; always compare against the iso date above.`;
 
   const basePrompt =
     deps.mode === "debrief" ? SCOUT_DEBRIEF_SYSTEM_PROMPT : SCOUT_SYSTEM_PROMPT;

--- a/apps/api/src/features/scout/tools/ask-db.ts
+++ b/apps/api/src/features/scout/tools/ask-db.ts
@@ -97,7 +97,7 @@ ${SCOUT_ALLOWED_TABLES.map((t) => `  - ${t}`).join("\n")}
 
 CRITICAL rules — apply on every query:
 
-1. **match_date is text in dd/mm/yyyy.** Lexicographic ordering is wrong ("31/08/2013" sorts after "07/06/2025"). Always use to_date(match_date, 'DD/MM/YYYY') for any ORDER BY, comparison, or BETWEEN.
+1. **match_date is text in ISO YYYY-MM-DD.** Lex order matches chronological order, so ORDER BY / WHERE / BETWEEN work on the plain text column. Compare against today as '${iso}' (or current_date::text). The Play Cricket *API* still returns dd/mm/yyyy — that only matters when you're reading tool output, not when querying our DB. Don't wrap match_date in to_date(...).
 
 2. **Aggregate in SQL, never in your head.** Counts, sums, averages, distributions, top-N — write a query that COMPUTES the answer. Pulling 200 rows back to count them is wasteful and inaccurate.
 

--- a/apps/api/src/features/scout/tools/db.ts
+++ b/apps/api/src/features/scout/tools/db.ts
@@ -166,13 +166,13 @@ Aggregate-first patterns:
   SELECT player_name, runs, match_date
   FROM match_performance_batting
   WHERE runs >= 100
-  ORDER BY to_date(match_date, 'DD/MM/YYYY') DESC
+  ORDER BY match_date DESC
   LIMIT 1;
 
 When you DO need raw rows (e.g. quoting one specific innings in your reply), narrow with WHERE + ORDER BY + LIMIT, and SELECT only the columns you'll quote — do not SELECT *.
 
-CRITICAL — match_date is text, not date:
-\`match_date\` columns (on match_performance_*, match_result, play_cricket_match_cache, etc.) are stored as text in dd/mm/yyyy format because that's how Play Cricket returns them. Lexicographic ordering is WRONG: "31/08/2013" sorts AFTER "07/06/2025". Always wrap in to_date(match_date, 'DD/MM/YYYY') for any ORDER BY, comparison, or BETWEEN. Example: ORDER BY to_date(match_date, 'DD/MM/YYYY') DESC.`,
+NOTE — match_date is text in ISO YYYY-MM-DD:
+\`match_date\` on match_performance_*, match_result, play_cricket_match_cache, matchday, availability_fixture, etc. is stored as text in YYYY-MM-DD. Lexicographic order matches chronological order, so plain ORDER BY / WHERE / BETWEEN on the text column works. Compare against today as 'YYYY-MM-DD' (or current_date::text). Note: the Play Cricket *API* still returns DD/MM/YYYY — that only matters when you're inspecting tool output, not when querying our DB. Don't wrap match_date in to_date(...).`,
       inputSchema: z.object({
         query: z.string().describe("A single SELECT or WITH statement."),
       }),

--- a/apps/web/src/pages/scout/debrief-launcher.tsx
+++ b/apps/web/src/pages/scout/debrief-launcher.tsx
@@ -1,7 +1,13 @@
 import { Button } from "@/components/ui/button";
 import { api, callApi } from "@/lib/api-client";
 import { useQuery } from "@tanstack/react-query";
+import { format, parseISO } from "date-fns";
 import { useState } from "react";
+
+function formatMatchDate(iso: string): string {
+  const d = parseISO(iso);
+  return isNaN(d.getTime()) ? iso : format(d, "dd/MM/yyyy");
+}
 
 interface DebriefLauncherProps {
   /** Send a user message into the chat. The launcher hands the agent a
@@ -65,7 +71,7 @@ export function DebriefLauncher({ onLaunch }: DebriefLauncherProps) {
                   submit(
                     `Debriefing match ${m.id} — ${m.ourTeam} ${
                       m.homeAway === "home" ? "vs" : "at"
-                    } ${m.opposition} on ${m.matchDate}.`,
+                    } ${m.opposition} on ${formatMatchDate(m.matchDate)}.`,
                   )
                 }
                 className="block w-full rounded border border-amber-200 bg-white px-3 py-2 text-left text-sm text-gray-900 shadow-sm hover:border-amber-400 hover:bg-amber-100"
@@ -79,7 +85,7 @@ export function DebriefLauncher({ onLaunch }: DebriefLauncherProps) {
                     {m.opposition}
                   </span>
                   <span className="shrink-0 text-xs text-gray-500">
-                    {m.matchDate}
+                    {formatMatchDate(m.matchDate)}
                   </span>
                 </div>
                 {m.result && (

--- a/packages/db/src/migrations/2026-05-04T13:00:00.000Z.ts
+++ b/packages/db/src/migrations/2026-05-04T13:00:00.000Z.ts
@@ -1,0 +1,53 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Convert match_date columns from DD/MM/YYYY (raw Play Cricket format) to
+ * ISO YYYY-MM-DD across the tables hydrated by play-cricket sync. Lex
+ * ordering on the old format is wrong ("31/08/2013" > "07/06/2025"), and
+ * any consumer comparing against `new Date().toISOString().slice(0,10)`
+ * silently filtered everything out.
+ *
+ * `matchday`, `availability_fixture`, `availability_response` already store
+ * ISO (their writers convert) and are intentionally left alone.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const tables = [
+    "match_result",
+    "match_performance_batting",
+    "match_performance_bowling",
+    "match_performance_fielding",
+    "play_cricket_match_cache",
+  ] as const;
+
+  for (const table of tables) {
+    await sql`
+      UPDATE ${sql.raw(table)}
+      SET match_date =
+        substring(match_date FROM 7 FOR 4) || '-' ||
+        substring(match_date FROM 4 FOR 2) || '-' ||
+        substring(match_date FROM 1 FOR 2)
+      WHERE match_date ~ '^\\d{2}/\\d{2}/\\d{4}$'
+    `.execute(db);
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const tables = [
+    "match_result",
+    "match_performance_batting",
+    "match_performance_bowling",
+    "match_performance_fielding",
+    "play_cricket_match_cache",
+  ] as const;
+
+  for (const table of tables) {
+    await sql`
+      UPDATE ${sql.raw(table)}
+      SET match_date =
+        substring(match_date FROM 9 FOR 2) || '/' ||
+        substring(match_date FROM 6 FOR 2) || '/' ||
+        substring(match_date FROM 1 FOR 4)
+      WHERE match_date ~ '^\\d{4}-\\d{2}-\\d{2}$'
+    `.execute(db);
+  }
+}


### PR DESCRIPTION
## Summary
- Play Cricket sync was writing `match_date` raw (DD/MM/YYYY from the API) into `match_result`, the three `match_performance_*` tables, and `play_cricket_match_cache`. Anything comparing against an ISO today/cutoff string silently filtered every row out — `"01/05/2026"` lex-sorts *before* `"2026-04-20"`. Most visible symptom: Scout's debrief launcher always said "No Percy Main matches in the last 14 days." `getLiveScores` was broken the same way, and any honours-board ORDER BY on `match_date` was sorting by day-of-month first.
- Convert at the sync boundary: build `matchDateIso` from the dd/mm/yyyy parse already happening in sync.ts and pass it to every DB write (match_result + match_performance_*). Same conversion in the cache-write path in `play-cricket/service.ts`.
- New migration rewrites existing rows in all five affected tables from DD/MM/YYYY to ISO. Down-migration is the reverse string surgery.
- Drop the dual-format branch from fantasy's `parseMatchDate` / `parseMatchDateForFilter` — ISO-only now.
- Update the Scout SQL sub-agent prompts (`tools/db.ts`, `tools/ask-db.ts`) so they no longer wrap `match_date` in `to_date(...)`. The main agent's `todayLine` now distinguishes Play Cricket *API* (DD/MM/YYYY) from our *DB* (ISO).
- Debrief launcher reformats ISO back to DD/MM/YYYY for display so the change is invisible to the captain.

`matchday`, `availability_fixture`, `availability_response` already stored ISO (their writers convert) and are intentionally untouched. `games` / `og-image` / `sponsorship` consume `match_date` directly from the live PC API (still DD/MM/YYYY there) — unaffected.

## Test plan
- [x] `pnpm typecheck` clean across api/web/db
- [x] `pnpm lint` clean
- [x] API unit tests: 388 passed
- [x] Integration tests (play-cricket, scout, fantasy, records, matchday, admin, availability, treasurer, cricket-leaderboard): 263 passed
- [x] Migration applied to local dev DB; 0 rows remain in DD/MM/YYYY across all 5 tables
- [ ] After CI applies the migration in prod, confirm Scout debrief launcher shows recent matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)