### PR TITLE
Scout: share threads read-only with other officials

### DIFF
--- a/apps/api/src/features/scout/integration.test.ts
+++ b/apps/api/src/features/scout/integration.test.ts
@@ -14,9 +14,15 @@ import {
   createThread,
   deleteThread,
   getThread,
+  listOfficials,
   listRecentDebriefMatches,
+  listSharees,
   listThreads,
+  ShareForbiddenError,
+  ShareInvalidRecipientError,
+  shareThread,
   ThreadNotFoundError,
+  unshareThread,
 } from "./service.ts";
 import { createScoutCache } from "./tools/cache.ts";
 import { createDbTools } from "./tools/db.ts";
@@ -330,6 +336,184 @@ describe("scout thread service (integration)", () => {
     await expect(assertOwned(userId, debrief.id)).resolves.toEqual({
       mode: "debrief",
     });
+  });
+});
+
+describe("scout thread sharing (integration)", () => {
+  it("listOfficials returns admins and officials excluding the current user, ordered by name", async () => {
+    const { userId: viewer } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+      name: "Zara Owner",
+    });
+    const { userId: alice } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+      name: "Alice Official",
+    });
+    const { userId: bob } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "admin",
+      name: "Bob Admin",
+    });
+    // Plain user (no role) — must NOT appear in the picker.
+    await seedTestUser(ctx.db, {
+      withMember: false,
+      role: null as unknown as string,
+      name: "Charlie Civilian",
+    });
+
+    const officials = await listOfficials(ctx.db)(viewer);
+    const ids = officials.map((o) => o.id);
+    expect(ids).toContain(alice);
+    expect(ids).toContain(bob);
+    expect(ids).not.toContain(viewer);
+    // Alphabetical by name
+    const aIdx = officials.findIndex((o) => o.id === alice);
+    const bIdx = officials.findIndex((o) => o.id === bob);
+    expect(aIdx).toBeLessThan(bIdx);
+  });
+
+  it("share + getThread: a recipient can read the shared thread and sees sharedBy populated", async () => {
+    const { userId: owner, name: ownerName } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+      name: "Owner Person",
+    });
+    const { userId: recipient } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+
+    const thread = await createThread(ctx.db)(owner, "Shared scout thread");
+    await shareThread(ctx.db)(owner, thread.id, [recipient]);
+
+    const ownerView = await getThread(ctx.db)(owner, thread.id);
+    expect(ownerView.thread.sharedBy).toBeNull();
+    expect(ownerView.thread.sharedByMe).toBe(true);
+
+    const recipientView = await getThread(ctx.db)(recipient, thread.id);
+    expect(recipientView.thread.sharedBy?.id).toBe(owner);
+    expect(recipientView.thread.sharedBy?.name).toBe(ownerName);
+    expect(recipientView.thread.sharedByMe).toBe(false);
+  });
+
+  it("listThreads merges owned + shared, with sharedBy / sharedByMe set per row", async () => {
+    const { userId: alice } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+    const { userId: bob } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+
+    const aliceThread = await createThread(ctx.db)(alice, "Alice's analysis");
+    const bobsShared = await createThread(ctx.db)(bob, "Bob's plan");
+    await shareThread(ctx.db)(bob, bobsShared.id, [alice]);
+
+    const aliceList = await listThreads(ctx.db)(alice);
+    const own = aliceList.find((t) => t.id === aliceThread.id);
+    const shared = aliceList.find((t) => t.id === bobsShared.id);
+    expect(own?.sharedByMe).toBe(false); // owns it but hasn't shared
+    expect(own?.sharedBy).toBeNull();
+    expect(shared?.sharedBy?.id).toBe(bob);
+    expect(shared?.sharedByMe).toBe(false);
+
+    // Alice now shares her own thread with Bob → sharedByMe flips for her.
+    await shareThread(ctx.db)(alice, aliceThread.id, [bob]);
+    const aliceListAfter = await listThreads(ctx.db)(alice);
+    expect(
+      aliceListAfter.find((t) => t.id === aliceThread.id)?.sharedByMe,
+    ).toBe(true);
+  });
+
+  it("share + unshare are idempotent (no duplicate rows; unshare twice is fine)", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+    const { userId: rec } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+
+    const thread = await createThread(ctx.db)(owner, "Idempotent thread");
+    await shareThread(ctx.db)(owner, thread.id, [rec]);
+    await shareThread(ctx.db)(owner, thread.id, [rec]); // re-share, no-op
+    const sharees = await listSharees(ctx.db)(owner, thread.id);
+    expect(sharees.map((s) => s.id)).toEqual([rec]);
+
+    await unshareThread(ctx.db)(owner, thread.id, rec);
+    await unshareThread(ctx.db)(owner, thread.id, rec); // unshare twice, no-op
+    expect(await listSharees(ctx.db)(owner, thread.id)).toEqual([]);
+  });
+
+  it("share + unshare refuse to run for a non-owner (ShareForbiddenError)", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+    const { userId: imposter } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "admin",
+    });
+    const { userId: target } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+
+    const thread = await createThread(ctx.db)(owner, "Locked");
+    await expect(
+      shareThread(ctx.db)(imposter, thread.id, [target]),
+    ).rejects.toBeInstanceOf(ShareForbiddenError);
+    await expect(
+      unshareThread(ctx.db)(imposter, thread.id, target),
+    ).rejects.toBeInstanceOf(ShareForbiddenError);
+  });
+
+  it("share rejects recipients without admin/official role", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+    const { userId: civilian } = await seedTestUser(ctx.db, {
+      withMember: false,
+      // explicit no role — `null` is the default for plain users
+      role: null as unknown as string,
+    });
+
+    const thread = await createThread(ctx.db)(owner, "Restricted");
+    await expect(
+      shareThread(ctx.db)(owner, thread.id, [civilian]),
+    ).rejects.toBeInstanceOf(ShareInvalidRecipientError);
+  });
+
+  it("share rejects sharing with self", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+    const thread = await createThread(ctx.db)(owner, "Solo");
+    await expect(
+      shareThread(ctx.db)(owner, thread.id, [owner]),
+    ).rejects.toBeInstanceOf(ShareInvalidRecipientError);
+  });
+
+  it("a non-shared, non-owner user cannot read the thread (404 via ThreadNotFoundError)", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+    const { userId: stranger } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
+    const thread = await createThread(ctx.db)(owner, "Private");
+
+    await expect(
+      getThread(ctx.db)(stranger, thread.id),
+    ).rejects.toBeInstanceOf(ThreadNotFoundError);
   });
 });
 

--- a/apps/api/src/features/scout/integration.test.ts
+++ b/apps/api/src/features/scout/integration.test.ts
@@ -511,9 +511,9 @@ describe("scout thread sharing (integration)", () => {
     });
     const thread = await createThread(ctx.db)(owner, "Private");
 
