### PR TITLE
Scout: chart hover labels + debrief launcher fix

### DIFF
--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -575,6 +575,12 @@ describe("play-cricket sync (integration)", () => {
     expect(result.result).toBe("Won by 5 wickets");
     expect(result.home_team_id).toBe(OUR_TEAM_ID);
     expect(result.season).toBe(2026);
+    // club_id / club_name are the disambiguators for "is this our match",
+    // since PC stores team names bare. Both sides must be persisted.
+    expect(result.home_club_id).toBe(SITE_ID);
+    expect(result.home_club_name).toBe("Percy Main");
+    expect(result.away_club_id).toBe("999");
+    expect(result.away_club_name).toBe("Opposition CC");
   });
 
   it("logs sync to play_cricket_sync_log", async () => {

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -529,6 +529,14 @@ async function syncMatches(
             away_team_id: detail.away_team_id,
             home_team_name: detail.home_team_name,
             away_team_name: detail.away_team_name,
+            // Source club fields from the summary, not the detail payload —
+            // the detail schema makes club_id optional with "" default and
+            // we'd rather store NULL than an empty string that breaks the
+            // launcher's club_id = siteId filter.
+            home_club_id: match.home_club_id,
+            home_club_name: match.home_club_name,
+            away_club_id: match.away_club_id,
+            away_club_name: match.away_club_name,
             result: matchResult,
             result_description: detail.result_description ?? "",
             result_applied_to: detail.result_applied_to ?? "",
@@ -542,6 +550,10 @@ async function syncMatches(
               result_description: detail.result_description ?? "",
               result_applied_to: detail.result_applied_to ?? "",
               match_date: matchDateIso,
+              home_club_id: match.home_club_id,
+              home_club_name: match.home_club_name,
+              away_club_id: match.away_club_id,
+              away_club_name: match.away_club_name,
             }),
           )
           .execute();

--- a/apps/api/src/features/scout/integration.test.ts
+++ b/apps/api/src/features/scout/integration.test.ts
@@ -518,16 +518,17 @@ describe("scout thread sharing (integration)", () => {
 });
 
 describe("listRecentDebriefMatches (integration)", () => {
-  it("returns Percy Main matches in the last 14 days, descending, with home/away derived from team-name prefix", async () => {
+  it("returns matches identified by club_id in the last 14 days, descending, joining club_name + team_name for display", async () => {
+    const SITE_ID = "134";
     const now = new Date("2026-05-04T12:00:00Z");
     const within = "2026-05-01"; // 3 days before now
     const oldest = "2026-04-22"; // 12 days before now (in window)
     const stale = "2026-04-15"; // 19 days before now (outside)
 
-    // Wipe + seed match_result rows directly. We don't need every column
-    // realistic — just enough for the listRecentDebriefMatches query +
-    // mapping to exercise its branches (home, away, oldest, stale-cutoff,
-    // non-Percy-Main row).
+    // Wipe + seed match_result rows directly. PC stores team names bare
+    // ("1st XI", "2nd XI") for both sides; club_id is the only reliable
+    // disambiguator. Each fixture exercises a branch: home, away, stale,
+    // non-ours, and a legacy NULL-club_id row that the filter must skip.
     await ctx.db.deleteFrom("match_result").execute();
     await ctx.db
       .insertInto("match_result")
@@ -538,8 +539,12 @@ describe("listRecentDebriefMatches (integration)", () => {
           match_date: within,
           home_team_id: "h1",
           away_team_id: "a1",
-          home_team_name: "Percy Main 1st XI",
-          away_team_name: "Mitford CC 1st XI",
+          home_team_name: "1st XI",
+          away_team_name: "1st XI",
+          home_club_id: SITE_ID,
+          home_club_name: "Percy Main",
+          away_club_id: "201",
+          away_club_name: "Mitford CC",
           result: "won",
           result_description: "Won by 5 wickets",
           result_applied_to: "h1",
@@ -552,8 +557,12 @@ describe("listRecentDebriefMatches (integration)", () => {
           match_date: oldest,
           home_team_id: "h2",
           away_team_id: "a2",
-          home_team_name: "Tynemouth CC 2nd XI",
-          away_team_name: "Percy Main 2nd XI",
+          home_team_name: "2nd XI",
+          away_team_name: "2nd XI",
+          home_club_id: "202",
+          home_club_name: "Tynemouth CC",
+          away_club_id: SITE_ID,
+          away_club_name: "Percy Main",
           result: "lost",
           result_description: "Lost by 30 runs",
           result_applied_to: "h2",
@@ -566,8 +575,12 @@ describe("listRecentDebriefMatches (integration)", () => {
           match_date: stale,
           home_team_id: "h3",
           away_team_id: "a3",
-          home_team_name: "Percy Main 1st XI",
-          away_team_name: "Northumberland CC",
+          home_team_name: "1st XI",
+          away_team_name: "1st XI",
+          home_club_id: SITE_ID,
+          home_club_name: "Percy Main",
+          away_club_id: "203",
+          away_club_name: "Northumberland CC",
           result: "won",
           result_description: "Won",
           result_applied_to: "h3",
@@ -580,21 +593,42 @@ describe("listRecentDebriefMatches (integration)", () => {
           match_date: within,
           home_team_id: "h4",
           away_team_id: "a4",
-          home_team_name: "Tynemouth CC 1st XI",
-          away_team_name: "Mitford CC 1st XI",
+          home_team_name: "1st XI",
+          away_team_name: "1st XI",
+          home_club_id: "202",
+          home_club_name: "Tynemouth CC",
+          away_club_id: "201",
+          away_club_name: "Mitford CC",
           result: "won",
           result_description: "Won by 50 runs",
           result_applied_to: "h4",
           competition_type: "League",
           season: 2026,
         },
+        {
+          // Legacy row written before the migration: club_id columns NULL.
+          // The launcher's club_id equality filter must skip it cleanly.
+          id: crypto.randomUUID(),
+          match_id: "1005",
+          match_date: within,
+          home_team_id: "h5",
+          away_team_id: "a5",
+          home_team_name: "3rd XI",
+          away_team_name: "3rd XI",
+          result: "won",
+          result_description: "Won",
+          result_applied_to: "h5",
+          competition_type: "League",
+          season: 2026,
+        },
       ])
       .execute();
 
-    const out = await listRecentDebriefMatches(ctx.db)(14, now);
+    const out = await listRecentDebriefMatches(ctx.db, SITE_ID)(14, now);
 
-    // Two in-window Percy Main rows; the stale one and the non-Percy-Main
-    // row are excluded. Most-recent first.
+    // Only 1001 (home) and 1002 (away) match: in-window AND our club_id is
+    // home or away. 1003 is stale, 1004 is two other clubs, 1005 is legacy
+    // NULL club_id. Most-recent first.
     expect(out.map((m) => m.id)).toEqual(["1001", "1002"]);
 
     expect(out[0]).toMatchObject({

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -125,6 +125,7 @@ import {
   listSharees,
   listThreads,
   listUpcomingScoutMatches,
+  type RecentDebriefMatch,
   ReportNotFoundError,
   ShareForbiddenError,
   ShareInvalidRecipientError,
@@ -147,7 +148,12 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
   const sharees = listSharees(app.db);
   const share = shareThread(app.db);
   const unshare = unshareThread(app.db);
-  const recentMatches = listRecentDebriefMatches(app.db);
+  // PLAY_CRICKET_SITE_ID is optional in config; if it's not set there are
+  // no Percy Main matches to surface, so the launcher returns an empty
+  // list rather than 503'ing the rest of Scout.
+  const recentMatches = app.config.PLAY_CRICKET_SITE_ID
+    ? listRecentDebriefMatches(app.db, app.config.PLAY_CRICKET_SITE_ID)
+    : () => Promise.resolve([] as RecentDebriefMatch[]);
   const upcomingMatches = listUpcomingScoutMatches(app.db);
   const reportsList = listReports(app.db);
   const reportForDownload = getReportForDownload(app.db);

--- a/apps/api/src/features/scout/service.ts
+++ b/apps/api/src/features/scout/service.ts
@@ -360,11 +360,18 @@ export interface RecentDebriefMatch {
 
 /**
  * Recent Percy Main matches (last 14 days, descending) used to populate
- * the debrief launcher. We match by team-name prefix because the local
- * MatchResult mirror doesn't carry club_ids — every Percy Main team
- * starts with "Percy Main" (e.g. "Percy Main 1st XI", "Percy Main 2nd XI").
+ * the debrief launcher. Identified by club_id — Play Cricket stores
+ * team names bare ("1st XI", "2nd XI") with no club prefix for either
+ * side, so the only reliable disambiguator is club_id, persisted on
+ * match_result by sync. Pre-migration rows have NULL club_ids and are
+ * filtered out by the equality check; they fall out of the 14-day
+ * window naturally.
+ *
+ * Display strings are "{club_name} {team_name}" so the launcher reads
+ * "Percy Main 2nd XI vs Mitford 2nd XI" rather than the bare,
+ * ambiguous "2nd XI vs 2nd XI" the API alone would produce.
  */
-export function listRecentDebriefMatches(db: Kysely<DB>) {
+export function listRecentDebriefMatches(db: Kysely<DB>, siteId: string) {
   return async (
     days = 14,
     now: Date = new Date(),
@@ -381,6 +388,10 @@ export function listRecentDebriefMatches(db: Kysely<DB>) {
         "match_date",
         "home_team_name",
         "away_team_name",
+        "home_club_id",
+        "home_club_name",
+        "away_club_id",
+        "away_club_name",
         "result",
         "result_description",
       ])
@@ -388,25 +399,38 @@ export function listRecentDebriefMatches(db: Kysely<DB>) {
       .where("match_date", "<=", today)
       .where((eb) =>
         eb.or([
-          eb("home_team_name", "like", "Percy Main%"),
-          eb("away_team_name", "like", "Percy Main%"),
+          eb("home_club_id", "=", siteId),
+          eb("away_club_id", "=", siteId),
         ]),
       )
       .orderBy("match_date", "desc")
       .execute();
 
     return rows.map((r) => {
-      const isHome = r.home_team_name.startsWith("Percy Main");
+      const isHome = r.home_club_id === siteId;
+      const ourTeam = isHome
+        ? joinClubAndTeam(r.home_club_name, r.home_team_name)
+        : joinClubAndTeam(r.away_club_name, r.away_team_name);
+      const opposition = isHome
+        ? joinClubAndTeam(r.away_club_name, r.away_team_name)
+        : joinClubAndTeam(r.home_club_name, r.home_team_name);
       return {
         id: r.match_id,
         matchDate: r.match_date,
-        opposition: isHome ? r.away_team_name : r.home_team_name,
+        opposition,
         homeAway: isHome ? ("home" as const) : ("away" as const),
-        ourTeam: isHome ? r.home_team_name : r.away_team_name,
+        ourTeam,
         result: r.result_description || r.result || null,
       };
     });
   };
+}
+
+// Defensive join — club_name is always written alongside club_id by sync,
+// but if the API ever returns one without the other we don't want a
+// stray "null 2nd XI" leaking to the FE.
+function joinClubAndTeam(clubName: string | null, teamName: string): string {
+  return clubName ? `${clubName} ${teamName}` : teamName;
 }
 
 export interface UpcomingScoutMatch {

--- a/apps/api/src/features/scout/tools/chart.ts
+++ b/apps/api/src/features/scout/tools/chart.ts
@@ -28,7 +28,7 @@ export function createChartTool(deps: ChartToolDeps) {
 When to render:
 - Trend over time (a player's batting average across innings, our average score by month) → type: "line"
 - Categorical comparison (dismissals by mode, runs by opposition, points by division) → type: "bar"
-- Correlation between two numeric variables (innings score vs air temperature) → type: "scatter", and put a per-point label so users can identify outliers
+- Correlation between two numeric variables (innings score vs air temperature) → type: "scatter", and put a per-point label so users can identify outliers (see "Per-point hover labels" below)
 - Composition / share-of-whole → type: "pie" or "doughnut" (only when categories sum to a meaningful total)
 - Multiple comparable metrics for a few entities → type: "radar"
 
@@ -107,7 +107,35 @@ EXAMPLE — multi-series line (one dataset per series):
   }
 }
 
-EXAMPLE — scatter with labelled points (each datum is {x, y}; the dataset.label shows in the legend):
+Per-point hover labels (scatter / bubble):
+The default tooltip for scatter is "{dataset.label}: ({x}, {y})". Since callbacks aren't allowed (JSON-only), the ONLY way to show a per-point name on hover is to make each point its own dataset with the entity name as dataset.label. Yes, that means N datasets for N points — that's correct, do it. Hide the legend (it would be unusable at that size) and either share colours by category or vary per dataset.
+
+EXAMPLE — scatter with per-point hover labels (one dataset per player, coloured by quadrant, legend hidden):
+{
+  "chart": {
+    "type": "scatter",
+    "data": {
+      "datasets": [
+        { "label": "Philip Cramman",  "data": [{ "x": 603, "y": 54 }], "backgroundColor": "rgba(31, 119, 180, 0.8)" },
+        { "label": "Patrick Rathbone","data": [{ "x": 481, "y": 38 }], "backgroundColor": "rgba(31, 119, 180, 0.8)" },
+        { "label": "Andrew Beer",     "data": [{ "x": 312, "y": 22 }], "backgroundColor": "rgba(255, 127, 14, 0.8)" }
+      ]
+    },
+    "options": {
+      "plugins": {
+        "legend": { "display": false },
+        "tooltip": { "intersect": true, "mode": "nearest" }
+      },
+      "scales": {
+        "x": { "title": { "display": true, "text": "Runs scored" } },
+        "y": { "title": { "display": true, "text": "Innings" } }
+      }
+    },
+    "caption": "Top-right = high volume + high availability."
+  }
+}
+
+EXAMPLE — scatter without per-point labels (when you don't need names; one dataset, just shape):
 {
   "chart": {
     "type": "scatter",

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -526,10 +526,14 @@ export interface MatchPerformanceFielding {
 }
 
 export interface MatchResult {
+  away_club_id: string | null;
+  away_club_name: string | null;
   away_team_id: string;
   away_team_name: string;
   competition_type: Generated<string>;
   created_at: Generated<string>;
+  home_club_id: string | null;
+  home_club_name: string | null;
   home_team_id: string;
   home_team_name: string;
   id: string;

--- a/packages/db/src/migrations/2026-05-07T09:59:27.000Z.ts
+++ b/packages/db/src/migrations/2026-05-07T09:59:27.000Z.ts
@@ -1,0 +1,40 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Persist club_id / club_name on match_result so consumers can identify
+ * which side was Percy Main.
+ *
+ * Play Cricket's match-detail API returns team names bare ("1st XI",
+ * "2nd XI") with no club prefix — for both home and away. The only
+ * disambiguator is the club_id, which sync already has on hand
+ * (match.home_club_id / match.away_club_id from the summary endpoint
+ * and detail.{home,away}_club_id in the detail endpoint) but never
+ * stored. Without it, listRecentDebriefMatches can't tell which row
+ * is "ours" except by string-matching team names — which fails because
+ * PC stores them un-prefixed.
+ *
+ * Columns are nullable: existing rows stay NULL forever (sync does not
+ * backfill historic matches outside the resync window). Going forward,
+ * every newly-written or upserted match_result row carries the four
+ * fields. The launcher's 14-day window means the NULL legacy rows
+ * naturally fall out of view within two weeks.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("match_result")
+    .addColumn("home_club_id", "text")
+    .addColumn("home_club_name", "text")
+    .addColumn("away_club_id", "text")
+    .addColumn("away_club_name", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("match_result")
+    .dropColumn("home_club_id")
+    .dropColumn("home_club_name")
+    .dropColumn("away_club_id")
+    .dropColumn("away_club_name")
+    .execute();
+}


### PR DESCRIPTION
## Summary

Two unrelated Scout fixes bundled together (apologies — got caught up):

**1. Chart hover labels.** The chart agent kept re-deriving from first principles how to get a per-point name in a Chart.js scatter tooltip when our spec is JSON-only (no callbacks). The default scatter tooltip is \`{dataset.label}: ({x}, {y})\` so the only way to get per-point labels is one dataset per point. Encoded the pattern in the tool prompt with a worked example (37-player batting/availability quadrant). No deps added.

**2. Debrief launcher showed "No Percy Main matches in the last 14 days."** Diagnosed against prod via the read-only DB role: \`match_result\` has the rows, but Play Cricket stores team names bare (\`"1st XI"\`, \`"2nd XI"\`) for both sides — there is no \`"Percy Main"\` prefix to filter on. Fix: persist \`{home,away}_club_id\` / \`{home,away}_club_name\` on \`match_result\` (data was at sync time, never stored), filter by \`club_id = siteId\`, render display as \`"{club_name} {team_name}"\` so the launcher reads "Percy Main 2nd XI vs Mitford 2nd XI" instead of two indistinguishable "2nd XI"s. Historic rows stay NULL on the new columns and fall out of the 14-day window naturally — sync only writes them on new inserts/upserts.

## Test plan

- [x] \`pnpm test\` (api) — 414 passing
- [x] \`pnpm test:integration\` (api) — 263 passing, including new \`listRecentDebriefMatches\` cases for home/away/stale/non-ours/legacy-NULL-club_id
- [x] \`pnpm typecheck\` (api + db)
- [x] \`pnpm openapi:generate\` — no diff (response shape unchanged, only values)
- [x] Migration applies cleanly locally; \`db:types\` regen picks up the new nullable columns
- [ ] After merge: confirm next sync writes club_id for new \`match_result\` rows in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)