### PR TITLE
Adopt React Compiler 1.0 + upgrade to Vite 8

### DIFF
--- a/COMPILER_AUDIT.md
+++ b/COMPILER_AUDIT.md
@@ -1,0 +1,110 @@
+# React Compiler trial — branch summary
+
+Branch: `react-compiler-trial`
+
+## What this branch does
+
+1. Upgrades the toolchain to **Vite 8** (Rolldown bundler) + `@vitejs/plugin-react@6` + `@tailwindcss/vite@4.3` + `tailwindcss@4.3`.
+2. Installs **React Compiler 1.0** (stable, Oct 2025) and wires it into Vite via `@rolldown/plugin-babel` + `reactCompilerPreset()` — the post-v6 `plugin-react` no longer accepts Babel plugins directly.
+3. Switches the apps/web ESLint scope to `eslint-plugin-react-hooks/configs/recommended-latest` (compiler-aware rules).
+4. Strips the manual memoization the compiler now subsumes (~50 sites across 19 files).
+
+## Versions before / after
+
+| Package | Before | After |
+| --- | --- | --- |
+| `vite` | `^6.4.2` | `^8.0.11` |
+| `@vitejs/plugin-react` | `^4.3.4` | `^6.0.1` |
+| `@rolldown/plugin-babel` | — | `^0.2.3` (new) |
+| `babel-plugin-react-compiler` | — | `^1.0.0` (new) |
+| `@tailwindcss/vite` | `^4.0.0` | `^4.3.0` |
+| `tailwindcss` | `^4.0.0` | `^4.3.0` |
+
+Node engine requirement is unchanged (Vite 8 needs 20.19+/22.12+; we're on 22.21).
+
+## vite.config.ts wiring
+
+The new pattern (post-`plugin-react@6`):
+
+```ts
+import babel from "@rolldown/plugin-babel";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
+
+plugins: [
+  // …
+  react(),
+  babel({ presets: [reactCompilerPreset()] }),
+  tailwindcss(),
+  // …
+]
+```
+
+One Rolldown gotcha caught in this branch: object-form `manualChunks` is unsupported. Converted to function form keyed off `node_modules/(@tanstack/react-query|react|react-dom|react-router|scheduler)`.
+
+## ESLint config
+
+`eslint.config.mjs` now applies the compiler-aware ruleset to apps/web. The order matters — the apps/web override sits **after** the global `react-hooks/exhaustive-deps: "error"` block so the new ruleset's `warn` level wins. With the compiler doing dependency tracking and function-identity stabilisation, treating `exhaustive-deps` as a hard error in apps/web no longer reflects reality.
+
+The api / email packages keep the legacy `recommended` ruleset.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `pnpm --filter web typecheck` | clean |
+| `pnpm --filter web lint` | 0 errors, 106 warnings (all pre-existing `react-doctor`) |
+| `pnpm --filter web build` | ~8s (down from ~13.5s on Vite 6); compiler runtime present in main + vendor chunks; per-component cache scaffolding in 70+ chunks |
+| `pnpm --filter web test` | 514/514 pass |
+| HMR dev server | serves compiler-transformed components (`useMemoCache` calls visible in transformed source) |
+
+## Memoization stripped
+
+19 files. All call-sites where the wrapper was pure-derivation or a plain handler were converted to either an inlined expression or a non-memoized function. The compiler now caches them automatically.
+
+| File | Removed |
+| --- | --- |
+| `components/map.tsx` | 2× `useCallback` |
+| `components/marketing/lead-form.tsx` | 1× `useCallback` |
+| `components/members/two-factor.tsx` | 1× `useCallback` |
+| `components/site-header.tsx` | 3× `useCallback` |
+| `hooks/use-theme.tsx` | 2× `useCallback` |
+| `pages/admin/juniors-tab.tsx` | 2× `useMemo` |
+| `pages/admin/record-linking-tab.tsx` | 5× `useMemo` |
+| `pages/admin/sponsorships-tab.tsx` | 2× `useMemo` |
+| `pages/admin/treasurer-tab.tsx` | 4× `useMemo` |
+| `pages/auth/login/email-password.tsx` | 1× `useCallback` |
+| `pages/auth/login/forgot-password.tsx` | 1× `useCallback` |
+| `pages/auth/login/recovery.tsx` | 1× `useCallback` |
+| `pages/auth/login/reset-password.tsx` | 1× `useCallback` |
+| `pages/auth/login/two-fa.tsx` | 1× `useCallback` |
+| `pages/auth/register.tsx` | 2× `useCallback` |
+| `pages/availability/public-availability.tsx` | 2× `useMemo`, 3× `useCallback` |
+| `pages/calendar/calendar-month.tsx` | 7× `useMemo` |
+| `pages/game/be-the-keeper.tsx` | 1× `useCallback` |
+| `pages/home.tsx` | 1× `useMemo` |
+| `pages/members/members-fantasy.tsx` | 2× `useMemo` |
+| `pages/official/availability.tsx` | 3× `useCallback` |
+| `pages/scout/attachments/use-attachment-upload.ts` | 4× `useCallback` |
+| `pages/scout/scout.tsx` | 3× `useMemo` |
+| `pages/scout/share-thread-modal.tsx` | 2× `useMemo` |
+
+## Memoization kept (intentional)
+
+- **`pages/scout/use-scout-chat.ts`** — the `DefaultChatTransport` instance must not lose identity across renders or `useChat` treats it as a new chat session. The compiler would memoize equivalently, but this is third-party-library-coupled state — left explicit, with a smoke-test in the post-merge plan.
+- **`pages/scout/message-view.tsx`** — already had no manual `useMemo`/`useCallback`; the existing ref-in-effect pattern (with the `react-hooks/purity`-satisfying comment) is unchanged.
+
+## Patterns the compiler is happy with
+
+Verified across the codebase: no `React.memo`, no `forwardRef`, no `"use no memo"` directives, no mutation in render bodies, no conditional / for-looped hook calls, no class components.
+
+## Pre-existing manual `exhaustive-deps` suppressions
+
+Two suppressions remain (unchanged by this branch):
+- `pages/admin/record-linking-tab.tsx:158` — `// eslint-disable-next-line react-hooks/exhaustive-deps -- same pattern as v1`. Could be re-evaluated now that the surrounding `useMemo`s are gone.
+- `pages/scout/facts-admin.tsx:442` — closes over latest fact via the hook caller. The compiler now stabilises identity; the suppression is likely unnecessary.
+
+## Smoke-tests still pending (manual)
+
+- Scout chat session: start a thread, send a few messages, switch threads, verify no chat-session reset.
+- `be-the-keeper` game loop: the `handleGameOver` was previously stabilised by `useCallback` and is now relied upon to be compiler-stabilised (used in a `useEffect` deps array). The lint rule was relaxed to warn-level for this case; verify the game-over flow still works end-to-end.
+- `availability/public-availability`: the draft-merge logic in `setDateResponse`/`setDateNote` closes over `serverResponses`. Test by completing an availability response, signing out, signing back in, and confirming the draft re-merges correctly.

--- a/COMPILER_AUDIT.md
+++ b/COMPILER_AUDIT.md
@@ -11,14 +11,14 @@ Branch: `react-compiler-trial`
 
 ## Versions before / after
 
-| Package | Before | After |
-| --- | --- | --- |
-| `vite` | `^6.4.2` | `^8.0.11` |
-| `@vitejs/plugin-react` | `^4.3.4` | `^6.0.1` |
-| `@rolldown/plugin-babel` | — | `^0.2.3` (new) |
-| `babel-plugin-react-compiler` | — | `^1.0.0` (new) |
-| `@tailwindcss/vite` | `^4.0.0` | `^4.3.0` |
-| `tailwindcss` | `^4.0.0` | `^4.3.0` |
+| Package                       | Before   | After          |
+| ----------------------------- | -------- | -------------- |
+| `vite`                        | `^6.4.2` | `^8.0.11`      |
+| `@vitejs/plugin-react`        | `^4.3.4` | `^6.0.1`       |
+| `@rolldown/plugin-babel`      | —        | `^0.2.3` (new) |
+| `babel-plugin-react-compiler` | —        | `^1.0.0` (new) |
+| `@tailwindcss/vite`           | `^4.0.0` | `^4.3.0`       |
+| `tailwindcss`                 | `^4.0.0` | `^4.3.0`       |
 
 Node engine requirement is unchanged (Vite 8 needs 20.19+/22.12+; we're on 22.21).
 
@@ -36,7 +36,7 @@ plugins: [
   babel({ presets: [reactCompilerPreset()] }),
   tailwindcss(),
   // …
-]
+];
 ```
 
 One Rolldown gotcha caught in this branch: object-form `manualChunks` is unsupported. Converted to function form keyed off `node_modules/(@tanstack/react-query|react|react-dom|react-router|scheduler)`.
@@ -49,44 +49,44 @@ The api / email packages keep the legacy `recommended` ruleset.
 
 ## Verification
 
-| Check | Result |
-| --- | --- |
-| `pnpm --filter web typecheck` | clean |
-| `pnpm --filter web lint` | 0 errors, 106 warnings (all pre-existing `react-doctor`) |
-| `pnpm --filter web build` | ~8s (down from ~13.5s on Vite 6); compiler runtime present in main + vendor chunks; per-component cache scaffolding in 70+ chunks |
-| `pnpm --filter web test` | 514/514 pass |
-| HMR dev server | serves compiler-transformed components (`useMemoCache` calls visible in transformed source) |
+| Check                         | Result                                                                                                                            |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm --filter web typecheck` | clean                                                                                                                             |
+| `pnpm --filter web lint`      | 0 errors, 106 warnings (all pre-existing `react-doctor`)                                                                          |
+| `pnpm --filter web build`     | ~8s (down from ~13.5s on Vite 6); compiler runtime present in main + vendor chunks; per-component cache scaffolding in 70+ chunks |
+| `pnpm --filter web test`      | 514/514 pass                                                                                                                      |
+| HMR dev server                | serves compiler-transformed components (`useMemoCache` calls visible in transformed source)                                       |
 
 ## Memoization stripped
 
 19 files. All call-sites where the wrapper was pure-derivation or a plain handler were converted to either an inlined expression or a non-memoized function. The compiler now caches them automatically.
 
-| File | Removed |
-| --- | --- |
-| `components/map.tsx` | 2× `useCallback` |
-| `components/marketing/lead-form.tsx` | 1× `useCallback` |
-| `components/members/two-factor.tsx` | 1× `useCallback` |
-| `components/site-header.tsx` | 3× `useCallback` |
-| `hooks/use-theme.tsx` | 2× `useCallback` |
-| `pages/admin/juniors-tab.tsx` | 2× `useMemo` |
-| `pages/admin/record-linking-tab.tsx` | 5× `useMemo` |
-| `pages/admin/sponsorships-tab.tsx` | 2× `useMemo` |
-| `pages/admin/treasurer-tab.tsx` | 4× `useMemo` |
-| `pages/auth/login/email-password.tsx` | 1× `useCallback` |
-| `pages/auth/login/forgot-password.tsx` | 1× `useCallback` |
-| `pages/auth/login/recovery.tsx` | 1× `useCallback` |
-| `pages/auth/login/reset-password.tsx` | 1× `useCallback` |
-| `pages/auth/login/two-fa.tsx` | 1× `useCallback` |
-| `pages/auth/register.tsx` | 2× `useCallback` |
-| `pages/availability/public-availability.tsx` | 2× `useMemo`, 3× `useCallback` |
-| `pages/calendar/calendar-month.tsx` | 7× `useMemo` |
-| `pages/game/be-the-keeper.tsx` | 1× `useCallback` |
-| `pages/home.tsx` | 1× `useMemo` |
-| `pages/members/members-fantasy.tsx` | 2× `useMemo` |
-| `pages/official/availability.tsx` | 3× `useCallback` |
-| `pages/scout/attachments/use-attachment-upload.ts` | 4× `useCallback` |
-| `pages/scout/scout.tsx` | 3× `useMemo` |
-| `pages/scout/share-thread-modal.tsx` | 2× `useMemo` |
+| File                                               | Removed                        |
+| -------------------------------------------------- | ------------------------------ |
+| `components/map.tsx`                               | 2× `useCallback`               |
+| `components/marketing/lead-form.tsx`               | 1× `useCallback`               |
+| `components/members/two-factor.tsx`                | 1× `useCallback`               |
+| `components/site-header.tsx`                       | 3× `useCallback`               |
+| `hooks/use-theme.tsx`                              | 2× `useCallback`               |
+| `pages/admin/juniors-tab.tsx`                      | 2× `useMemo`                   |
+| `pages/admin/record-linking-tab.tsx`               | 5× `useMemo`                   |
+| `pages/admin/sponsorships-tab.tsx`                 | 2× `useMemo`                   |
+| `pages/admin/treasurer-tab.tsx`                    | 4× `useMemo`                   |
+| `pages/auth/login/email-password.tsx`              | 1× `useCallback`               |
+| `pages/auth/login/forgot-password.tsx`             | 1× `useCallback`               |
+| `pages/auth/login/recovery.tsx`                    | 1× `useCallback`               |
+| `pages/auth/login/reset-password.tsx`              | 1× `useCallback`               |
+| `pages/auth/login/two-fa.tsx`                      | 1× `useCallback`               |
+| `pages/auth/register.tsx`                          | 2× `useCallback`               |
+| `pages/availability/public-availability.tsx`       | 2× `useMemo`, 3× `useCallback` |
+| `pages/calendar/calendar-month.tsx`                | 7× `useMemo`                   |
+| `pages/game/be-the-keeper.tsx`                     | 1× `useCallback`               |
+| `pages/home.tsx`                                   | 1× `useMemo`                   |
+| `pages/members/members-fantasy.tsx`                | 2× `useMemo`                   |
+| `pages/official/availability.tsx`                  | 3× `useCallback`               |
+| `pages/scout/attachments/use-attachment-upload.ts` | 4× `useCallback`               |
+| `pages/scout/scout.tsx`                            | 3× `useMemo`                   |
+| `pages/scout/share-thread-modal.tsx`               | 2× `useMemo`                   |
 
 ## Memoization kept (intentional)
 
@@ -100,6 +100,7 @@ Verified across the codebase: no `React.memo`, no `forwardRef`, no `"use no memo
 ## Pre-existing manual `exhaustive-deps` suppressions
 
 Two suppressions remain (unchanged by this branch):
+
 - `pages/admin/record-linking-tab.tsx:158` — `// eslint-disable-next-line react-hooks/exhaustive-deps -- same pattern as v1`. Could be re-evaluated now that the surrounding `useMemo`s are gone.
 - `pages/scout/facts-admin.tsx:442` — closes over latest fact via the hook caller. The compiler now stabilises identity; the suppression is likely unnecessary.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,19 +54,21 @@
     "remark-gfm": "^4.0.1",
     "remark-mdx-frontmatter": "^5.2.0",
     "tailwind-merge": "^3.0.1",
-    "tailwindcss": "^4.0.0",
+    "tailwindcss": "^4.3.0",
     "ts-pattern": "^5.6.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.0.0",
+    "@rolldown/plugin-babel": "^0.2.3",
+    "@tailwindcss/vite": "^4.3.0",
     "@types/google.maps": "^3.58.1",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.1",
+    "babel-plugin-react-compiler": "^1.0.0",
     "typescript": "^5.9.3",
-    "vite": "^6.4.2",
+    "vite": "^8.0.11",
     "vite-imagetools": "^7.1.1",
     "vitest": "^4.1.0"
   }

