### PR TITLE
Scout: render_video — embed YouTube clips inline

### DIFF
--- a/apps/api/src/features/scout/agent.ts
+++ b/apps/api/src/features/scout/agent.ts
@@ -29,6 +29,7 @@ import { createGenerateReportTool } from "./tools/generate-report.ts";
 import { createKnowledgeTools } from "./tools/knowledge.ts";
 import { createPlayCricketCitationTools } from "./tools/play-cricket-citations.ts";
 import { createPlayCricketTools } from "./tools/play-cricket.ts";
+import { createRenderVideoTool } from "./tools/render-video.ts";
 import { createWeatherTools } from "./tools/weather.ts";
 
 // streamText's providerOptions is typed as a deep alias not re-exported from
@@ -144,6 +145,12 @@ export function createScoutAgent(deps: ScoutAgentDeps): ScoutAgent {
   const chartTools =
     deps.mode === "chat" || deps.mode === "scout"
       ? createChartTool({ writer: deps.writer })
+      : {};
+  // render_video is gated to the same modes as chart_render. Debrief is a
+  // structured interview — embedding a clip mid-flow would derail it.
+  const videoTools =
+    deps.mode === "chat" || deps.mode === "scout"
+      ? createRenderVideoTool({ writer: deps.writer })
       : {};
   // generate_report builds a PDF and stores it in S3. Relevant in chat (the
   // captain may ask) and scout (the focused mode self-triggers the tool); not
@@ -272,6 +279,7 @@ When asked about the "next" or "upcoming" match for ANY club (Percy Main or oppo
       ...ballByBallTools,
       ...weatherTools,
       ...chartTools,
+      ...videoTools,
       ...reportTools,
       ...askQuestionTools,
       ...factTools,

--- a/apps/api/src/features/scout/system-prompt.ts
+++ b/apps/api/src/features/scout/system-prompt.ts
@@ -173,6 +173,13 @@ Sometimes a chart is just clearer than prose or a table. The chart_render tool a
 
 Don't chart 3 data points; don't chart what reads better as one number. After rendering a chart, still summarise the headline finding in your prose. The chart supplements your analysis, it doesn't replace it. The user sees the chart inline — don't describe what the chart shows axis-by-axis, just call out the takeaway.`;
 
+const VIDEO_RULES = `Video clips (render_video):
+When ask_ball_by_ball returns rows that include a real video_id (from match_stream) AND a ball_offset_seconds for the ball you want to highlight, prefer render_video over a youtu.be URL in prose. The tool embeds the YouTube player inline at the right offset so the captain hits play and sees the delivery instantly — no new tab, no scrubbing.
+
+Use it for 1–3 specific deliveries the captain would want to actually watch (the hundred ball, the wicket ball, the partnership winner). Don't embed every ball in a sequence — pick the moments and write the rest as prose. Don't use it for aggregate or cross-match questions; that's what charts and tables are for.
+
+Never invent a video_id. If ball_offset_seconds is null, the match wasn't live-streamed — say so in prose; do NOT call render_video.`;
+
 export const IMPORTANT_CONTEXT = `Important context:
 - The club is Percy Main CC. The league is the Northumberland and Tyneside Cricket League (NTCL) — never call it the "North East Premier League" or anything else.
 - The user is a club captain. They know cricket. Skip basic explanations of cricket concepts.
@@ -206,6 +213,8 @@ ${FACT_MEMORY_RULES}
 ${KNOWLEDGE_BASE_RULES}
 
 ${CHART_RULES}
+
+${VIDEO_RULES}
 
 Reports (generate_report):
 When the captain asks for a "scouting report", a "report PDF", or otherwise wants a saveable artefact, call generate_report. The tool's input is just the match identifiers — { matchId, ourTeam, opposition, matchDate, competition?, intent? } — NOT the report content. The tool queues a background job that does all the gathering and synthesis itself; you do not author the report content here, you do not pre-stream stats into the args. Find the match details first via pc_match_summary (project matches[].id + match_date + home_team_name/id + away_team_name/id + competition_name and filter by date / opponent), or via ask_db if the captain is asking about a past Percy Main fixture, then call generate_report with the identifiers.
@@ -248,6 +257,8 @@ ${FACT_MEMORY_RULES}
 ${KNOWLEDGE_BASE_RULES}
 
 ${CHART_RULES}
+
+${VIDEO_RULES}
 
 ${IMPORTANT_CONTEXT}`;
 

--- a/apps/api/src/features/scout/tools/render-video.ts
+++ b/apps/api/src/features/scout/tools/render-video.ts
@@ -1,0 +1,86 @@
+import { videoSpecSchema, type VideoSpec } from "@percy-main/shared";
+import { tool, type UIMessageStreamWriter } from "ai";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+export interface RenderVideoToolDeps {
+  // Same writer pattern as chart_render — the route wraps streamText in a
+  // createUIMessageStream and hands the writer down so this tool can emit a
+  // data-video part inline with the assistant's prose.
+  writer: UIMessageStreamWriter;
+}
+
+// Anthropic requires every tool's input_schema to be an OBJECT at the top
+// level. Wrap the spec in a `{ video: ... }` envelope to match chart_render.
+const renderVideoInputSchema = z.object({
+  video: videoSpecSchema,
+});
+
+export function createRenderVideoTool(deps: RenderVideoToolDeps) {
+  const { writer } = deps;
+
+  return {
+    render_video: tool({
+      description: `Render a YouTube video player inline in the chat at a specific moment. The frontend embeds the player at \`startSeconds\` so the captain hits play and immediately sees the delivery you're talking about — no new tab, no scrubbing, no copy-paste.
+
+When to render:
+- The captain asked to see a moment from a live-scored match (e.g. "show me my hundred", "the wicket ball", "the partnership winner").
+- ask_ball_by_ball returned ball-level rows with a \`video_id\` AND a \`ball_offset_seconds\` for the ball you want to highlight.
+- You're calling out 1–3 specific deliveries and an embedded clip is more useful than a YouTube URL the user has to click.
+
+When NOT to render:
+- You don't have a real \`video_id\` from match_stream — never invent one. If \`ball_offset_seconds\` is null the match wasn't live-streamed; say so in prose instead.
+- Aggregate / cross-match questions ("his dot-ball % this season") — use a chart or table.
+- You're rendering more than ~3 clips in one reply. Pick the most interesting moments rather than embedding every ball.
+
+Inputs:
+- \`videoId\` — REQUIRED. The 11-character YouTube id (e.g. "cu4A54DjCDI"), not a full URL.
+- \`startSeconds\` — usually \`match_ball.ball_offset_seconds\` for the delivery you're highlighting. Subtract a few seconds if you want a run-up rather than a hard cut to the moment of impact.
+- \`endSeconds\` — optional clip end. Useful for an over or a short passage of play (e.g. start at the wicket-ball offset, end ~12 seconds later).
+- \`title\` — one short line shown above the player. Lead with the cricket context, not the URL: "The hundred — over 34, ball 1" reads better than "Highlight clip".
+- \`caption\` — one short line below the player (sample, source, anything that doesn't fit the title).
+
+After rendering, still write the surrounding prose. The clip supplements your analysis; it doesn't replace it. Don't describe what the user is about to see in detail — call out the takeaway and let the video do the rest.
+
+EXAMPLE — a single ball deep-link:
+{
+  "video": {
+    "videoId": "cu4A54DjCDI",
+    "startSeconds": 1843,
+    "title": "The hundred — over 34, ball 1",
+    "caption": "Worked Degwekar for two to bring up the ton off 91 balls."
+  }
+}
+
+EXAMPLE — a short clipped passage:
+{
+  "video": {
+    "videoId": "cu4A54DjCDI",
+    "startSeconds": 1830,
+    "endSeconds": 1872,
+    "title": "Hundred-and-out: balls 91–93"
+  }
+}`,
+      inputSchema: renderVideoInputSchema,
+      // eslint-disable-next-line @typescript-eslint/require-await -- AI SDK execute signature is async; this tool has no async work to do.
+      execute: async ({ video }: { video: VideoSpec }) => {
+        const id = randomUUID();
+        writer.write({
+          type: "data-video",
+          id,
+          data: video,
+        });
+        // Short receipt for the LLM. The actual video payload is already
+        // streaming to the client via the data part above.
+        return {
+          rendered: true,
+          videoId: id,
+          startSeconds: video.startSeconds ?? null,
+          endSeconds: video.endSeconds ?? null,
+        };
+      },
+    }),
+  };
+}
+
+export type RenderVideoTools = ReturnType<typeof createRenderVideoTool>;

--- a/apps/web/src/pages/scout/message-view.tsx
+++ b/apps/web/src/pages/scout/message-view.tsx
@@ -2,12 +2,14 @@ import type { UIMessage } from "@ai-sdk/react";
 import {
   type ChartSpec,
   type ReportData as SharedReportData,
+  type VideoSpec,
 } from "@percy-main/shared";
 import React, { useEffect, useRef, useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ReportCard } from "./report-card.tsx";
 import { ScoutChart } from "./scout-chart.tsx";
+import { ScoutVideo } from "./scout-video.tsx";
 
 const REMARK_PLUGINS = [remarkGfm];
 
@@ -533,6 +535,13 @@ function PartView({
     // The schema is validated server-side (Zod) so the FE trusts the shape.
     const chartPart = part as { type: "data-chart"; data: ChartSpec };
     return <ScoutChart spec={chartPart.data} />;
+  }
+
+  if (part.type === "data-video") {
+    // render_video — server-side Zod-validated; the spec is YouTube-only and
+    // includes optional start/end offsets for ball-level deep-links.
+    const videoPart = part as { type: "data-video"; data: VideoSpec };
+    return <ScoutVideo spec={videoPart.data} />;
   }
 
   if (part.type === "data-question") {

--- a/apps/web/src/pages/scout/scout-video.tsx
+++ b/apps/web/src/pages/scout/scout-video.tsx
@@ -1,0 +1,49 @@
+import type { VideoSpec } from "@percy-main/shared";
+
+// YouTube nocookie embed: same player, no third-party tracking until the user
+// hits play. ?start=N seeks to N seconds before playing; ?end=N stops at N
+// (inclusive of start). rel=0 keeps the post-roll suggestions to the same
+// channel, modestbranding=1 hides the YouTube logo while playing.
+const EMBED_BASE = "https://www.youtube-nocookie.com/embed";
+
+function buildSrc(spec: VideoSpec): string {
+  const params = new URLSearchParams();
+  if (spec.startSeconds !== undefined) {
+    params.set("start", String(spec.startSeconds));
+  }
+  if (spec.endSeconds !== undefined) {
+    params.set("end", String(spec.endSeconds));
+  }
+  params.set("rel", "0");
+  params.set("modestbranding", "1");
+  const qs = params.toString();
+  return `${EMBED_BASE}/${spec.videoId}${qs ? `?${qs}` : ""}`;
+}
+
+export function ScoutVideo({ spec }: { spec: VideoSpec }) {
+  const src = buildSrc(spec);
+  return (
+    <figure className="my-3 rounded border border-gray-200 bg-white p-3">
+      {spec.title ? (
+        <figcaption className="mb-2 text-sm font-medium text-gray-900">
+          {spec.title}
+        </figcaption>
+      ) : null}
+      <div className="relative w-full overflow-hidden rounded bg-black pb-[56.25%]">
+        <iframe
+          src={src}
+          title={spec.title ?? "Match highlight"}
+          className="absolute inset-0 h-full w-full"
+          loading="lazy"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+        />
+      </div>
+      {spec.caption ? (
+        <figcaption className="mt-2 text-xs text-gray-500">
+          {spec.caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,6 +32,8 @@ export { nameSimilarity, normalizeName } from "./name-similarity.ts";
 
 export { chartSpecSchema, type ChartSpec } from "./scout-chart.ts";
 
+export { videoSpecSchema, type VideoSpec } from "./scout-video.ts";
+
 export {
   scoutLeagueTableSchema,
   scoutReportContentSchema,

--- a/packages/shared/src/scout-video.ts
+++ b/packages/shared/src/scout-video.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+// Spec for the render_video tool. Currently YouTube-only; that's all the
+// upstream data carries (match_stream.video_id is a YouTube id and
+// match_ball.ball_offset_seconds is an offset into that video). If we ever
+// add another source we'd switch this to a discriminated union on `provider`.
+
+// YouTube video ids are 11 chars, [A-Za-z0-9_-]. Validate strictly so a
+// hallucinated value (or an accidental full URL) fails fast in the tool's
+// execute() rather than producing a broken iframe.
+const YOUTUBE_ID = /^[A-Za-z0-9_-]{11}$/;
+
+export const videoSpecSchema = z
+  .object({
+    videoId: z
+      .string()
+      .regex(YOUTUBE_ID, "videoId must be an 11-character YouTube video id")
+      .describe("YouTube video id, e.g. 'cu4A54DjCDI' (NOT the full URL)."),
+    title: z
+      .string()
+      .max(140)
+      .optional()
+      .describe(
+        "Optional one-line title shown above the player (e.g. 'The hundred — over 34, ball 1').",
+      ),
+    caption: z
+      .string()
+      .max(280)
+      .optional()
+      .describe(
+        "Optional one-line caption shown below the player (context, source, sample-size note).",
+      ),
+    startSeconds: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Seconds offset to start playback from. Use match_ball.ball_offset_seconds when deep-linking a specific delivery.",
+      ),
+    endSeconds: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        "Seconds offset to stop playback at. Use to clip a short highlight (e.g. start at the dismissal ball, end ~10s later).",
+      ),
+  })
+  .refine(
+    (v) =>
+      v.endSeconds === undefined ||
+      v.startSeconds === undefined ||
+      v.endSeconds > v.startSeconds,
+    { message: "endSeconds must be greater than startSeconds." },
+  );
+
+export type VideoSpec = z.infer<typeof videoSpecSchema>;


### PR DESCRIPTION
## Summary
- New `render_video` agent tool: emits a `data-video` UIMessageStream part containing `{ videoId, title?, caption?, startSeconds?, endSeconds? }`. FE renders a 16:9 YouTube-nocookie iframe inline so the captain hits play and immediately sees the moment.
- Wired for chat + focused-scout modes (skipped in debrief, like `chart_render`). System prompt nudges the model to prefer `render_video` over a `youtu.be` link in prose when `ask_ball_by_ball` returns rows with a real `match_stream.video_id` and non-null `match_ball.ball_offset_seconds`.

Pattern mirrors `chart_render`: shared Zod spec in `packages/shared`, server tool closes over the writer, FE `PartView` swaps in the new component.

## Test plan
- [ ] Ask Scout a ball-by-ball question that has a streamed match (e.g. "show me the wicket ball" / "the hundred"). Confirm the inline player loads at the right offset.
- [ ] Ask about a non-streamed match — confirm the agent falls back to prose, no embedded player, no fabricated `videoId`.
- [ ] Confirm `chart_render` still works (no regression in tool dispatch).
- [ ] Confirm debrief mode does NOT register `render_video` (no embed even if explicitly asked).
- [ ] Visual: title above, caption below, 16:9 ratio, lazy-loads, fullscreen works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)