### PR TITLE
Hotfix: pin RDS backup retention to 1 day (Free Plan cap)

### DIFF
--- a/docs/adrs/041-rds-backup-retention-pinned-to-free-plan-cap.md
+++ b/docs/adrs/041-rds-backup-retention-pinned-to-free-plan-cap.md
@@ -1,0 +1,46 @@
+# ADR 041: RDS backup retention pinned to 1 day until AWS Free Plan is exited
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #216 bumped `backup_retention_period` from `1` to `7` in `infra/modules/rds/main.tf` so a missed weekend backup wouldn't leave Monday morning with nothing to restore. The change applied cleanly in plan; on first apply against production (2026-05-09), AWS returned:
+
+```
+Error: updating RDS DB Instance (percy-main-production-db):
+operation error RDS: ModifyDBInstance, https response error
+StatusCode: 400, RequestID: 1a96a7c5-bc1b-4582-bb1a-9a26fc5a28c0,
+api error FreeTierRestrictionError: The specified backup retention
+period exceeds the maximum available to free tier customers. To
+remove all limitations, upgrade your account plan.
+```
+
+The account is on the AWS Free Plan (separate from "free tier" usage credits). The Free Plan caps `backup_retention_period` at 1 day for RDS — there is no Terraform-level workaround.
+
+## Decision
+
+Revert `backup_retention_period` to `1` in the RDS module. Keep the DB event subscription (`enable_event_subscription = true`) and the alarms wiring from #216 in place — those don't depend on retention length, and surface backup failures via SNS regardless.
+
+When the account moves off the Free Plan (typically when the non-profit AWS Activate credits land or billing migrates to Pay-As-You-Go), bump retention back to 7 and revisit this ADR.
+
+## Why not the alternatives
+
+- **Upgrade the AWS billing plan now.** Out of repo scope; depends on the non-profit credit timing and whoever administers the AWS account billing. Tracked separately.
+- **Take manual snapshots on a schedule** to compensate for the 1-day automated retention. Possible (Lambda + EventBridge or a workflow), but adds operational surface area for a stop-gap. Defer until Free Plan upgrade is ruled out for the long term.
+- **Multi-AZ for the durability gap** instead of longer retention. Multi-AZ also has a Free Plan restriction and would change the cost profile materially.
+
+## Consequences
+
+- Backup horizon stays at ~1 day. A missed Sunday backup means Monday's restore target is the most recent Sunday-or-later snapshot — which may be insufficient if a corruption was introduced on Friday and only spotted Monday.
+- The DB event subscription will surface "backup failed" / "backup skipped" events via the `percy-main-production-db-events` SNS topic, so the gap is visible.
+- The RDS restore drill (ADR 039) acquires extra value here: with a 1-day window, the restore path matters more, not less.
+- Issue #216 stays open with the bump-to-7 change as a follow-up; this ADR is the "why we backed off" record.
+
+## Trigger to revisit
+
+Any of:
+- AWS account moves off the Free Plan (activated Activate credits, billing change).
+- A real recovery scenario hits the 1-day window and we lose data.
+- The DB event subscription fires on a backup failure that can't be retried within the 1-day window.

--- a/docs/adrs/041-rds-backup-retention-pinned-to-free-plan-cap.md
+++ b/docs/adrs/041-rds-backup-retention-pinned-to-free-plan-cap.md
@@ -41,6 +41,7 @@ When the account moves off the Free Plan (typically when the non-profit AWS Acti
 ## Trigger to revisit
 
 Any of:
+
 - AWS account moves off the Free Plan (activated Activate credits, billing change).
 - A real recovery scenario hits the 1-day window and we lose data.
 - The DB event subscription fires on a backup failure that can't be retried within the 1-day window.

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -161,11 +161,14 @@ resource "aws_db_instance" "main" {
   vpc_security_group_ids = [var.security_group_id]
 
   publicly_accessible = false
-  # 7 days gives us a working week of recovery points; combined with
-  # multi_az = false (single AZ) this is the minimum viable RDS
-  # backup posture. A missed weekend backup no longer leaves nothing
-  # on Monday morning.
-  backup_retention_period = 7
+  # Pinned to 1 day by AWS Free Plan: ModifyDBInstance returns
+  # FreeTierRestrictionError when retention > 1. Apply with retention
+  # = 7 (#216 / ADR 041) failed in production on 2026-05-09.
+  # Revisit this when the account moves off the Free Plan; the desired
+  # value is 7 (working week of recovery points). The DB event
+  # subscription added in #216 is in place, so a missed/failed backup
+  # at least surfaces via SNS now.
+  backup_retention_period = 1
   backup_window           = "02:00-03:00"
   maintenance_window      = "mon:03:00-mon:04:00"
 


### PR DESCRIPTION
## Summary

- Production apply on 2026-05-09 (post-#249 merge) failed with `FreeTierRestrictionError`: AWS Free Plan caps `backup_retention_period` at 1.
- Reverts the 1→7 bump from #216 in `infra/modules/rds/main.tf`.
- Keeps the DB event subscription from #216 in place — backup failures still surface via SNS.
- Adds ADR 041 documenting the constraint and the trigger to revisit (account moving off Free Plan).

## Test plan

- [ ] CI passes (terraform plan production should now succeed)
- [ ] After merge, deploy.yml's `terraform-production` apply step completes without the FreeTierRestrictionError
- [ ] Verify in RDS console that the `percy-main-production-db` event subscription is wired

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)