--- a/apps/web/src/components/map.tsx
+++ b/apps/web/src/components/map.tsx
@@ -5,7 +5,7 @@ import {
   InfoWindow,
   useAdvancedMarkerRef,
 } from "@vis.gl/react-google-maps";
-import { useCallback, useState, type FC, type PropsWithChildren } from "react";
+import { useState, type FC, type PropsWithChildren } from "react";
 
 const MAPS_API_KEY = String(import.meta.env.VITE_MAPS_API_KEY ?? "");
 const MAPS_MAP_ID = String(import.meta.env.VITE_MAPS_MAP_ID ?? "");
@@ -26,13 +26,13 @@ const MarkerWithInfoWindow: FC<
   const [markerRef, marker] = useAdvancedMarkerRef();
   const [infoWindowShown, setInfoWindowShown] = useState(true);
 
-  const handleMarkerClick = useCallback(() => {
+  const handleMarkerClick = () => {
     setInfoWindowShown((isShown) => !isShown);
-  }, []);
+  };
 
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     setInfoWindowShown(false);
-  }, []);
+  };
 
   return (
     <>

--- a/apps/web/src/components/marketing/lead-form.tsx
+++ b/apps/web/src/components/marketing/lead-form.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/lib/marketing/consent.js";
 import { trackLeadGenerated } from "@/lib/marketing/track-lead.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState, type FC } from "react";
+import { useState, type FC } from "react";
 
 type Variant = "adult" | "junior";
 
@@ -142,19 +142,16 @@ export const LeadForm: FC<LeadFormProps> = ({
     },
   });
 
-  const handleSubmit = useCallback(
-    (event: React.SyntheticEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      if (mutation.isPending) return;
-      // Capture the display name the moment the user submits so the success
-      // copy stays personalised even if state is later reset.
-      setSubmittedDisplayName(
-        variant === "junior" ? junior.childName.trim() : adult.name.trim(),
-      );
-      mutation.mutate();
-    },
-    [adult.name, junior.childName, mutation, variant],
-  );
+  const handleSubmit = (event: React.SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (mutation.isPending) return;
+    // Capture the display name the moment the user submits so the success
+    // copy stays personalised even if state is later reset.
+    setSubmittedDisplayName(
+      variant === "junior" ? junior.childName.trim() : adult.name.trim(),
+    );
+    mutation.mutate();
+  };
 
   if (mutation.isSuccess) {
     return (

--- a/apps/web/src/components/members/two-factor.tsx
+++ b/apps/web/src/components/members/two-factor.tsx
@@ -2,7 +2,7 @@ import { SimpleInput } from "@/components/form/simple-input";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import QRCode from "react-qr-code";
 import { match, P } from "ts-pattern";
 
@@ -43,11 +43,11 @@ export function TwoFactor({ user }: Props) {
     },
   });
 
