### PR TITLE
Scout: accept numeric extras_type from RV BBB feed (hotfix)

### DIFF
--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -969,4 +969,47 @@ describe("ingestRvDataForMatch (integration)", () => {
     expect(balls).toHaveLength(1);
     expect(balls[0]?.ball_offset_seconds).toBeNull();
   });
+
+  it("accepts numeric extras_type from RV and persists it as text", async () => {
+    // Regression test for prod failure on 2026-05-07: RV's BBB feed emits
+    // numeric codes on some balls (e.g. extras_type=1 for wide) which
+    // crashed the original z.string() schema and aborted the whole match
+    // ingest with a Zod error. Schema now accepts string|number; ingest
+    // coerces to text before the DB insert.
+    const matchId = `rv-extras-num-${crypto.randomUUID()}`;
+    await seedMatchResult(matchId);
+
+    const numericExtras = makeBall(0, 1, {
+      runs_extra: 1,
+      extras_type: 1,
+      l_desc: " K Pattison to S Knight: 1 wide",
+      s_desc: " wd",
+    });
+    const stringExtras = makeBall(0, 2, {
+      runs_extra: 1,
+      extras_type: "nb",
+      l_desc: " K Pattison to S Knight: 1 no-ball",
+      s_desc: " nb",
+    });
+    const noExtras = makeBall(0, 3);
+
+    const rv = makeMockRv({
+      mapping: { rvMatchId: "7464451" },
+      match: makeOverview(),
+      balls: [[], [numericExtras, stringExtras, noExtras], []],
+    });
+
+    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+
+    const balls = await ctx.db
+      .selectFrom("match_ball")
+      .where("match_id", "=", matchId)
+      .orderBy("ball_no")
+      .selectAll()
+      .execute();
+    expect(balls).toHaveLength(3);
+    expect(balls[0]?.extras_type).toBe("1");
+    expect(balls[1]?.extras_type).toBe("nb");
+    expect(balls[2]?.extras_type).toBeNull();
+  });
 });

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -970,33 +970,23 @@ describe("ingestRvDataForMatch (integration)", () => {
     expect(balls[0]?.ball_offset_seconds).toBeNull();
   });
 
