### PR TITLE
Scout: ResultsVault ball-by-ball + match-stream ingest

### DIFF
--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -7,8 +7,47 @@ import {
   type TestContext,
 } from "../../test/containers.ts";
 import type { PlayCricketApiClient } from "./api-client.ts";
+import type { RvClient } from "./rv-client.ts";
+import { ingestRvDataForMatch } from "./rv-ingest.ts";
+import type {
+  RvBall,
+  RvMatchOverview as RvMatchOverviewT,
+} from "./rv-schemas.ts";
 import { getMatchDetail, getPlayerCareerStats, getTeams } from "./service.ts";
 import { runSync } from "./sync.ts";
+
+// Mock RV client for the ingest tests below — wired with the same
+// curried-deps pattern as the real createRvClient. Each method returns
+// either a plain value or a function that yields a value per call (so
+// tests can stage different responses across multiple invocations).
+function makeMockRv(overrides: {
+  mapping?: { rvMatchId: string } | null;
+  match?: RvMatchOverviewT | null;
+  balls?: RvBall[][] | RvBall[];
+}): RvClient & { calls: { mapping: number; match: number; balls: number } } {
+  const calls = { mapping: 0, match: 0, balls: 0 };
+  const ballsArray = Array.isArray(overrides.balls?.[0])
+    ? (overrides.balls as RvBall[][])
+    : overrides.balls
+      ? [overrides.balls as RvBall[]]
+      : [[]];
+  return {
+    calls,
+    getMatchMapping: vi.fn(() => {
+      calls.mapping++;
+      return Promise.resolve(overrides.mapping ?? null);
+    }),
+    getMatch: vi.fn(() => {
+      calls.match++;
+      return Promise.resolve(overrides.match ?? null);
+    }),
+    getBalls: vi.fn(() => {
+      const next = ballsArray[calls.balls] ?? [];
+      calls.balls++;
+      return Promise.resolve(next);
+    }),
+  };
+}
 
 let ctx: TestContext;
 