-  const reset = useCallback(() => {
+  const reset = () => {
     setIsEnabling(false);
     setIsDisabling(false);
     setPassword("");
-  }, []);
+  };
 
   return (
     <section>

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -2,7 +2,6 @@ import { useSession } from "@/lib/auth-client.js";
 import { getMainMenuItems } from "@/lib/content.js";
 import { getPriceId } from "@/lib/stripe-env.js";
 import {
-  useCallback,
   useEffect,
   useRef,
   useState,
@@ -164,39 +163,35 @@ export const SiteHeader: FC = () => {
     };
   }, [drawerOpen]);
 
-  const openDrawer = useCallback(() => setDrawerOpen(true), []);
-  const closeDrawer = useCallback(() => setDrawerOpen(false), []);
+  const openDrawer = () => setDrawerOpen(true);
+  const closeDrawer = () => setDrawerOpen(false);
 
-  // Focus trap: loop Tab between first and last focusable elements, Escape closes
-  const handleDrawerKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === "Escape") {
-        closeDrawer();
-        return;
-      }
-      if (e.key !== "Tab") return;
+  const handleDrawerKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      closeDrawer();
+      return;
+    }
+    if (e.key !== "Tab") return;
 
-      const drawer = drawerRef.current;
-      if (!drawer) return;
+    const drawer = drawerRef.current;
+    if (!drawer) return;
 
-      const focusable = drawer.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusable.length === 0) return;
+    const focusable = drawer.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    if (focusable.length === 0) return;
 
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
 
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    },
-    [closeDrawer],
-  );
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
 
   return (
     <>

--- a/apps/web/src/hooks/use-theme.tsx
+++ b/apps/web/src/hooks/use-theme.tsx
@@ -1,7 +1,6 @@
 import {
   createContext,
   use,
-  useCallback,
   useEffect,
   useState,
   type ReactNode,
@@ -46,14 +45,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const resolved = resolveTheme(theme);
 
-  const setTheme = useCallback((next: Theme) => {
+  const setTheme = (next: Theme) => {
     localStorage.setItem(STORAGE_KEY, next);
     setThemeState(next);
-  }, []);
+  };
 
-  const toggleTheme = useCallback(() => {
+  const toggleTheme = () => {
     setTheme(resolved === "dark" ? "light" : "dark");
-  }, [resolved, setTheme]);
+  };
 
   // Apply dark class on mount and whenever resolved theme changes
   useEffect(() => {

--- a/apps/web/src/hooks/use-theme.tsx
+++ b/apps/web/src/hooks/use-theme.tsx
@@ -1,10 +1,4 @@
-import {
-  createContext,
-  use,
-  useEffect,
-  useState,
-  type ReactNode,
-} from "react";
+import { createContext, use, useEffect, useState, type ReactNode } from "react";
 
 type Theme = "light" | "dark" | "system";
 type ResolvedTheme = "light" | "dark";

--- a/apps/web/src/pages/admin/juniors-tab.tsx
+++ b/apps/web/src/pages/admin/juniors-tab.tsx
@@ -27,7 +27,7 @@ import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
 import { AGE_GROUPS } from "@percy-main/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import {
   initialJuniorsFilterState,
   juniorsFilterReducer,
@@ -112,11 +112,11 @@ export function JuniorsTab() {
       ),
   });
 
-  const juniors = useMemo<Junior[]>(() => data?.juniors ?? [], [data]);
+  const juniors: Junior[] = data?.juniors ?? [];
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
-  const grouped = useMemo(() => {
+  const grouped = (() => {
     const groups = new Map<string, Junior[]>();
 
     for (const junior of juniors) {
@@ -129,7 +129,6 @@ export function JuniorsTab() {
       }
     }
 
-    // Sort teams according to the defined order
     const sorted = new Map<string, Junior[]>();
     for (const teamKey of TEAM_ORDER) {
       const members = groups.get(teamKey);
@@ -137,14 +136,13 @@ export function JuniorsTab() {
         sorted.set(teamKey, members);
       }
     }
-    // Append overage players at the end
     const overage = groups.get("Overage");
     if (overage && overage.length > 0) {
       sorted.set("Overage", overage);
     }
 
     return sorted;
-  }, [juniors]);
+  })();
 
   return (
     <div className="flex flex-col gap-4">

--- a/apps/web/src/pages/admin/record-linking-tab.lib.ts
+++ b/apps/web/src/pages/admin/record-linking-tab.lib.ts
@@ -157,10 +157,7 @@ export interface ScoredPlayCricketPlayer extends PlayCricketPlayer {
   score: number;
 }
 
-/**
- * Filter and rank Play-Cricket players for the link-suggestion list.
- * Mirrors the original useMemo body in DetailModal.
- */
+/** Filter and rank Play-Cricket players for the link-suggestion list. */
 export function rankPlayCricketSuggestions(
   pcPlayers: readonly PlayCricketPlayer[],
   personName: string | null,

--- a/apps/web/src/pages/admin/record-linking-tab.tsx
+++ b/apps/web/src/pages/admin/record-linking-tab.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   buildPlayerNameMap,
   filterPeople,
@@ -132,47 +132,36 @@ export function RecordLinkingTab() {
   });
 
   // Combine members and dependents into a single list
-  const allPeople: PersonRow[] = useMemo(() => {
-    if (!linkingData) return [];
-    const members: PersonRow[] = linkingData.members.map((m) => ({
-      id: m.id,
-      name: m.name,
-      playCricketId: m.play_cricket_id,
-      slug: m.slug,
-      type: "member" as const,
-    }));
-    const deps: PersonRow[] = linkingData.dependents.map((d) => ({
-      id: d.id,
-      name: d.name,
-      parentName: d.parentName,
-      playCricketId: d.play_cricket_id,
-      type: "dependent" as const,
-    }));
-    return [...members, ...deps];
-  }, [linkingData]);
+  const allPeople: PersonRow[] = linkingData
+    ? [
+        ...linkingData.members.map<PersonRow>((m) => ({
+          id: m.id,
+          name: m.name,
+          playCricketId: m.play_cricket_id,
+          slug: m.slug,
+          type: "member" as const,
+        })),
+        ...linkingData.dependents.map<PersonRow>((d) => ({
+          id: d.id,
+          name: d.name,
+          parentName: d.parentName,
+          playCricketId: d.play_cricket_id,
+          type: "dependent" as const,
+        })),
+      ]
+    : [];
 
-  // Filter people
-  const filteredPeople = useMemo(
-    () =>
-      filterPeople(allPeople, {
-        search: debouncedSearch,
-        showLinked,
-        showUnlinked,
-        personTypeFilter,
-      }),
-    [allPeople, debouncedSearch, showLinked, showUnlinked, personTypeFilter],
-  );
+  const filteredPeople = filterPeople(allPeople, {
+    search: debouncedSearch,
+    showLinked,
+    showUnlinked,
+    personTypeFilter,
+  });
 
-  // Stats
-  const stats = useMemo(() => summarisePersonStats(allPeople), [allPeople]);
   const { totalMembers, totalDependents, linkedPcMembers, linkedPcDeps } =
-    stats;
+    summarisePersonStats(allPeople);
 
-  // Player name lookup for PC IDs
-  const playerNameById = useMemo(
-    () => buildPlayerNameMap(pcPlayers),
-    [pcPlayers],
-  );
+  const playerNameById = buildPlayerNameMap(pcPlayers);
 
   // Keep detail modal person in sync with linkingData refreshes
   useEffect(() => {
@@ -464,11 +453,10 @@ function DetailModal({
   onClose: () => void;
 }) {
   const [slugInput, setSlugInput] = useState("");
-  // Suggested PC players
-  const suggestedPcPlayers = useMemo(() => {
-    if (!pcPlayers || !linking) return [];
-    return rankPlayCricketSuggestions(pcPlayers, person.name, linkSearch);
-  }, [pcPlayers, linking, linkSearch, person.name]);
+  const suggestedPcPlayers =
+    pcPlayers && linking
+      ? rankPlayCricketSuggestions(pcPlayers, person.name, linkSearch)
+      : [];
 
   return (
     <Dialog

--- a/apps/web/src/pages/admin/sponsorships-tab.tsx
+++ b/apps/web/src/pages/admin/sponsorships-tab.tsx
@@ -27,7 +27,7 @@ import { api, callApi } from "@/lib/api-client";
 import { resizeLogo } from "@/lib/logo-resize";
 import { getAllPeople } from "@/lib/people";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useReducer, useRef, useState } from "react";
+import { useReducer, useRef, useState } from "react";
 import {
   buildGameSponsorshipPayload,
   buildPlayerSponsorshipPayload,
@@ -62,11 +62,9 @@ function PlayerSelect({
   const [query, setQuery] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
-  const available = useMemo(() => {
-    return getAllPeople()
-      .filter((p) => !p.hasLeftClub && !takenSlugs.has(p.slug))
-      .sort((a, b) => a.name.localeCompare(b.name));
-  }, [takenSlugs]);
+  const available = getAllPeople()
+    .filter((p) => !p.hasLeftClub && !takenSlugs.has(p.slug))
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   const filtered = query.trim()
     ? available.filter((p) =>
@@ -663,10 +661,7 @@ function CreatePlayerSponsorshipDialog({
     enabled: open,
   });
 
-  const takenSlugs = useMemo(
-    () => new Set(takenSlugsQuery.data?.slugs ?? []),
-    [takenSlugsQuery.data],
-  );
+  const takenSlugs = new Set(takenSlugsQuery.data?.slugs ?? []);
 
   const createMutation = useMutation({
     mutationFn: (body: PlayerSponsorshipPayload) =>

--- a/apps/web/src/pages/admin/treasurer-tab.tsx
+++ b/apps/web/src/pages/admin/treasurer-tab.tsx
@@ -13,7 +13,7 @@ import {
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
 import { useQuery } from "@tanstack/react-query";
-import { Suspense, lazy, useMemo, useState } from "react";
+import { Suspense, lazy, useState } from "react";
 import { formatPence } from "./status-pill";
 import { TreasurerExpensesSection } from "./treasurer-expenses-section";
 import { TreasurerOutstandingSection } from "./treasurer-outstanding-section";
@@ -112,32 +112,28 @@ export function TreasurerTab() {
 
   // --- Derived data ---
 
-  const totalChargesIncome = useMemo(() => {
-    if (!incomeQuery.data) return 0;
-    return incomeQuery.data.charges.reduce((sum, c) => sum + c.total_pence, 0);
-  }, [incomeQuery.data]);
+  const totalChargesIncome = incomeQuery.data
+    ? incomeQuery.data.charges.reduce((sum, c) => sum + c.total_pence, 0)
+    : 0;
 
-  const totalSponsorIncome = useMemo(() => {
-    if (!incomeQuery.data) return 0;
-    const game = incomeQuery.data.gameSponsorIncome.reduce(
-      (sum, s) => sum + s.total_pence,
-      0,
-    );
-    const player = incomeQuery.data.playerSponsorIncome.reduce(
-      (sum, s) => sum + s.total_pence,
-      0,
-    );
-    return game + player;
-  }, [incomeQuery.data]);
+  const totalSponsorIncome = incomeQuery.data
+    ? incomeQuery.data.gameSponsorIncome.reduce(
+        (sum, s) => sum + s.total_pence,
+        0,
+      ) +
+      incomeQuery.data.playerSponsorIncome.reduce(
+        (sum, s) => sum + s.total_pence,
+        0,
+      )
+    : 0;
 
   const totalIncome = totalChargesIncome + totalSponsorIncome;
 
-  const membershipIncome = useMemo(() => {
-    if (!incomeQuery.data) return 0;
-    return incomeQuery.data.charges
-      .filter((c) => c.type === "membership")
-      .reduce((sum, c) => sum + c.total_pence, 0);
-  }, [incomeQuery.data]);
+  const membershipIncome = incomeQuery.data
+    ? incomeQuery.data.charges
+        .filter((c) => c.type === "membership")
+        .reduce((sum, c) => sum + c.total_pence, 0)
+    : 0;
 
   const outstandingTotal = outstandingQuery.data?.total ?? 0;
 
@@ -145,7 +141,7 @@ export function TreasurerTab() {
 
   // --- Chart data ---
 
-  const chartData = useMemo(() => {
+  const chartData = (() => {
     if (!incomeQuery.data) return [];
 
     const monthMap = new Map<
@@ -209,7 +205,7 @@ export function TreasurerTab() {
     return Array.from(monthMap.values()).sort((a, b) =>
       a.month.localeCompare(b.month),
     );
-  }, [incomeQuery.data]);
+  })();
 
   // --- Reset handler ---
 

--- a/apps/web/src/pages/auth/login/email-password.tsx
+++ b/apps/web/src/pages/auth/login/email-password.tsx
@@ -2,7 +2,7 @@ import { SimpleInput } from "@/components/form/simple-input.js";
 import { Button } from "@/components/ui/button.js";
 import { authClient } from "@/lib/auth-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useState, type FC } from "react";
+import { useEffect, useState, type FC } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 import type { LoginPhase } from "../login.js";
 
@@ -86,13 +86,10 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
       }),
   });
 
-  const handleSubmit = useCallback(
-    (event: React.SyntheticEvent) => {
-      event.preventDefault();
-      signin.mutate();
-    },
-    [signin],
-  );
+  const handleSubmit = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    signin.mutate();
+  };
 
   const error = signin.error ?? googleSignIn.error ?? googleSignIn.data?.error;
 

--- a/apps/web/src/pages/auth/login/forgot-password.tsx
+++ b/apps/web/src/pages/auth/login/forgot-password.tsx
@@ -2,7 +2,7 @@ import { SimpleInput } from "@/components/form/simple-input.js";
 import { Button } from "@/components/ui/button.js";
 import { authClient } from "@/lib/auth-client.js";
 import { useMutation } from "@tanstack/react-query";
-import { useCallback, useState, type FC } from "react";
+import { useState, type FC } from "react";
 import { match, P } from "ts-pattern";
 
 export const ForgotPassword: FC = () => {
@@ -17,13 +17,10 @@ export const ForgotPassword: FC = () => {
       }),
   });
 
-  const handleSubmit = useCallback(
-    (event: React.SyntheticEvent) => {
-      event.preventDefault();
-      requestReset.mutate();
-    },
-    [requestReset],
-  );
+  const handleSubmit = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    requestReset.mutate();
+  };
 
   const error = requestReset.error ?? requestReset.data?.error;
 

--- a/apps/web/src/pages/auth/login/recovery.tsx
+++ b/apps/web/src/pages/auth/login/recovery.tsx
@@ -2,7 +2,7 @@ import { SimpleInput } from "@/components/form/simple-input.js";
 import { Button } from "@/components/ui/button.js";
 import { authClient } from "@/lib/auth-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState, type FC } from "react";
+import { useState, type FC } from "react";
 import { useNavigate } from "react-router";
 import type { LoginPhase } from "../login.js";
 
@@ -31,13 +31,10 @@ export const Recovery: FC<Props> = ({ setPhase }) => {
     },
   });
 
-  const handleSubmit = useCallback(
-    (event: React.SyntheticEvent) => {
-      event.preventDefault();
-      verifyBackupCode.mutate();
-    },
-    [verifyBackupCode],
-  );
+  const handleSubmit = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    verifyBackupCode.mutate();
+  };
 
   const error = verifyBackupCode.error ?? verifyBackupCode.data?.error;
 

--- a/apps/web/src/pages/auth/login/reset-password.tsx
+++ b/apps/web/src/pages/auth/login/reset-password.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button.js";
 import { useSearchParam } from "@/hooks/use-search-param.js";
 import { authClient } from "@/lib/auth-client.js";
 import { useMutation } from "@tanstack/react-query";
-import { useCallback, useState, type FC } from "react";
+import { useState, type FC } from "react";
 import { z } from "zod";
 import type { LoginPhase } from "../login.js";
 
@@ -40,13 +40,10 @@ export const ResetPassword: FC<Props> = ({ setPhase }) => {
       ),
   });
 
-  const handleSubmit = useCallback(
-    (event: React.SyntheticEvent) => {
-      event.preventDefault();
-      resetPassword.mutate();
-    },
-    [resetPassword],
-  );
+  const handleSubmit = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    resetPassword.mutate();
+  };
 
   const error = resetPassword.error ?? resetPassword.data?.error;
 

--- a/apps/web/src/pages/auth/login/two-fa.tsx
+++ b/apps/web/src/pages/auth/login/two-fa.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/input-otp.js";
 import { authClient } from "@/lib/auth-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState, type FC } from "react";
+import { useState, type FC } from "react";
 import { useNavigate } from "react-router";
 import type { LoginPhase } from "../login.js";
 
@@ -36,13 +36,10 @@ export const TwoFA: FC<Props> = ({ setPhase }) => {
     },
   });
 