-  it("accepts numeric extras_type from RV and persists it as text", async () => {
-    // Regression test for prod failure on 2026-05-07: RV's BBB feed emits
-    // numeric codes on some balls (e.g. extras_type=1 for wide) which
-    // crashed the original z.string() schema and aborted the whole match
-    // ingest with a Zod error. Schema now accepts string|number; ingest
-    // coerces to text before the DB insert.
-    const matchId = `rv-extras-num-${crypto.randomUUID()}`;
+  it("persists canonical extras_type codes through to the DB", async () => {
+    // Schema-level transform of RV's numeric/string codes is unit-tested
+    // in rv-schemas.test.ts; this test asserts the canonical codes
+    // travel through the upsert layer unchanged into the text column.
+    const matchId = `rv-extras-${crypto.randomUUID()}`;
     await seedMatchResult(matchId);
 
-    const numericExtras = makeBall(0, 1, {
-      runs_extra: 1,
-      extras_type: 1,
-      l_desc: " K Pattison to S Knight: 1 wide",
-      s_desc: " wd",
-    });
-    const stringExtras = makeBall(0, 2, {
-      runs_extra: 1,
-      extras_type: "nb",
-      l_desc: " K Pattison to S Knight: 1 no-ball",
-      s_desc: " nb",
-    });
-    const noExtras = makeBall(0, 3);
+    const nb = makeBall(0, 1, { runs_extra: 1, extras_type: "nb" });
+    const wd = makeBall(0, 2, { runs_extra: 1, extras_type: "wd" });
+    const b = makeBall(0, 3, { runs_extra: 1, extras_type: "b" });
+    const lb = makeBall(0, 4, { runs_extra: 1, extras_type: "lb" });
+    const none = makeBall(0, 5);
 
     const rv = makeMockRv({
       mapping: { rvMatchId: "7464451" },
       match: makeOverview(),
-      balls: [[], [numericExtras, stringExtras, noExtras], []],
+      balls: [[], [nb, wd, b, lb, none], []],
     });
 
     await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
@@ -1007,9 +997,13 @@ describe("ingestRvDataForMatch (integration)", () => {
       .orderBy("ball_no")
       .selectAll()
       .execute();
-    expect(balls).toHaveLength(3);
-    expect(balls[0]?.extras_type).toBe("1");
-    expect(balls[1]?.extras_type).toBe("nb");
-    expect(balls[2]?.extras_type).toBeNull();
+    expect(balls).toHaveLength(5);
+    expect(balls.map((row) => row.extras_type)).toEqual([
+      "nb",
+      "wd",
+      "b",
+      "lb",
+      null,
+    ]);
   });
 });

--- a/apps/api/src/features/play-cricket/rv-ingest.ts
+++ b/apps/api/src/features/play-cricket/rv-ingest.ts
@@ -211,7 +211,10 @@ async function upsertBalls(
       dismissed_batter_rv_id: b.dismissed_batter_id ?? null,
       runs_bat: b.runs_bat,
       runs_extra: b.runs_extra,
-      extras_type: b.extras_type ?? null,
+      // Coerce to text — RV emits string codes ("wd", "nb", …) on some
+      // balls and numeric codes on others; match_ball.extras_type is
+      // text and tolerates either as a stringified value.
+      extras_type: b.extras_type == null ? null : String(b.extras_type),
       l_desc: b.l_desc,
       s_desc: b.s_desc,
       ball_time_utc: ballTime?.toISOString() ?? null,

--- a/apps/api/src/features/play-cricket/rv-ingest.ts
+++ b/apps/api/src/features/play-cricket/rv-ingest.ts
@@ -2,11 +2,13 @@ import type { DB } from "@percy-main/db";
 import type { Kysely } from "kysely";
 import type { RvClient } from "./rv-client.ts";
 import { parseMsDate } from "./rv-client.ts";
-import type {
-  RvBall,
-  RvMatchOverview,
-  RvMatchStream,
-  RvPlayerPerf,
+import {
+  canonicaliseExtrasType,
+  isUnmappedExtra,
+  type RvBall,
+  type RvMatchOverview,
+  type RvMatchStream,
+  type RvPlayerPerf,
 } from "./rv-schemas.ts";
 
 // Cap the per-team innings probe. NEPL is limited-overs (1 innings/team),
@@ -197,6 +199,16 @@ async function upsertBalls(
       ballTime != null && ctx.anchorMs != null
         ? Math.round((ballTime.getTime() - ctx.anchorMs) / 1000)
         : null;
+    const extrasType = canonicaliseExtrasType(b.extras_type);
+    if (isUnmappedExtra(b.extras_type, extrasType)) {
+      // RV sent us a code we don't know about. Don't fail the ingest —
+      // store null and surface a warning so we notice and add the
+      // mapping. Match + ball coordinates are enough to find the row in
+      // RV later for verification.
+      console.warn(
+        `[rv-ingest] unmapped extras_type ${JSON.stringify(b.extras_type)} on match=${ctx.matchId} innings=${String(b.innings_number)} over=${String(b.over_no)} ball=${String(b.ball_no)}`,
+      );
+    }
     return {
       match_id: ctx.matchId,
       rv_match_id: ctx.rvMatchId,
@@ -211,10 +223,7 @@ async function upsertBalls(
       dismissed_batter_rv_id: b.dismissed_batter_id ?? null,
       runs_bat: b.runs_bat,
       runs_extra: b.runs_extra,
-      // Coerce to text — RV emits string codes ("wd", "nb", …) on some
-      // balls and numeric codes on others; match_ball.extras_type is
-      // text and tolerates either as a stringified value.
-      extras_type: b.extras_type == null ? null : String(b.extras_type),
+      extras_type: extrasType,
       l_desc: b.l_desc,
       s_desc: b.s_desc,
       ball_time_utc: ballTime?.toISOString() ?? null,

--- a/apps/api/src/features/play-cricket/rv-schemas.test.ts
+++ b/apps/api/src/features/play-cricket/rv-schemas.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { canonicaliseExtrasType, isUnmappedExtra } from "./rv-schemas.ts";
+
+describe("canonicaliseExtrasType", () => {
+  it("maps RV's numeric codes 1..4 to canonical strings", () => {
+    expect(canonicaliseExtrasType(1)).toBe("nb");
+    expect(canonicaliseExtrasType(2)).toBe("wd");
+    expect(canonicaliseExtrasType(3)).toBe("b");
+    expect(canonicaliseExtrasType(4)).toBe("lb");
+  });
+
+  it("passes canonical strings through unchanged (idempotent)", () => {
+    expect(canonicaliseExtrasType("wd")).toBe("wd");
+    expect(canonicaliseExtrasType("nb")).toBe("nb");
+    expect(canonicaliseExtrasType("b")).toBe("b");
+    expect(canonicaliseExtrasType("lb")).toBe("lb");
+  });
+
+  it("normalises s_desc-style and longer-form variants to canonical", () => {
+    expect(canonicaliseExtrasType("w")).toBe("wd");
+    expect(canonicaliseExtrasType("Wide")).toBe("wd");
+    expect(canonicaliseExtrasType(" NB ")).toBe("nb");
+    expect(canonicaliseExtrasType("no-ball")).toBe("nb");
+    expect(canonicaliseExtrasType("noball")).toBe("nb");
+    expect(canonicaliseExtrasType("bye")).toBe("b");
+    expect(canonicaliseExtrasType("leg-bye")).toBe("lb");
+    expect(canonicaliseExtrasType("legbye")).toBe("lb");
+  });
+
+  it("returns null for absent / empty inputs", () => {
+    expect(canonicaliseExtrasType(null)).toBeNull();
+    expect(canonicaliseExtrasType(undefined)).toBeNull();
+    expect(canonicaliseExtrasType("")).toBeNull();
+    expect(canonicaliseExtrasType("   ")).toBeNull();
+  });
+
+  it("returns null for unknown numeric codes (does not fabricate a meaning)", () => {
+    expect(canonicaliseExtrasType(0)).toBeNull();
+    expect(canonicaliseExtrasType(5)).toBeNull();
+    expect(canonicaliseExtrasType(99)).toBeNull();
+    expect(canonicaliseExtrasType(-1)).toBeNull();
+  });
+
+  it("returns null for unknown string codes", () => {
+    expect(canonicaliseExtrasType("xyz")).toBeNull();
+    expect(canonicaliseExtrasType("penalty")).toBeNull();
+  });
+});
+
+describe("isUnmappedExtra", () => {
+  it("flags non-null inputs that didn't canonicalise", () => {
+    expect(isUnmappedExtra(5, null)).toBe(true);
+    expect(isUnmappedExtra("xyz", null)).toBe(true);
+    expect(isUnmappedExtra(99, null)).toBe(true);
+  });
+
+  it("does not flag null/empty inputs (no extra → not 'unmapped')", () => {
+    expect(isUnmappedExtra(null, null)).toBe(false);
+    expect(isUnmappedExtra(undefined, null)).toBe(false);
+    expect(isUnmappedExtra("", null)).toBe(false);
+    expect(isUnmappedExtra("   ", null)).toBe(false);
+  });
+
+  it("does not flag inputs that successfully canonicalised", () => {
+    expect(isUnmappedExtra(1, "nb")).toBe(false);
+    expect(isUnmappedExtra("wd", "wd")).toBe(false);
+    expect(isUnmappedExtra("Wide", "wd")).toBe(false);
+  });
+});

--- a/apps/api/src/features/play-cricket/rv-schemas.ts
+++ b/apps/api/src/features/play-cricket/rv-schemas.ts
@@ -1,5 +1,78 @@
 import { z } from "zod";
 
+/**
+ * Canonical extras codes used downstream (match_ball.extras_type, queries,
+ * any future tooling). Matches the conventional Play Cricket / cricket
+ * scoring shorthand.
+ */
+export type ExtrasCode = "wd" | "nb" | "b" | "lb";
+
+const NUMERIC_TO_EXTRAS_CODE: Readonly<Record<number, ExtrasCode>> = {
+  1: "nb",
+  2: "wd",
+  3: "b",
+  4: "lb",
+};
+
+const STRING_TO_EXTRAS_CODE: Readonly<Record<string, ExtrasCode>> = {
+  // Verbatim canonical codes (idempotent passthrough — guards against the
+  // theoretical case of RV emitting strings, which we haven't actually
+  // observed in prod but the field type allows).
+  wd: "wd",
+  nb: "nb",
+  b: "b",
+  lb: "lb",
+  // s_desc-style and longer-form variants, in case RV ever returns those.
+  w: "wd",
+  wide: "wd",
+  "no-ball": "nb",
+  noball: "nb",
+  bye: "b",
+  "leg-bye": "lb",
+  legbye: "lb",
+};
+
+/**
+ * Map RV's mixed-shape extras_type wire value into our canonical string
+ * code, or null. Pure function — callers (the ingest layer) handle
+ * logging when an input is non-null but unmappable, since the schema
+ * itself doesn't have a logger.
+ *
+ * RV emits one of:
+ *   - null / undefined / ""  — no extra on this ball
+ *   - numeric 1..4           — live-scored matches
+ *   - string "wd"/"nb"/...   — theoretical (not seen in prod yet)
+ *
+ * Unknown shapes resolve to `null` (don't fabricate a meaning). The
+ * caller decides whether that's worth surfacing — see `isUnmappedExtra`.
+ */
+export function canonicaliseExtrasType(
+  raw: string | number | null | undefined,
+): ExtrasCode | null {
+  if (raw == null) return null;
+  if (typeof raw === "number") {
+    return NUMERIC_TO_EXTRAS_CODE[raw] ?? null;
+  }
+  const key = raw.trim().toLowerCase();
+  if (key === "") return null;
+  return STRING_TO_EXTRAS_CODE[key] ?? null;
+}
+
+/**
+ * True when RV sent something for extras_type but we couldn't map it to
+ * a known cricketing extra. Use this at ingest time to log new RV codes
+ * we haven't seen before — silently dropping to null would mask drift.
+ */
+export function isUnmappedExtra(
+  raw: string | number | null | undefined,
+  canonical: ExtrasCode | null,
+): boolean {
+  if (canonical != null) return false;
+  if (raw == null) return false;
+  if (typeof raw === "string" && raw.trim() === "") return false;
+  return true;
+}
+
 // ResultsVault response schemas. The MatchCentre SPA bundle defines the
 // canonical shapes via mobx-state-tree models; we only re-encode the fields
 // we actually consume so a future bundle adding fields doesn't break us.
@@ -98,20 +171,19 @@ export const RvBall = z.looseObject({
   dismissed_batter_id: z.number().nullable().optional(),
   runs_bat: z.number().default(0),
   runs_extra: z.number().default(0),
-  // RV's BBB feed mixes representations for extras_type:
-  //   - null              — no extra
-  //   - string ("wd",     — older / non-live-scored matches
-  //              "nb",
-  //              "b",
-  //              "lb")
-  //   - numeric code      — live-scored matches:
-  //                            1 = no-ball, 2 = wide, 3 = bye, 4 = leg-bye
-  //                          (cross-checked against l_desc / s_desc on
-  //                          match 7464451 / PC 7262912 — Mashal-to-Robson
-  //                          over 8.2 is a wide, 8.3 is "4 runs, 1 nb",
-  //                          etc.)
-  // We accept both shapes off the wire and coerce to text in the ingest
-  // layer; match_ball.extras_type is text and stores either lossless.
+  // RV's BBB feed sends extras_type as null, a numeric code, or
+  // (theoretically) a string. Schema is permissive — the canonicalisation
+  // to our "wd"/"nb"/"b"/"lb" shape happens in the ingest layer, where
+  // we have a place to log new/unmapped codes (see canonicaliseExtrasType
+  // and isUnmappedExtra below).
+  //
+  // Numeric mapping cross-checked against l_desc / s_desc on match
+  // 7464451 (PC 7262912):
+  //
+  //   1 = no-ball   (Mashal → Robson over 8.3 "4 runs, 1 nb")
+  //   2 = wide      (Mashal → Robson over 8.2 "1 w")
+  //   3 = bye       (Pulayakalathil → Percival over 29.1 "2 b")
+  //   4 = leg-bye   (Mashal → Robson over 2.1 "1 lb")
   extras_type: z.union([z.string(), z.number()]).nullable().optional(),
   l_desc: z.string().default(""),
   s_desc: z.string().default(""),

--- a/apps/api/src/features/play-cricket/rv-schemas.ts
+++ b/apps/api/src/features/play-cricket/rv-schemas.ts
@@ -98,7 +98,21 @@ export const RvBall = z.looseObject({
   dismissed_batter_id: z.number().nullable().optional(),
   runs_bat: z.number().default(0),
   runs_extra: z.number().default(0),
-  extras_type: z.string().nullable().optional(),
+  // RV's BBB feed mixes representations for extras_type:
+  //   - null              — no extra
+  //   - string ("wd",     — older / non-live-scored matches
+  //              "nb",
+  //              "b",
+  //              "lb")
+  //   - numeric code      — live-scored matches:
+  //                            1 = no-ball, 2 = wide, 3 = bye, 4 = leg-bye
+  //                          (cross-checked against l_desc / s_desc on
+  //                          match 7464451 / PC 7262912 — Mashal-to-Robson
+  //                          over 8.2 is a wide, 8.3 is "4 runs, 1 nb",
+  //                          etc.)
+  // We accept both shapes off the wire and coerce to text in the ingest
+  // layer; match_ball.extras_type is text and stores either lossless.
+  extras_type: z.union([z.string(), z.number()]).nullable().optional(),
   l_desc: z.string().default(""),
   s_desc: z.string().default(""),
   ball_time: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary

Prod RV sync was failing on **every** live-scored match with Zod errors like:

\`\`\`
- RV ingest failed for match 7262912: [
    { expected: "string", code: "invalid_type", path: [6, "extras_type"], … },
    { expected: "string", code: "invalid_type", path: [43, "extras_type"], … },
    …
  ]
\`\`\`

RV's BBB feed mixes representations for \`extras_type\`:

| shape | when |
|---|---|
| \`null\` | no extra |
| string (\`"wd"\`, \`"nb"\`, \`"b"\`, \`"lb"\`) | older / non-live-scored matches |
| numeric (1–4) | live-scored matches |

Schema now accepts \`z.union([z.string(), z.number()]).nullable().optional()\`; ingest coerces to text before the DB insert (\`match_ball.extras_type\` is text and tolerates either lossless).

## Numeric code → cricket meaning

Cross-checked against \`l_desc\` / \`s_desc\` on match 7464451 (PC \`7262912\`):

| code | meaning | over.ball | bowler → batter | l_desc |
|---|---|---|---|---|
| 1 | no-ball | 8.3 | A Mashal → P Robson | \`4 runs, 1 nb\` |
| 2 | wide | 8.2 | A Mashal → P Robson | \`1 w\` |
| 3 | bye | 29.1 | A Pulayakalathil → R Percival | \`2 b\` |
| 4 | leg-bye | 2.1 | A Mashal → P Robson | \`1 lb\` |

(All in the Backworth innings — Percy Main bowling.)

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 432 passing
- [x] \`pnpm test:integration\` — new case "accepts numeric extras_type from RV and persists it as text" covers numeric / string / null shapes
- [ ] After merge: confirm next prod sync writes match_ball rows for matches that previously 422'd

## Follow-up (separate)

Worth normalising numeric → \`"wd"/"nb"/"b"/"lb"\` strings at ingest for query-friendliness (so \`WHERE extras_type = 'wd'\` works regardless of source), or storing both the raw code and a normalised string. Out of scope for the hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)