-    await expect(
-      getThread(ctx.db)(stranger, thread.id),
-    ).rejects.toBeInstanceOf(ThreadNotFoundError);
+    await expect(getThread(ctx.db)(stranger, thread.id)).rejects.toBeInstanceOf(
+      ThreadNotFoundError,
+    );
   });
 });
 

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -92,13 +92,18 @@ import {
   kbSaveFromAttachmentResponseSchema,
   listFactsQuerySchema,
   listFactsResponseSchema,
+  listOfficialsResponseSchema,
   listReportsResponseSchema,
+  listShareesResponseSchema,
   listThreadsResponseSchema,
   recentDebriefMatchesResponseSchema,
   reportDetailResponseSchema,
   reportDownloadResponseSchema,
   reportIdParamSchema,
+  shareThreadBodySchema,
+  shareThreadResponseSchema,
   threadIdParamSchema,
+  unshareUserParamSchema,
   upcomingScoutMatchesResponseSchema,
   updateFactBodySchema,
   updateFactResponseSchema,
@@ -114,12 +119,18 @@ import {
   getReportDetail,
   getReportForDownload,
   getThread,
+  listOfficials,
   listRecentDebriefMatches,
   listReports,
+  listSharees,
   listThreads,
   listUpcomingScoutMatches,
   ReportNotFoundError,
+  ShareForbiddenError,
+  ShareInvalidRecipientError,
+  shareThread,
   ThreadNotFoundError,
+  unshareThread,
 } from "./service.ts";
 import { maybeGenerateTitle } from "./title.ts";
 
@@ -132,6 +143,10 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
   const append = appendMessage(app.db);
   const bump = bumpThreadUpdatedAt(app.db);
   const assertOwned = assertThreadOwnership(app.db);
+  const officials = listOfficials(app.db);
+  const sharees = listSharees(app.db);
+  const share = shareThread(app.db);
+  const unshare = unshareThread(app.db);
   const recentMatches = listRecentDebriefMatches(app.db);
   const upcomingMatches = listUpcomingScoutMatches(app.db);
   const reportsList = listReports(app.db);
@@ -340,6 +355,128 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
         if (err instanceof ThreadNotFoundError) {
           throw Object.assign(new Error("Thread not found"), {
             statusCode: 404,
+          });
+        }
+        throw err;
+      }
+    },
+  );
+
+  // ── Thread sharing ──
+  // Owner-only management of read-only access grants. Recipients see the
+  // thread in their list with a "Shared by X" badge and can read messages
+  // but cannot post — write paths still gate on assertThreadOwnership.
+
+  // Source for the share modal's picker. Listed for any caller with
+  // Scout access; sharing semantics are still enforced on the share POST.
+  app.get(
+    "/scout/officials",
+    {
+      preHandler: [requireScoutAccess],
+      schema: {
+        response: { 200: listOfficialsResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return { officials: await officials(user.id) };
+    },
+  );
+
+  app.get(
+    "/scout/threads/:threadId/shares",
+    {
+      preHandler: [requireScoutAccess],
+      schema: {
+        params: threadIdParamSchema,
+        response: { 200: listShareesResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      try {
+        return { sharees: await sharees(user.id, request.params.threadId) };
+      } catch (err) {
+        if (err instanceof ThreadNotFoundError) {
+          throw Object.assign(new Error("Thread not found"), {
+            statusCode: 404,
+          });
+        }
+        if (err instanceof ShareForbiddenError) {
+          throw Object.assign(new Error("Only the thread owner can manage sharing"), {
+            statusCode: 403,
+          });
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.post(
+    "/scout/threads/:threadId/shares",
+    {
+      preHandler: [requireScoutAccess],
+      schema: {
+        params: threadIdParamSchema,
+        body: shareThreadBodySchema,
+        response: { 200: shareThreadResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      try {
+        const updated = await share(
+          user.id,
+          request.params.threadId,
+          request.body.userIds,
+        );
+        return { sharees: updated };
+      } catch (err) {
+        if (err instanceof ThreadNotFoundError) {
+          throw Object.assign(new Error("Thread not found"), {
+            statusCode: 404,
+          });
+        }
+        if (err instanceof ShareForbiddenError) {
+          throw Object.assign(new Error("Only the thread owner can manage sharing"), {
+            statusCode: 403,
+          });
+        }
+        if (err instanceof ShareInvalidRecipientError) {
+          throw Object.assign(new Error(err.message), { statusCode: 400 });
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.delete(
+    "/scout/threads/:threadId/shares/:userId",
+    {
+      preHandler: [requireScoutAccess],
+      schema: {
+        params: unshareUserParamSchema,
+        response: { 200: shareThreadResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      try {
+        const updated = await unshare(
+          user.id,
+          request.params.threadId,
+          request.params.userId,
+        );
+        return { sharees: updated };
+      } catch (err) {
+        if (err instanceof ThreadNotFoundError) {
+          throw Object.assign(new Error("Thread not found"), {
+            statusCode: 404,
+          });
+        }
+        if (err instanceof ShareForbiddenError) {
+          throw Object.assign(new Error("Only the thread owner can manage sharing"), {
+            statusCode: 403,
           });
         }
         throw err;

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -403,9 +403,12 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
           });
         }
         if (err instanceof ShareForbiddenError) {
-          throw Object.assign(new Error("Only the thread owner can manage sharing"), {
-            statusCode: 403,
-          });
+          throw Object.assign(
+            new Error("Only the thread owner can manage sharing"),
+            {
+              statusCode: 403,
+            },
+          );
         }
         throw err;
       }
@@ -438,9 +441,12 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
           });
         }
         if (err instanceof ShareForbiddenError) {
-          throw Object.assign(new Error("Only the thread owner can manage sharing"), {
-            statusCode: 403,
-          });
+          throw Object.assign(
+            new Error("Only the thread owner can manage sharing"),
+            {
+              statusCode: 403,
+            },
+          );
         }
         if (err instanceof ShareInvalidRecipientError) {
           throw Object.assign(new Error(err.message), { statusCode: 400 });
@@ -475,9 +481,12 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
           });
         }
         if (err instanceof ShareForbiddenError) {
-          throw Object.assign(new Error("Only the thread owner can manage sharing"), {
-            statusCode: 403,
-          });
+          throw Object.assign(
+            new Error("Only the thread owner can manage sharing"),
+            {
+              statusCode: 403,
+            },
+          );
         }
         throw err;
       }

--- a/apps/api/src/features/scout/schemas.ts
+++ b/apps/api/src/features/scout/schemas.ts
@@ -18,12 +18,27 @@ export const threadIdParamSchema = z.object({
 export const scoutModeSchema = z.enum(["chat", "debrief", "scout"]);
 export type ScoutMode = z.infer<typeof scoutModeSchema>;
 
+// Identity surfaced in sharing responses. We don't expose the avatar /
+// emailVerified flag — the share modal and "shared by" header only need
+// name + email, and the id is what every mutation keys off.
+export const shareActorSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+});
+
 export const threadSummarySchema = z.object({
   id: z.uuid(),
   title: z.string(),
   mode: scoutModeSchema,
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime(),
+  /** Owner identity when the current viewer is a recipient of a share;
+   *  null when the viewer owns the thread. */
+  sharedBy: shareActorSchema.nullable(),
+  /** True only on threads the viewer owns AND has shared. Used by the
+   *  list view to render a small share-icon next to the title. */
+  sharedByMe: z.boolean(),
 });
 
 export const listThreadsResponseSchema = z.object({
@@ -457,4 +472,29 @@ export const kbSaveFromAttachmentBodySchema = z.object({
 export const kbSaveFromAttachmentResponseSchema = z.object({
   documentId: z.uuid(),
   status: kbDocumentStatusSchema,
+});
+
+// ── Thread sharing ──
+
+export const listOfficialsResponseSchema = z.object({
+  officials: z.array(shareActorSchema),
+});
+
+export const shareThreadBodySchema = z.object({
+  // Cap the bulk add to keep accidental "share with the whole club"
+  // mistakes contained. 25 is well above the realistic ceiling (~12
+  // captains and a handful of officials) and small enough to round-trip
+  // synchronously without batching.
+  userIds: z.array(z.string()).min(1).max(25),
+});
+
+export const listShareesResponseSchema = z.object({
+  sharees: z.array(shareActorSchema),
+});
+
+export const shareThreadResponseSchema = listShareesResponseSchema;
+
+export const unshareUserParamSchema = z.object({
+  threadId: z.uuid(),
+  userId: z.string(),
 });

--- a/apps/api/src/features/scout/service.ts
+++ b/apps/api/src/features/scout/service.ts
@@ -708,7 +708,9 @@ export function listOfficials(db: Kysely<DB>) {
       .selectFrom("user")
       .where("role", "in", Array.from(SHAREABLE_ROLES))
       .where("id", "!=", currentUserId)
-      .where((eb) => eb.or([eb("banned", "is", null), eb("banned", "=", false)]))
+      .where((eb) =>
+        eb.or([eb("banned", "is", null), eb("banned", "=", false)]),
+      )
       .select(["id", "name", "email"])
       .orderBy("name", "asc")
       .execute();
@@ -717,10 +719,7 @@ export function listOfficials(db: Kysely<DB>) {
 }
 
 export function listSharees(db: Kysely<DB>) {
-  return async (
-    userId: string,
-    threadId: string,
-  ): Promise<ShareActor[]> => {
+  return async (userId: string, threadId: string): Promise<ShareActor[]> => {
     await assertOwnerForShare(db, userId, threadId);
     const rows = await db
       .selectFrom("scout_thread_share as s")
@@ -742,9 +741,12 @@ export function shareThread(db: Kysely<DB>) {
     await assertOwnerForShare(db, ownerUserId, threadId);
 
     const unique = Array.from(new Set(recipientUserIds));
-    if (unique.length === 0) return await listSharees(db)(ownerUserId, threadId);
+    if (unique.length === 0)
+      return await listSharees(db)(ownerUserId, threadId);
     if (unique.includes(ownerUserId)) {
-      throw new ShareInvalidRecipientError("Cannot share a thread with yourself.");
+      throw new ShareInvalidRecipientError(
+        "Cannot share a thread with yourself.",
+      );
     }
 
     // Validate every recipient is still a real, role-eligible user. Doing
@@ -755,7 +757,9 @@ export function shareThread(db: Kysely<DB>) {
       .selectFrom("user")
       .where("id", "in", unique)
       .where("role", "in", Array.from(SHAREABLE_ROLES))
-      .where((eb) => eb.or([eb("banned", "is", null), eb("banned", "=", false)]))
+      .where((eb) =>
+        eb.or([eb("banned", "is", null), eb("banned", "=", false)]),
+      )
       .select(["id"])
       .execute();
     const validIds = new Set(valid.map((r) => r.id));

--- a/apps/api/src/features/scout/service.ts
+++ b/apps/api/src/features/scout/service.ts
@@ -2,12 +2,30 @@ import type { DB } from "@percy-main/db";
 import type { Kysely } from "kysely";
 import type { ScoutMode } from "./schemas.ts";
 
+/**
+ * Sharing actor identity used in API responses (the owner who shared,
+ * or — on a list of sharees — the recipient). We only ever surface
+ * what's needed to render "Shared by Alex" / "Shared with: Alex, Jo".
+ */
+export interface ShareActor {
+  id: string;
+  name: string;
+  email: string;
+}
+
 export interface ThreadSummary {
   id: string;
   title: string;
   mode: ScoutMode;
   createdAt: string;
   updatedAt: string;
+  /** When the current viewer is a recipient (not the owner), the owner
+   * who shared the thread with them. Null on owned threads. */
+  sharedBy: ShareActor | null;
+  /** True when the current viewer owns the thread AND has shared it with
+   * at least one other user. Lets the FE render a "shared" badge in the
+   * list without an extra round-trip to count sharees. */
+  sharedByMe: boolean;
 }
 
 export interface PersistedMessage {
@@ -24,25 +42,99 @@ export class ThreadNotFoundError extends Error {
   }
 }
 
+export class ShareForbiddenError extends Error {
+  constructor() {
+    super("Only the thread owner can manage sharing");
+  }
+}
+
+// Inherits Error's (message: string) constructor — service.ts callers do
+// `throw new ShareInvalidRecipientError("…")` and route handlers re-throw
+// with statusCode: 400 using err.message verbatim.
+export class ShareInvalidRecipientError extends Error {}
+
 const toIso = (value: Date | string): string =>
   value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 
 export function listThreads(db: Kysely<DB>) {
   return async (userId: string): Promise<ThreadSummary[]> => {
-    const rows = await db
+    // Three queries, then merge in JS:
+    //   1. owned threads
+    //   2. threads shared WITH me (recipient view)
+    //   3. ids of owned threads I've shared with someone (so the list view
+    //      can render a "shared" badge on my own row)
+    // Doing it as one giant CTE+UNION+OUTER-JOIN was a tighter SQL but a
+    // worse read; the row counts are tiny (a captain has tens of threads,
+    // not thousands) so this is plenty fast.
+    const ownedRows = await db
       .selectFrom("scout_thread")
       .where("user_id", "=", userId)
       .select(["id", "title", "mode", "created_at", "updated_at"])
       .orderBy("updated_at", "desc")
       .execute();
 
-    return rows.map((r) => ({
+    const sharedRows = await db
+      .selectFrom("scout_thread_share as s")
+      .innerJoin("scout_thread as t", "t.id", "s.thread_id")
+      .innerJoin("user as u", "u.id", "s.shared_by_user_id")
+      .where("s.shared_with_user_id", "=", userId)
+      .select([
+        "t.id as id",
+        "t.title as title",
+        "t.mode as mode",
+        "t.created_at as created_at",
+        "t.updated_at as updated_at",
+        "u.id as owner_id",
+        "u.name as owner_name",
+        "u.email as owner_email",
+      ])
+      .execute();
+
+    const sharedByMeIds =
+      ownedRows.length === 0
+        ? new Set<string>()
+        : new Set(
+            (
+              await db
+                .selectFrom("scout_thread_share")
+                .where(
+                  "thread_id",
+                  "in",
+                  ownedRows.map((r) => r.id),
+                )
+                .select("thread_id")
+                .distinct()
+                .execute()
+            ).map((r) => r.thread_id),
+          );
+
+    const owned: ThreadSummary[] = ownedRows.map((r) => ({
       id: r.id,
       title: r.title,
       mode: r.mode as ScoutMode,
       createdAt: toIso(r.created_at),
       updatedAt: toIso(r.updated_at),
+      sharedBy: null,
+      sharedByMe: sharedByMeIds.has(r.id),
     }));
+
+    const shared: ThreadSummary[] = sharedRows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      mode: r.mode as ScoutMode,
+      createdAt: toIso(r.created_at),
+      updatedAt: toIso(r.updated_at),
+      sharedBy: {
+        id: r.owner_id,
+        name: r.owner_name,
+        email: r.owner_email,
+      },
+      sharedByMe: false,
+    }));
+
+    return [...owned, ...shared].sort((a, b) =>
+      a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0,
+    );
   };
 }
 
@@ -64,6 +156,8 @@ export function createThread(db: Kysely<DB>) {
       mode: row.mode as ScoutMode,
       createdAt: toIso(row.created_at),
       updatedAt: toIso(row.updated_at),
+      sharedBy: null,
+      sharedByMe: false,
     };
   };
 }
@@ -84,14 +178,52 @@ export function getThread(db: Kysely<DB>) {
     messages: PersistedMessage[];
     usage: ThreadUsage;
   }> => {
+    // Fetch the thread + owner identity, then check access against the
+    // current viewer. Access = owner OR a row in scout_thread_share. We
+    // do the access check after the row fetch (rather than embedding it
+    // in WHERE) so a non-existent thread and a forbidden thread look
+    // identical to the caller — both throw ThreadNotFoundError → 404.
     const thread = await db
-      .selectFrom("scout_thread")
-      .where("id", "=", threadId)
-      .where("user_id", "=", userId)
-      .select(["id", "title", "mode", "created_at", "updated_at"])
+      .selectFrom("scout_thread as t")
+      .innerJoin("user as u", "u.id", "t.user_id")
+      .where("t.id", "=", threadId)
+      .select([
+        "t.id",
+        "t.user_id",
+        "t.title",
+        "t.mode",
+        "t.created_at",
+        "t.updated_at",
+        "u.id as owner_id",
+        "u.name as owner_name",
+        "u.email as owner_email",
+      ])
       .executeTakeFirst();
 
     if (!thread) throw new ThreadNotFoundError();
+
+    const isOwner = thread.user_id === userId;
+    if (!isOwner) {
+      const share = await db
+        .selectFrom("scout_thread_share")
+        .where("thread_id", "=", threadId)
+        .where("shared_with_user_id", "=", userId)
+        .select("id")
+        .executeTakeFirst();
+      if (!share) throw new ThreadNotFoundError();
+    }
+
+    // Owner-side flag: have I shared this with anyone? Used by the FE
+    // to render a small "shared" indicator next to the thread title.
+    let sharedByMe = false;
+    if (isOwner) {
+      const any = await db
+        .selectFrom("scout_thread_share")
+        .where("thread_id", "=", threadId)
+        .select("id")
+        .executeTakeFirst();
+      sharedByMe = !!any;
+    }
 
     const messageRows = await db
       .selectFrom("scout_message")
@@ -128,6 +260,14 @@ export function getThread(db: Kysely<DB>) {
         mode: thread.mode as ScoutMode,
         createdAt: toIso(thread.created_at),
         updatedAt: toIso(thread.updated_at),
+        sharedBy: isOwner
+          ? null
+          : {
+              id: thread.owner_id,
+              name: thread.owner_name,
+              email: thread.owner_email,
+            },
+        sharedByMe,
       },
       messages: messageRows.map((m) => ({
         id: m.id,
@@ -525,5 +665,140 @@ export function cancelReport(db: Kysely<DB>) {
       .where("id", "=", reportId)
       .execute();
     return { alreadyComplete: false };
+  };
+}
+
+// ── Thread sharing ──
+//
+// v1 sharing model: an owner grants read-only access to one or more other
+// admin/official users. Recipients can view the full thread (messages,
+// charts, video embeds, reports) but cannot post — that's enforced by
+// keeping every write path on `assertThreadOwnership`. "Branch my own
+// thread" is the deferred follow-up if/when recipients want to continue
+// the conversation in their own copy.
+
+const SHAREABLE_ROLES = new Set(["admin", "official"]);
+
+/**
+ * Verify the current viewer owns the thread. Throws ThreadNotFoundError
+ * if the thread doesn't exist; ShareForbiddenError if it exists but the
+ * viewer isn't the owner. The two are split so the caller can map
+ * 404 vs 403 in the route layer.
+ */
+async function assertOwnerForShare(
+  db: Kysely<DB>,
+  userId: string,
+  threadId: string,
+): Promise<void> {
+  const row = await db
+    .selectFrom("scout_thread")
+    .where("id", "=", threadId)
+    .select(["user_id"])
+    .executeTakeFirst();
+  if (!row) throw new ThreadNotFoundError();
+  if (row.user_id !== userId) throw new ShareForbiddenError();
+}
+
+export function listOfficials(db: Kysely<DB>) {
+  // Source for the share-modal picker: every admin / official EXCEPT the
+  // current viewer (who'd never share with themselves — the unique-recipient
+  // constraint also blocks it but we don't want them in the list).
+  return async (currentUserId: string): Promise<ShareActor[]> => {
+    const rows = await db
+      .selectFrom("user")
+      .where("role", "in", Array.from(SHAREABLE_ROLES))
+      .where("id", "!=", currentUserId)
+      .where((eb) => eb.or([eb("banned", "is", null), eb("banned", "=", false)]))
+      .select(["id", "name", "email"])
+      .orderBy("name", "asc")
+      .execute();
+    return rows.map((r) => ({ id: r.id, name: r.name, email: r.email }));
+  };
+}
+
+export function listSharees(db: Kysely<DB>) {
+  return async (
+    userId: string,
+    threadId: string,
+  ): Promise<ShareActor[]> => {
+    await assertOwnerForShare(db, userId, threadId);
+    const rows = await db
+      .selectFrom("scout_thread_share as s")
+      .innerJoin("user as u", "u.id", "s.shared_with_user_id")
+      .where("s.thread_id", "=", threadId)
+      .select(["u.id", "u.name", "u.email"])
+      .orderBy("u.name", "asc")
+      .execute();
+    return rows.map((r) => ({ id: r.id, name: r.name, email: r.email }));
+  };
+}
+
+export function shareThread(db: Kysely<DB>) {
+  return async (
+    ownerUserId: string,
+    threadId: string,
+    recipientUserIds: string[],
+  ): Promise<ShareActor[]> => {
+    await assertOwnerForShare(db, ownerUserId, threadId);
+
+    const unique = Array.from(new Set(recipientUserIds));
+    if (unique.length === 0) return await listSharees(db)(ownerUserId, threadId);
+    if (unique.includes(ownerUserId)) {
+      throw new ShareInvalidRecipientError("Cannot share a thread with yourself.");
+    }
+
+    // Validate every recipient is still a real, role-eligible user. Doing
+    // this here (rather than relying on the FK alone) lets us return a
+    // useful 4xx instead of a Postgres-shaped error if someone bypassed
+    // the picker; it also keeps the role rule colocated with the feature.
+    const valid = await db
+      .selectFrom("user")
+      .where("id", "in", unique)
+      .where("role", "in", Array.from(SHAREABLE_ROLES))
+      .where((eb) => eb.or([eb("banned", "is", null), eb("banned", "=", false)]))
+      .select(["id"])
+      .execute();
+    const validIds = new Set(valid.map((r) => r.id));
+    const invalid = unique.filter((id) => !validIds.has(id));
+    if (invalid.length > 0) {
+      throw new ShareInvalidRecipientError(
+        `Recipient(s) not eligible for sharing: ${invalid.join(", ")}.`,
+      );
+    }
+
+    // ON CONFLICT DO NOTHING on the unique (thread_id, shared_with_user_id)
+    // constraint — resharing the same person is a silent no-op so the FE
+    // can call this idempotently without checking what's already there.
+    await db
+      .insertInto("scout_thread_share")
+      .values(
+        unique.map((id) => ({
+          thread_id: threadId,
+          shared_by_user_id: ownerUserId,
+          shared_with_user_id: id,
+        })),
+      )
+      .onConflict((oc) =>
+        oc.columns(["thread_id", "shared_with_user_id"]).doNothing(),
+      )
+      .execute();
+
+    return await listSharees(db)(ownerUserId, threadId);
+  };
+}
+
+export function unshareThread(db: Kysely<DB>) {
+  return async (
+    ownerUserId: string,
+    threadId: string,
+    recipientUserId: string,
+  ): Promise<ShareActor[]> => {
+    await assertOwnerForShare(db, ownerUserId, threadId);
+    await db
+      .deleteFrom("scout_thread_share")
+      .where("thread_id", "=", threadId)
+      .where("shared_with_user_id", "=", recipientUserId)
+      .execute();
+    return await listSharees(db)(ownerUserId, threadId);
   };
 }

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -8872,6 +8872,12 @@ export interface paths {
                                 createdAt: string;
                                 /** Format: date-time */
                                 updatedAt: string;
+                                sharedBy: {
+                                    id: string;
+                                    name: string;
+                                    email: string;
+                                } | null;
+                                sharedByMe: boolean;
                             }[];
                         };
                     };
@@ -8916,6 +8922,12 @@ export interface paths {
                             createdAt: string;
                             /** Format: date-time */
                             updatedAt: string;
+                            sharedBy: {
+                                id: string;
+                                name: string;
+                                email: string;
+                            } | null;
+                            sharedByMe: boolean;
                         };
                     };
                 };
@@ -9055,6 +9067,12 @@ export interface paths {
                                 createdAt: string;
                                 /** Format: date-time */
                                 updatedAt: string;
+                                sharedBy: {
+                                    id: string;
+                                    name: string;
+                                    email: string;
+                                } | null;
+                                sharedByMe: boolean;
                             };
                             messages: {
                                 /** Format: uuid */
@@ -9100,6 +9118,167 @@ export interface paths {
                         "application/json": {
                             /** @enum {boolean} */
                             ok: true;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scout/officials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            officials: {
+                                id: string;
+                                name: string;
+                                email: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scout/threads/{threadId}/shares": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    threadId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            sharees: {
+                                id: string;
+                                name: string;
+                                email: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    threadId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        userIds: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            sharees: {
+                                id: string;
+                                name: string;
+                                email: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scout/threads/{threadId}/shares/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    threadId: string;
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            sharees: {
+                                id: string;
+                                name: string;
+                                email: string;
+                            }[];
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -15475,6 +15475,30 @@
                             "type": "string",
                             "format": "date-time",
                             "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                          },
+                          "sharedBy": {
+                            "nullable": true,
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "email": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "email"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "sharedByMe": {
+                            "type": "boolean"
                           }
                         },
                         "required": [
@@ -15482,7 +15506,9 @@
                           "title",
                           "mode",
                           "createdAt",
-                          "updatedAt"
+                          "updatedAt",
+                          "sharedBy",
+                          "sharedByMe"
                         ],
                         "additionalProperties": false
                       }
@@ -15559,6 +15585,30 @@
                       "type": "string",
                       "format": "date-time",
                       "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "sharedBy": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "email"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "sharedByMe": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -15566,7 +15616,9 @@
                     "title",
                     "mode",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "sharedBy",
+                    "sharedByMe"
                   ],
                   "additionalProperties": false
                 }
@@ -15759,6 +15811,30 @@
                           "type": "string",
                           "format": "date-time",
                           "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                        },
+                        "sharedBy": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "email": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "email"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "sharedByMe": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -15766,7 +15842,9 @@
                         "title",
                         "mode",
                         "createdAt",
-                        "updatedAt"
+                        "updatedAt",
+                        "sharedBy",
+                        "sharedByMe"
                       ],
                       "additionalProperties": false
                     },
@@ -15893,6 +15971,251 @@
                   },
                   "required": [
                     "ok"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/scout/officials": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "officials": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "officials"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/scout/threads/{threadId}/shares": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "threadId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sharees": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "sharees"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userIds": {
+                    "minItems": 1,
+                    "maxItems": 25,
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "userIds"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "threadId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sharees": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "sharees"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/scout/threads/{threadId}/shares/{userId}": {
+      "delete": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "threadId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "userId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sharees": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "sharees"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/pages/scout/scout.tsx
+++ b/apps/web/src/pages/scout/scout.tsx
@@ -15,6 +15,7 @@ import { KnowledgeAdminView } from "./knowledge-admin.js";
 import { MessageView } from "./message-view.js";
 import { ReportsView } from "./reports-view.js";
 import { ScoutLauncher } from "./scout-launcher.js";
+import { ShareThreadModal } from "./share-thread-modal.js";
 import { ThreadList } from "./thread-list.js";
 import { useScoutChat } from "./use-scout-chat.js";
 
@@ -192,7 +193,13 @@ function ActiveThread({ threadId }: { threadId: string }) {
 interface ChatViewProps {
   threadId: string;
   loaded: {
-    thread: { id: string; title: string; mode: ScoutMode };
+    thread: {
+      id: string;
+      title: string;
+      mode: ScoutMode;
+      sharedBy: { id: string; name: string; email: string } | null;
+      sharedByMe: boolean;
+    };
     messages: Array<{
       id: string;
       role: "user" | "assistant" | "tool" | "system";
@@ -328,6 +335,8 @@ function ChatView({ threadId, loaded }: ChatViewProps) {
 
   const isStreaming = status === "submitted" || status === "streaming";
   const mode = loaded.thread.mode;
+  const isReadOnly = loaded.thread.sharedBy !== null;
+  const [shareModalOpen, setShareModalOpen] = useState(false);
 
   // When the chat connection drops mid-report, useChat surfaces a generic
   // "network error" with no useful info. The report's pipeline card stays
@@ -382,19 +391,56 @@ function ChatView({ threadId, loaded }: ChatViewProps) {
               Scout
             </span>
           )}
+          {isReadOnly && (
+            <span
+              className="rounded bg-violet-100 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-violet-800 uppercase"
+              title={`Shared by ${loaded.thread.sharedBy?.name ?? ""}`}
+            >
+              Shared
+            </span>
+          )}
+          {!isReadOnly && loaded.thread.sharedByMe && (
+            <span
+              className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold tracking-wide text-blue-800 uppercase"
+              title="You've shared this thread"
+            >
+              Shared by you
+            </span>
+          )}
           <span className="truncate">{loaded.thread.title}</span>
         </h2>
-        <span className="text-xs text-gray-400">
-          {messages.length} message{messages.length === 1 ? "" : "s"}
-          {import.meta.env.DEV && (
-            <>
-              {" · "}
-              {loaded.usage.inputTokens.toLocaleString()} in /{" "}
-              {loaded.usage.outputTokens.toLocaleString()} out
-            </>
+        <div className="flex items-center gap-3">
+          {!isReadOnly && (
+            <button
+              type="button"
+              onClick={() => setShareModalOpen(true)}
+              className="inline-flex items-center gap-1 rounded border border-gray-200 px-2 py-1 text-xs text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+            >
+              <ShareIcon className="h-3.5 w-3.5" />
+              Share
+            </button>
           )}
-        </span>
+          <span className="text-xs text-gray-400">
+            {messages.length} message{messages.length === 1 ? "" : "s"}
+            {import.meta.env.DEV && (
+              <>
+                {" · "}
+                {loaded.usage.inputTokens.toLocaleString()} in /{" "}
+                {loaded.usage.outputTokens.toLocaleString()} out
+              </>
+            )}
+          </span>
+        </div>
       </header>
+      {isReadOnly && loaded.thread.sharedBy && (
+        <div className="border-b border-violet-200 bg-violet-50 px-4 py-2 text-xs text-violet-900">
+          Shared by{" "}
+          <span className="font-medium">{loaded.thread.sharedBy.name}</span>{" "}
+          <span className="text-violet-700">
+            · read-only — you can read the conversation but can&rsquo;t reply.
+          </span>
+        </div>
+      )}
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-2">
         {messages.length === 0 &&
           (mode === "debrief" ? (
@@ -462,19 +508,50 @@ function ChatView({ threadId, loaded }: ChatViewProps) {
           </div>
         )}
       </div>
-      <Composer
-        initialDraft={draft}
-        onDraftChange={setDraft}
-        isStreaming={isStreaming}
-        thinkingMode={thinkingMode}
-        onThinkingModeChange={setThinkingMode}
-        onSubmit={send}
-        onStop={() => void stop()}
-        attachments={turnAttachments}
-        onUploadFile={(file) => void uploadAttachment(file)}
-        onRemoveAttachment={removeAttachment}
-        isUploadingAttachments={isUploadingAttachments}
-      />
+      {!isReadOnly && (
+        <Composer
+          initialDraft={draft}
+          onDraftChange={setDraft}
+          isStreaming={isStreaming}
+          thinkingMode={thinkingMode}
+          onThinkingModeChange={setThinkingMode}
+          onSubmit={send}
+          onStop={() => void stop()}
+          attachments={turnAttachments}
+          onUploadFile={(file) => void uploadAttachment(file)}
+          onRemoveAttachment={removeAttachment}
+          isUploadingAttachments={isUploadingAttachments}
+        />
+      )}
+      {!isReadOnly && (
+        <ShareThreadModal
+          threadId={threadId}
+          threadTitle={loaded.thread.title}
+          open={shareModalOpen}
+          onOpenChange={setShareModalOpen}
+        />
+      )}
     </>
+  );
+}
+
+function ShareIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+    </svg>
   );
 }

--- a/apps/web/src/pages/scout/share-thread-modal.tsx
+++ b/apps/web/src/pages/scout/share-thread-modal.tsx
@@ -1,0 +1,282 @@
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { api, callApi } from "@/lib/api-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+
+interface ShareActor {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface Props {
+  threadId: string;
+  threadTitle: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ShareThreadModal({
+  threadId,
+  threadTitle,
+  open,
+  onOpenChange,
+}: Props) {
+  const queryClient = useQueryClient();
+  const [filter, setFilter] = useState("");
+  // Multi-select staging: officials ticked but not yet committed. The
+  // commit lands on "Share" — keeps the modal feel transactional rather
+  // than firing a network call per checkbox tick.
+  const [selectedToAdd, setSelectedToAdd] = useState<Set<string>>(new Set());
+  const [copied, setCopied] = useState(false);
+
+  // Officials picker. Only enabled while the modal is open so we don't
+  // hit the API every page render. Stale-time short — list rarely changes
+  // mid-session but a new official COULD appear via the admin UI.
+  const officialsQuery = useQuery({
+    queryKey: ["scout", "officials"],
+    queryFn: () => callApi(api.GET("/api/scout/officials")),
+    enabled: open,
+    staleTime: 30_000,
+  });
+
+  // Current sharees for this thread. Owner-only endpoint; we surface a
+  // friendly empty state (rather than a generic error) when it 403s,
+  // since the modal is owner-only by construction anyway.
+  const shareesQuery = useQuery({
+    queryKey: ["scout", "thread-shares", threadId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/scout/threads/{threadId}/shares", {
+          params: { path: { threadId } },
+        }),
+      ),
+    enabled: open,
+  });
+
+  const sharedIds = useMemo(
+    () => new Set(shareesQuery.data?.sharees.map((s) => s.id) ?? []),
+    [shareesQuery.data],
+  );
+
+  const candidates = useMemo(() => {
+    const all = officialsQuery.data?.officials ?? [];
+    const q = filter.trim().toLowerCase();
+    return all
+      .filter((o) => !sharedIds.has(o.id))
+      .filter(
+        (o) =>
+          q === "" ||
+          o.name.toLowerCase().includes(q) ||
+          o.email.toLowerCase().includes(q),
+      );
+  }, [officialsQuery.data, sharedIds, filter]);
+
+  const shareMutation = useMutation({
+    mutationFn: (userIds: string[]) =>
+      callApi(
+        api.POST("/api/scout/threads/{threadId}/shares", {
+          params: { path: { threadId } },
+          body: { userIds },
+        }),
+      ),
+    onSuccess: async () => {
+      setSelectedToAdd(new Set());
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["scout", "thread-shares", threadId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ["scout", "threads"] }),
+      ]);
+    },
+  });
+
+  const unshareMutation = useMutation({
+    mutationFn: (userId: string) =>
+      callApi(
+        api.DELETE("/api/scout/threads/{threadId}/shares/{userId}", {
+          params: { path: { threadId, userId } },
+        }),
+      ),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["scout", "thread-shares", threadId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ["scout", "threads"] }),
+      ]);
+    },
+  });
+
+  const handleToggle = (id: string) => {
+    setSelectedToAdd((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleShare = () => {
+    if (selectedToAdd.size === 0) return;
+    shareMutation.mutate(Array.from(selectedToAdd));
+  };
+
+  const handleCopyLink = async () => {
+    const url = `${window.location.origin}/scout/${threadId}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // Fallback: select the text in a hidden input. Rare path — modern
+      // browsers grant clipboard write to user-gesture handlers.
+      window.prompt("Copy this link:", url);
+    }
+  };
+
+  const hasShares = (shareesQuery.data?.sharees.length ?? 0) > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share thread</DialogTitle>
+          <DialogDescription>
+            Give other officials read-only access to{" "}
+            <span className="font-medium text-gray-900">{threadTitle}</span>.
+            They&rsquo;ll see the full conversation but can&rsquo;t reply.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* ── Already shared with ───────────────────────────────── */}
+        {shareesQuery.data && hasShares ? (
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-gray-500">Shared with</div>
+            <ul className="divide-y divide-gray-100 rounded border border-gray-200">
+              {shareesQuery.data.sharees.map((s) => (
+                <li
+                  key={s.id}
+                  className="flex items-center justify-between gap-2 px-3 py-2 text-sm"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate font-medium text-gray-900">
+                      {s.name}
+                    </div>
+                    <div className="truncate text-xs text-gray-500">
+                      {s.email}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => unshareMutation.mutate(s.id)}
+                    disabled={unshareMutation.isPending}
+                    className="text-xs text-gray-500 hover:text-red-700 disabled:opacity-50"
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {/* ── Picker ────────────────────────────────────────────── */}
+        <div className="space-y-2">
+          <Input
+            placeholder="Search officials by name or email…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            disabled={officialsQuery.isLoading}
+          />
+          <div className="max-h-48 overflow-y-auto rounded border border-gray-200">
+            {officialsQuery.isLoading && (
+              <div className="p-3 text-sm text-gray-500">Loading…</div>
+            )}
+            {!officialsQuery.isLoading && candidates.length === 0 && (
+              <div className="p-3 text-sm text-gray-500">
+                {filter
+                  ? "No matching officials."
+                  : hasShares
+                    ? "Already shared with everyone available."
+                    : "No other officials yet."}
+              </div>
+            )}
+            <ul className="divide-y divide-gray-100">
+              {candidates.map((o: ShareActor) => {
+                const checked = selectedToAdd.has(o.id);
+                return (
+                  <li key={o.id}>
+                    <label className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-gray-50">
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={() => handleToggle(o.id)}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium text-gray-900">
+                          {o.name}
+                        </div>
+                        <div className="truncate text-xs text-gray-500">
+                          {o.email}
+                        </div>
+                      </div>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
+
+        {shareMutation.error && (
+          <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {shareMutation.error instanceof Error
+              ? shareMutation.error.message
+              : "Failed to share thread"}
+          </div>
+        )}
+
+        <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-between">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void handleCopyLink()}
+            disabled={!hasShares}
+            title={
+              hasShares
+                ? "Copy a link to this thread"
+                : "Share with someone first, then copy the link"
+            }
+          >
+            {copied ? "Link copied" : "Copy link"}
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Done
+            </Button>
+            <Button
+              onClick={handleShare}
+              disabled={selectedToAdd.size === 0 || shareMutation.isPending}
+            >
+              {shareMutation.isPending
+                ? "Sharing…"
+                : selectedToAdd.size === 0
+                  ? "Share"
+                  : `Share with ${String(selectedToAdd.size)}`}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/scout/thread-list.tsx
+++ b/apps/web/src/pages/scout/thread-list.tsx
@@ -26,6 +26,8 @@ interface ThreadSummary {
   title: string;
   mode: ScoutMode;
   updatedAt: string;
+  sharedBy: { id: string; name: string; email: string } | null;
+  sharedByMe: boolean;
 }
 
 const MODE_OPTIONS: ReadonlyArray<{
@@ -150,23 +152,47 @@ export function ThreadList() {
                 >
                   <div className="flex items-center gap-1.5">
                     <ModeBadge mode={t.mode} />
+                    {t.sharedBy && (
+                      <span
+                        className="text-violet-600"
+                        title={`Shared by ${t.sharedBy.name}`}
+                        aria-label={`Shared by ${t.sharedBy.name}`}
+                      >
+                        <ShareGlyph className="h-3 w-3" />
+                      </span>
+                    )}
+                    {t.sharedByMe && !t.sharedBy && (
+                      <span
+                        className="text-blue-600"
+                        title="You've shared this thread"
+                        aria-label="Shared by you"
+                      >
+                        <ShareGlyph className="h-3 w-3" />
+                      </span>
+                    )}
                     <span className="truncate">{t.title}</span>
                   </div>
                   <div className="truncate text-xs text-gray-400">
+                    {t.sharedBy ? `Shared by ${t.sharedBy.name} · ` : ""}
                     {new Date(t.updatedAt).toLocaleString()}
                   </div>
                 </Link>
-                <button
-                  type="button"
-                  aria-label={`Delete ${t.title}`}
-                  className="absolute top-2 right-2 rounded p-1 text-gray-400 opacity-0 group-hover:opacity-100 hover:bg-gray-200 hover:text-red-700"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    setPendingDelete(t);
-                  }}
-                >
-                  ×
-                </button>
+                {/* Recipients can't delete a shared-with-me thread; the BE
+                    would 404 anyway, but hiding the button keeps the UX
+                    obvious. */}
+                {!t.sharedBy && (
+                  <button
+                    type="button"
+                    aria-label={`Delete ${t.title}`}
+                    className="absolute top-2 right-2 rounded p-1 text-gray-400 opacity-0 group-hover:opacity-100 hover:bg-gray-200 hover:text-red-700"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setPendingDelete(t);
+                    }}
+                  >
+                    ×
+                  </button>
+                )}
               </li>
             );
           })}
@@ -296,6 +322,27 @@ function NewThreadSplitButton({
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
+  );
+}
+
+function ShareGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2.25}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+    </svg>
   );
 }
 

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -782,6 +782,14 @@ export interface ScoutThread {
   user_id: string;
 }
 
+export interface ScoutThreadShare {
+  created_at: Generated<Timestamp>;
+  id: Generated<string>;
+  shared_by_user_id: string;
+  shared_with_user_id: string;
+  thread_id: string;
+}
+
 export interface ScoutToolCache {
   cache_key: string;
   created_at: Generated<Timestamp>;
@@ -893,6 +901,7 @@ export interface DB {
   scout_message: ScoutMessage;
   scout_report: ScoutReport;
   scout_thread: ScoutThread;
+  scout_thread_share: ScoutThreadShare;
   scout_tool_cache: ScoutToolCache;
   session: Session;
   team_official: TeamOfficial;

--- a/packages/db/src/migrations/2026-05-07T03:56:32.275Z.ts
+++ b/packages/db/src/migrations/2026-05-07T03:56:32.275Z.ts
@@ -1,0 +1,54 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // ── scout_thread_share: read-only access grants from a thread owner to
+  //    other officials/admins. v1 is read-only — recipients can view the
+  //    full conversation but cannot post; "branch my thread" is deferred.
+  //    One row per (thread, recipient); resharing is a no-op via the
+  //    unique constraint. shared_by is denormalised so the FE can render
+  //    "Shared by X" without joining back to scout_thread.user_id (which
+  //    is also the same person, but keeping it explicit lets us surface
+  //    the original sharer if ownership ever transfers later).
+  await db.schema
+    .createTable("scout_thread_share")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("thread_id", "uuid", (col) =>
+      col.notNull().references("scout_thread.id").onDelete("cascade"),
+    )
+    .addColumn("shared_by_user_id", "text", (col) =>
+      col.notNull().references("user.id").onDelete("cascade"),
+    )
+    .addColumn("shared_with_user_id", "text", (col) =>
+      col.notNull().references("user.id").onDelete("cascade"),
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addUniqueConstraint("scout_thread_share_unique_recipient", [
+      "thread_id",
+      "shared_with_user_id",
+    ])
+    .addCheckConstraint(
+      "scout_thread_share_no_self",
+      sql`shared_by_user_id <> shared_with_user_id`,
+    )
+    .execute();
+
+  // Hot path: "list threads shared with me, most-recent first".
+  await sql`CREATE INDEX scout_thread_share_recipient_created_idx ON scout_thread_share (shared_with_user_id, created_at DESC)`.execute(
+    db,
+  );
+
+  // Used when listing the sharees for a single thread (share modal).
+  await db.schema
+    .createIndex("scout_thread_share_thread_idx")
+    .on("scout_thread_share")
+    .column("thread_id")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("scout_thread_share").execute();
+}


### PR DESCRIPTION
## Summary

- New `scout_thread_share` table grants read-only access from a thread owner to one or more admin/official users. Recipients see the thread in their list (with a violet \"shared\" glyph and a \"Shared by Alex · …\" timestamp prefix) and read the full conversation; the composer is hidden so they can't reply. \"Branch my own thread\" is the deferred follow-up if/when recipients want to continue the discussion in their own copy.
- Share button in the chat-view header opens a modal: search-and-multi-select picker of admin+official users (excluding self & already-shared), staged commit, current-sharees list with per-row \"Remove\", and a \"Copy link\" button (just `/scout/threads/:id` — recipient must already be in the share list).
- New endpoints: `GET /scout/officials`, `GET /scout/threads/:id/shares`, `POST /scout/threads/:id/shares`, `DELETE /scout/threads/:id/shares/:userId`.
- Auth model: `getThread` allows owner OR a recipient (404 looks identical for non-existent and forbidden). All write paths (`POST messages`, `DELETE thread`, attachment mint, etc.) still gate on `assertThreadOwnership`. Sharing endpoints themselves are owner-only via `ShareForbiddenError → 403`.
- 8 integration tests cover picker filtering, share/get/list visibility, idempotent re-share/unshare, owner-only enforcement, role-eligible recipients, no-self-share, and stranger-no-access.

## Worth knowing
- Reports and attachments still scoped by `user_id` — a recipient sees the in-thread cards/chips but clicking download will 404. Flagged in the commit message; extending those ACLs to share recipients is the obvious follow-up if it bites in practice.
- \"Copy link\" is the simple model: pick people first, then copy. The link doesn't grant access on its own; the recipient must be in the share list AND logged in as admin/official.

## Test plan

- [ ] As an admin/official: open a chat thread → click Share → tick a couple of names → click \"Share with N\" → modal updates with the new sharees, \"Copy link\" enables.
- [ ] Click \"Copy link\" → URL copied; pasted into a new tab as a different official → the thread loads with a violet \"Shared by …\" banner and no composer.
- [ ] As the recipient, the thread appears in the sidebar with a violet share glyph and \"Shared by Alex · …\" timestamp prefix; delete button is hidden on that row.
- [ ] As the owner, the same thread shows a blue \"Shared by you\" pill in the header AND a blue glyph in the sidebar.
- [ ] Try to POST a message via the API as the recipient → 404 (recipient is read-only).
- [ ] Try to share with a non-admin/official user via direct API call → 400 with a useful error.
- [ ] Re-share with the same person via the modal → no duplicate row, no error (idempotent).
- [ ] Revoke a share → recipient's thread list refreshes and the thread disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)