-  const handleSubmit = useCallback(
-    (event: React.SyntheticEvent) => {
-      event.preventDefault();
-      signin.mutate();
-    },
-    [signin],
-  );
+  const handleSubmit = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    signin.mutate();
+  };
 
   const error = signin.error ?? signin.data?.error;
 

--- a/apps/web/src/pages/auth/register.tsx
+++ b/apps/web/src/pages/auth/register.tsx
@@ -4,7 +4,7 @@ import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { authClient } from "@/lib/auth-client.js";
 import { trackEvent } from "@/lib/marketing/gtag.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState, type FC } from "react";
+import { useState, type FC } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 
 const GoogleIcon: FC = () => (
@@ -75,22 +75,19 @@ export function Component() {
       }),
   });
 
-  const handleGoogleClick = useCallback(() => {
+  const handleGoogleClick = () => {
     googleSignUp.mutate();
-  }, [googleSignUp]);
+  };
 
-  const handleSubmit = useCallback(
-    (event: React.SyntheticEvent) => {
-      event.preventDefault();
-      if (!ageConfirmed) {
-        setAgeError(true);
-        return;
-      }
-      setAgeError(false);
-      register.mutate();
-    },
-    [ageConfirmed, register],
-  );
+  const handleSubmit = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    if (!ageConfirmed) {
+      setAgeError(true);
+      return;
+    }
+    setAgeError(false);
+    register.mutate();
+  };
 
   const isUserExists =
     register.data?.error?.code === "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL";

--- a/apps/web/src/pages/availability/public-availability.tsx
+++ b/apps/web/src/pages/availability/public-availability.tsx
@@ -7,7 +7,7 @@ import type { paths } from "@/lib/api.gen.js";
 import { useSession } from "@/lib/auth-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { IoLockClosed } from "react-icons/io5";
 import { Link, useParams } from "react-router";
 