@@ -642,5 +681,292 @@ describe("play-cricket sync (integration)", () => {
       .executeTakeFirst();
 
     expect(result).toBeUndefined();
+  });
+});
+
+// --- RV ingest integration ---
+
+describe("ingestRvDataForMatch (integration)", () => {
+  // The ingest writes match_ball / match_stream rows that FK to
+  // match_result.match_id, so each test seeds a parent match_result row
+  // first. We don't go through runSync — that's covered separately —
+  // and stay focused on the RV side of the pipeline.
+  async function seedMatchResult(matchId: string, matchDate = "2026-05-02") {
+    await ctx.db
+      .insertInto("match_result")
+      .values({
+        id: crypto.randomUUID(),
+        match_id: matchId,
+        home_team_id: "1",
+        away_team_id: "2",
+        home_team_name: "1st XI",
+        away_team_name: "1st XI",
+        match_date: matchDate,
+        season: 2026,
+      })
+      .onConflict((oc) => oc.column("match_id").doNothing())
+      .execute();
+  }
+
+  function makeOverview(
+    overrides: Partial<RvMatchOverviewT> = {},
+  ): RvMatchOverviewT {
+    return {
+      match_id: 7464451,
+      external_match_id: 7262912,
+      MatchTeams: [
+        {
+          team_name: "Backworth CC 2nd XI",
+          result_id: 25398667,
+          Innings: [{ innings_number: 1, PlayerPerfs: [] }],
+        },
+        {
+          team_name: "Percy Main CC 1st XI",
+          result_id: 25398668,
+          Innings: [
+            {
+              innings_number: 1,
+              PlayerPerfs: [
+                {
+                  player_id: 11680433,
+                  external_id: "4386566",
+                  player_name: "S Knight",
+                },
+                {
+                  player_id: 12367961,
+                  external_id: "5102931",
+                  player_name: "K Pattison",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      matchStreams: [
+        {
+          id: 71781,
+          match_id: 7464451,
+          video_id: "cu4A54DjCDI",
+          frogbox_stream_id: "59e32fe6-7502-4433-9044-413838f2f20e",
+          stream_provider_id: 3,
+          start_utc: "/Date(1777718649000+0100)/",
+          recording_started_utc: "/Date(1777718779000+0100)/",
+          publish_status_id: 0,
+          description: null,
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  function makeBall(
+    over_no: number,
+    ball_no: number,
+    overrides: Partial<RvBall> = {},
+  ): RvBall {
+    // ball_time anchored ~20 minutes after recording_started for ball 1,
+    // each subsequent ball nominally 30s later. Lets us assert that
+    // ball_offset_seconds is computed from the recording anchor.
+    const recordingMs = 1777718779000;
+    return {
+      innings_number: 1,
+      over_no,
+      ball_no,
+      ball_no_disp: ball_no,
+      result_id: 25398668,
+      batter_id: 11680433,
+      batter_id_ns: 12367961,
+      bowler_id: 12367961,
+      runs_bat: 0,
+      runs_extra: 0,
+      extras_type: null,
+      l_desc: " K Pattison to S Knight: No run",
+      s_desc: " .",
+      ball_time: `/Date(${recordingMs + 1200_000 + ball_no * 30_000}+0100)/`,
+      match_highlight_events: [],
+      ...overrides,
+    };
+  }
+
+  it("happy path: maps PC->RV, persists player mapping, stream, and balls (with offsets)", async () => {
+    const matchId = `rv-happy-${crypto.randomUUID()}`;
+    await seedMatchResult(matchId);
+
+    const ball1 = makeBall(0, 1);
+    const ball2 = makeBall(0, 2, {
+      runs_bat: 4,
+      l_desc: " K Pattison to S Knight: 4 runs",
+      s_desc: " 4",
+      match_highlight_events: [{ event_id: 1002, metric: 4 }],
+    });
+    const wicket = makeBall(0, 3, {
+      runs_bat: 0,
+      dismissed_batter_id: 11680433,
+      l_desc: " K Pattison to S Knight: dismissed",
+      s_desc: " W",
+    });
+
+    const rv = makeMockRv({
+      mapping: { rvMatchId: "7464451" },
+      match: makeOverview(),
+      // First call is for result_id 25398667 inn 1 (Backworth) — empty.
+      // Second call is for 25398668 inn 1 (Percy Main) — three balls.
+      // The probe stops at the first empty innings per result_id, so
+      // there should be exactly four getBalls calls total (1 empty for
+      // Backworth, 1 with balls for PM, 1 empty for PM probing inn 2).
+      balls: [[], [ball1, ball2, wicket], []],
+    });
+
+    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+
+    expect(wrote).toBe(true);
+
+    const balls = await ctx.db
+      .selectFrom("match_ball")
+      .where("match_id", "=", matchId)
+      .orderBy("ball_no")
+      .selectAll()
+      .execute();
+    expect(balls).toHaveLength(3);
+    expect(balls[0]?.s_desc).toBe(" .");
+    expect(balls[1]?.runs_bat).toBe(4);
+    expect(balls[1]?.highlight_events).toEqual([{ event_id: 1002, metric: 4 }]);
+    expect(balls[2]?.dismissed_batter_rv_id).toBe(11680433);
+    expect(balls[2]?.s_desc).toBe(" W");
+
+    // ball_offset_seconds is rounded(ball_time - recording_started_utc).
+    // Anchor is 1777718779000; ball1's ball_time is anchor + 1200s + 30s
+    // = anchor + 1230s.
+    expect(balls[0]?.ball_offset_seconds).toBe(1230);
+    expect(balls[1]?.ball_offset_seconds).toBe(1260);
+    expect(balls[2]?.ball_offset_seconds).toBe(1290);
+
+    const streams = await ctx.db
+      .selectFrom("match_stream")
+      .where("match_id", "=", matchId)
+      .selectAll()
+      .execute();
+    expect(streams).toHaveLength(1);
+    expect(streams[0]?.video_id).toBe("cu4A54DjCDI");
+
+    const mappings = await ctx.db
+      .selectFrom("rv_player_mapping")
+      .where("rv_player_id", "in", [11680433, 12367961])
+      .selectAll()
+      .execute();
+    expect(mappings).toHaveLength(2);
+    const knight = mappings.find((m) => m.rv_player_id === 11680433);
+    expect(knight?.pc_player_id).toBe("4386566");
+    expect(knight?.player_name).toBe("S Knight");
+  });
+
+  it("idempotent: re-running for the same match produces no duplicates and applies updates", async () => {
+    const matchId = `rv-idem-${crypto.randomUUID()}`;
+    await seedMatchResult(matchId);
+
+    const initial = makeBall(0, 1, {
+      runs_bat: 2,
+      l_desc: " K Pattison to S Knight: 2 runs",
+    });
+    const corrected = makeBall(0, 1, {
+      runs_bat: 4,
+      l_desc: " K Pattison to S Knight: 4 runs (corrected)",
+      s_desc: " 4",
+    });
+
+    const rvFirst = makeMockRv({
+      mapping: { rvMatchId: "7464451" },
+      match: makeOverview(),
+      balls: [[], [initial], []],
+    });
+    await ingestRvDataForMatch(ctx.db, rvFirst, matchId, "2026-05-02");
+
+    const rvSecond = makeMockRv({
+      mapping: { rvMatchId: "7464451" },
+      match: makeOverview(),
+      balls: [[], [corrected], []],
+    });
+    await ingestRvDataForMatch(ctx.db, rvSecond, matchId, "2026-05-02");
+
+    const balls = await ctx.db
+      .selectFrom("match_ball")
+      .where("match_id", "=", matchId)
+      .selectAll()
+      .execute();
+    expect(balls).toHaveLength(1);
+    expect(balls[0]?.runs_bat).toBe(4);
+    expect(balls[0]?.l_desc).toContain("corrected");
+  });
+
+  it("skips silently when the mapping endpoint returns no mapping", async () => {
+    const matchId = `rv-nomap-${crypto.randomUUID()}`;
+    await seedMatchResult(matchId);
+
+    const rv = makeMockRv({ mapping: null });
+    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+
+    expect(wrote).toBe(false);
+    expect(rv.calls.mapping).toBe(1);
+    expect(rv.calls.match).toBe(0);
+    expect(rv.calls.balls).toBe(0);
+    const balls = await ctx.db
+      .selectFrom("match_ball")
+      .where("match_id", "=", matchId)
+      .selectAll()
+      .execute();
+    expect(balls).toHaveLength(0);
+  });
+
+  it("skips silently when the overview returns null (404 / unknown match)", async () => {
+    const matchId = `rv-no-overview-${crypto.randomUUID()}`;
+    await seedMatchResult(matchId);
+
+    const rv = makeMockRv({
+      mapping: { rvMatchId: "7464451" },
+      match: null,
+    });
+    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+
+    expect(wrote).toBe(false);
+    expect(rv.calls.match).toBe(1);
+    expect(rv.calls.balls).toBe(0);
+  });
+
+  it("skips silently when MatchTeams is empty", async () => {
+    const matchId = `rv-empty-teams-${crypto.randomUUID()}`;
+    await seedMatchResult(matchId);
+
+    const rv = makeMockRv({
+      mapping: { rvMatchId: "7464451" },
+      match: makeOverview({ MatchTeams: [] }),
+    });
+    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+
+    expect(wrote).toBe(false);
+    expect(rv.calls.balls).toBe(0);
+  });
+
+  it("leaves ball_offset_seconds null when no stream has a recording_started_utc", async () => {
+    const matchId = `rv-no-anchor-${crypto.randomUUID()}`;
+    await seedMatchResult(matchId);
+
+    const overview = makeOverview({
+      matchStreams: [], // no stream at all → no anchor
+    });
+    const rv = makeMockRv({
+      mapping: { rvMatchId: "7464451" },
+      match: overview,
+      balls: [[], [makeBall(0, 1)], []],
+    });
+
+    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+
+    const balls = await ctx.db
+      .selectFrom("match_ball")
+      .where("match_id", "=", matchId)
+      .selectAll()
+      .execute();
+    expect(balls).toHaveLength(1);
+    expect(balls[0]?.ball_offset_seconds).toBeNull();
   });
 });

--- a/apps/api/src/features/play-cricket/rv-client.test.ts
+++ b/apps/api/src/features/play-cricket/rv-client.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRvClient, mintXIasToken, parseMsDate } from "./rv-client.ts";
+
+// 24-byte ASCII secret matching the format used by the Match Centre SPA.
+// The literal value used by RV at the time of writing is captured locally
+// in BALL_BY_BALL_FETCHING.md (gitignored). For tests we use any 24-byte
+// string — the algorithm doesn't care about contents, only length.
+const TEST_SECRET = "ABCDEFGHIJKLMNOPQRSTUVWX";
+
+describe("mintXIasToken", () => {
+  it("produces a deterministic 24-char base64 token for a given clock time", () => {
+    const secret = Buffer.from(TEST_SECRET, "utf8");
+    // 2026-05-07T00:00:00Z — fixed clock so the test is reproducible.
+    const fixed = new Date("2026-05-07T00:00:00.000Z").getTime();
+    const a = mintXIasToken(secret, fixed);
+    const b = mintXIasToken(secret, fixed);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[A-Za-z0-9+/]{22}==$/);
+  });
+
+  it("changes when the clock advances by a second", () => {
+    const secret = Buffer.from(TEST_SECRET, "utf8");
+    const t = new Date("2026-05-07T00:00:00.000Z").getTime();
+    const a = mintXIasToken(secret, t);
+    const b = mintXIasToken(secret, t + 1000);
+    expect(a).not.toBe(b);
+  });
+
+  it("groups inputs by rounded-second of (now/1000 - 60)", () => {
+    // We can't peek the plaintext, but we can prove the rounding semantics
+    // by picking a base time and showing two inputs in the same rounded
+    // second match, while two inputs in different rounded seconds differ.
+    // A future refactor to floor() instead of round() would change which
+    // bucket a given ms falls into and fail one of these.
+    const secret = Buffer.from(TEST_SECRET, "utf8");
+    const t = new Date("2026-05-07T00:00:00.000Z").getTime();
+    // t and t+400ms both round to the same second.
+    expect(mintXIasToken(secret, t)).toBe(mintXIasToken(secret, t + 400));
+    // t and t+1500ms round to seconds 1 apart — distinct tokens.
+    expect(mintXIasToken(secret, t)).not.toBe(mintXIasToken(secret, t + 1500));
+  });
+});
+
+describe("parseMsDate", () => {
+  it("parses /Date(epochms+TZ)/ to a UTC-equivalent Date", () => {
+    // 1777719950000 is the ms epoch in the doc example.
+    const d = parseMsDate("/Date(1777719950000+0100)/");
+    expect(d).toBeInstanceOf(Date);
+    expect(d?.getTime()).toBe(1777719950000);
+  });
+
+  it("parses bare /Date(epochms)/ without a TZ suffix", () => {
+    expect(parseMsDate("/Date(1000)/")?.getTime()).toBe(1000);
+  });
+
+  it("returns null on null / empty / junk input", () => {
+    expect(parseMsDate(null)).toBeNull();
+    expect(parseMsDate(undefined)).toBeNull();
+    expect(parseMsDate("")).toBeNull();
+    expect(parseMsDate("not a date")).toBeNull();
+    expect(parseMsDate("/Date(abc)/")).toBeNull();
+  });
+});
+
+// Helper to build a Response-like object the client's getJson can consume.
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(body === null ? "" : JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("createRvClient.getMatchMapping", () => {
+  it("returns the rvMatchId when object_id1 is non-zero", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { object_id1: 7464451 }));
+    const client = createRvClient({
+      sharedSecret: TEST_SECRET,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const out = await client.getMatchMapping("7262912");
+
+    expect(out).toEqual({ rvMatchId: "7464451" });
+    const url = fetchMock.mock.calls[0][0] as URL;
+    expect(url.pathname).toBe("/rv/mappings/4/12/7262912/");
+    expect(url.searchParams.get("apiid")).toBe("1003");
+    expect(url.searchParams.get("sportid")).toBe("1");
+    // Auth header gets minted — sanity check it's present.
+    const headers = (
+      fetchMock.mock.calls[0][1] as { headers: Record<string, string> }
+    ).headers;
+    expect(headers["x-ias-api-request"]).toMatch(/^[A-Za-z0-9+/]{22}==$/);
+  });
+
+  it("returns null when RV reports no mapping (object_id1: 0)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { object_id1: 0 }));
+    const client = createRvClient({
+      sharedSecret: TEST_SECRET,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(await client.getMatchMapping("9999999")).toBeNull();
+  });
+
+  it("returns null on 404", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(404, null));
+    const client = createRvClient({
+      sharedSecret: TEST_SECRET,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(await client.getMatchMapping("9999999")).toBeNull();
+  });
+
+  it("throws on non-2xx, non-404 responses (e.g. 401)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("<html>Request Error</html>", { status: 401 }),
+      );
+    const client = createRvClient({
+      sharedSecret: TEST_SECRET,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(client.getMatchMapping("123")).rejects.toThrow(/HTTP 401/);
+  });
+});
+
+describe("createRvClient.getMatch", () => {
+  it("parses a minimal overview", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        match_id: 7464451,
+        external_match_id: 7262912,
+        MatchTeams: [
+          {
+            team_name: "Backworth CC 2nd XI",
+            result_id: 25398667,
+            Innings: [{ innings_number: 1, PlayerPerfs: [] }],
+          },
+          {
+            team_name: "Percy Main CC 1st XI",
+            result_id: 25398668,
+            Innings: [
+              {
+                innings_number: 1,
+                PlayerPerfs: [
+                  {
+                    player_id: 11680433,
+                    external_id: "4386566",
+                    player_name: "S Knight",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        matchStreams: [
+          {
+            id: 71781,
+            match_id: 7464451,
+            video_id: "cu4A54DjCDI",
+            frogbox_stream_id: "59e32fe6-7502-4433-9044-413838f2f20e",
+            stream_provider_id: 3,
+            start_utc: "/Date(1777718649307+0100)/",
+            recording_started_utc: "/Date(1777718779000+0100)/",
+            publish_status_id: 0,
+            description: null,
+          },
+        ],
+      }),
+    );
+    const client = createRvClient({
+      sharedSecret: TEST_SECRET,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const out = await client.getMatch("7464451");
+
+    expect(out?.match_id).toBe(7464451);
+    expect(out?.MatchTeams).toHaveLength(2);
+    expect(out?.matchStreams[0]?.video_id).toBe("cu4A54DjCDI");
+    expect(out?.MatchTeams[1]?.Innings[0]?.PlayerPerfs[0]?.external_id).toBe(
+      "4386566",
+    );
+  });
+
+  it("returns null on 404", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(404, null));
+    const client = createRvClient({
+      sharedSecret: TEST_SECRET,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(await client.getMatch("9999999")).toBeNull();
+  });
+});
+
+describe("createRvClient.getBalls", () => {
+  it("parses a balls array and preserves ordering", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(200, [
+        {
+          innings_number: 1,
+          over_no: 0,
+          ball_no: 1,
+          ball_no_disp: 1,
+          result_id: 25398668,
+          batter_id: 11680433,
+          bowler_id: 12367961,
+          runs_bat: 0,
+          runs_extra: 0,
+          extras_type: null,
+          l_desc: " K Pattison to S Knight: No run",
+          s_desc: " .",
+          ball_time: "/Date(1777719950000+0100)/",
+          match_highlight_events: [],
+        },
+        {
+          innings_number: 1,
+          over_no: 0,
+          ball_no: 2,
+          ball_no_disp: 2,
+          result_id: 25398668,
+          batter_id: 11680433,
+          bowler_id: 12367961,
+          runs_bat: 4,
+          runs_extra: 0,
+          extras_type: null,
+          l_desc: " K Pattison to S Knight: 4 runs",
+          s_desc: " 4",
+          match_highlight_events: [{ event_id: 1002, metric: 4 }],
+        },
+      ]),
+    );
+    const client = createRvClient({
+      sharedSecret: TEST_SECRET,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const out = await client.getBalls("7464451", 25398668, 1);
+
+    expect(out).toHaveLength(2);
+    expect(out[0]?.ball_no).toBe(1);
+    expect(out[1]?.match_highlight_events).toEqual([
+      { event_id: 1002, metric: 4 },
+    ]);
+
+    // URL parameter sanity.
+    const url = fetchMock.mock.calls[0][0] as URL;
+    expect(url.searchParams.get("action")).toBe("getballs");
+    expect(url.searchParams.get("resultid")).toBe("25398668");
+    expect(url.searchParams.get("inningsnumber")).toBe("1");
+  });
+
+  it("returns [] on 404", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(404, null));
+    const client = createRvClient({
+      sharedSecret: TEST_SECRET,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(await client.getBalls("9999999", 1, 1)).toEqual([]);
+  });
+});

--- a/apps/api/src/features/play-cricket/rv-client.test.ts
+++ b/apps/api/src/features/play-cricket/rv-client.test.ts
@@ -1,11 +1,63 @@
 import { describe, expect, it, vi } from "vitest";
-import { createRvClient, mintXIasToken, parseMsDate } from "./rv-client.ts";
+import {
+  assertValidRvSharedSecret,
+  createRvClient,
+  mintXIasToken,
+  parseMsDate,
+} from "./rv-client.ts";
 
 // 24-byte ASCII secret matching the format used by the Match Centre SPA.
 // The literal value used by RV at the time of writing is captured locally
 // in BALL_BY_BALL_FETCHING.md (gitignored). For tests we use any 24-byte
 // string — the algorithm doesn't care about contents, only length.
 const TEST_SECRET = "ABCDEFGHIJKLMNOPQRSTUVWX";
+
+describe("assertValidRvSharedSecret", () => {
+  it("accepts a 24-ASCII-byte secret", () => {
+    expect(() => assertValidRvSharedSecret(TEST_SECRET)).not.toThrow();
+  });
+
+  it("rejects shorter / longer secrets up front", () => {
+    expect(() => assertValidRvSharedSecret("short")).toThrow(
+      /must be exactly 24 ASCII bytes/,
+    );
+    expect(() => assertValidRvSharedSecret("A".repeat(32))).toThrow(
+      /must be exactly 24 ASCII bytes/,
+    );
+  });
+});
+
+describe("createRvClient construction", () => {
+  it("validates the shared secret at construction (not lazily on first call)", () => {
+    expect(() =>
+      createRvClient({
+        sharedSecret: "too-short",
+        fetch: vi.fn() as unknown as typeof fetch,
+      }),
+    ).toThrow(/24 ASCII bytes/);
+  });
+});
+
+describe("createRvClient timeout", () => {
+  it("aborts a stalled fetch after timeoutMs and throws a timeout error", async () => {
+    const fetchMock = vi.fn(
+      (_url: URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          // Resolve only when the caller's AbortSignal fires.
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+    const client = createRvClient({
+      sharedSecret: TEST_SECRET,
+      fetch: fetchMock as unknown as typeof fetch,
+      timeoutMs: 30,
+    });
+
+    await expect(client.getMatchMapping("123")).rejects.toThrow(/timeout/i);
+  });
+});
 
 describe("mintXIasToken", () => {
   it("produces a deterministic 24-char base64 token for a given clock time", () => {

--- a/apps/api/src/features/play-cricket/rv-client.ts
+++ b/apps/api/src/features/play-cricket/rv-client.ts
@@ -1,0 +1,209 @@
+import crypto from "node:crypto";
+import {
+  RvBallsResponse,
+  RvMappingInfo,
+  RvMatchOverview,
+  type RvBall,
+  type RvMatchOverview as RvMatchOverviewType,
+} from "./rv-schemas.ts";
+
+// ResultsVault read-only client. Reverse-engineered from InteractSport's
+// Match Centre SPA — see BALL_BY_BALL_FETCHING.md (local, gitignored) for
+// the full how-and-why. This module deliberately knows nothing about our
+// PC sync; callers wire it up.
+//
+// Auth is a 3DES-ECB-encrypted current Unix-second timestamp, base64'd
+// into the `x-ias-api-request` header. Tokens are valid for ~30 minutes
+// server-side; we just mint per-request — it's microseconds of CPU.
+
+const RV_BASE = "https://api.resultsvault.co.uk";
+const RV_TENANT_ID = "130000"; // ECB master_entity_id (= 13e4 in the bundle)
+const RV_API_ID = "1003";
+const RV_SPORT_ID = "1";
+
+// Mapping path constants — see the mappings endpoint section of the doc.
+// 4 = mapping_instance (PC↔RV bind for matches), 12 = object_type_id
+// (match). These are baked into the SPA's call sites; they do not vary
+// across tenants we'd plausibly serve.
+const RV_MAPPING_INSTANCE = "4";
+const RV_OBJECT_TYPE_MATCH = "12";
+
+export interface RvClientConfig {
+  /**
+   * The shared secret embedded in the Match Centre SPA bundle. 24 ASCII
+   * bytes, used directly as the 3DES key (NOT decoded as hex). Rotates
+   * approximately never — but if 401s start, re-grep the bundle. See
+   * BALL_BY_BALL_FETCHING.md for the exact procedure.
+   */
+  sharedSecret: string;
+  /**
+   * Override fetch — primarily for tests. Defaults to global fetch.
+   */
+  fetch?: typeof fetch;
+}
+
+export interface RvMatchMapping {
+  rvMatchId: string;
+}
+
+export interface RvClient {
+  /**
+   * Look up the RV match id for a given Play Cricket match id.
+   *
+   * Resolves to `null` when no mapping exists (RV returns
+   * `object_id1: 0`) or when the endpoint 404s. Throws on any other
+   * non-2xx — callers should let the existing per-match try/catch in
+   * the sync handle those.
+   */
+  getMatchMapping(pcMatchId: string): Promise<RvMatchMapping | null>;
+
+  /**
+   * Match overview by RV match id. Resolves to `null` on 404 (RV doesn't
+   * recognise the match — common; matches without live scoring just
+   * aren't in their backend).
+   */
+  getMatch(rvMatchId: string): Promise<RvMatchOverviewType | null>;
+
+  /**
+   * Ball-by-ball for a single team-innings. Resolves to `[]` for empty
+   * innings (the common "this innings hasn't been played yet" case) or
+   * for 404 — callers should treat empty as "no data, move on".
+   */
+  getBalls(
+    rvMatchId: string,
+    rvResultId: string | number,
+    inningsNumber: number,
+  ): Promise<RvBall[]>;
+}
+
+export function createRvClient(config: RvClientConfig): RvClient {
+  const fetchImpl = config.fetch ?? fetch;
+  const secretBuf = Buffer.from(config.sharedSecret, "utf8");
+
+  function mintToken(): string {
+    return mintXIasToken(secretBuf);
+  }
+
+  async function getJson(url: URL): Promise<{
+    status: number;
+    body: unknown;
+  }> {
+    const res = await fetchImpl(url, {
+      headers: {
+        "x-ias-api-request": mintToken(),
+        accept: "application/json",
+      },
+    });
+    if (res.status === 404) return { status: 404, body: null };
+    const text = await res.text();
+    if (!res.ok) {
+      throw new Error(
+        `ResultsVault API error (HTTP ${String(res.status)}) for ${url.pathname}: ${text.slice(0, 300)}`,
+      );
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new Error(
+        `ResultsVault API returned non-JSON for ${url.pathname}: ${text.slice(0, 300)}`,
+      );
+    }
+    return { status: res.status, body: parsed };
+  }
+
+  return {
+    async getMatchMapping(pcMatchId: string): Promise<RvMatchMapping | null> {
+      const url = new URL(
+        `${RV_BASE}/rv/mappings/${RV_MAPPING_INSTANCE}/${RV_OBJECT_TYPE_MATCH}/${encodeURIComponent(
+          pcMatchId,
+        )}/`,
+      );
+      url.searchParams.set("apiid", RV_API_ID);
+      url.searchParams.set("sportid", RV_SPORT_ID);
+
+      const { status, body } = await getJson(url);
+      if (status === 404) return null;
+      const parsed = RvMappingInfo.parse(body);
+      // RV signals "no mapping" by returning object_id1: 0 alongside a
+      // 200 — treat that the same as 404.
+      if (!parsed.object_id1) return null;
+      return { rvMatchId: String(parsed.object_id1) };
+    },
+
+    async getMatch(rvMatchId: string): Promise<RvMatchOverviewType | null> {
+      const url = new URL(
+        `${RV_BASE}/rv/${RV_TENANT_ID}/matches/${encodeURIComponent(rvMatchId)}/`,
+      );
+      url.searchParams.set("apiid", RV_API_ID);
+
+      const { status, body } = await getJson(url);
+      if (status === 404) return null;
+      return RvMatchOverview.parse(body);
+    },
+
+    async getBalls(
+      rvMatchId: string,
+      rvResultId: string | number,
+      inningsNumber: number,
+    ): Promise<RvBall[]> {
+      const url = new URL(
+        `${RV_BASE}/rv/${RV_TENANT_ID}/matches/${encodeURIComponent(rvMatchId)}/`,
+      );
+      url.searchParams.set("apiid", RV_API_ID);
+      url.searchParams.set("action", "getballs");
+      url.searchParams.set("sportid", RV_SPORT_ID);
+      url.searchParams.set("resultid", String(rvResultId));
+      url.searchParams.set("inningsnumber", String(inningsNumber));
+
+      const { status, body } = await getJson(url);
+      if (status === 404) return [];
+      return RvBallsResponse.parse(body);
+    },
+  };
+}
+
+/**
+ * Mint a fresh `x-ias-api-request` token.
+ *
+ * Algorithm (lifted from the Match Centre SPA, function `ce(e)`):
+ *   plaintext = String(round(Date.now()/1000 - 60))     // ASCII decimal
+ *   padded    = plaintext + PKCS7 to next 8-byte block
+ *   ct        = 3DES-ECB(key=sharedSecret-as-ASCII, padded)
+ *   token     = base64(ct)
+ *
+ * Exposed for unit testing; ordinary callers go through `createRvClient`.
+ */
+export function mintXIasToken(
+  secret: Buffer,
+  now: number = Date.now(),
+): string {
+  const ts = Math.round(now / 1000 - 60).toString();
+  const padLen = 8 - (ts.length % 8); // PKCS7: always 1..8
+  const data = Buffer.concat([
+    Buffer.from(ts, "ascii"),
+    Buffer.alloc(padLen, padLen),
+  ]);
+  // Node's `des-ede3-ecb` expects a 24-byte key for 3DES. ECB mode takes
+  // a null IV. We pad manually and disable Node's auto-padding so the
+  // ciphertext length matches the SPA's exactly.
+  const cipher = crypto.createCipheriv("des-ede3-ecb", secret, null);
+  cipher.setAutoPadding(false);
+  return Buffer.concat([cipher.update(data), cipher.final()]).toString(
+    "base64",
+  );
+}
+
+/**
+ * Parse Microsoft DateTime serialisation: `"/Date(1777719950000+0100)/"`.
+ * Returns `null` for null/empty/junk inputs so junk timestamps don't
+ * abort an entire ingest.
+ */
+export function parseMsDate(input: string | null | undefined): Date | null {
+  if (!input) return null;
+  const m = /^\/Date\((-?\d+)([+-]\d{4})?\)\/$/.exec(input);
+  if (!m) return null;
+  const ms = Number(m[1]);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms);
+}

--- a/apps/api/src/features/play-cricket/rv-client.ts
+++ b/apps/api/src/features/play-cricket/rv-client.ts
@@ -40,6 +40,31 @@ export interface RvClientConfig {
    * Override fetch — primarily for tests. Defaults to global fetch.
    */
   fetch?: typeof fetch;
+  /**
+   * Per-request timeout in milliseconds. Defaults to 15s. RV is hit
+   * inside the per-match sync loop, so a stalled connection would
+   * otherwise hold the entire sync hostage even though RV failures are
+   * meant to be non-fatal.
+   */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const SHARED_SECRET_BYTES = 24; // 3DES needs exactly 24 bytes of key material.
+
+/**
+ * Validate the shared-secret byte length up front so a misconfigured
+ * RV_SHARED_SECRET fails at boot rather than at first crypto call.
+ */
+export function assertValidRvSharedSecret(secret: string): void {
+  const bytes = Buffer.from(secret, "utf8").length;
+  if (bytes !== SHARED_SECRET_BYTES) {
+    throw new Error(
+      `RV_SHARED_SECRET must be exactly ${String(
+        SHARED_SECRET_BYTES,
+      )} ASCII bytes (got ${String(bytes)}).`,
+    );
+  }
 }
 
 export interface RvMatchMapping {
@@ -77,7 +102,9 @@ export interface RvClient {
 }
 
 export function createRvClient(config: RvClientConfig): RvClient {
+  assertValidRvSharedSecret(config.sharedSecret);
   const fetchImpl = config.fetch ?? fetch;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const secretBuf = Buffer.from(config.sharedSecret, "utf8");
 
   function mintToken(): string {
@@ -88,12 +115,30 @@ export function createRvClient(config: RvClientConfig): RvClient {
     status: number;
     body: unknown;
   }> {
-    const res = await fetchImpl(url, {
-      headers: {
-        "x-ias-api-request": mintToken(),
-        accept: "application/json",
-      },
-    });
+    // Bound the request — the per-match try/catch in sync logs RV
+    // failures non-fatally, but only if the request actually returns.
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), timeoutMs);
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        headers: {
+          "x-ias-api-request": mintToken(),
+          accept: "application/json",
+        },
+        signal: ac.signal,
+      });
+    } catch (err) {
+      if (ac.signal.aborted) {
+        throw new Error(
+          `ResultsVault API timeout (${String(timeoutMs)}ms) for ${url.pathname}`,
+          { cause: err },
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
     if (res.status === 404) return { status: 404, body: null };
     const text = await res.text();
     if (!res.ok) {

--- a/apps/api/src/features/play-cricket/rv-ingest.ts
+++ b/apps/api/src/features/play-cricket/rv-ingest.ts
@@ -1,0 +1,257 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import type { RvClient } from "./rv-client.ts";
+import { parseMsDate } from "./rv-client.ts";
+import type {
+  RvBall,
+  RvMatchOverview,
+  RvMatchStream,
+  RvPlayerPerf,
+} from "./rv-schemas.ts";
+
+// Cap the per-team innings probe. NEPL is limited-overs (1 innings/team),
+// but the sync should tolerate longer formats without us hard-coding 1.
+// We stop at the first innings that returns no balls, so the cap only
+// matters as a safety net.
+const MAX_INNINGS_PER_TEAM = 4;
+
+/**
+ * Ingest ResultsVault ball-by-ball + match-stream data for a single match.
+ *
+ * Idempotent: every write is an upsert against a stable natural key, so
+ * re-running this for the same match is a no-op when nothing's changed
+ * and a corrective upsert when RV has fixed something post-match.
+ *
+ * Resolves silently (returns false) when the match has no RV-side data
+ * — a 404 on the mapping endpoint, a 0 mapping result, or an overview
+ * with no MatchTeams. The PC sync calls this for every processed match;
+ * the "no live scoring" case is the common one and shouldn't be noisy.
+ *
+ * Throws on unexpected RV failures (token rejection, malformed schema,
+ * etc.) so the caller's per-match try/catch logs them to the sync log.
+ *
+ * Returns true when at least one ball or stream row was written.
+ */
+export async function ingestRvDataForMatch(
+  db: Kysely<DB>,
+  rv: RvClient,
+  pcMatchId: string,
+  matchDateIso: string,
+): Promise<boolean> {
+  const mapping = await rv.getMatchMapping(pcMatchId);
+  if (!mapping) return false;
+
+  const overview = await rv.getMatch(mapping.rvMatchId);
+  if (!overview || overview.MatchTeams.length === 0) return false;
+
+  await upsertPlayerMappings(db, overview, matchDateIso);
+
+  const streamRows = await upsertMatchStreams(
+    db,
+    overview,
+    pcMatchId,
+    mapping.rvMatchId,
+  );
+
+  // Anchor for ball_offset_seconds (used for YouTube deep-links). Use the
+  // earliest recording_started_utc across the match's streams; if none
+  // have a recording start, leave offsets null on every ball.
+  const anchor = pickRecordingAnchor(overview.matchStreams);
+
+  let ballsWritten = 0;
+  for (const team of overview.MatchTeams) {
+    for (let innings = 1; innings <= MAX_INNINGS_PER_TEAM; innings++) {
+      const balls = await rv.getBalls(
+        mapping.rvMatchId,
+        team.result_id,
+        innings,
+      );
+      if (balls.length === 0) break;
+      ballsWritten += await upsertBalls(db, balls, {
+        matchId: pcMatchId,
+        rvMatchId: mapping.rvMatchId,
+        rvResultId: String(team.result_id),
+        anchorMs: anchor?.getTime() ?? null,
+      });
+    }
+  }
+
+  return ballsWritten > 0 || streamRows > 0;
+}
+
+async function upsertPlayerMappings(
+  db: Kysely<DB>,
+  overview: RvMatchOverview,
+  matchDateIso: string,
+): Promise<void> {
+  const seen = new Map<number, RvPlayerPerf>();
+  for (const team of overview.MatchTeams) {
+    for (const innings of team.Innings) {
+      for (const perf of innings.PlayerPerfs) {
+        // Drop perfs with no PC external_id — we'd just be storing names
+        // against an int with no resolve path back to our member table.
+        if (!perf.external_id) continue;
+        // De-dupe within a match (same player can appear in batting and
+        // bowling perfs). Last-write-wins on name.
+        seen.set(perf.player_id, perf);
+      }
+    }
+  }
+  if (seen.size === 0) return;
+
+  const rows = Array.from(seen.values()).map((perf) => ({
+    rv_player_id: perf.player_id,
+    pc_player_id: perf.external_id ?? "",
+    player_name: perf.player_name,
+    last_seen_match_date: matchDateIso,
+  }));
+
+  await db
+    .insertInto("rv_player_mapping")
+    .values(rows)
+    .onConflict((oc) =>
+      oc.column("rv_player_id").doUpdateSet({
+        pc_player_id: (eb) => eb.ref("excluded.pc_player_id"),
+        player_name: (eb) => eb.ref("excluded.player_name"),
+        last_seen_match_date: (eb) => eb.ref("excluded.last_seen_match_date"),
+        updated_at: new Date().toISOString(),
+      }),
+    )
+    .execute();
+}
+
+async function upsertMatchStreams(
+  db: Kysely<DB>,
+  overview: RvMatchOverview,
+  pcMatchId: string,
+  rvMatchId: string,
+): Promise<number> {
+  if (overview.matchStreams.length === 0) return 0;
+
+  const rows = overview.matchStreams.map((s) => ({
+    match_id: pcMatchId,
+    rv_match_id: rvMatchId,
+    rv_stream_id: s.id,
+    video_id: s.video_id,
+    frogbox_stream_id: s.frogbox_stream_id,
+    stream_provider_id: s.stream_provider_id,
+    start_utc: parseMsDate(s.start_utc)?.toISOString() ?? null,
+    recording_started_utc:
+      parseMsDate(s.recording_started_utc)?.toISOString() ?? null,
+    publish_status_id: s.publish_status_id ?? null,
+    description: s.description ?? null,
+  }));
+
+  await db
+    .insertInto("match_stream")
+    .values(rows)
+    .onConflict((oc) =>
+      oc.column("rv_stream_id").doUpdateSet({
+        match_id: (eb) => eb.ref("excluded.match_id"),
+        rv_match_id: (eb) => eb.ref("excluded.rv_match_id"),
+        video_id: (eb) => eb.ref("excluded.video_id"),
+        frogbox_stream_id: (eb) => eb.ref("excluded.frogbox_stream_id"),
+        stream_provider_id: (eb) => eb.ref("excluded.stream_provider_id"),
+        start_utc: (eb) => eb.ref("excluded.start_utc"),
+        recording_started_utc: (eb) => eb.ref("excluded.recording_started_utc"),
+        publish_status_id: (eb) => eb.ref("excluded.publish_status_id"),
+        description: (eb) => eb.ref("excluded.description"),
+      }),
+    )
+    .execute();
+
+  return rows.length;
+}
+
+interface UpsertBallsContext {
+  matchId: string;
+  rvMatchId: string;
+  rvResultId: string;
+  anchorMs: number | null;
+}
+
+async function upsertBalls(
+  db: Kysely<DB>,
+  balls: RvBall[],
+  ctx: UpsertBallsContext,
+): Promise<number> {
+  if (balls.length === 0) return 0;
+
+  const rows = balls.map((b) => {
+    const ballTime = parseMsDate(b.ball_time);
+    const offsetSeconds =
+      ballTime != null && ctx.anchorMs != null
+        ? Math.round((ballTime.getTime() - ctx.anchorMs) / 1000)
+        : null;
+    return {
+      match_id: ctx.matchId,
+      rv_match_id: ctx.rvMatchId,
+      rv_result_id: ctx.rvResultId,
+      innings_number: b.innings_number,
+      over_no: b.over_no,
+      ball_no: b.ball_no,
+      ball_no_disp: b.ball_no_disp,
+      batter_rv_id: b.batter_id ?? null,
+      batter_ns_rv_id: b.batter_id_ns ?? null,
+      bowler_rv_id: b.bowler_id ?? null,
+      dismissed_batter_rv_id: b.dismissed_batter_id ?? null,
+      runs_bat: b.runs_bat,
+      runs_extra: b.runs_extra,
+      extras_type: b.extras_type ?? null,
+      l_desc: b.l_desc,
+      s_desc: b.s_desc,
+      ball_time_utc: ballTime?.toISOString() ?? null,
+      ball_offset_seconds: offsetSeconds,
+      highlight_events: JSON.stringify(b.match_highlight_events),
+      ball_spot_x: b.ball_spot_x ?? null,
+      ball_spot_y: b.ball_spot_y ?? null,
+      shot_angle: b.shot_angle ?? null,
+      shot_length: b.shot_length ?? null,
+    };
+  });
+
+  await db
+    .insertInto("match_ball")
+    .values(rows)
+    .onConflict((oc) =>
+      oc.constraint("match_ball_natural_key_uq").doUpdateSet({
+        // Only fields that can actually change post-write — RV does
+        // emit corrections for runs, descriptions, dismissals etc.
+        // The natural-key columns themselves are excluded (they're how
+        // we found the row in the first place).
+        match_id: (eb) => eb.ref("excluded.match_id"),
+        over_no: (eb) => eb.ref("excluded.over_no"),
+        ball_no_disp: (eb) => eb.ref("excluded.ball_no_disp"),
+        batter_rv_id: (eb) => eb.ref("excluded.batter_rv_id"),
+        batter_ns_rv_id: (eb) => eb.ref("excluded.batter_ns_rv_id"),
+        bowler_rv_id: (eb) => eb.ref("excluded.bowler_rv_id"),
+        dismissed_batter_rv_id: (eb) =>
+          eb.ref("excluded.dismissed_batter_rv_id"),
+        runs_bat: (eb) => eb.ref("excluded.runs_bat"),
+        runs_extra: (eb) => eb.ref("excluded.runs_extra"),
+        extras_type: (eb) => eb.ref("excluded.extras_type"),
+        l_desc: (eb) => eb.ref("excluded.l_desc"),
+        s_desc: (eb) => eb.ref("excluded.s_desc"),
+        ball_time_utc: (eb) => eb.ref("excluded.ball_time_utc"),
+        ball_offset_seconds: (eb) => eb.ref("excluded.ball_offset_seconds"),
+        highlight_events: (eb) => eb.ref("excluded.highlight_events"),
+        ball_spot_x: (eb) => eb.ref("excluded.ball_spot_x"),
+        ball_spot_y: (eb) => eb.ref("excluded.ball_spot_y"),
+        shot_angle: (eb) => eb.ref("excluded.shot_angle"),
+        shot_length: (eb) => eb.ref("excluded.shot_length"),
+      }),
+    )
+    .execute();
+
+  return rows.length;
+}
+
+function pickRecordingAnchor(streams: RvMatchStream[]): Date | null {
+  let best: Date | null = null;
+  for (const s of streams) {
+    const d = parseMsDate(s.recording_started_utc);
+    if (!d) continue;
+    if (!best || d.getTime() < best.getTime()) best = d;
+  }
+  return best;
+}

--- a/apps/api/src/features/play-cricket/rv-ingest.ts
+++ b/apps/api/src/features/play-cricket/rv-ingest.ts
@@ -113,7 +113,13 @@ async function upsertPlayerMappings(
       oc.column("rv_player_id").doUpdateSet({
         pc_player_id: (eb) => eb.ref("excluded.pc_player_id"),
         player_name: (eb) => eb.ref("excluded.player_name"),
-        last_seen_match_date: (eb) => eb.ref("excluded.last_seen_match_date"),
+        // last_seen_match_date should only ever advance — backfilling an
+        // older match must not move the marker backwards.
+        last_seen_match_date: (eb) =>
+          eb.fn("greatest", [
+            eb.ref("rv_player_mapping.last_seen_match_date"),
+            eb.ref("excluded.last_seen_match_date"),
+          ]),
         updated_at: new Date().toISOString(),
       }),
     )
@@ -128,7 +134,15 @@ async function upsertMatchStreams(
 ): Promise<number> {
   if (overview.matchStreams.length === 0) return 0;
 
-  const rows = overview.matchStreams.map((s) => ({
+  // Streams without a video_id aren't useful — the whole point of the row
+  // is to deep-link to the video. RV's schema permits empty defaults; we
+  // drop those rather than persist hollow records.
+  const usable = overview.matchStreams.filter(
+    (s) => s.video_id.length > 0 && s.frogbox_stream_id.length > 0,
+  );
+  if (usable.length === 0) return 0;
+
+  const rows = usable.map((s) => ({
     match_id: pcMatchId,
     rv_match_id: rvMatchId,
     rv_stream_id: s.id,

--- a/apps/api/src/features/play-cricket/rv-schemas.ts
+++ b/apps/api/src/features/play-cricket/rv-schemas.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+
+// ResultsVault response schemas. The MatchCentre SPA bundle defines the
+// canonical shapes via mobx-state-tree models; we only re-encode the fields
+// we actually consume so a future bundle adding fields doesn't break us.
+//
+// All schemas use `.passthrough()`/`.loose()` semantics where it matters so
+// unknown keys are tolerated.
+
+// ── Mappings (PC id ↔ RV id) ──
+//
+// /rv/mappings/{instance}/{type}/{external_id}/?apiid=...&sportid=...
+//
+// `object_id1` is the RV-side id. Returns 0 when no mapping exists for the
+// supplied external_id (rather than 404'ing).
+export const RvMappingInfo = z.looseObject({
+  object_id1: z.number(),
+  mapping_id: z.number().optional(),
+  object_type_id: z.number().optional(),
+  mapping_instance: z.number().optional(),
+});
+export type RvMappingInfo = z.output<typeof RvMappingInfo>;
+
+// ── Match overview ──
+//
+// /rv/130000/matches/{rvMatchId}/?apiid=...
+//
+// Massive payload — we only encode the fields the ingest reads. Each
+// MatchTeam holds an Innings list whose PlayerPerfs carry the RV→PC
+// player id mapping for free.
+
+const RvPlayerPerf = z.looseObject({
+  player_id: z.number(), // RV player id
+  external_id: z.string().nullable().optional(), // PC's external id (string!)
+  player_name: z.string().default(""),
+  number: z.number().optional(), // batting position; not currently persisted
+});
+export type RvPlayerPerf = z.output<typeof RvPlayerPerf>;
+
+const RvInnings = z.looseObject({
+  innings_number: z.number().optional(),
+  PlayerPerfs: z.array(RvPlayerPerf).default([]),
+});
+
+const RvMatchTeam = z.looseObject({
+  team_name: z.string().default(""),
+  result_id: z.number(),
+  Innings: z.array(RvInnings).default([]),
+});
+export type RvMatchTeam = z.output<typeof RvMatchTeam>;
+
+const RvMatchStream = z.looseObject({
+  id: z.number(),
+  match_id: z.number().optional(),
+  video_id: z.string().default(""),
+  frogbox_stream_id: z.string().default(""),
+  stream_provider_id: z.number().default(0),
+  // Microsoft DateTime serialisation: "/Date(epochms+TZ)/" — parsed downstream.
+  start_utc: z.string().nullable().optional(),
+  recording_started_utc: z.string().nullable().optional(),
+  publish_status_id: z.number().nullable().optional(),
+  description: z.string().nullable().optional(),
+});
+export type RvMatchStream = z.output<typeof RvMatchStream>;
+
+export const RvMatchOverview = z.looseObject({
+  match_id: z.number(),
+  external_match_id: z.number().optional(), // PC match id when sourced via mapping
+  MatchTeams: z.array(RvMatchTeam).default([]),
+  matchStreams: z.array(RvMatchStream).default([]),
+});
+export type RvMatchOverview = z.output<typeof RvMatchOverview>;
+
+// ── Ball-by-ball ──
+//
+// /rv/130000/matches/{rvMatchId}/?apiid=...&action=getballs
+//                                &sportid=1
+//                                &resultid={result_id}
+//                                &inningsnumber={n}
+//
+// Returns a flat array. Each ball describes a single delivery — RV uses
+// 0-based over_no and a per-innings 1-based ball_no that includes extras.
+
+const RvHighlightEvent = z.looseObject({
+  event_id: z.number(),
+  metric: z.number().optional(),
+});
+
+export const RvBall = z.looseObject({
+  innings_number: z.number(),
+  over_no: z.number(),
+  ball_no: z.number(),
+  ball_no_disp: z.number(),
+  result_id: z.number(),
+  batter_id: z.number().nullable().optional(),
+  batter_id_ns: z.number().nullable().optional(),
+  bowler_id: z.number().nullable().optional(),
+  dismissed_batter_id: z.number().nullable().optional(),
+  runs_bat: z.number().default(0),
+  runs_extra: z.number().default(0),
+  extras_type: z.string().nullable().optional(),
+  l_desc: z.string().default(""),
+  s_desc: z.string().default(""),
+  ball_time: z.string().nullable().optional(),
+  match_highlight_events: z.array(RvHighlightEvent).default([]),
+  ball_spot_x: z.number().nullable().optional(),
+  ball_spot_y: z.number().nullable().optional(),
+  shot_angle: z.number().nullable().optional(),
+  shot_length: z.number().nullable().optional(),
+});
+export type RvBall = z.output<typeof RvBall>;
+
+export const RvBallsResponse = z.array(RvBall);

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -10,6 +10,8 @@ import {
 } from "./api-schemas.ts";
 
 import type { PlayCricketApiClient } from "./api-client.ts";
+import type { RvClient } from "./rv-client.ts";
+import { ingestRvDataForMatch } from "./rv-ingest.ts";
 
 // --- Helpers ---
 
@@ -346,6 +348,7 @@ async function storeFieldingPerformances(
 async function syncMatches(
   db: Kysely<DB>,
   api: PlayCricketApiClient,
+  rv: RvClient | null,
   config: SyncConfig,
   startTime: number,
 ): Promise<SyncResult> {
@@ -544,6 +547,23 @@ async function syncMatches(
           .execute();
       }
 
+      // ResultsVault ball-by-ball + match-stream ingest. Independent of
+      // the PC sync above; failures (token rejection, schema drift, RV
+      // outage) are logged but never propagated. The "match has no RV
+      // data" case is the common one and resolves silently inside
+      // ingestRvDataForMatch.
+      if (rv) {
+        try {
+          await ingestRvDataForMatch(db, rv, matchId, matchDateIso);
+        } catch (rvErr) {
+          errors.push(
+            `RV ingest failed for match ${matchId}: ${
+              rvErr instanceof Error ? rvErr.message : String(rvErr)
+            }`,
+          );
+        }
+      }
+
       matchesProcessed++;
     } catch (err) {
       const msg = `Error processing match ${matchId}: ${err instanceof Error ? err.message : String(err)}`;
@@ -564,14 +584,18 @@ async function syncMatches(
  *
  * TODO: Wire up as EventBridge scheduled task or admin HTTP trigger
  */
-export function runSync(db: Kysely<DB>, api: PlayCricketApiClient) {
+export function runSync(
+  db: Kysely<DB>,
+  api: PlayCricketApiClient,
+  rv: RvClient | null = null,
+) {
   return async (config: SyncConfig): Promise<SyncResult> => {
     const logId = crypto.randomUUID();
     const startedAt = new Date().toISOString();
     const startTime = Date.now();
 
     try {
-      const result = await syncMatches(db, api, config, startTime);
+      const result = await syncMatches(db, api, rv, config, startTime);
 
       // Log the sync
       await db

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -552,7 +552,14 @@ async function syncMatches(
       // outage) are logged but never propagated. The "match has no RV
       // data" case is the common one and resolves silently inside
       // ingestRvDataForMatch.
-      if (rv) {
+      //
+      // Gate on `shouldWriteResult` — otherwise we'd run the ingest for
+      // a recent match whose match_result row was deliberately skipped
+      // (no result entered yet, isRecent=true). match_ball / match_stream
+      // both FK to match_result.match_id, so writing them now would FK-
+      // violate. The next sync within the resync window picks the match
+      // up once the result lands.
+      if (rv && shouldWriteResult) {
         try {
           await ingestRvDataForMatch(db, rv, matchId, matchDateIso);
         } catch (rvErr) {

--- a/apps/api/src/sync-runner.ts
+++ b/apps/api/src/sync-runner.ts
@@ -8,11 +8,17 @@
 
 import { createClient } from "@percy-main/db";
 import { createApiClient } from "./features/play-cricket/api-client.ts";
+import { createRvClient } from "./features/play-cricket/rv-client.ts";
 import { runSync } from "./features/play-cricket/sync.ts";
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const PLAY_CRICKET_API_TOKEN = process.env.PLAY_CRICKET_API_TOKEN;
 const PLAY_CRICKET_SITE_ID = process.env.PLAY_CRICKET_SITE_ID;
+// ResultsVault shared secret (lifted from InteractSport's Match Centre
+// SPA bundle). Optional: when unset, the BBB ingest is skipped — the PC
+// sync still runs end-to-end. See BALL_BY_BALL_FETCHING.md (gitignored)
+// for how to obtain / rotate this.
+const RV_SHARED_SECRET = process.env.RV_SHARED_SECRET;
 
 if (!DATABASE_URL) throw new Error("Missing required env var: DATABASE_URL");
 if (!PLAY_CRICKET_API_TOKEN)
@@ -25,11 +31,16 @@ const api = createApiClient({
   apiToken: PLAY_CRICKET_API_TOKEN,
   siteId: PLAY_CRICKET_SITE_ID,
 });
+const rv = RV_SHARED_SECRET
+  ? createRvClient({ sharedSecret: RV_SHARED_SECRET })
+  : null;
 
 try {
-  console.log("Starting Play Cricket sync...");
+  console.log(
+    `Starting Play Cricket sync${rv ? " (with RV ingest)" : " (PC only)"}...`,
+  );
 
-  const sync = runSync(client, api);
+  const sync = runSync(client, api, rv);
   const result = await sync({ siteId: PLAY_CRICKET_SITE_ID });
 
   console.log(`Sync complete: ${result.matchesProcessed} matches processed`);

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -192,7 +192,11 @@ module "ecs" {
     GOOGLE_CLIENT_ID       = "${aws_secretsmanager_secret.app_secrets.arn}:GOOGLE_CLIENT_ID::"
     GOOGLE_CLIENT_SECRET   = "${aws_secretsmanager_secret.app_secrets.arn}:GOOGLE_CLIENT_SECRET::"
     PLAY_CRICKET_API_TOKEN = "${aws_secretsmanager_secret.app_secrets.arn}:PLAY_CRICKET_API_TOKEN::"
-    SLACK_WEBHOOK_URL      = "${aws_secretsmanager_secret.app_secrets.arn}:SLACK_WEBHOOK_URL::"
+    # ResultsVault shared secret used by the BBB ingest hook in
+    # sync-runner. Optional: if the JSON key is missing or empty, the
+    # ingest is skipped and the PC sync runs unchanged.
+    RV_SHARED_SECRET  = "${aws_secretsmanager_secret.app_secrets.arn}:RV_SHARED_SECRET::"
+    SLACK_WEBHOOK_URL = "${aws_secretsmanager_secret.app_secrets.arn}:SLACK_WEBHOOK_URL::"
 
     # Scout (alex-only AI cricket analyst). All keys must be populated in
     # the app_secrets blob before this redeploys; the streaming route

--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -156,7 +156,11 @@ module "ecs" {
     GOOGLE_CLIENT_ID       = "${aws_secretsmanager_secret.app_secrets.arn}:GOOGLE_CLIENT_ID::"
     GOOGLE_CLIENT_SECRET   = "${aws_secretsmanager_secret.app_secrets.arn}:GOOGLE_CLIENT_SECRET::"
     PLAY_CRICKET_API_TOKEN = "${aws_secretsmanager_secret.app_secrets.arn}:PLAY_CRICKET_API_TOKEN::"
-    SLACK_WEBHOOK_URL      = "${aws_secretsmanager_secret.app_secrets.arn}:SLACK_WEBHOOK_URL::"
+    # ResultsVault shared secret used by the BBB ingest hook in
+    # sync-runner. Optional: if the JSON key is missing or empty, the
+    # ingest is skipped and the PC sync runs unchanged.
+    RV_SHARED_SECRET  = "${aws_secretsmanager_secret.app_secrets.arn}:RV_SHARED_SECRET::"
+    SLACK_WEBHOOK_URL = "${aws_secretsmanager_secret.app_secrets.arn}:SLACK_WEBHOOK_URL::"
 
     # Scout (alex-only AI cricket analyst). All keys must be populated in
     # the app_secrets blob before this redeploys; Scout boots without

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -385,6 +385,34 @@ export interface MarketingOutbox {
   succeeded_at: string | null;
 }
 
+export interface MatchBall {
+  ball_no: number;
+  ball_no_disp: number;
+  ball_offset_seconds: number | null;
+  ball_spot_x: number | null;
+  ball_spot_y: number | null;
+  ball_time_utc: Timestamp | null;
+  batter_ns_rv_id: number | null;
+  batter_rv_id: number | null;
+  bowler_rv_id: number | null;
+  created_at: Generated<Timestamp>;
+  dismissed_batter_rv_id: number | null;
+  extras_type: string | null;
+  highlight_events: Generated<Json>;
+  id: Generated<string>;
+  innings_number: number;
+  l_desc: string;
+  match_id: string;
+  over_no: number;
+  runs_bat: number;
+  runs_extra: number;
+  rv_match_id: string;
+  rv_result_id: string;
+  s_desc: string;
+  shot_angle: number | null;
+  shot_length: number | null;
+}
+
 export interface Matchday {
   competition_type: string | null;
   confirmed_at: string | null;
@@ -513,6 +541,21 @@ export interface MatchResult {
   season: number;
 }
 
+export interface MatchStream {
+  created_at: Generated<Timestamp>;
+  description: string | null;
+  frogbox_stream_id: string;
+  id: Generated<string>;
+  match_id: string;
+  publish_status_id: number | null;
+  recording_started_utc: Timestamp | null;
+  rv_match_id: string;
+  rv_stream_id: number;
+  start_utc: Timestamp | null;
+  stream_provider_id: number;
+  video_id: string;
+}
+
 export interface Member {
   address: string | null;
   deleted_at: string | null;
@@ -598,6 +641,15 @@ export interface PlayerSponsorship {
   sponsor_phone: string | null;
   sponsor_website: string | null;
   stripe_payment_intent_id: string | null;
+}
+
+export interface RvPlayerMapping {
+  created_at: Generated<Timestamp>;
+  last_seen_match_date: string;
+  pc_player_id: string;
+  player_name: string;
+  rv_player_id: number;
+  updated_at: Generated<Timestamp>;
 }
 
 export interface ScoutAttachment {
@@ -814,11 +866,13 @@ export interface DB {
   lead: Lead;
   marketing_event: MarketingEvent;
   marketing_outbox: MarketingOutbox;
+  match_ball: MatchBall;
   match_fee_rate: MatchFeeRate;
   match_performance_batting: MatchPerformanceBatting;
   match_performance_bowling: MatchPerformanceBowling;
   match_performance_fielding: MatchPerformanceFielding;
   match_result: MatchResult;
+  match_stream: MatchStream;
   matchday: Matchday;
   matchday_expense: MatchdayExpense;
   matchday_player: MatchdayPlayer;
@@ -829,6 +883,7 @@ export interface DB {
   play_cricket_sync_log: PlayCricketSyncLog;
   play_cricket_team: PlayCricketTeam;
   player_sponsorship: PlayerSponsorship;
+  rv_player_mapping: RvPlayerMapping;
   scout_attachment: ScoutAttachment;
   scout_attachment_cache: ScoutAttachmentCache;
   scout_fact: ScoutFact;

--- a/packages/db/src/migrations/2026-05-07T00:35:34.071Z.ts
+++ b/packages/db/src/migrations/2026-05-07T00:35:34.071Z.ts
@@ -1,0 +1,169 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * ResultsVault ball-by-ball + match-stream ingest tables.
+ *
+ *   rv_player_mapping  — bridge from RV's numeric player_id to PC's
+ *                        external_id (which lines up with member.play_cricket_id).
+ *                        Populated from MatchTeams[].Innings[].PlayerPerfs[]
+ *                        on every overview fetch — every player we see across
+ *                        any of our matches lands here, including opposition.
+ *
+ *   match_stream       — one row per match recording (Frogbox stream → YouTube).
+ *                        Sparse: only matches whose ground had a camera get rows.
+ *
+ *   match_ball         — one row per delivery (legal + illegal). The bulk of
+ *                        the data. Player ids stored as RV ints; resolve to
+ *                        PC via rv_player_mapping when joining to member.
+ *
+ * Player ids on match_ball are RV-native (int) rather than PC-native (text)
+ * for two reasons: (1) the BBB feed gives RV ids, so storing those keeps
+ * the write path lossless and the unique constraint stable; (2) the player
+ * mapping can lag if a player appears in BBB before their PlayerPerf row is
+ * written (e.g. a partial overview fetch) — we don't want to drop ball rows
+ * when the mapping isn't ready yet.
+ *
+ * No ON DELETE CASCADE from match_result → these tables: ball / stream
+ * deletion is rare enough to do explicitly. But we do FK to match_result so
+ * an orphan match_ball row can't be written.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // -- rv_player_mapping --
+  await db.schema
+    .createTable("rv_player_mapping")
+    .addColumn("rv_player_id", "integer", (col) => col.primaryKey())
+    .addColumn("pc_player_id", "text", (col) => col.notNull())
+    .addColumn("player_name", "text", (col) => col.notNull())
+    .addColumn("last_seen_match_date", "text", (col) => col.notNull())
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  // Lookup by PC id — resolving "all RV ids that ever mapped to this player"
+  // (rare but the player_career view eventually wants it).
+  await db.schema
+    .createIndex("rv_player_mapping_pc_player_id_idx")
+    .on("rv_player_mapping")
+    .column("pc_player_id")
+    .execute();
+
+  // -- match_stream --
+  await db.schema
+    .createTable("match_stream")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("match_id", "text", (col) =>
+      col.notNull().references("match_result.match_id"),
+    )
+    .addColumn("rv_match_id", "text", (col) => col.notNull())
+    .addColumn("rv_stream_id", "integer", (col) => col.notNull().unique())
+    .addColumn("video_id", "text", (col) => col.notNull())
+    .addColumn("frogbox_stream_id", "text", (col) => col.notNull())
+    .addColumn("stream_provider_id", "integer", (col) => col.notNull())
+    .addColumn("start_utc", "timestamptz")
+    .addColumn("recording_started_utc", "timestamptz")
+    .addColumn("publish_status_id", "integer")
+    .addColumn("description", "text")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("match_stream_match_id_idx")
+    .on("match_stream")
+    .column("match_id")
+    .execute();
+
+  // -- match_ball --
+  await db.schema
+    .createTable("match_ball")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    // Match identity
+    .addColumn("match_id", "text", (col) =>
+      col.notNull().references("match_result.match_id"),
+    )
+    .addColumn("rv_match_id", "text", (col) => col.notNull())
+    .addColumn("rv_result_id", "text", (col) => col.notNull())
+    .addColumn("innings_number", "integer", (col) => col.notNull())
+    // Ball identity
+    .addColumn("over_no", "integer", (col) => col.notNull())
+    .addColumn("ball_no", "integer", (col) => col.notNull())
+    .addColumn("ball_no_disp", "integer", (col) => col.notNull())
+    // Participants — RV ids; resolve to PC via rv_player_mapping
+    .addColumn("batter_rv_id", "integer")
+    .addColumn("batter_ns_rv_id", "integer")
+    .addColumn("bowler_rv_id", "integer")
+    .addColumn("dismissed_batter_rv_id", "integer")
+    // Outcome
+    .addColumn("runs_bat", "integer", (col) => col.notNull())
+    .addColumn("runs_extra", "integer", (col) => col.notNull())
+    .addColumn("extras_type", "text")
+    .addColumn("l_desc", "text", (col) => col.notNull())
+    .addColumn("s_desc", "text", (col) => col.notNull())
+    // Timing & video deep-link
+    .addColumn("ball_time_utc", "timestamptz")
+    .addColumn("ball_offset_seconds", "integer")
+    // Raw event markers (boundary / wicket flags etc.) — kept as jsonb for
+    // forward-compat; cheap to keep, no agreed normalisation yet.
+    .addColumn("highlight_events", "jsonb", (col) =>
+      col.notNull().defaultTo(sql`'[]'::jsonb`),
+    )
+    // Hawkeye-style data — all null for amateur today; persisted in case
+    // future feeds populate them.
+    .addColumn("ball_spot_x", sql`real`)
+    .addColumn("ball_spot_y", sql`real`)
+    .addColumn("shot_angle", sql`real`)
+    .addColumn("shot_length", sql`real`)
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addUniqueConstraint("match_ball_natural_key_uq", [
+      "rv_match_id",
+      "rv_result_id",
+      "innings_number",
+      "ball_no",
+    ])
+    .execute();
+
+  // Hot path: chronological retrieval of a match's balls.
+  await db.schema
+    .createIndex("match_ball_match_innings_order_idx")
+    .on("match_ball")
+    .columns(["match_id", "innings_number", "over_no", "ball_no"])
+    .execute();
+
+  // Player-balls-this-season analytics (use case 2 — dismissal patterns).
+  await db.schema
+    .createIndex("match_ball_batter_idx")
+    .on("match_ball")
+    .columns(["batter_rv_id", "match_id", "innings_number", "ball_no"])
+    .execute();
+
+  // Bowling spell analytics — symmetric to batter index.
+  await db.schema
+    .createIndex("match_ball_bowler_idx")
+    .on("match_ball")
+    .columns(["bowler_rv_id", "match_id", "innings_number", "ball_no"])
+    .execute();
+
+  // Dismissals are rare per innings — partial index keeps the cardinality low.
+  await sql`
+    CREATE INDEX match_ball_dismissed_idx
+    ON match_ball (dismissed_batter_rv_id)
+    WHERE dismissed_batter_rv_id IS NOT NULL
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("match_ball").execute();
+  await db.schema.dropTable("match_stream").execute();
+  await db.schema.dropTable("rv_player_mapping").execute();
+}


### PR DESCRIPTION
## Summary

Pulls ResultsVault ball-by-ball and match-stream data into our DB whenever it
exists for a Percy Main match, alongside the existing PC sync. Tracks ~6/8
recent NEPL matches in the prod sample (live-scored matches only — RV doesn't
hold non-live-scored fixtures).

The reverse-engineering / fetch details, agent-usage sketches, and storage
plan are kept locally only (gitignored): \`BALL_BY_BALL_FETCHING.md\`,
\`BBB_PLAN.md\`, \`BBB_USAGE.md\`. Ping me for the doc set if you're picking
this up.

### Schema (one migration)

Three new tables:

- \`rv_player_mapping\` — bridge from RV's numeric \`player_id\` to PC's \`external_id\` (lines up with \`member.play_cricket_id\`). Populated from \`PlayerPerfs[]\` on every overview fetch.
- \`match_stream\` — one row per video recording (Frogbox stream → YouTube). Sparse.
- \`match_ball\` — one row per delivery. Player ids stored as RV ints; resolve to PC via the mapping table.

Indexes are sized for the two known query shapes: per-batter / per-bowler season-wide ordering, and a partial index on dismissals for the rare-event lookup.

### Client + ingest

- \`rv-client.ts\` — \`getMatchMapping\`, \`getMatch\`, \`getBalls\`. 404 / no-mapping resolve to null/[]; non-2xx throws so the per-match try/catch in sync logs meaningfully. Auth header (\`x-ias-api-request\`) minted per request — 3DES-ECB encrypted Unix timestamp, base64'd. Shared secret comes from \`RV_SHARED_SECRET\` env var.
- \`rv-ingest.ts\` — \`ingestRvDataForMatch(db, rv, pcMatchId, matchDate)\`. Idempotent end-to-end via natural-key upserts. \`ball_offset_seconds\` is precomputed at ingest from the earliest \`recording_started_utc\` so YouTube deep-links don't need read-time math.
- \`sync.ts\` — per-match loop calls the helper after \`match_result\` upsert. RV failures are logged into the existing \`errors[]\` (and thus \`play_cricket_sync_log.errors\`) without breaking the PC sync. The \`RvClient\` arg is optional: with no \`RV_SHARED_SECRET\` set, the BBB step is skipped.

### Test plan

- [x] \`pnpm -r typecheck\` clean
- [x] \`pnpm -r lint\` clean
- [x] \`pnpm test\` — 428 passing (14 new RV client unit tests for token mint, parseMsDate, mapping/match/balls happy + 404 + 401 paths)
- [x] \`pnpm test:integration\` — 269 passing (6 new RV ingest cases against testcontainer Postgres: happy path, idempotency, no-mapping skip, no-overview skip, empty-MatchTeams skip, no-anchor → null offsets)
- [ ] After merge, set \`RV_SHARED_SECRET\` in the prod ECS task env. Confirm next sync writes \`match_ball\` rows. Will need a one-shot backfill PR for current-season matches that pre-date the sync.

### Deferred / follow-ups

- Backfill script for the current 2026 season — separate PR, runs once.
- Scout tools (\`pc_innings_walkthrough\`, \`pc_dismissal_patterns\`) that consume the new tables.
- Opposition batting perfs (flip the \`isBattingTeamOurs\` gate) — needed if we ever want \`how_out\` for opposition batters.
- CloudWatch alarm on RV-specific failure rate — separate metric so secret rotation surfaces distinctly from PC outages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)