### PR TITLE
Scout: agent-page polish — tab alignment, mobile drawer, user name in prompt

### DIFF
--- a/apps/api/src/features/scout/agent.test.ts
+++ b/apps/api/src/features/scout/agent.test.ts
@@ -35,6 +35,7 @@ function makeAgent(mode: "chat" | "debrief" | "scout" = "chat") {
     config: stubConfig,
     writer: stubWriter,
     userId: "test-user",
+    userName: "Test User",
     mode,
     scoutReports: stubScoutReports,
     thinkingMode: "thinking",

--- a/apps/api/src/features/scout/agent.ts
+++ b/apps/api/src/features/scout/agent.ts
@@ -70,6 +70,11 @@ export interface ScoutAgentDeps {
   // every recorded fact for traceability.
   voyage?: VoyageClient;
   userId: string;
+  // Display name of the authenticated caller. Injected into the system
+  // prompt so the agent can address the captain by name in conversation
+  // (DeepSeek otherwise defaults to generic "Captain"-style openers, which
+  // reads off in a 1:1 chat).
+  userName: string;
   threadId?: string;
   // Interaction mode — fixed at thread creation. Picks system prompt and
   // toggles the ask_question / chart_render tool surface (debrief uses
@@ -250,6 +255,8 @@ When asked about the "next" or "upcoming" match for ANY club (Percy Main or oppo
         ? SCOUT_FOCUSED_SYSTEM_PROMPT
         : SCOUT_SYSTEM_PROMPT;
 
+  const userLine = `You are speaking with ${deps.userName} (a Percy Main official or admin). Address them by their first name when it reads naturally — don't force it into every reply.`;
+
   const resolved = resolveModel(
     deps.config.SCOUT_PROVIDER_CHAT,
     deps.config.SCOUT_MODEL_CHAT,
@@ -272,7 +279,7 @@ When asked about the "next" or "upcoming" match for ANY club (Percy Main or oppo
 
   return {
     model: resolved.model,
-    system: `${basePrompt}\n\n${todayLine}`,
+    system: `${basePrompt}\n\n${userLine}\n\n${todayLine}`,
     tools: {
       ...playCricketTools,
       ...dbTools,

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -778,6 +778,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
             logger: app.log,
             voyage,
             userId: user.id,
+            userName: user.name,
             threadId,
             mode: threadMode,
             scoutReports: app.scoutReports,

--- a/apps/web/src/pages/scout/scout.tsx
+++ b/apps/web/src/pages/scout/scout.tsx
@@ -16,7 +16,7 @@ import { MessageView } from "./message-view.js";
 import { ReportsView } from "./reports-view.js";
 import { ScoutLauncher } from "./scout-launcher.js";
 import { ShareThreadModal } from "./share-thread-modal.js";
-import { ThreadList } from "./thread-list.js";
+import { NewThreadButton, ThreadList } from "./thread-list.js";
 import { useScoutChat } from "./use-scout-chat.js";
 
 type ScoutMode = "chat" | "debrief" | "scout";
@@ -49,12 +49,55 @@ export function Component() {
     );
   };
 
+  // Mobile-only drawer state. On lg+ the ThreadList renders inline as a
+  // sidebar and this flag is ignored. Below lg, the sidebar is positioned
+  // off-screen by default and slides in when this flips to true.
+  const [threadDrawerOpen, setThreadDrawerOpen] = useState(false);
+
+  // Snap the drawer shut if the viewport grows past lg — otherwise the
+  // overlay/backdrop stays mounted under the now-visible sidebar.
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const onChange = () => {
+      if (mq.matches) setThreadDrawerOpen(false);
+    };
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  // Escape-to-close. Body scroll lock is left off — the drawer doesn't fill
+  // the viewport (the site header is still visible above the scout shell)
+  // and locking would cause the page to jump.
+  useEffect(() => {
+    if (!threadDrawerOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setThreadDrawerOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [threadDrawerOpen]);
+
   return (
     <div className="container mx-auto h-[calc(100vh-8rem)] px-0">
-      <div className="flex h-full overflow-hidden rounded-lg border border-gray-200 bg-white">
-        <ThreadList />
-        <main className="flex flex-1 flex-col">
-          <ScoutTabs view={view} setView={setView} />
+      <div className="relative flex h-full overflow-hidden rounded-lg border border-gray-200 bg-white">
+        {threadDrawerOpen && (
+          <button
+            type="button"
+            aria-label="Close threads"
+            className="absolute inset-0 z-30 bg-black/40 lg:hidden"
+            onClick={() => setThreadDrawerOpen(false)}
+          />
+        )}
+        <ThreadList
+          mobileOpen={threadDrawerOpen}
+          onMobileClose={() => setThreadDrawerOpen(false)}
+        />
+        <main className="flex min-w-0 flex-1 flex-col">
+          <ScoutTabs
+            view={view}
+            setView={setView}
+            onOpenThreadDrawer={() => setThreadDrawerOpen(true)}
+          />
           {view === "reports" ? (
             <ReportsView />
           ) : view === "facts" ? (
@@ -75,12 +118,25 @@ export function Component() {
 function ScoutTabs({
   view,
   setView,
+  onOpenThreadDrawer,
 }: {
   view: ScoutView;
   setView: (next: ScoutView) => void;
+  onOpenThreadDrawer: () => void;
 }) {
+  // h-12 matches the sidebar's NewThreadSplitButton container so the bottom
+  // border on the tabs nav lines up exactly with the bottom border under
+  // "New chat".
   return (
-    <nav className="flex shrink-0 border-b border-gray-200 bg-gray-50">
+    <nav className="flex h-12 shrink-0 items-stretch border-b border-gray-200 bg-gray-50">
+      <button
+        type="button"
+        onClick={onOpenThreadDrawer}
+        aria-label="Open threads"
+        className="inline-flex items-center px-3 text-gray-600 hover:text-gray-900 lg:hidden"
+      >
+        <ThreadsIcon className="h-5 w-5" />
+      </button>
       <TabButton
         active={view === "chat"}
         onClick={() => setView("chat")}
@@ -120,8 +176,8 @@ function TabButton({
       onClick={onClick}
       className={
         active
-          ? "-mb-px border-b-2 border-blue-600 px-4 py-2 text-sm font-medium text-blue-700"
-          : "px-4 py-2 text-sm text-gray-600 hover:text-gray-900"
+          ? "-mb-px inline-flex items-center border-b-2 border-blue-600 px-4 text-sm font-medium text-blue-700"
+          : "inline-flex items-center px-4 text-sm text-gray-600 hover:text-gray-900"
       }
     >
       {label}
@@ -143,15 +199,15 @@ function EmptyState() {
           </div>
         </div>
         <div className="max-w-md">
-          <div className="mb-1 font-medium text-gray-700">
-            Pick a thread, or start a new one.
-          </div>
           <div>
             <strong>Chat</strong> for free-form opposition research,{" "}
             <strong>Debrief</strong> to walk through a recent match, or{" "}
             <strong>Scout</strong> to build a report PDF for an upcoming
             fixture.
           </div>
+        </div>
+        <div className="flex w-64">
+          <NewThreadButton />
         </div>
       </div>
     </div>
@@ -552,6 +608,25 @@ function ShareIcon({ className }: { className?: string }) {
       <circle cx="18" cy="19" r="3" />
       <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
       <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+    </svg>
+  );
+}
+
+function ThreadsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="18" x2="21" y2="18" />
     </svg>
   );
 }

--- a/apps/web/src/pages/scout/thread-list.tsx
+++ b/apps/web/src/pages/scout/thread-list.tsx
@@ -58,7 +58,17 @@ const TITLE_FOR_MODE: Record<ScoutMode, string> = {
   scout: "Scouting report",
 };
 
-export function ThreadList() {
+interface ThreadListProps {
+  // Below lg the sidebar renders as an off-canvas drawer that slides in from
+  // the left. mobileOpen drives the slide-in; onMobileClose lets the sidebar
+  // dismiss itself when the captain picks a thread (so the chat content is
+  // visible again immediately) or hits the close button. On lg+ both props
+  // are ignored — the sidebar sits in normal flex flow.
+  mobileOpen: boolean;
+  onMobileClose: () => void;
+}
+
+export function ThreadList({ mobileOpen, onMobileClose }: ThreadListProps) {
   const params = useParams<{ threadId?: string }>();
   const activeThreadId = params.threadId;
   const navigate = useNavigate();
@@ -66,29 +76,10 @@ export function ThreadList() {
   const [pendingDelete, setPendingDelete] = useState<ThreadSummary | null>(
     null,
   );
-  // Active mode for the split-button. Local state — survives clicks within
-  // the page but not reload; the dropdown is a transient affordance, not a
-  // navigable URL state.
-  const [activeMode, setActiveMode] = useState<ScoutMode>("chat");
 
   const threadsQuery = useQuery({
     queryKey: ["scout", "threads"],
     queryFn: () => callApi(api.GET("/api/scout/threads")),
-  });
-
-  const createMutation = useMutation({
-    mutationFn: (mode: ScoutMode) =>
-      callApi(
-        api.POST("/api/scout/threads", {
-          body: { title: TITLE_FOR_MODE[mode], mode },
-        }),
-      ),
-    onSuccess: async (thread) => {
-      await queryClient.invalidateQueries({
-        queryKey: ["scout", "threads"],
-      });
-      void navigate(`/scout/${thread.id}`);
-    },
   });
 
   const deleteMutation = useMutation({
@@ -107,19 +98,31 @@ export function ThreadList() {
     },
   });
 
+  // Below lg: drawer — fixed-position overlay that translates off/on screen.
+  // lg+: in-flow sidebar at w-64. The lg: overrides reset every drawer-only
+  // class so layout flips cleanly at the breakpoint.
+  const asideClass = [
+    "absolute inset-y-0 left-0 z-40 flex h-full w-72 transform flex-col border-r border-gray-200 bg-gray-50 shadow-xl transition-transform duration-200",
+    mobileOpen ? "translate-x-0" : "-translate-x-full",
+    "lg:relative lg:inset-auto lg:z-auto lg:w-64 lg:translate-x-0 lg:shadow-none lg:transition-none",
+  ].join(" ");
+
   return (
-    <aside className="flex h-full w-64 flex-col border-r border-gray-200 bg-gray-50">
+    <aside className={asideClass}>
       {/* h-12 matches ChatView's header (also h-12). Same fixed height
           on both sides keeps the border-bottom divider continuous across
           the sidebar/main split, regardless of the natural size of the
           contents on either side. */}
       <div className="flex h-12 shrink-0 items-center gap-2 border-b border-gray-200 px-3">
-        <NewThreadSplitButton
-          activeMode={activeMode}
-          onModeChange={setActiveMode}
-          onCreate={() => createMutation.mutate(activeMode)}
-          pending={createMutation.isPending}
-        />
+        <NewThreadButton onCreated={onMobileClose} />
+        <button
+          type="button"
+          onClick={onMobileClose}
+          aria-label="Close threads"
+          className="rounded p-1 text-gray-500 hover:bg-gray-200 hover:text-gray-900 lg:hidden"
+        >
+          <CloseIcon className="h-4 w-4" />
+        </button>
       </div>
       <div className="flex-1 overflow-y-auto">
         {threadsQuery.isLoading && (
@@ -144,6 +147,7 @@ export function ThreadList() {
               <li key={t.id} className="group relative">
                 <Link
                   to={`/scout/${t.id}`}
+                  onClick={onMobileClose}
                   className={`block px-3 py-2 pr-10 text-sm hover:bg-white ${
                     isActive
                       ? "bg-white font-medium text-blue-700"
@@ -262,12 +266,53 @@ function ModeBadge({ mode }: { mode: ScoutMode }) {
   return null;
 }
 
+// ── Self-contained "new thread" control ───────────────────────────────
+//
+// Owns its own activeMode state + create mutation + post-create navigate so
+// the same control can drop into the sidebar header AND the empty-state
+// hero without lifting state to a common parent. onCreated is the optional
+// post-success hook — the sidebar uses it to dismiss the mobile drawer
+// once a thread has been created.
+export function NewThreadButton({ onCreated }: { onCreated?: () => void }) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  // Active mode for the split-button. Local state — survives clicks within
+  // the page but not reload; the dropdown is a transient affordance, not a
+  // navigable URL state.
+  const [activeMode, setActiveMode] = useState<ScoutMode>("chat");
+
+  const createMutation = useMutation({
+    mutationFn: (mode: ScoutMode) =>
+      callApi(
+        api.POST("/api/scout/threads", {
+          body: { title: TITLE_FOR_MODE[mode], mode },
+        }),
+      ),
+    onSuccess: async (thread) => {
+      await queryClient.invalidateQueries({
+        queryKey: ["scout", "threads"],
+      });
+      void navigate(`/scout/${thread.id}`);
+      onCreated?.();
+    },
+  });
+
+  return (
+    <NewThreadSplitButton
+      activeMode={activeMode}
+      onModeChange={setActiveMode}
+      onCreate={() => createMutation.mutate(activeMode)}
+      pending={createMutation.isPending}
+    />
+  );
+}
+
 // ── Split-button: pick mode from the dropdown, click to create ──────────
 //
 // Three modes (Chat / Debrief / Scout). Left button creates a thread of the
 // active mode; right caret opens a Radix DropdownMenu radio group so the
-// captain can flip the active mode. Local state — no need to persist the
-// selection across reloads.
+// captain can flip the active mode. Stateless presentational component —
+// state lives in NewThreadButton above.
 function NewThreadSplitButton({
   activeMode,
   onModeChange,
@@ -359,6 +404,23 @@ function ChevronDownIcon({ className }: { className?: string }) {
       aria-hidden="true"
     >
       <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function CloseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6L6 18M6 6l12 12" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- Tabs nav is now `h-12` so its bottom border lines up with the sidebar's New-thread row — the divider between sidebar and main is continuous again.
- Below `lg`, the thread list becomes an off-canvas drawer that slides in from the left (hamburger toggle on the tabs nav, backdrop / Escape / picking-or-creating a thread all dismiss it). Especially helps debrief on mobile where the sidebar previously ate half the viewport.
- Agent system prompt now includes `user.name` so ImbuzAI can address the captain by name instead of opening with generic "Captain"-style greetings.
- Empty state: dropped the "Pick a thread" line and surfaced a copy of the Chat/Debrief/Scout split-button under the modes blurb. `NewThreadButton` is now a self-contained component reused by both the sidebar header and the empty state.

## Test plan
- [ ] Resize narrow → confirm sidebar slides off, hamburger appears in tabs row, tap opens drawer
- [ ] Tap a thread / "New chat" / backdrop / Escape — drawer dismisses
- [ ] Resize wide ≥ `lg` → drawer snaps shut, sidebar reverts to in-flow column
- [ ] Eyeball the tab/sidebar bottom border continuity at `lg+`
- [ ] Start a chat — assistant addresses you by first name in greetings (no longer "Hi Captain")
- [ ] On the empty state, the new-thread split-button creates threads and navigates to them

🤖 Generated with [Claude Code](https://claude.com/claude-code)