@@ -70,7 +70,7 @@ export function Component() {
   const isSignedIn = !!session;
 
   // Load draft from localStorage (once, on mount — for users returning after sign-up)
-  const initialResponses = useMemo(() => {
+  const initialResponses = (() => {
     if (!requestId || !isSignedIn) return new Map<string, DraftResponse>();
     const draft = loadDraft(requestId);
     if (!draft) return new Map<string, DraftResponse>();
@@ -79,14 +79,14 @@ export function Component() {
       map.set(r.matchDate, r);
     }
     return map;
-  }, [requestId, isSignedIn]);
+  })();
 
   const [responses, setResponses] =
     useState<Map<string, DraftResponse>>(initialResponses);
   const [submitted, setSubmitted] = useState(false);
 
   // Populate from server responses if signed in and no draft exists
-  const serverResponses = useMemo(() => {
+  const serverResponses = (() => {
     if (!memberQuery.data || !requestId) return null;
     if (initialResponses.size > 0) return null;
     const activeRequest = memberQuery.data.items.find(
@@ -102,44 +102,41 @@ export function Component() {
       });
     }
     return map;
-  }, [memberQuery.data, requestId, initialResponses.size]);
+  })();
 
   // Use server responses if we haven't interacted yet
   const effectiveResponses =
     responses.size > 0 ? responses : (serverResponses ?? responses);
 
-  const setDateResponse = useCallback(
-    (matchDate: string, status: "available" | "unavailable") => {
-      setResponses((prev) => {
-        // Merge with server responses if user hasn't interacted yet
-        const base = prev.size > 0 ? prev : (serverResponses ?? prev);
-        const next = new Map(base);
-        const existing = next.get(matchDate);
-        next.set(matchDate, {
-          matchDate,
-          status,
-          note: existing?.note,
-        });
-        return next;
+  const setDateResponse = (
+    matchDate: string,
+    status: "available" | "unavailable",
+  ) => {
+    setResponses((prev) => {
+      // Merge with server responses if user hasn't interacted yet
+      const base = prev.size > 0 ? prev : (serverResponses ?? prev);
+      const next = new Map(base);
+      const existing = next.get(matchDate);
+      next.set(matchDate, {
+        matchDate,
+        status,
+        note: existing?.note,
       });
-    },
-    [serverResponses],
-  );
+      return next;
+    });
+  };
 
-  const setDateNote = useCallback(
-    (matchDate: string, note: string) => {
-      setResponses((prev) => {
-        const base = prev.size > 0 ? prev : (serverResponses ?? prev);
-        const next = new Map(base);
-        const existing = next.get(matchDate);
-        if (existing) {
-          next.set(matchDate, { ...existing, note });
-        }
-        return next;
-      });
-    },
-    [serverResponses],
-  );
+  const setDateNote = (matchDate: string, note: string) => {
+    setResponses((prev) => {
+      const base = prev.size > 0 ? prev : (serverResponses ?? prev);
+      const next = new Map(base);
+      const existing = next.get(matchDate);
+      if (existing) {
+        next.set(matchDate, { ...existing, note });
+      }
+      return next;
+    });
+  };
 
   const queryClient = useQueryClient();
 
@@ -166,10 +163,10 @@ export function Component() {
     },
   });
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = () => {
     if (!requestId) return;
     submitMutation.mutate();
-  }, [requestId, submitMutation]);
+  };
 
   if (query.isPending || sessionPending) {
     return (

--- a/apps/web/src/pages/calendar/calendar-month.tsx
+++ b/apps/web/src/pages/calendar/calendar-month.tsx
@@ -14,7 +14,7 @@ import {
   startOfMonth,
 } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { IoChevronForward } from "react-icons/io5";
 import { Link, useParams } from "react-router";
 import {
@@ -433,10 +433,9 @@ export function Component() {
   const [activeFilter, setActiveFilter] = useState<Filter>("all");
   const [selectedDay, setSelectedDay] = useState<number | null>(null);
 
-  const date = useMemo(
-    () => (parsed ? new Date(parsed.year, parsed.monthIndex, 1) : new Date()),
-    [parsed],
-  );
+  const date = parsed
+    ? new Date(parsed.year, parsed.monthIndex, 1)
+    : new Date();
   const season = parsed?.year ?? new Date().getFullYear();
 
   const { data: games } = useQuery({
@@ -459,10 +458,9 @@ export function Component() {
   };
 
   // Build calendar items: merge games (from API) + events (from MDX)
-  const allItems = useMemo((): CalendarItem[] => {
+  const allItems: CalendarItem[] = (() => {
     const items: CalendarItem[] = [];
 
-    // Add games for this month
     if (games) {
       for (const game of games) {
         if (!game.when) continue;
@@ -491,7 +489,6 @@ export function Component() {
       }
     }
 
-    // Add events for this month
     const events = getAllEvents();
     for (const event of events) {
       const eventDate = new Date(event.when);
@@ -511,31 +508,13 @@ export function Component() {
     }
 
     return sortCalendarItems(items);
-  }, [games, date]);
+  })();
 
-  // Filter
-  const filteredItems = useMemo(
-    () => filterItemsByCategory(allItems, activeFilter),
-    [allItems, activeFilter],
-  );
-
-  // Group by date
-  const grouped = useMemo(
-    () => groupItemsByDate(filteredItems),
-    [filteredItems],
-  );
-
-  // Items by day number for mini calendar
-  const itemsByDay = useMemo(() => groupItemsByDay(allItems), [allItems]);
-
-  // Stats
-  const stats = useMemo(() => summariseMonth(allItems, new Date()), [allItems]);
-
-  // Divider position
-  const dividerIndex = useMemo(
-    () => findDividerIndex(grouped, new Date()),
-    [grouped],
-  );
+  const filteredItems = filterItemsByCategory(allItems, activeFilter);
+  const grouped = groupItemsByDate(filteredItems);
+  const itemsByDay = groupItemsByDay(allItems);
+  const stats = summariseMonth(allItems, new Date());
+  const dividerIndex = findDividerIndex(grouped, new Date());
 
   // Navigation
   const prevDate = addMonths(date, -1);

--- a/apps/web/src/pages/game/be-the-keeper.tsx
+++ b/apps/web/src/pages/game/be-the-keeper.tsx
@@ -1,7 +1,7 @@
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
 import { useSession } from "@/lib/auth-client";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
 
 // ══════════════════════════════════════════════════════════════
@@ -1498,7 +1498,7 @@ function BeTheKeeper() {
     isLoggedInRef.current = isLoggedIn;
   }, [isLoggedIn]);
 
-  const handleGameOver = useCallback(async (s: GS) => {
+  const handleGameOver = async (s: GS) => {
     // Guard: only write back if the game hasn't been restarted
     const isStillOver = () => s.phase === "over";
 
@@ -1548,7 +1548,7 @@ function BeTheKeeper() {
         /* score submit failed silently */
       }
     }
-  }, []);
+  };
 
   useEffect(() => {
     const cvs = canvasRef.current;

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -10,7 +10,6 @@ import { getPriceId } from "@/lib/stripe-env.js";
 import { useQuery } from "@tanstack/react-query";
 import { format, isAfter } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
-import { useMemo } from "react";
 import { Link } from "react-router";
 
 const DONATE_URL = `/purchase/${getPriceId("donation")}`;
@@ -155,7 +154,7 @@ function UpcomingStrip() {
     staleTime: 5 * 60_000,
   });
 
-  const items = useMemo((): UpcomingItem[] => {
+  const items: UpcomingItem[] = (() => {
     const now = new Date();
     const upcoming: UpcomingItem[] = [];
 
@@ -209,7 +208,7 @@ function UpcomingStrip() {
     });
 
     return upcoming.slice(0, 5);
-  }, [games]);
+  })();
 
   if (items.length === 0) return null;
 

--- a/apps/web/src/pages/members/members-fantasy.tsx
+++ b/apps/web/src/pages/members/members-fantasy.tsx
@@ -34,7 +34,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router";
 import {
   BUDGET,
@@ -249,11 +249,7 @@ function TeamBuilder({
     },
   });
 
-  // Derived state
-  const squadPlayerIds = useMemo(
-    () => new Set(squad.map((p) => p.playCricketId)),
-    [squad],
-  );
+  const squadPlayerIds = new Set(squad.map((p) => p.playCricketId));
 
   const slotCounts = countSlots(squad);
   const validation = validateSquadComposition(squad);
@@ -314,7 +310,7 @@ function TeamBuilder({
     setSquad((prev) => moveSquadPlayerToSlot(prev, playCricketId, slotType));
   }
 
-  const availablePlayers = useMemo(() => {
+  const availablePlayers = (() => {
     const term = search.toLowerCase();
     return eligiblePlayers
       .filter(
@@ -323,7 +319,7 @@ function TeamBuilder({
           (!search || p.player_name.toLowerCase().includes(term)),
       )
       .toSorted((a, b) => b.previousSeasonPoints - a.previousSeasonPoints);
-  }, [eligiblePlayers, squadPlayerIds, search]);
+  })();
 
   const [activeId, setActiveId] = useState<string | null>(null);
   const activePlayer = activeId

--- a/apps/web/src/pages/official/availability.tsx
+++ b/apps/web/src/pages/official/availability.tsx
@@ -22,7 +22,7 @@ import type { paths } from "@/lib/api.gen.js";
 import { useSession } from "@/lib/auth-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { addDays, format } from "date-fns";
-import { useCallback, useReducer, useState } from "react";
+import { useReducer, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 import {
   buildPreviewPayload,
@@ -1020,19 +1020,19 @@ function NotifyDialog({ requestId }: { requestId: string }) {
     },
   });
 
-  const toggleRecipient = useCallback((email: string) => {
+  const toggleRecipient = (email: string) => {
     dispatch({ type: "toggleRecipient", email });
-  }, []);
+  };
 
-  const toggleAll = useCallback(() => {
+  const toggleAll = () => {
     dispatch({ type: "toggleAll" });
-  }, []);
+  };
 
-  const reset = useCallback(() => {
+  const reset = () => {
     dispatch({ type: "reset" });
     sendMutation.reset();
     previewMutation.reset();
-  }, [sendMutation, previewMutation]);
+  };
 
   return (
     <>

--- a/apps/web/src/pages/scout/attachments/use-attachment-upload.ts
+++ b/apps/web/src/pages/scout/attachments/use-attachment-upload.ts
@@ -1,5 +1,5 @@
 import { api, callApi } from "@/lib/api-client";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
 const ACCEPTED_TYPES = [
   "image/png",
@@ -54,130 +54,118 @@ export function useAttachmentUpload({
 }: UseAttachmentUploadArgs) {
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
 
-  const update = useCallback(
-    (localId: string, patch: Partial<PendingAttachment>) => {
-      setAttachments((prev) =>
-        prev.map((a) => (a.localId === localId ? { ...a, ...patch } : a)),
+  const update = (localId: string, patch: Partial<PendingAttachment>) => {
+    setAttachments((prev) =>
+      prev.map((a) => (a.localId === localId ? { ...a, ...patch } : a)),
+    );
+  };
+
+  const upload = async (file: File): Promise<void> => {
+    if (!isAcceptedAttachment(file)) return;
+
+    const localId =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `local-${Date.now()}-${Math.random()}`;
+    const contentType = file.type as AcceptedContentType;
+    const kind: "image" | "pdf" =
+      contentType === "application/pdf" ? "pdf" : "image";
+    const previewUrl = kind === "image" ? URL.createObjectURL(file) : null;
+
+    const pending: PendingAttachment = {
+      localId,
+      id: null,
+      filename: file.name,
+      contentType,
+      sizeBytes: file.size,
+      kind,
+      previewUrl,
+      status: "uploading",
+      error: null,
+    };
+
+    // Reject before mint if the cap would be exceeded so we don't burn an
+    // S3 PUT only to silently drop the chip.
+    let exceeded = false;
+    setAttachments((prev) => {
+      if (prev.length >= maxPerTurn) {
+        exceeded = true;
+        return prev;
+      }
+      return [...prev, pending];
+    });
+    if (exceeded) {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+      return;
+    }
+
+    try {
+      const mint = await callApi(
+        api.POST("/api/scout/threads/{threadId}/attachments", {
+          params: { path: { threadId } },
+          body: {
+            filename: file.name,
+            contentType,
+            sizeBytes: file.size,
+          },
+        }),
       );
-    },
-    [],
-  );
+      update(localId, { id: mint.id });
 
-  const upload = useCallback(
-    async (file: File): Promise<void> => {
-      if (!isAcceptedAttachment(file)) return;
-
-      const localId =
-        typeof crypto !== "undefined" && "randomUUID" in crypto
-          ? crypto.randomUUID()
-          : `local-${Date.now()}-${Math.random()}`;
-      const contentType = file.type as AcceptedContentType;
-      const kind: "image" | "pdf" =
-        contentType === "application/pdf" ? "pdf" : "image";
-      const previewUrl = kind === "image" ? URL.createObjectURL(file) : null;
-
-      const pending: PendingAttachment = {
-        localId,
-        id: null,
-        filename: file.name,
-        contentType,
-        sizeBytes: file.size,
-        kind,
-        previewUrl,
-        status: "uploading",
-        error: null,
-      };
-
-      // Reject before mint if the cap would be exceeded so we don't burn an
-      // S3 PUT only to silently drop the chip.
-      let exceeded = false;
-      setAttachments((prev) => {
-        if (prev.length >= maxPerTurn) {
-          exceeded = true;
-          return prev;
-        }
-        return [...prev, pending];
+      const putRes = await fetch(mint.uploadUrl, {
+        method: "PUT",
+        body: file,
+        headers: { "Content-Type": contentType },
       });
-      if (exceeded) {
-        if (previewUrl) URL.revokeObjectURL(previewUrl);
-        return;
-      }
-
-      try {
-        const mint = await callApi(
-          api.POST("/api/scout/threads/{threadId}/attachments", {
-            params: { path: { threadId } },
-            body: {
-              filename: file.name,
-              contentType,
-              sizeBytes: file.size,
-            },
-          }),
+      if (!putRes.ok) {
+        throw new Error(
+          `Upload to S3 failed (${putRes.status} ${putRes.statusText})`,
         );
-        update(localId, { id: mint.id });
-
-        const putRes = await fetch(mint.uploadUrl, {
-          method: "PUT",
-          body: file,
-          headers: { "Content-Type": contentType },
-        });
-        if (!putRes.ok) {
-          throw new Error(
-            `Upload to S3 failed (${putRes.status} ${putRes.statusText})`,
-          );
-        }
-
-        update(localId, { status: "processing" });
-
-        const committed = await callApi(
-          api.POST(
-            "/api/scout/threads/{threadId}/attachments/{attachmentId}/commit",
-            {
-              params: {
-                path: { threadId, attachmentId: mint.id },
-              },
-            },
-          ),
-        );
-        update(localId, {
-          status: committed.processingState === "ready" ? "ready" : "failed",
-          error: committed.processingError,
-        });
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        update(localId, { status: "failed", error: message });
       }
-    },
-    [threadId, maxPerTurn, update],
-  );
 
-  const remove = useCallback(
-    (localId: string) => {
-      const target = attachments.find((a) => a.localId === localId);
-      if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl);
-      setAttachments((prev) => prev.filter((a) => a.localId !== localId));
-      // Best-effort: ask the server to drop the row + S3 bytes if mint
-      // already returned. Not awaited — the chip is gone locally either way.
-      if (target?.id) {
-        void callApi(
-          api.DELETE(
-            "/api/scout/threads/{threadId}/attachments/{attachmentId}",
-            {
-              params: { path: { threadId, attachmentId: target.id } },
+      update(localId, { status: "processing" });
+
+      const committed = await callApi(
+        api.POST(
+          "/api/scout/threads/{threadId}/attachments/{attachmentId}/commit",
+          {
+            params: {
+              path: { threadId, attachmentId: mint.id },
             },
-          ),
-        ).catch(() => undefined);
-      }
-    },
-    [attachments, threadId],
-  );
+          },
+        ),
+      );
+      update(localId, {
+        status: committed.processingState === "ready" ? "ready" : "failed",
+        error: committed.processingError,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      update(localId, { status: "failed", error: message });
+    }
+  };
 
-  const clear = useCallback(() => {
+  const remove = (localId: string) => {
+    const target = attachments.find((a) => a.localId === localId);
+    if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl);
+    setAttachments((prev) => prev.filter((a) => a.localId !== localId));
+    // Best-effort: ask the server to drop the row + S3 bytes if mint
+    // already returned. Not awaited — the chip is gone locally either way.
+    if (target?.id) {
+      void callApi(
+        api.DELETE("/api/scout/threads/{threadId}/attachments/{attachmentId}", {
+          params: { path: { threadId, attachmentId: target.id } },
+        }),
+      ).catch(() => undefined);
+    }
+  };
+
+  const clear = () => {
     for (const a of attachments) {
       if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
     }
     setAttachments([]);
-  }, [attachments]);
+  };
 
   const readyIds = attachments.flatMap((a) =>
     a.status === "ready" && a.id ? [a.id] : [],

--- a/apps/web/src/pages/scout/scout.tsx
+++ b/apps/web/src/pages/scout/scout.tsx
@@ -4,7 +4,7 @@ import { api, callApi } from "@/lib/api-client";
 import type { UIMessage } from "@ai-sdk/react";
 import type { ReportData } from "@percy-main/shared";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { MessageAttachments } from "./attachments/message-attachments.js";
 import { useAttachmentUpload } from "./attachments/use-attachment-upload.js";
@@ -266,25 +266,21 @@ interface ChatViewProps {
 }
 
 function ChatView({ threadId, loaded }: ChatViewProps) {
-  const initialMessages = useMemo<UIMessage[]>(
-    () =>
-      filterMessagesByRole(loaded.messages, ["user", "assistant"]).map(
-        (m) =>
-          ({
-            id: m.id,
-            role: m.role,
-            parts: m.parts,
-          }) as unknown as UIMessage,
-      ),
-    [loaded.messages],
+  const initialMessages: UIMessage[] = filterMessagesByRole(loaded.messages, [
+    "user",
+    "assistant",
+  ]).map(
+    (m) =>
+      ({
+        id: m.id,
+        role: m.role,
+        parts: m.parts,
+      }) as unknown as UIMessage,
   );
   // Historical attachment ids by message id. Live messages (still streaming
   // / not yet refetched) won't appear here — that's fine; the user just
   // sees thumbnails on the next thread reload.
-  const attachmentIdsByMessage = useMemo(
-    () => summariseAttachments(loaded.messages),
-    [loaded.messages],
-  );
+  const attachmentIdsByMessage = summariseAttachments(loaded.messages);
 
   const { messages, sendMessage, status, error, stop } = useScoutChat({
     threadId,
@@ -402,10 +398,7 @@ function ChatView({ threadId, loaded }: ChatViewProps) {
   // state (ready / failed) so a stale "generating" snapshot for the same
   // reportId emitted earlier in the stream doesn't get surfaced as
   // in-flight.
-  const inFlightReport = useMemo<ReportData | null>(
-    () => findInFlightReport(messages),
-    [messages],
-  );
+  const inFlightReport: ReportData | null = findInFlightReport(messages);
 
   return (
     <>

--- a/apps/web/src/pages/scout/share-thread-modal.tsx
+++ b/apps/web/src/pages/scout/share-thread-modal.tsx
@@ -64,9 +64,7 @@ export function ShareThreadModal({
     enabled: open,
   });
 
-  const sharedIds = new Set(
-    shareesQuery.data?.sharees.map((s) => s.id) ?? [],
-  );
+  const sharedIds = new Set(shareesQuery.data?.sharees.map((s) => s.id) ?? []);
 
   const candidates = (() => {
     const all = officialsQuery.data?.officials ?? [];

--- a/apps/web/src/pages/scout/share-thread-modal.tsx
+++ b/apps/web/src/pages/scout/share-thread-modal.tsx
@@ -11,7 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { api, callApi } from "@/lib/api-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 interface ShareActor {
   id: string;
@@ -64,12 +64,11 @@ export function ShareThreadModal({
     enabled: open,
   });
 
-  const sharedIds = useMemo(
-    () => new Set(shareesQuery.data?.sharees.map((s) => s.id) ?? []),
-    [shareesQuery.data],
+  const sharedIds = new Set(
+    shareesQuery.data?.sharees.map((s) => s.id) ?? [],
   );
 
-  const candidates = useMemo(() => {
+  const candidates = (() => {
     const all = officialsQuery.data?.officials ?? [];
     const q = filter.trim().toLowerCase();
     return all.filter(
@@ -79,7 +78,7 @@ export function ShareThreadModal({
           o.name.toLowerCase().includes(q) ||
           o.email.toLowerCase().includes(q)),
     );
-  }, [officialsQuery.data, sharedIds, filter]);
+  })();
 
   const shareMutation = useMutation({
     mutationFn: (userIds: string[]) =>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,7 @@
 import mdx from "@mdx-js/rollup";
+import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
-import react from "@vitejs/plugin-react";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import path from "path";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
@@ -53,6 +54,9 @@ export default defineConfig(({ mode }) => ({
       providerImportSource: "@mdx-js/react",
     }),
     react(),
+    babel({
+      presets: [reactCompilerPreset()],
+    }),
     tailwindcss(),
     imagetools({
       defaultDirectives: (url) => {
@@ -69,13 +73,14 @@ export default defineConfig(({ mode }) => ({
   build: {
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: [
-            "react",
-            "react-dom",
-            "react-router",
-            "@tanstack/react-query",
-          ],
+        manualChunks(id) {
+          if (
+            /[\\/]node_modules[\\/](\.pnpm[\\/])?(@tanstack[\\/]react-query|react|react-dom|react-router|scheduler)([\\/@]|$)/.test(
+              id,
+            )
+          ) {
+            return "vendor";
+          }
         },
       },
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,18 @@ export default tseslint.config(
       "react-hooks/exhaustive-deps": "error",
     },
   },
+  // apps/web runs the React Compiler — recommended-latest's compiler-aware
+  // ruleset replaces the legacy "exhaustive-deps as error" stance (the
+  // compiler now handles dep tracking and function stability for us).
+  // This block must come after the global "exhaustive-deps: error" override
+  // above so its `warn` level wins for apps/web.
+  {
+    files: ["apps/web/src/**/*.{ts,tsx}"],
+    plugins: {
+      "react-hooks": hooksPlugin,
+    },
+    rules: hooksPlugin.configs["recommended-latest"].rules,
+  },
   {
     rules: {
       "no-undef": "off",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,10 +58,10 @@ importers:
         version: 3.1022.0
       '@better-auth/infra':
         specifier: ^0.1.13
-        version: 0.1.13(e468de69e442b8816a24782b85e995e8)
+        version: 0.1.13(bd0fa884e4f2adc463371c57e14a5856)
       '@better-auth/passkey':
         specifier: ^1.5.4
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
@@ -133,7 +133,7 @@ importers:
         version: 6.0.174(zod@4.3.6)
       better-auth:
         specifier: ^1.5.4
-        version: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       better-call:
         specifier: 1.3.2
         version: 1.3.2(zod@4.3.6)
@@ -209,7 +209,7 @@ importers:
         version: 7.2.0
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       dotenv:
         specifier: ^17.3.0
         version: 17.3.1
@@ -230,7 +230,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/email-viewer:
     dependencies:
@@ -249,13 +249,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.7.0(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web:
     dependencies:
@@ -264,7 +264,7 @@ importers:
         version: 3.0.176(react@19.2.4)(zod@4.3.6)
       '@better-auth/passkey':
         specifier: ^1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -321,7 +321,7 @@ importers:
         version: 6.0.174(zod@4.3.6)
       better-auth:
         specifier: ^1.5.5
-        version: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       better-call:
         specifier: 1.3.2
         version: 1.3.2(zod@4.3.6)
@@ -386,8 +386,8 @@ importers:
         specifier: ^3.0.1
         version: 3.5.0
       tailwindcss:
-        specifier: ^4.0.0
-        version: 4.2.1
+        specifier: ^4.3.0
+        version: 4.3.0
       ts-pattern:
         specifier: ^5.6.0
         version: 5.9.0
@@ -398,9 +398,12 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@tailwindcss/vite':
-        specifier: ^4.0.0
-        version: 4.2.1(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^4.3.0
+        version: 4.3.0(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@types/google.maps':
         specifier: ^3.58.1
         version: 3.58.1
@@ -411,26 +414,29 @@ importers:
         specifier: ^19.0.2
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^6.0.1
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
-        specifier: ^6.4.2
-        version: 6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^8.0.11
+        version: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
       vite-imagetools:
         specifier: ^7.1.1
         version: 7.1.1(rollup@4.60.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   infra:
     devDependencies:
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -510,7 +516,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       react-email:
         specifier: 3.0.6
-        version: 3.0.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 3.0.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3663,8 +3669,120 @@ packages:
       react-redux:
         optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/plugin-babel@0.2.3':
+    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rolldown/pluginutils@1.0.0-rc.18':
+    resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -4216,65 +4334,65 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@tailwindcss/node@4.2.1':
-    resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
-  '@tailwindcss/oxide-android-arm64@4.2.1':
-    resolution: {integrity: sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==}
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.2.1':
-    resolution: {integrity: sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==}
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-x64@4.2.1':
-    resolution: {integrity: sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==}
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.2.1':
-    resolution: {integrity: sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==}
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
-    resolution: {integrity: sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==}
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
-    resolution: {integrity: sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
-    resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
-    resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
-    resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
-    resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -4285,26 +4403,26 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
-    resolution: {integrity: sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
-    resolution: {integrity: sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==}
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@tailwindcss/oxide@4.2.1':
-    resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/vite@4.2.1':
-    resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
     peerDependencies:
-      vite: ^5.2.0 || ^6 || ^7
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
@@ -4579,6 +4697,19 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
   '@vitest/coverage-v8@4.1.0':
     resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
     peerDependencies:
@@ -4778,6 +4909,9 @@ packages:
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -5414,8 +5548,8 @@ packages:
     resolution: {integrity: sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==}
     engines: {node: '>=10.2.0'}
 
-  enhanced-resolve@5.20.0:
-    resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
+  enhanced-resolve@5.21.2:
+    resolution: {integrity: sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==}
     engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
@@ -6074,10 +6208,6 @@ packages:
   jay-peg@1.1.1:
     resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
 
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
-    hasBin: true
-
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -6232,74 +6362,74 @@ packages:
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
-  lightningcss-android-arm64@1.31.1:
-    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.31.1:
-    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.31.1:
-    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.31.1:
-    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.31.1:
-    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.31.1:
-    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-arm64-musl@1.31.1:
-    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-x64-gnu@1.31.1:
-    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
-  lightningcss-linux-x64-musl@1.31.1:
-    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
-  lightningcss-win32-arm64-msvc@1.31.1:
-    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.31.1:
-    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
-  lightningcss@1.31.1:
-    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   linebreak@1.1.0:
@@ -7373,6 +7503,11 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  rolldown@1.0.0-rc.18:
+    resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -7653,11 +7788,11 @@ packages:
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
-  tailwindcss@4.2.1:
-    resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-fs@2.1.4:
@@ -7948,6 +8083,49 @@ packages:
       less:
         optional: true
       lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.11:
+    resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
         optional: true
       sass:
         optional: true
@@ -9424,12 +9602,12 @@ snapshots:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/infra@0.1.13(e468de69e442b8816a24782b85e995e8)':
+  '@better-auth/infra@0.1.13(bd0fa884e4f2adc463371c57e14a5856)':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1)
-      '@better-auth/sso': 1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))
+      '@better-auth/sso': 1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
+      better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       better-call: 1.3.4(zod@4.3.6)
       jose: 6.2.1
       libphonenumber-js: 1.12.40
@@ -9452,26 +9630,26 @@ snapshots:
       '@better-auth/utils': 0.3.1
       mongodb: 7.1.0
 
-  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
+  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
+      better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       better-call: 1.3.2(zod@4.3.6)
       nanostores: 1.1.1
       zod: 4.3.6
 
-  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
+  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
+      better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       better-call: 1.3.2(zod@4.3.6)
       nanostores: 1.1.1
       zod: 4.3.6
@@ -9481,12 +9659,12 @@ snapshots:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/sso@1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))':
+  '@better-auth/sso@1.5.6(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(better-call@1.3.2(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))
+      better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       better-call: 1.3.2(zod@4.3.6)
       fast-xml-parser: 5.7.3
       jose: 6.2.3
@@ -11943,7 +12121,69 @@ snapshots:
       react: 19.2.4
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.18
+    optionalDependencies:
+      '@babel/runtime': 7.29.2
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.18': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.3)':
     dependencies:
@@ -12725,73 +12965,73 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/node@4.2.1':
+  '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.20.0
-      jiti: 2.6.1
-      lightningcss: 1.31.1
+      enhanced-resolve: 5.21.2
+      jiti: 2.7.0
+      lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.2.1
+      tailwindcss: 4.3.0
 
-  '@tailwindcss/oxide-android-arm64@4.2.1':
+  '@tailwindcss/oxide-android-arm64@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.2.1':
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
     optional: true
 
-  '@tailwindcss/oxide@4.2.1':
+  '@tailwindcss/oxide@4.3.0':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.2.1
-      '@tailwindcss/oxide-darwin-arm64': 4.2.1
-      '@tailwindcss/oxide-darwin-x64': 4.2.1
-      '@tailwindcss/oxide-freebsd-x64': 4.2.1
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.1
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.1
-      '@tailwindcss/oxide-linux-arm64-musl': 4.2.1
-      '@tailwindcss/oxide-linux-x64-gnu': 4.2.1
-      '@tailwindcss/oxide-linux-x64-musl': 4.2.1
-      '@tailwindcss/oxide-wasm32-wasi': 4.2.1
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
-      '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.2.1(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@tailwindcss/node': 4.2.1
-      '@tailwindcss/oxide': 4.2.1
-      tailwindcss: 4.2.1
-      vite: 6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/query-core@5.90.20': {}
 
@@ -13124,7 +13364,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -13132,11 +13372,19 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      babel-plugin-react-compiler: 1.0.0
+
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -13148,7 +13396,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -13159,13 +13407,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.0(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -13354,6 +13602,10 @@ snapshots:
 
   b4a@1.8.0: {}
 
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.0
+
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -13407,7 +13659,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
@@ -13428,11 +13680,11 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       mongodb: 7.1.0
-      next: 15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       pg: 8.20.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
 
@@ -13907,10 +14159,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  enhanced-resolve@5.20.0:
+  enhanced-resolve@5.21.2:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.3
 
   entities@4.5.0: {}
 
@@ -14778,8 +15030,6 @@ snapshots:
     dependencies:
       restructure: 3.0.2
 
-  jiti@2.6.1: {}
-
   jiti@2.7.0: {}
 
   jose@6.2.1: {}
@@ -14926,54 +15176,54 @@ snapshots:
       process-warning: 4.0.1
       set-cookie-parser: 2.7.2
 
-  lightningcss-android-arm64@1.31.1:
+  lightningcss-android-arm64@1.32.0:
     optional: true
 
-  lightningcss-darwin-arm64@1.31.1:
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
-  lightningcss-darwin-x64@1.31.1:
+  lightningcss-darwin-x64@1.32.0:
     optional: true
 
-  lightningcss-freebsd-x64@1.31.1:
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.31.1:
+  lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.31.1:
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.31.1:
+  lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.31.1:
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.31.1:
+  lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.31.1:
+  lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.31.1:
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
-  lightningcss@1.31.1:
+  lightningcss@1.32.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.31.1
-      lightningcss-darwin-arm64: 1.31.1
-      lightningcss-darwin-x64: 1.31.1
-      lightningcss-freebsd-x64: 1.31.1
-      lightningcss-linux-arm-gnueabihf: 1.31.1
-      lightningcss-linux-arm64-gnu: 1.31.1
-      lightningcss-linux-arm64-musl: 1.31.1
-      lightningcss-linux-x64-gnu: 1.31.1
-      lightningcss-linux-x64-musl: 1.31.1
-      lightningcss-win32-arm64-msvc: 1.31.1
-      lightningcss-win32-x64-msvc: 1.31.1
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   linebreak@1.1.0:
     dependencies:
@@ -15565,7 +15815,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next@15.1.2(@babel/core@7.24.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.1.2(@babel/core@7.24.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.1.2
       '@swc/counter': 0.1.3
@@ -15586,12 +15836,13 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.1.2
       '@next/swc-win32-x64-msvc': 15.1.2
       '@opentelemetry/api': 1.9.0
+      babel-plugin-react-compiler: 1.0.0
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.1.2
       '@swc/counter': 0.1.3
@@ -15612,6 +15863,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.1.2
       '@next/swc-win32-x64-msvc': 15.1.2
       '@opentelemetry/api': 1.9.0
+      babel-plugin-react-compiler: 1.0.0
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -16103,7 +16355,7 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-email@3.0.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-email@3.0.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@babel/core': 7.24.5
       '@babel/parser': 7.24.5
@@ -16115,7 +16367,7 @@ snapshots:
       glob: 10.3.4
       log-symbols: 4.1.0
       mime-types: 2.1.35
-      next: 15.1.2(@babel/core@7.24.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 15.1.2(@babel/core@7.24.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       normalize-path: 3.0.0
       ora: 5.4.1
       socket.io: 4.8.0
@@ -16416,6 +16668,27 @@ snapshots:
   rimraf@5.0.10:
     dependencies:
       glob: 10.5.0
+
+  rolldown@1.0.0-rc.18:
+    dependencies:
+      '@oxc-project/types': 0.128.0
+      '@rolldown/pluginutils': 1.0.0-rc.18
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.18
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.18
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.18
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.18
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
 
   rollup@4.60.3:
     dependencies:
@@ -16805,9 +17078,9 @@ snapshots:
 
   tailwind-merge@3.5.0: {}
 
-  tailwindcss@4.2.1: {}
+  tailwindcss@4.3.0: {}
 
-  tapable@2.3.0: {}
+  tapable@2.3.3: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -17135,7 +17408,7 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -17147,14 +17420,29 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
       jiti: 2.7.0
-      lightningcss: 1.31.1
+      lightningcss: 1.32.0
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0-rc.18
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.5.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.0(vite@8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -17171,7 +17459,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@25.5.0)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.11(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Summary

- Installs **React Compiler 1.0** (stable, Oct 2025) via `babel-plugin-react-compiler`, wired through `@rolldown/plugin-babel` + `reactCompilerPreset()` — the path required by `@vitejs/plugin-react@6`, which dropped its internal Babel pass for oxc.
- Bumps the toolchain: `vite` 6.4 → 8.0.11, `@vitejs/plugin-react` 4 → 6.0.1, `@tailwindcss/vite` and `tailwindcss` 4.0 → 4.3, plus `@rolldown/plugin-babel` 0.2.3 (new). Object-form `manualChunks` was converted to function form for Rolldown compatibility.
- Switches the apps/web ESLint scope to `eslint-plugin-react-hooks/configs/recommended-latest` (compiler-aware rules: `use-memo`, `preserve-manual-memoization`, `static-components`, `purity`, `set-state-in-effect`, etc).
- Strips ~50 manual `useMemo` / `useCallback` wrappers across 19 files that the compiler now subsumes — full inventory in `COMPILER_AUDIT.md`. Two memos kept on purpose: the `DefaultChatTransport` instance in `use-scout-chat.ts` (third-party identity coupling) and the existing ref-in-effect pattern in `message-view.tsx`.

Local production build dropped from ~13.5s to ~8s.

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint` (0 errors; same 106 pre-existing `react-doctor` warnings)
- [x] `pnpm --filter web build` (compiler runtime present in main + vendor; per-component cache scaffolding in 70+ chunks)
- [x] `pnpm --filter web test` (514/514)
- [x] HMR dev server serves compiler-transformed components (`useMemoCache` calls visible)
- [ ] Manual smoke-test: Scout chat session — start a thread, send messages, switch threads, verify no chat-session reset
- [ ] Manual smoke-test: `be-the-keeper` game-over flow — `handleGameOver` is now compiler-stabilised rather than `useCallback`-stabilised; verify the score-submission + leaderboard refresh still work
- [ ] Manual smoke-test: `availability/public-availability` draft-merge — complete a response, sign out, sign back in, confirm the draft re-merges correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)