### PR TITLE
Bug-batch-2: 10 fixes (issues 190–201, scout/health/Stripe/NR-AWS)

### DIFF
--- a/.github/workflows/deploy-api-manual.yml
+++ b/.github/workflows/deploy-api-manual.yml
@@ -208,20 +208,18 @@ jobs:
       - name: Smoke test
         id: smoke
         run: |
-          # Assert /health returns { status: "ok", database: "connected" }.
-          # 200 alone proves only the LB reaches the task; the body fields
-          # additionally prove DB connectivity. Until #193 splits to
-          # /health/ready and switches to 503-on-degraded, we body-grep.
+          # /health/ready returns 200 when ready, 503 on DB outage
+          # (#193). curl -fsSL fails non-zero on the 5xx so status
+          # alone is sufficient.
           for i in $(seq 1 10); do
-            BODY=$(curl -fsSL --max-time 10 https://api.v2.percymain.org/health || true)
-            if echo "$BODY" | jq -e '.status == "ok" and .database == "connected"' >/dev/null 2>&1; then
-              echo "Smoke test passed: $BODY"
+            if curl -fsSL --max-time 10 https://api.v2.percymain.org/health/ready -o /tmp/health.json; then
+              echo "Smoke test passed: $(cat /tmp/health.json)"
               exit 0
             fi
-            echo "Attempt $i: body=$BODY, retrying..."
+            echo "Attempt $i failed; retrying..."
             sleep 5
           done
-          echo "Smoke test failed (last body: $BODY)"
+          echo "Smoke test failed"
           exit 1
 
       - name: Record deployment in New Relic

--- a/.github/workflows/deploy-terraform-manual.yml
+++ b/.github/workflows/deploy-terraform-manual.yml
@@ -40,6 +40,10 @@ defaults:
 env:
   AWS_REGION: eu-west-2
   TF_VERSION: "1.7"
+  # NR provider — newrelic_cloud_aws_link_account in shared (#201).
+  # Workflow-level so both shared + production jobs inherit.
+  NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+  TF_VAR_newrelic_account_id: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
 
 jobs:
   terraform-shared:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -441,20 +441,19 @@ jobs:
       - name: Smoke test
         id: smoke
         run: |
-          # Assert /health returns { status: "ok", database: "connected" }.
-          # 200 alone proves only the LB reaches the task; the body fields
-          # additionally prove DB connectivity. Until #193 splits to
-          # /health/ready and switches to 503-on-degraded, we body-grep.
+          # /health/ready returns 200 with database=connected when ready,
+          # 503 with database=disconnected on DB outage (#193). curl
+          # -fsSL fails non-zero on the 5xx, so a single status check is
+          # sufficient — no body-grep needed.
           for i in $(seq 1 10); do
-            BODY=$(curl -fsSL --max-time 10 https://api.v2.percymain.org/health || true)
-            if echo "$BODY" | jq -e '.status == "ok" and .database == "connected"' >/dev/null 2>&1; then
-              echo "Smoke test passed: $BODY"
+            if curl -fsSL --max-time 10 https://api.v2.percymain.org/health/ready -o /tmp/health.json; then
+              echo "Smoke test passed: $(cat /tmp/health.json)"
               exit 0
             fi
-            echo "Attempt $i: body=$BODY, retrying..."
+            echo "Attempt $i failed; retrying..."
             sleep 5
           done
-          echo "Smoke test failed (last body: $BODY)"
+          echo "Smoke test failed"
           exit 1
 
       - name: Record deployment in New Relic

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,13 @@ jobs:
     environment: production
     env:
       TF_VERSION: "1.7"
+      # NR provider — newrelic_cloud_aws_link_account in shared (#201).
+      # Both values are REQUIRED for plan/apply against shared to
+      # succeed: the var is required (no default) and the provider
+      # validates auth at config time. Already populated in repo
+      # secrets/vars from the wave-1 NR change-marker work.
+      NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+      TF_VAR_newrelic_account_id: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -28,6 +28,10 @@ defaults:
 env:
   AWS_REGION: eu-west-2
   TF_VERSION: "1.7"
+  # NR provider (#201) — needed so drift detection can plan against
+  # the newrelic_cloud_aws_link_account resource in shared.
+  NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+  TF_VAR_newrelic_account_id: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
 
 jobs:
   drift:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -21,6 +21,9 @@ defaults:
 env:
   AWS_REGION: eu-west-2
   TF_VERSION: "1.7"
+  # NR provider — newrelic_cloud_aws_link_account in shared (#201).
+  NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+  TF_VAR_newrelic_account_id: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
 
 jobs:
   plan:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -48,16 +48,62 @@ jobs:
         working-directory: infra/environments/${{ matrix.environment }}
         run: terraform init
 
+      - name: Record job start (for stale-lock detection)
+        id: jobstart
+        run: echo "ts=$(date -u +%s)" >> "$GITHUB_OUTPUT"
+
       - name: Terraform Plan
         id: plan
         working-directory: infra/environments/${{ matrix.environment }}
         # Use PIPESTATUS so a non-zero from terraform isn't masked by tee's 0.
         # (setup-terraform's wrapper appears to break the runner's default
         # `pipefail`, so we have to check explicitly.)
+        # -lock-timeout: queue briefly behind a concurrent in-flight plan
+        # rather than failing immediately on lock contention.
         run: |
-          terraform plan -no-color -out=tfplan 2>&1 | tee plan.txt
+          terraform plan -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
           exit ${PIPESTATUS[0]}
         continue-on-error: true
+
+      - name: Release stale state lock left by cancelled plan
+        # cancel-in-progress above SIGKILLs an in-flight terraform when
+        # a new commit lands, leaving the DynamoDB lock orphaned forever.
+        # Run unconditionally: on success terraform already released the
+        # lock so this no-ops; on cancel/fail it cleans up our own mess.
+        # Guards against clobbering an unrelated active lock by checking
+        # both that the holder is a CI runner AND that the lock predates
+        # this job's start time.
+        if: always()
+        working-directory: infra/environments/${{ matrix.environment }}
+        env:
+          JOB_START_TS: ${{ steps.jobstart.outputs.ts }}
+        run: |
+          KEY="percy-main-terraform-state-bucket/${{ matrix.environment }}/terraform.tfstate-md5"
+          INFO=$(aws dynamodb get-item \
+            --region "${AWS_REGION}" \
+            --table-name percy-main-terraform-locks \
+            --key "{\"LockID\":{\"S\":\"$KEY\"}}" \
+            --query 'Item.Info.S' --output text 2>/dev/null) || INFO=""
+          if [ -z "$INFO" ] || [ "$INFO" = "None" ]; then
+            echo "No state lock held — nothing to do."
+            exit 0
+          fi
+          LOCK_ID=$(jq -r '.ID' <<<"$INFO")
+          LOCK_WHO=$(jq -r '.Who' <<<"$INFO")
+          LOCK_CREATED=$(jq -r '.Created' <<<"$INFO")
+          case "$LOCK_WHO" in
+            runner@*) ;;
+            *)
+              echo "Lock holder $LOCK_WHO is not a CI runner — leaving alone."
+              exit 0 ;;
+          esac
+          LOCK_TS=$(date -u -d "$LOCK_CREATED" +%s 2>/dev/null || echo 0)
+          if [ "$LOCK_TS" -ge "$JOB_START_TS" ]; then
+            echo "Lock was created at/after this job started ($LOCK_CREATED ≥ $JOB_START_TS) — likely active, leaving alone."
+            exit 0
+          fi
+          echo "Stale CI lock $LOCK_ID (held by $LOCK_WHO since $LOCK_CREATED) — force-unlocking."
+          terraform force-unlock -force "$LOCK_ID"
 
       - name: Plan summary
         if: always()

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -90,6 +90,44 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   const app = Fastify({
     logger: {
       level: config.LOG_LEVEL,
+      // Strip PII / secrets at the Pino layer. We need both the
+      // top-level paths (log.info({ email })) and the `*.X` wildcards
+      // (log.info({ user: { email } })) — Pino wildcards match exactly
+      // one path segment, so the bare and prefixed forms are not
+      // interchangeable. Headers paths cover OIDC / cookie auth.
+      // Add new paths here when a new sensitive field appears in any
+      // log call.
+      redact: {
+        paths: [
+          "email",
+          "password",
+          "passwordHash",
+          "token",
+          "apiKey",
+          "authorization",
+          "recipientEmail",
+          "*.email",
+          "*.password",
+          "*.passwordHash",
+          "*.token",
+          "*.apiKey",
+          "*.authorization",
+          "*.recipientEmail",
+          "*.*.email",
+          "*.*.password",
+          "*.*.token",
+          "req.headers.authorization",
+          "req.headers.cookie",
+          "req.headers['set-cookie']",
+        ],
+        censor: "[REDACTED]",
+      },
+      // Fastify's default req/res serializers + Pino's default err
+      // serializer (which captures stack, type, cause, and enumerable
+      // own props on Error subclasses) are inherited when not
+      // explicitly overridden — leaving serializers off means we get
+      // those defaults plus any custom Error subclass fields
+      // (AdsValidationError.fieldErrors, etc).
       transport:
         config.NODE_ENV !== "production"
           ? { target: "pino-pretty" }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -133,7 +133,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   app.decorate("send", send);
 
   // Create and decorate the auth instance
-  const auth = createAuth(config, dialect, send);
+  const auth = createAuth(config, dialect, send, app.log);
   app.decorate("auth", auth);
 
   // Create and decorate the S3 uploader (receipt images)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,7 +4,7 @@ import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import { createClient as createDbClient, type DB } from "@percy-main/db";
 import { createSend, type Email } from "@percy-main/email";
-import Fastify from "fastify";
+import Fastify, { type FastifyError } from "fastify";
 import {
   jsonSchemaTransform,
   serializerCompiler,
@@ -225,6 +225,31 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
     ],
   });
   await app.register(cookie);
+
+  // Custom error handler. Reasons over Fastify's default:
+  //  - Stops 4xx (deliberately thrown via Object.assign(new Error,
+  //    { statusCode: 4xx })) from polluting NR's error-rate alarm.
+  //    400/401/403/404 log at warn with kind=http_client_error.
+  //  - 5xx and unknown statuses log at error with kind=http_error.
+  //  - Pino redact (#171) handles PII in the err object;
+  //    setErrorHandler doesn't need to re-redact.
+  //  - Reply body keeps the existing { error: message } shape so
+  //    clients aren't broken.
+  app.setErrorHandler((err: FastifyError, request, reply) => {
+    const status = err.statusCode ?? 500;
+    if (status >= 500) {
+      request.log.error(
+        { err, event: "http_error", status },
+        err.message || "internal_server_error",
+      );
+    } else {
+      request.log.warn(
+        { err, event: "http_client_error", status },
+        err.message,
+      );
+    }
+    return reply.status(status).send({ error: err.message });
+  });
 
   // Register all feature routes
   await app.register(healthRoutes);

--- a/apps/api/src/features/auth/auth.ts
+++ b/apps/api/src/features/auth/auth.ts
@@ -4,6 +4,7 @@ import { ResetPassword, VerifyEmail, type Email } from "@percy-main/email";
 import { render } from "@react-email/render";
 import { betterAuth } from "better-auth";
 import { admin, twoFactor } from "better-auth/plugins";
+import type { FastifyBaseLogger } from "fastify";
 import type { PostgresDialect } from "kysely";
 import { createElement } from "react";
 import type { Config } from "../../config.ts";
@@ -12,6 +13,7 @@ export function createAuth(
   config: Config,
   dialect: PostgresDialect,
   send: (email: Email) => Promise<void>,
+  log: FastifyBaseLogger,
 ) {
   const baseURL = config.BASE_URL;
   const apiBaseURL = config.API_BASE_URL;
@@ -46,34 +48,58 @@ export function createAuth(
       enabled: true,
       requireEmailVerification: true,
       sendResetPassword: async ({ user, url }) => {
-        await send({
-          to: user.email,
-          subject: ResetPassword.subject,
-          html: await render(
-            createElement(ResetPassword.component, {
-              url,
-              imageBaseUrl: `${baseURL}/images`,
-              name: user.name,
-            }),
-            { pretty: true },
-          ),
-        });
+        try {
+          await send({
+            to: user.email,
+            subject: ResetPassword.subject,
+            html: await render(
+              createElement(ResetPassword.component, {
+                url,
+                imageBaseUrl: `${baseURL}/images`,
+                name: user.name,
+              }),
+              { pretty: true },
+            ),
+          });
+          log.info(
+            { event: "auth.email", kind: "reset", userId: user.id },
+            "auth_email_sent",
+          );
+        } catch (err) {
+          log.error(
+            { event: "auth.email", kind: "reset", userId: user.id, err },
+            "auth_email_failed",
+          );
+          throw err;
+        }
       },
     },
     emailVerification: {
       sendVerificationEmail: async ({ user, url }) => {
-        await send({
-          to: user.email,
-          subject: VerifyEmail.subject,
-          html: await render(
-            createElement(VerifyEmail.component, {
-              url,
-              imageBaseUrl: `${baseURL}/images`,
-              name: user.name,
-            }),
-            { pretty: true },
-          ),
-        });
+        try {
+          await send({
+            to: user.email,
+            subject: VerifyEmail.subject,
+            html: await render(
+              createElement(VerifyEmail.component, {
+                url,
+                imageBaseUrl: `${baseURL}/images`,
+                name: user.name,
+              }),
+              { pretty: true },
+            ),
+          });
+          log.info(
+            { event: "auth.email", kind: "verify", userId: user.id },
+            "auth_email_sent",
+          );
+        } catch (err) {
+          log.error(
+            { event: "auth.email", kind: "verify", userId: user.id, err },
+            "auth_email_failed",
+          );
+          throw err;
+        }
       },
     },
   });

--- a/apps/api/src/features/availability/routes.ts
+++ b/apps/api/src/features/availability/routes.ts
@@ -285,7 +285,11 @@ export const availabilityRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await sendNotification(request.params.requestId, request.body);
+      return await sendNotification(
+        request.params.requestId,
+        request.body,
+        request.log,
+      );
     },
   );
 

--- a/apps/api/src/features/availability/schemas.ts
+++ b/apps/api/src/features/availability/schemas.ts
@@ -263,6 +263,13 @@ export const notifySendSchema = z.object({
 
 export const notifySendResponseSchema = z.object({
   sent: z.number(),
+  failed: z.number(),
+  failures: z.array(
+    z.object({
+      email: z.string(),
+      reason: z.string(),
+    }),
+  ),
 });
 
 // ── Public request schema ──

--- a/apps/api/src/features/availability/service.ts
+++ b/apps/api/src/features/availability/service.ts
@@ -1,6 +1,7 @@
 import type { DB } from "@percy-main/db";
 import { AvailabilityRequest } from "@percy-main/email";
 import { render } from "@react-email/render";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import { createElement } from "react";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
@@ -989,7 +990,11 @@ export function sendAvailabilityNotification(
   }) => Promise<void>,
   baseUrl: string,
 ) {
-  return async (requestId: string, data: NotifySend) => {
+  return async (
+    requestId: string,
+    data: NotifySend,
+    log: FastifyBaseLogger,
+  ) => {
     // Fetch request details
     const request = await db
       .selectFrom("availability_request")
@@ -1011,27 +1016,54 @@ export function sendAvailabilityNotification(
     const url = `${baseUrl}/availability/${requestId}`;
 
     let sent = 0;
+    const failures: { email: string; reason: string }[] = [];
     for (const recipient of data.recipients) {
-      const html = await render(
-        createElement(AvailabilityRequest.component, {
-          imageBaseUrl,
-          name: recipient.name,
-          dateFrom: request.date_from,
-          dateTo: request.date_to,
-          fixtureCount,
-          url,
-        }),
-      );
-
-      await sendEmail({
-        to: recipient.email,
-        subject: AvailabilityRequest.subject,
-        html,
-      });
-      sent++;
+      // Render INSIDE the try so a render-time failure for one
+      // recipient (template throw, missing locale, etc) doesn't abort
+      // the rest of the batch — same isolation as a SES send failure.
+      try {
+        const html = await render(
+          createElement(AvailabilityRequest.component, {
+            imageBaseUrl,
+            name: recipient.name,
+            dateFrom: request.date_from,
+            dateTo: request.date_to,
+            fixtureCount,
+            url,
+          }),
+        );
+        await sendEmail({
+          to: recipient.email,
+          subject: AvailabilityRequest.subject,
+          html,
+        });
+        sent++;
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        failures.push({ email: recipient.email, reason });
+        log.warn(
+          {
+            err,
+            requestId,
+            recipientEmail: recipient.email,
+          },
+          "availability_notification_failed",
+        );
+      }
     }
 
-    return { sent };
+    if (failures.length > 0) {
+      log.warn(
+        {
+          requestId,
+          failureCount: failures.length,
+          totalCount: data.recipients.length,
+        },
+        "availability_notification_partial",
+      );
+    }
+
+    return { sent, failed: failures.length, failures };
   };
 }
 

--- a/apps/api/src/features/availability/service.ts
+++ b/apps/api/src/features/availability/service.ts
@@ -1016,7 +1016,7 @@ export function sendAvailabilityNotification(
     const url = `${baseUrl}/availability/${requestId}`;
 
     let sent = 0;
-    const failures: { email: string; reason: string }[] = [];
+    const failures: Array<{ email: string; reason: string }> = [];
     for (const recipient of data.recipients) {
       // Render INSIDE the try so a render-time failure for one
       // recipient (template throw, missing locale, etc) doesn't abort

--- a/apps/api/src/features/charges/integration.test.ts
+++ b/apps/api/src/features/charges/integration.test.ts
@@ -264,6 +264,84 @@ describe("charges service (integration)", () => {
         }),
       );
     });
+
+    it("scopes to the supplied chargeIds when provided (#93)", async () => {
+      const email = `scoped-${crypto.randomUUID()}@test.com`;
+      const { memberId } = await seedTestUser(ctx.db, { email });
+
+      const targetId = `ch-target-${crypto.randomUUID()}`;
+      const otherId = `ch-other-${crypto.randomUUID()}`;
+
+      await ctx.db
+        .insertInto("charge")
+        .values([
+          {
+            id: targetId,
+            member_id: memberId ?? "",
+            description: "Junior signup just created",
+            amount_pence: 4000,
+            charge_date: "2026-05-01",
+            created_by: "system",
+            type: "junior_membership",
+            source: "website",
+          },
+          {
+            id: otherId,
+            member_id: memberId ?? "",
+            description: "Parent's own outstanding fee",
+            amount_pence: 9000,
+            charge_date: "2026-04-01",
+            created_by: "system",
+            type: "membership",
+            source: "admin",
+          },
+        ])
+        .execute();
+
+      mockPaymentIntentsCreate.mockResolvedValue({
+        id: "pi_scoped_789",
+        client_secret: "pi_scoped_789_secret",
+      } as never);
+
+      const result = await payOutstandingCharges(ctx.db, mockStripe)(email, [
+        targetId,
+      ]);
+
+      expect(result.chargeIds).toEqual([targetId]);
+      expect(result.totalAmountPence).toBe(4000);
+
+      const charges = await getMyCharges(ctx.db)(email);
+      const other = charges.find((c) => c.id === otherId);
+      expect(other?.stripe_payment_intent_id).toBeNull();
+    });
+
+    it("ignores chargeIds belonging to a different member", async () => {
+      const email = `safety-${crypto.randomUUID()}@test.com`;
+      await seedTestUser(ctx.db, { email });
+
+      const otherEmail = `other-${crypto.randomUUID()}@test.com`;
+      const { memberId: otherMemberId } = await seedTestUser(ctx.db, {
+        email: otherEmail,
+      });
+      const otherChargeId = `ch-foreign-${crypto.randomUUID()}`;
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: otherChargeId,
+          member_id: otherMemberId ?? "",
+          description: "Foreign charge",
+          amount_pence: 5000,
+          charge_date: "2026-04-01",
+          created_by: "system",
+          type: "manual",
+          source: "admin",
+        })
+        .execute();
+
+      await expect(
+        payOutstandingCharges(ctx.db, mockStripe)(email, [otherChargeId]),
+      ).rejects.toThrow("No unpaid charges found");
+    });
   });
 
   describe("confirmPayment", () => {

--- a/apps/api/src/features/charges/routes.ts
+++ b/apps/api/src/features/charges/routes.ts
@@ -6,6 +6,7 @@ import {
   confirmPaymentResponseSchema,
   confirmPaymentSchema,
   payOutstandingResponseSchema,
+  payOutstandingSchema,
 } from "./schemas.ts";
 import {
   confirmPayment,
@@ -42,12 +43,13 @@ export const chargeRoutes: FastifyPluginAsyncZod = async (app) => {
     {
       preHandler: [requireAuth],
       schema: {
+        body: payOutstandingSchema,
         response: { 200: payOutstandingResponseSchema },
       },
     },
     async (request) => {
       const { user } = getAuthSession(request);
-      return await payOutstanding(user.email);
+      return await payOutstanding(user.email, request.body.chargeIds);
     },
   );
 

--- a/apps/api/src/features/charges/schemas.ts
+++ b/apps/api/src/features/charges/schemas.ts
@@ -6,6 +6,23 @@ export const confirmPaymentSchema = z.object({
 
 export type ConfirmPayment = z.infer<typeof confirmPaymentSchema>;
 
+/**
+ * Optional scope for pay-outstanding (#93). When `chargeIds` is set,
+ * the bundle is restricted to those charges (and only the
+ * authenticated member's). When omitted, every unpaid charge for the
+ * member is bundled — the original behaviour, kept for the members
+ * "Pay outstanding" page where the user explicitly wants \"all of it
+ * at once\".
+ */
+export const payOutstandingSchema = z.object({
+  // .min(1) so an explicit empty array doesn't silently fall through
+  // to "pay everything outstanding" — that contract requires the
+  // chargeIds key to be omitted entirely.
+  chargeIds: z.array(z.string()).min(1).optional(),
+});
+
+export type PayOutstanding = z.infer<typeof payOutstandingSchema>;
+
 const chargeSchema = z.object({
   id: z.string(),
   member_id: z.string(),

--- a/apps/api/src/features/charges/service.ts
+++ b/apps/api/src/features/charges/service.ts
@@ -27,7 +27,7 @@ export function getMyCharges(db: Kysely<DB>) {
 }
 
 export function payOutstandingCharges(db: Kysely<DB>, stripe: Stripe) {
-  return async (email: string) => {
+  return async (email: string, scopeChargeIds?: string[]) => {
     const member = await db
       .selectFrom("member")
       .where("email", "=", email)
@@ -45,12 +45,21 @@ export function payOutstandingCharges(db: Kysely<DB>, stripe: Stripe) {
     // Use a transaction with FOR UPDATE to prevent concurrent requests
     // from creating duplicate PaymentIntents for the same charges
     return await db.transaction().execute(async (trx) => {
-      const unpaidCharges = await trx
+      // When scopeChargeIds is provided (#93 — junior registration
+      // pays only the charge it created), narrow the bundle. The
+      // member_id WHERE still applies, so a malicious client passing
+      // someone else's chargeIds can only affect rows it already
+      // owned.
+      let query = trx
         .selectFrom("charge")
         .where("member_id", "=", member.id)
         .where("deleted_at", "is", null)
         .where("paid_at", "is", null)
-        .where("payment_confirmed_at", "is", null)
+        .where("payment_confirmed_at", "is", null);
+      if (scopeChargeIds && scopeChargeIds.length > 0) {
+        query = query.where("id", "in", scopeChargeIds);
+      }
+      const unpaidCharges = await query
         .select(["id", "amount_pence", "stripe_payment_intent_id"])
         .forUpdate()
         .execute();

--- a/apps/api/src/features/contact/integration.test.ts
+++ b/apps/api/src/features/contact/integration.test.ts
@@ -4,7 +4,10 @@ import {
   stopTestContainer,
   type TestContext,
 } from "../../test/containers.ts";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
 import { createContactSubmission, createEventSubscriber } from "./service.ts";
+
+const log = createNoopLogger();
 
 let ctx: TestContext;
 
@@ -21,12 +24,15 @@ describe("contact service (integration)", () => {
     it("stores a submission in the database and returns an id", async () => {
       const result = await createContactSubmission(ctx.db, {
         slackWebhookUrl: undefined,
-      })({
-        name: "Jane Doe",
-        email: "jane@example.com",
-        message: "Hello, I have a question.",
-        page: "/contact",
-      });
+      })(
+        {
+          name: "Jane Doe",
+          email: "jane@example.com",
+          message: "Hello, I have a question.",
+          page: "/contact",
+        },
+        log,
+      );
 
       expect(result.id).toBeDefined();
       expect(typeof result.id).toBe("string");

--- a/apps/api/src/features/contact/integration.test.ts
+++ b/apps/api/src/features/contact/integration.test.ts
@@ -1,10 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
 import {
   startTestContainer,
   stopTestContainer,
   type TestContext,
 } from "../../test/containers.ts";
-import { createNoopLogger } from "../../lib/worker-logger.ts";
 import { createContactSubmission, createEventSubscriber } from "./service.ts";
 
 const log = createNoopLogger();

--- a/apps/api/src/features/contact/routes.test.ts
+++ b/apps/api/src/features/contact/routes.test.ts
@@ -19,7 +19,10 @@ vi.stubGlobal("crypto", {
   randomUUID: vi.fn().mockReturnValue("test-uuid-1234"),
 });
 
+import { createNoopLogger } from "../../lib/worker-logger.ts";
 import { createContactSubmission, createEventSubscriber } from "./service.ts";
+
+const log = createNoopLogger();
 
 const db = mockQueryBuilder as unknown as Kysely<DB>;
 
@@ -40,7 +43,10 @@ describe("contact service", () => {
         page: "/about",
       };
 
-      await createContactSubmission(db, { slackWebhookUrl: undefined })(data);
+      await createContactSubmission(db, { slackWebhookUrl: undefined })(
+        data,
+        log,
+      );
 
       expect(mockQueryBuilder.insertInto).toHaveBeenCalledWith(
         "contact_submission",
@@ -64,7 +70,7 @@ describe("contact service", () => {
 
       const result = await createContactSubmission(db, {
         slackWebhookUrl: undefined,
-      })(data);
+      })(data, log);
 
       expect(result).toEqual({ id: "test-uuid-1234" });
     });

--- a/apps/api/src/features/contact/routes.ts
+++ b/apps/api/src/features/contact/routes.ts
@@ -23,7 +23,7 @@ export const contactRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await submitContact(request.body);
+      return await submitContact(request.body, request.log);
     },
   );
 

--- a/apps/api/src/features/contact/service.ts
+++ b/apps/api/src/features/contact/service.ts
@@ -1,5 +1,6 @@
 import type { DB } from "@percy-main/db";
 import { isCampaignId } from "@percy-main/shared/marketing";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import { emitMarketingEvent } from "../marketing/service.ts";
 import type { ContactSubmission, EventSubscriber } from "./schemas.ts";
@@ -30,7 +31,7 @@ export function createContactSubmission(
   const sendSlackNotification = createSlackNotifier(config.slackWebhookUrl);
   const emit = emitMarketingEvent(db);
 
-  return async (data: ContactSubmission) => {
+  return async (data: ContactSubmission, log: FastifyBaseLogger) => {
     const id = crypto.randomUUID();
 
     await db
@@ -67,13 +68,15 @@ export function createContactSubmission(
             }
           : null,
       });
-    } catch {
-      // Marketing pipeline failures must not affect the contact form response.
+    } catch (err) {
+      // Marketing pipeline failures must not affect the contact form
+      // response, but log so an SLI / alarm can fire on the warn rate.
+      log.warn({ err, submissionId: id }, "marketing_emit_failed");
     }
 
     // Fire-and-forget — don't block the response on Slack delivery
-    sendSlackNotification(data).catch(() => {
-      // Silently ignore Slack failures
+    sendSlackNotification(data).catch((err: unknown) => {
+      log.warn({ err, submissionId: id }, "slack_notify_failed");
     });
 
     return { id };

--- a/apps/api/src/features/games/routes.ts
+++ b/apps/api/src/features/games/routes.ts
@@ -54,7 +54,7 @@ export const gamesRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request) => {
       const { matchId } = request.params;
-      const game = await detail(matchId);
+      const game = await detail(matchId, request.log);
       if (!game) {
         const error = new Error("Game not found") as Error & {
           statusCode: number;

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -1,4 +1,5 @@
 import type { DB } from "@percy-main/db";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 
@@ -228,7 +229,10 @@ export function getGame(
   api: PlayCricketApiClient,
   siteId: string,
 ) {
-  return async (matchId: string): Promise<GameDetail | null> => {
+  return async (
+    matchId: string,
+    log: FastifyBaseLogger,
+  ): Promise<GameDetail | null> => {
     // Fetch match detail, DB data, and sponsorship in parallel
     // Match detail is the primary source — no season search needed
     const [
@@ -238,7 +242,15 @@ export function getGame(
       manualResult,
       confirmedMatchday,
     ] = await Promise.all([
-      api.getMatchDetail(matchId).catch(() => null),
+      api.getMatchDetail(matchId).catch((err: unknown) => {
+        // Continue with degraded behaviour but log so a PC outage
+        // can be detected via the warn rate.
+        log.warn(
+          { err, matchId },
+          "play_cricket_match_detail_unavailable",
+        );
+        return null;
+      }),
       db
         .selectFrom("match_result")
         .where("match_id", "=", matchId)

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -245,10 +245,7 @@ export function getGame(
       api.getMatchDetail(matchId).catch((err: unknown) => {
         // Continue with degraded behaviour but log so a PC outage
         // can be detected via the warn rate.
-        log.warn(
-          { err, matchId },
-          "play_cricket_match_detail_unavailable",
-        );
+        log.warn({ err, matchId }, "play_cricket_match_detail_unavailable");
         return null;
       }),
       db

--- a/apps/api/src/features/health/integration.test.ts
+++ b/apps/api/src/features/health/integration.test.ts
@@ -23,22 +23,41 @@ afterAll(async () => {
 });
 
 describe("health routes (integration)", () => {
-  it("returns ok with a connected database", async () => {
+  async function buildApp() {
     const logger = createTestLogger();
     const app = Fastify({ logger: { level: "info", stream: logger.stream } });
     app.setValidatorCompiler(validatorCompiler);
     app.setSerializerCompiler(serializerCompiler);
-    // Decorate with the test container's db so healthRoutes can use app.db
     app.decorate("db", ctx.db);
     await app.register(healthRoutes);
+    return app;
+  }
 
-    const res = await app.inject({ method: "GET", url: "/health" });
+  it("/health/live returns 200 ok regardless of DB", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/health/live" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ status: string }>()).toEqual({ status: "ok" });
+    await app.close();
+  });
 
+  it("/health/ready returns 200 with a connected database", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/health/ready" });
     expect(res.statusCode).toBe(200);
     const body = res.json<{ status: string; database: string }>();
     expect(body.status).toBe("ok");
     expect(body.database).toBe("connected");
+    await app.close();
+  });
 
+  it("/health (legacy) returns 200 with a connected database", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/health" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ status: string; database: string }>();
+    expect(body.status).toBe("ok");
+    expect(body.database).toBe("connected");
     await app.close();
   });
 });

--- a/apps/api/src/features/health/routes.ts
+++ b/apps/api/src/features/health/routes.ts
@@ -1,8 +1,76 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
-import { healthResponseSchema } from "./schemas.ts";
+import {
+  healthLiveResponseSchema,
+  healthReadyResponseSchema,
+  healthResponseSchema,
+} from "./schemas.ts";
+
+/**
+ * Three endpoints to keep the deploy story sane:
+ *
+ * - /health/live: liveness only. No deps. Used by orchestrators that
+ *   should restart the process if the event loop is wedged. Returning
+ *   200 here when the DB is down is correct — restarting the API task
+ *   on a DB outage just thrashes traffic.
+ *
+ * - /health/ready: readiness. Pings the DB. Returns 503 on failure so
+ *   ALB target groups (and any other readiness probe) drain the
+ *   instance instead of treating it as healthy. The ALB target group
+ *   in infra/modules/ecs-service.tf points here.
+ *
+ *   Caveat for production: task_count = 1 means there's only ever one
+ *   target. ALB fails open ("if all targets are unhealthy, route to
+ *   them all anyway") so 503 doesn't actually drain the box — it just
+ *   trips the unhealthy alarm so on-call notices. Real shed-traffic
+ *   would need either >1 task or a Lambda@Edge maintenance page. The
+ *   503 is still useful as a signal to NR alarms / R53 health checks.
+ *
+ * - /health: legacy shape kept for any external probes still wired to
+ *   the old endpoint. Always 200, body field reports degraded state.
+ *   Don't add new consumers; migrate them to /health/live or
+ *   /health/ready.
+ */
 
 // eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
 export const healthRoutes: FastifyPluginAsyncZod = async (app) => {
+  app.get(
+    "/health/live",
+    {
+      schema: {
+        response: { 200: healthLiveResponseSchema },
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await -- Fastify route handler signature
+    async () => ({ status: "ok" as const }),
+  );
+
+  app.get(
+    "/health/ready",
+    {
+      schema: {
+        response: {
+          200: healthReadyResponseSchema,
+          503: healthReadyResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        await app.db.selectFrom("user").select("id").limit(1).execute();
+        return {
+          status: "ok" as const,
+          database: "connected" as const,
+        };
+      } catch (err) {
+        request.log.warn({ err }, "health_ready_db_disconnected");
+        return reply.status(503).send({
+          status: "unhealthy" as const,
+          database: "disconnected" as const,
+        });
+      }
+    },
+  );
+
   app.get(
     "/health",
     {
@@ -10,11 +78,12 @@ export const healthRoutes: FastifyPluginAsyncZod = async (app) => {
         response: { 200: healthResponseSchema },
       },
     },
-    async () => {
+    async (request) => {
       try {
         await app.db.selectFrom("user").select("id").limit(1).execute();
         return { status: "ok" as const, database: "connected" as const };
-      } catch {
+      } catch (err) {
+        request.log.warn({ err }, "health_legacy_db_disconnected");
         return {
           status: "degraded" as const,
           database: "disconnected" as const,

--- a/apps/api/src/features/health/schemas.ts
+++ b/apps/api/src/features/health/schemas.ts
@@ -1,5 +1,21 @@
 import { z } from "zod";
 
+/** Liveness — process is up. Cheap (no deps). */
+export const healthLiveResponseSchema = z.object({
+  status: z.literal("ok"),
+});
+
+/** Readiness — process can serve real traffic (DB reachable). */
+export const healthReadyResponseSchema = z.object({
+  status: z.enum(["ok", "unhealthy"]),
+  database: z.enum(["connected", "disconnected"]),
+});
+
+/**
+ * Legacy `/health` shape kept for backwards compatibility — older
+ * external probes may still call it. Always returns 200 with the
+ * "degraded" string on DB outage (the legacy contract).
+ */
 export const healthResponseSchema = z.object({
   status: z.enum(["ok", "degraded"]),
   database: z.enum(["connected", "disconnected"]),

--- a/apps/api/src/features/incident-report/integration.test.ts
+++ b/apps/api/src/features/incident-report/integration.test.ts
@@ -60,7 +60,8 @@ describe("incident-report (integration)", () => {
       send,
     });
 
-    const { id } = await submit(validSubmission({
+    const { id } = await submit(
+      validSubmission({
         reporterName: "Full Submission",
         reporterPhone: "07123456789",
         affectedName: "Junior Player",
@@ -75,7 +76,9 @@ describe("incident-report (integration)", () => {
         firstAidDetails: "Ice pack applied",
         immediateActions: "Stopped training, contacted parent",
         witnesses: "Coach Smith, Player B",
-      }), log);
+      }),
+      log,
+    );
 
     const row = await ctx.db
       .selectFrom("accident_incident_report")
@@ -113,21 +116,24 @@ describe("incident-report (integration)", () => {
       send,
     });
 
-    const { id } = await submit({
-      reporterName: "Minimal",
-      reporterEmail: "minimal@example.com",
-      reporterRelationship: "visitor",
-      prefersNoContact: false,
-      affectedIsMinor: false,
-      occurredAt: "2026-04-24T10:00:00.000Z",
-      location: "Car park",
-      incidentType: "near_miss",
-      description: "Almost slipped on wet floor.",
-      injuryOccurred: false,
-      firstAidGiven: false,
-      medicalTreatmentRequired: false,
-      declarationConfirmed: true,
-    }, log);
+    const { id } = await submit(
+      {
+        reporterName: "Minimal",
+        reporterEmail: "minimal@example.com",
+        reporterRelationship: "visitor",
+        prefersNoContact: false,
+        affectedIsMinor: false,
+        occurredAt: "2026-04-24T10:00:00.000Z",
+        location: "Car park",
+        incidentType: "near_miss",
+        description: "Almost slipped on wet floor.",
+        injuryOccurred: false,
+        firstAidGiven: false,
+        medicalTreatmentRequired: false,
+        declarationConfirmed: true,
+      },
+      log,
+    );
 
     const row = await ctx.db
       .selectFrom("accident_incident_report")
@@ -183,7 +189,10 @@ describe("incident-report (integration)", () => {
       send,
     });
 
-    const { id } = await submit(validSubmission({ reporterName: "Round-trip Tester" }), log);
+    const { id } = await submit(
+      validSubmission({ reporterName: "Round-trip Tester" }),
+      log,
+    );
 
     // List finds it (status=new).
     const list = await listIncidentReports(ctx.db)({

--- a/apps/api/src/features/incident-report/integration.test.ts
+++ b/apps/api/src/features/incident-report/integration.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
 import {
   startTestContainer,
   stopTestContainer,
@@ -11,6 +12,8 @@ import {
   listIncidentReports,
   updateIncidentReport,
 } from "./service.ts";
+
+const log = createNoopLogger();
 
 // Render is React-heavy; stub it out for the integration test. We're not
 // testing email rendering here — only the DB round-trip.
@@ -57,8 +60,7 @@ describe("incident-report (integration)", () => {
       send,
     });
 
-    const { id } = await submit(
-      validSubmission({
+    const { id } = await submit(validSubmission({
         reporterName: "Full Submission",
         reporterPhone: "07123456789",
         affectedName: "Junior Player",
@@ -73,8 +75,7 @@ describe("incident-report (integration)", () => {
         firstAidDetails: "Ice pack applied",
         immediateActions: "Stopped training, contacted parent",
         witnesses: "Coach Smith, Player B",
-      }),
-    );
+      }), log);
 
     const row = await ctx.db
       .selectFrom("accident_incident_report")
@@ -126,7 +127,7 @@ describe("incident-report (integration)", () => {
       firstAidGiven: false,
       medicalTreatmentRequired: false,
       declarationConfirmed: true,
-    });
+    }, log);
 
     const row = await ctx.db
       .selectFrom("accident_incident_report")
@@ -155,10 +156,13 @@ describe("incident-report (integration)", () => {
       .select((eb) => eb.fn.countAll<string>().as("total"))
       .executeTakeFirstOrThrow();
 
-    const result = await submit({
-      ...validSubmission({ reporterEmail: "bot@example.com" }),
-      website: "http://spam.example.com",
-    } as IncidentReportSubmission);
+    const result = await submit(
+      {
+        ...validSubmission({ reporterEmail: "bot@example.com" }),
+        website: "http://spam.example.com",
+      } as IncidentReportSubmission,
+      log,
+    );
 
     // Fake id so bots can't detect rejection from the response.
     expect(result.id).toBeDefined();
@@ -179,9 +183,7 @@ describe("incident-report (integration)", () => {
       send,
     });
 
-    const { id } = await submit(
-      validSubmission({ reporterName: "Round-trip Tester" }),
-    );
+    const { id } = await submit(validSubmission({ reporterName: "Round-trip Tester" }), log);
 
     // List finds it (status=new).
     const list = await listIncidentReports(ctx.db)({
@@ -228,7 +230,7 @@ describe("incident-report (integration)", () => {
       send,
     });
 
-    const { id } = await submit(validSubmission());
+    const { id } = await submit(validSubmission(), log);
 
     await updateIncidentReport(ctx.db)(id, { riddorRequired: true });
     expect((await getIncidentReport(ctx.db)(id))?.riddorRequired).toBe(true);

--- a/apps/api/src/features/incident-report/routes.ts
+++ b/apps/api/src/features/incident-report/routes.ts
@@ -39,7 +39,7 @@ export const incidentReportRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await submit(request.body);
+      return await submit(request.body, request.log);
     },
   );
 

--- a/apps/api/src/features/incident-report/service.test.ts
+++ b/apps/api/src/features/incident-report/service.test.ts
@@ -55,6 +55,7 @@ const {
   };
 });
 
+import { createNoopLogger } from "../../lib/worker-logger.ts";
 import {
   incidentReportSubmissionSchema,
   type IncidentReportSubmission,
@@ -67,6 +68,7 @@ import {
 } from "./service.ts";
 
 const db = mockQueryBuilder as unknown as Kysely<DB>;
+const log = createNoopLogger();
 
 function validSubmission(
   overrides: Partial<IncidentReportSubmission> = {},
@@ -153,7 +155,7 @@ describe("createIncidentReportSubmission", () => {
     const result = await createIncidentReportSubmission(db, {
       baseUrl: "https://percymain.org",
       send,
-    })(validSubmission());
+    })(validSubmission(), log);
 
     expect(result.id).toBeDefined();
     expect(typeof result.id).toBe("string");
@@ -184,7 +186,7 @@ describe("createIncidentReportSubmission", () => {
     await createIncidentReportSubmission(db, {
       baseUrl: "https://percymain.org",
       send,
-    })(validSubmission({ reporterEmail: "reporter@example.com" }));
+    })(validSubmission({ reporterEmail: "reporter@example.com" }), log);
 
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledTimes(1);
@@ -207,7 +209,7 @@ describe("createIncidentReportSubmission", () => {
     await createIncidentReportSubmission(db, {
       baseUrl: "https://percymain.org",
       send,
-    })(validSubmission({ prefersNoContact: true }));
+    })(validSubmission({ prefersNoContact: true }), log);
 
     // Transactional receipt is always sent — see design Q3.
     expect(send).toHaveBeenCalledTimes(1);
@@ -220,7 +222,7 @@ describe("createIncidentReportSubmission", () => {
     const result = await createIncidentReportSubmission(db, {
       baseUrl: "https://percymain.org",
       send,
-    })(validSubmission());
+    })(validSubmission(), log);
 
     expect(typeof result.id).toBe("string");
     expect(result.id.length).toBeGreaterThan(0);
@@ -237,7 +239,7 @@ describe("createIncidentReportSubmission", () => {
       slackWebhookUrl: "https://hooks.slack.test/XYZ",
       baseUrl: "https://percymain.org",
       send,
-    })(validSubmission());
+    })(validSubmission(), log);
 
     // Slack fires fire-and-forget; give the microtask queue a tick.
     await new Promise((r) => setImmediate(r));
@@ -258,7 +260,7 @@ describe("createIncidentReportSubmission", () => {
     await createIncidentReportSubmission(db, {
       baseUrl: "https://percymain.org",
       send,
-    })(validSubmission());
+    })(validSubmission(), log);
 
     await new Promise((r) => setImmediate(r));
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -274,12 +276,15 @@ describe("createIncidentReportSubmission", () => {
       slackWebhookUrl: "https://hooks.slack.test/XYZ",
       baseUrl: "https://percymain.org",
       send,
-    })({
-      // Service receives parsed data; we bypass the schema's maxLength to
-      // simulate the insert-time guard directly.
-      ...validSubmission(),
-      website: "http://spam.example.com",
-    } as IncidentReportSubmission);
+    })(
+      {
+        // Service receives parsed data; we bypass the schema's maxLength to
+        // simulate the insert-time guard directly.
+        ...validSubmission(),
+        website: "http://spam.example.com",
+      } as IncidentReportSubmission,
+      log,
+    );
 
     // Fake id returned so the bot can't distinguish success from a drop.
     expect(result.id).toBeDefined();

--- a/apps/api/src/features/incident-report/service.ts
+++ b/apps/api/src/features/incident-report/service.ts
@@ -1,6 +1,7 @@
 import type { DB } from "@percy-main/db";
 import { IncidentReportConfirmation, type Email } from "@percy-main/email";
 import { render } from "@react-email/render";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import { createElement } from "react";
 import type {
@@ -73,7 +74,7 @@ export function createIncidentReportSubmission(
   const sendSlack = createSlackNotifier(config.slackWebhookUrl);
   const imageBaseUrl = `${config.baseUrl}/images`;
 
-  return async (data: IncidentReportSubmission) => {
+  return async (data: IncidentReportSubmission, log: FastifyBaseLogger) => {
     // Honeypot tripped — silently accept but don't persist or notify.
     if (data.website && data.website.length > 0) {
       return { id: crypto.randomUUID() };
@@ -128,8 +129,13 @@ export function createIncidentReportSubmission(
           }),
         ),
       });
-    } catch {
-      // Don't block submission on email failure.
+    } catch (err) {
+      // Don't block submission on email failure — but log at error
+      // level so safeguarding officers can chase missing audit trails.
+      log.error(
+        { err, reportId: id },
+        "incident_report_confirmation_email_failed",
+      );
     }
 
     // Fire-and-forget Slack notification.
@@ -144,8 +150,12 @@ export function createIncidentReportSubmission(
       injurySeverity: data.injurySeverity ?? null,
       description: data.description,
       adminUrl: `${config.baseUrl}/admin?tab=incidents`,
-    }).catch(() => {
-      // Silently ignore Slack failures.
+    }).catch((err: unknown) => {
+      // Don't block submission on Slack failure — but log at error
+      // level so admins can chase missing notifications. Safeguarding
+      // criticality means any failure should page on a single
+      // occurrence.
+      log.error({ err, reportId: id }, "incident_report_admin_slack_failed");
     });
 
     return { id };

--- a/apps/api/src/features/marketing/ads-client.ts
+++ b/apps/api/src/features/marketing/ads-client.ts
@@ -8,8 +8,9 @@ export class AdsValidationError extends Error {
   constructor(
     message: string,
     public readonly fieldErrors?: unknown,
+    options?: { cause?: unknown },
   ) {
-    super(message);
+    super(message, options);
     this.name = "AdsValidationError";
   }
 }
@@ -87,14 +88,19 @@ class GoogleAdsApiClient implements AdsClient {
         .partial_failure_error;
       if (partial) {
         let detail: string;
+        let stringifyError: unknown;
         try {
           detail = JSON.stringify(partial);
-        } catch {
+        } catch (err) {
+          // Likely a circular ref. Fall back to a stable string but
+          // preserve the original error so the chain ends up in NR.
           detail = Object.prototype.toString.call(partial);
+          stringifyError = err;
         }
         throw new AdsValidationError(
           `Google Ads partial_failure_error on uploadClickConversions: ${detail}`,
           partial,
+          stringifyError ? { cause: stringifyError } : undefined,
         );
       }
     } catch (err) {

--- a/apps/api/src/features/marketing/routes.ts
+++ b/apps/api/src/features/marketing/routes.ts
@@ -79,8 +79,11 @@ export const marketingRoutes: FastifyPluginAsyncZod = async (app) => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- generate_lead always creates a lead
       const leadId = result.leadId!;
 
-      // Fire-and-forget Slack notification.
-      void slackNotify({
+      // Fire-and-forget Slack notification. slackNotify currently
+      // catches internally so this `.catch` is defensive — if the body
+      // is ever changed to throw, this prevents an unhandled rejection
+      // and keeps the failure visible in NR.
+      slackNotify({
         baseUrl: app.config.BASE_URL,
         campaignId: body.campaignId,
         segment: body.segment,
@@ -90,7 +93,9 @@ export const marketingRoutes: FastifyPluginAsyncZod = async (app) => {
         notes:
           typeof body.fields?.notes === "string" ? body.fields.notes : null,
         leadId,
-      });
+      }).catch((err: unknown) =>
+        request.log.warn({ err, leadId }, "slack_notify_failed"),
+      );
 
       return { leadId };
     },

--- a/apps/api/src/features/marketing/slack.ts
+++ b/apps/api/src/features/marketing/slack.ts
@@ -25,14 +25,14 @@ export function createLeadSlackNotifier(slackWebhookUrl?: string) {
       .filter(Boolean)
       .join("\n");
 
-    try {
-      await fetch(slackWebhookUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text }),
-      });
-    } catch {
-      // Fire-and-forget — Slack failures must not affect the API response.
-    }
+    // No internal catch — let the caller's `.catch()` handle it so
+    // failures land in NR with a structured log line. The marketing
+    // route (#187) and contact service (#174) both wrap this with a
+    // .catch(err => log.warn(...)) at the call site.
+    await fetch(slackWebhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
   };
 }

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -132,7 +132,7 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
         });
       }
 
-      const image = await generateTeamNewsImage(data);
+      const image = await generateTeamNewsImage(data, request.log);
 
       return await reply
         .header("Content-Type", "image/png")

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -490,7 +490,13 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       const { user } = getAuthSession(request);
       const role = (user as { role?: string | null }).role ?? "user";
-      return await finish(user.id, role, request.params.matchId, request.body);
+      return await finish(
+        user.id,
+        role,
+        request.params.matchId,
+        request.body,
+        request.log,
+      );
     },
   );
 };

--- a/apps/api/src/features/matchday/service.test.ts
+++ b/apps/api/src/features/matchday/service.test.ts
@@ -38,8 +38,6 @@ const { mockExecute, mockExecuteTakeFirst, mockQueryBuilder } = vi.hoisted(
 
 import { noopS3Uploader } from "../../lib/s3-upload.ts";
 import { createNoopLogger } from "../../lib/worker-logger.ts";
-
-const log = createNoopLogger();
 import {
   addPlayer,
   approveExpense,
@@ -55,6 +53,8 @@ import {
   searchMembers,
   submitExpenseClaim,
 } from "./service.ts";
+
+const log = createNoopLogger();
 
 const db = mockQueryBuilder as unknown as Kysely<DB>;
 const s3 = noopS3Uploader;
@@ -445,9 +445,15 @@ describe("expense approval workflow", () => {
       // unpaid players query
       mockExecute.mockResolvedValueOnce([]);
 
-      const result = await finish("user-1", "admin", "match-1", {
-        resultType: "W",
-      }, log);
+      const result = await finish(
+        "user-1",
+        "admin",
+        "match-1",
+        {
+          resultType: "W",
+        },
+        log,
+      );
 
       expect(result.success).toBe(true);
       expect(mockQueryBuilder.set).toHaveBeenCalledWith(
@@ -474,9 +480,15 @@ describe("expense approval workflow", () => {
       // update matchday
       mockExecute.mockResolvedValueOnce([]);
 
-      const result = await finish("user-1", "admin", "match-1", {
-        resultType: "L",
-      }, log);
+      const result = await finish(
+        "user-1",
+        "admin",
+        "match-1",
+        {
+          resultType: "L",
+        },
+        log,
+      );
 
       expect(result.success).toBe(true);
       expect(result.emailsSent).toBe(0);

--- a/apps/api/src/features/matchday/service.test.ts
+++ b/apps/api/src/features/matchday/service.test.ts
@@ -37,6 +37,9 @@ const { mockExecute, mockExecuteTakeFirst, mockQueryBuilder } = vi.hoisted(
 );
 
 import { noopS3Uploader } from "../../lib/s3-upload.ts";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
+
+const log = createNoopLogger();
 import {
   addPlayer,
   approveExpense,
@@ -388,7 +391,7 @@ describe("expense approval workflow", () => {
       mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
 
       await expect(
-        finish("user-1", "admin", "match-1", { resultType: "W" }),
+        finish("user-1", "admin", "match-1", { resultType: "W" }, log),
       ).rejects.toThrow("Matchday not found");
     });
 
@@ -402,7 +405,7 @@ describe("expense approval workflow", () => {
       mockExecute.mockResolvedValueOnce([{ id: "team-1" }]);
 
       await expect(
-        finish("user-1", "admin", "match-1", { resultType: "W" }),
+        finish("user-1", "admin", "match-1", { resultType: "W" }, log),
       ).rejects.toThrow("Can only finish a confirmed matchday");
     });
 
@@ -416,7 +419,7 @@ describe("expense approval workflow", () => {
       mockExecute.mockResolvedValueOnce([]);
 
       await expect(
-        finish("user-1", "admin", "match-1", { resultType: "W" }),
+        finish("user-1", "admin", "match-1", { resultType: "W" }, log),
       ).rejects.toThrow("You do not have access to this matchday");
     });
 
@@ -444,7 +447,7 @@ describe("expense approval workflow", () => {
 
       const result = await finish("user-1", "admin", "match-1", {
         resultType: "W",
-      });
+      }, log);
 
       expect(result.success).toBe(true);
       expect(mockQueryBuilder.set).toHaveBeenCalledWith(
@@ -473,7 +476,7 @@ describe("expense approval workflow", () => {
 
       const result = await finish("user-1", "admin", "match-1", {
         resultType: "L",
-      });
+      }, log);
 
       expect(result.success).toBe(true);
       expect(result.emailsSent).toBe(0);

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -1,4 +1,5 @@
 import type { DB } from "@percy-main/db";
+import type { FastifyBaseLogger } from "fastify";
 import {
   format as formatDate,
   isBefore,
@@ -903,6 +904,7 @@ export function finishMatch(
     role: string,
     matchdayId: string,
     data: FinishMatch,
+    log: FastifyBaseLogger,
   ) => {
     const matchday = await db
       .selectFrom("matchday")
@@ -1073,9 +1075,9 @@ export function finishMatch(
           const msg =
             err instanceof Error ? err.message : "Unknown email error";
           emailErrors.push(`${player.member_email}: ${msg}`);
-          console.error(
-            `Failed to send charge notification to ${player.member_email}:`,
-            err,
+          log.error(
+            { err, recipientEmail: player.member_email, matchdayId },
+            "matchday_charge_notification_failed",
           );
         }
       }

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -1,5 +1,4 @@
 import type { DB } from "@percy-main/db";
-import type { FastifyBaseLogger } from "fastify";
 import {
   format as formatDate,
   isBefore,
@@ -7,6 +6,7 @@ import {
   startOfDay,
   subDays,
 } from "date-fns";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import type { S3Uploader } from "../../lib/s3-upload.ts";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";

--- a/apps/api/src/features/matchday/team-news-image.ts
+++ b/apps/api/src/features/matchday/team-news-image.ts
@@ -295,10 +295,7 @@ async function fetchImage(
   try {
     const res = await fetch(url);
     if (!res.ok) {
-      log.warn(
-        { url, status: res.status },
-        "team_news_image_fetch_non_ok",
-      );
+      log.warn({ url, status: res.status }, "team_news_image_fetch_non_ok");
       return null;
     }
     return Buffer.from(await res.arrayBuffer());
@@ -388,10 +385,7 @@ export async function generateTeamNewsImage(
       blend: "over",
     });
   } catch (err) {
-    log.warn(
-      { err, asset: CLUB_LOGO_PATH },
-      "team_news_image_asset_skipped",
-    );
+    log.warn({ err, asset: CLUB_LOGO_PATH }, "team_news_image_asset_skipped");
   }
 
   // Club sponsor (Crossling) — bottom-right corner, on a semi-transparent

--- a/apps/api/src/features/matchday/team-news-image.ts
+++ b/apps/api/src/features/matchday/team-news-image.ts
@@ -1,3 +1,4 @@
+import type { FastifyBaseLogger } from "fastify";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -287,18 +288,29 @@ ${playerPaths.join("\n")}
 </svg>`;
 }
 
-async function fetchImage(url: string): Promise<Buffer | null> {
+async function fetchImage(
+  url: string,
+  log: Pick<FastifyBaseLogger, "warn">,
+): Promise<Buffer | null> {
   try {
     const res = await fetch(url);
-    if (!res.ok) return null;
+    if (!res.ok) {
+      log.warn(
+        { url, status: res.status },
+        "team_news_image_fetch_non_ok",
+      );
+      return null;
+    }
     return Buffer.from(await res.arrayBuffer());
-  } catch {
+  } catch (err) {
+    log.warn({ err, url }, "team_news_image_fetch_failed");
     return null;
   }
 }
 
 export async function generateTeamNewsImage(
   data: TeamNewsData,
+  log: Pick<FastifyBaseLogger, "warn">,
 ): Promise<Buffer> {
   // Resize the photo to the canvas width preserving aspect so the entire
   // image is shown without cropping. Pad the top with a colour sampled from
@@ -338,7 +350,7 @@ export async function generateTeamNewsImage(
     left: number;
   } | null = null;
   if (data.matchSponsor?.logoUrl) {
-    const logoBuffer = await fetchImage(data.matchSponsor.logoUrl);
+    const logoBuffer = await fetchImage(data.matchSponsor.logoUrl, log);
     if (logoBuffer) {
       const resizedLogo = await sharp(logoBuffer)
         .resize({ height: 55, fit: "inside" })
@@ -375,8 +387,11 @@ export async function generateTeamNewsImage(
       left: 20,
       blend: "over",
     });
-  } catch {
-    // Skip if not found
+  } catch (err) {
+    log.warn(
+      { err, asset: CLUB_LOGO_PATH },
+      "team_news_image_asset_skipped",
+    );
   }
 
   // Club sponsor (Crossling) — bottom-right corner, on a semi-transparent
@@ -409,8 +424,11 @@ export async function generateTeamNewsImage(
       left: logoLeft,
       blend: "over",
     });
-  } catch {
-    // Skip if not found
+  } catch (err) {
+    log.warn(
+      { err, asset: CLUB_SPONSOR_PATH },
+      "team_news_image_asset_skipped",
+    );
   }
 
   // Match sponsor logo — sky band above the pitch (if present)

--- a/apps/api/src/features/og-image/routes.ts
+++ b/apps/api/src/features/og-image/routes.ts
@@ -26,7 +26,7 @@ export const ogImageRoutes: FastifyPluginAsync = async (app) => {
   // OG image endpoint — returns PNG
   app.get("/og/game/:matchId", async (request, reply) => {
     const { matchId } = parseParams(request, ogImageParamsSchema);
-    const image = await generate(matchId);
+    const image = await generate(matchId, request.log);
 
     if (!image) {
       const error = new Error("Match not found") as Error & {

--- a/apps/api/src/features/og-image/service.ts
+++ b/apps/api/src/features/og-image/service.ts
@@ -1,4 +1,5 @@
 import type { DB } from "@percy-main/db";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -240,10 +241,19 @@ async function getMatchTime(
   api: PlayCricketApiClient,
   siteId: string,
   matchId: string,
+  log: FastifyBaseLogger,
 ): Promise<string | null> {
   const currentYear = new Date().getFullYear();
   for (const season of [currentYear, currentYear - 1]) {
-    const response = await api.getMatchesSummary(season).catch(() => null);
+    const response = await api.getMatchesSummary(season).catch((err: unknown) => {
+      // Continue with degraded behaviour (no match_time) but log so a
+      // PC outage can be detected via the warn rate.
+      log.warn(
+        { err, matchId, season },
+        "play_cricket_matches_summary_unavailable",
+      );
+      return null;
+    });
     if (!response) continue;
     const match = response.matches.find((m) => m.id.toString() === matchId);
     if (match?.match_time) return match.match_time;
@@ -252,12 +262,19 @@ async function getMatchTime(
   return null;
 }
 
-async function fetchImage(url: string): Promise<Buffer | null> {
+async function fetchImage(
+  url: string,
+  log: FastifyBaseLogger,
+): Promise<Buffer | null> {
   try {
     const res = await fetch(url);
-    if (!res.ok) return null;
+    if (!res.ok) {
+      log.warn({ url, status: res.status }, "og_image_asset_fetch_non_ok");
+      return null;
+    }
     return Buffer.from(await res.arrayBuffer());
-  } catch {
+  } catch (err) {
+    log.warn({ err, url }, "og_image_asset_fetch_failed");
     return null;
   }
 }
@@ -269,9 +286,20 @@ export function generateOgImage(
   api: PlayCricketApiClient,
   siteId: string,
 ) {
-  return async (matchId: string): Promise<Buffer | null> => {
+  return async (
+    matchId: string,
+    log: FastifyBaseLogger,
+  ): Promise<Buffer | null> => {
     // Fetch match detail from Play Cricket API
-    const matchDetail = await api.getMatchDetail(matchId).catch(() => null);
+    const matchDetail = await api
+      .getMatchDetail(matchId)
+      .catch((err: unknown) => {
+        log.warn(
+          { err, matchId },
+          "play_cricket_match_detail_unavailable",
+        );
+        return null;
+      });
     if (!matchDetail) return null;
 
     const detail = matchDetail.match_details[0];
@@ -369,7 +397,7 @@ export function generateOgImage(
       teamName,
       oppositionName,
       matchDate: detail.match_date || "",
-      matchTime: await getMatchTime(api, siteId, matchId),
+      matchTime: await getMatchTime(api, siteId, matchId, log),
       outcome,
       resultDescription: detail.result_description,
       competitionName,
@@ -405,7 +433,7 @@ export function generateOgImage(
 
     // Composite sponsor logo into the footer if available
     if (matchData.sponsor?.logoUrl) {
-      const logoBuffer = await fetchImage(matchData.sponsor.logoUrl);
+      const logoBuffer = await fetchImage(matchData.sponsor.logoUrl, log);
       if (logoBuffer) {
         const resizedLogo = await sharp(logoBuffer)
           .resize({ height: 50, fit: "inside" })

--- a/apps/api/src/features/og-image/service.ts
+++ b/apps/api/src/features/og-image/service.ts
@@ -245,15 +245,17 @@ async function getMatchTime(
 ): Promise<string | null> {
   const currentYear = new Date().getFullYear();
   for (const season of [currentYear, currentYear - 1]) {
-    const response = await api.getMatchesSummary(season).catch((err: unknown) => {
-      // Continue with degraded behaviour (no match_time) but log so a
-      // PC outage can be detected via the warn rate.
-      log.warn(
-        { err, matchId, season },
-        "play_cricket_matches_summary_unavailable",
-      );
-      return null;
-    });
+    const response = await api
+      .getMatchesSummary(season)
+      .catch((err: unknown) => {
+        // Continue with degraded behaviour (no match_time) but log so a
+        // PC outage can be detected via the warn rate.
+        log.warn(
+          { err, matchId, season },
+          "play_cricket_matches_summary_unavailable",
+        );
+        return null;
+      });
     if (!response) continue;
     const match = response.matches.find((m) => m.id.toString() === matchId);
     if (match?.match_time) return match.match_time;
@@ -294,10 +296,7 @@ export function generateOgImage(
     const matchDetail = await api
       .getMatchDetail(matchId)
       .catch((err: unknown) => {
-        log.warn(
-          { err, matchId },
-          "play_cricket_match_detail_unavailable",
-        );
+        log.warn({ err, matchId }, "play_cricket_match_detail_unavailable");
         return null;
       });
     if (!matchDetail) return null;

--- a/apps/api/src/features/payments/webhook-service.ts
+++ b/apps/api/src/features/payments/webhook-service.ts
@@ -30,7 +30,10 @@ function logChargeResult(
   log: FastifyBaseLogger,
 ) {
   if (!result.created && result.reason === "no_member") {
-    log.warn(context, "Charge not created: no member found for email");
+    // Financial reconciliation issue: paid customer, no member row.
+    // Bumped from warn to error so this fires the on-call alarm —
+    // every dropped charge means a manual reconciliation later.
+    log.error(context, "charge_not_created_no_member");
   }
 }
 
@@ -592,9 +595,12 @@ export function handlePaymentIntentSucceeded({
       });
       logChargeResult(result, { email, type: "sponsorship" }, log);
     } else {
-      log.warn(
+      // Same reason as charge_not_created_no_member: paid sponsor with
+      // no email = manual reconciliation needed. Error level fires
+      // the alarm.
+      log.error(
         { paymentIntentId: paymentIntent.id, gameId: meta.gameId },
-        "Game sponsorship payment has no email — charge record not created",
+        "sponsorship_charge_not_created_no_email",
       );
     }
   }
@@ -658,12 +664,13 @@ export function handlePaymentIntentSucceeded({
       });
       logChargeResult(result, { email, type: "sponsorship" }, log);
     } else {
-      log.warn(
+      // Same reason as charge_not_created_no_member.
+      log.error(
         {
           paymentIntentId: paymentIntent.id,
           sponsorshipId: meta.sponsorshipId,
         },
-        "Player sponsorship payment has no email — charge record not created",
+        "player_sponsorship_charge_not_created_no_email",
       );
     }
   }

--- a/apps/api/src/features/payments/webhook.ts
+++ b/apps/api/src/features/payments/webhook.ts
@@ -1,11 +1,25 @@
 import type { FastifyPluginAsync } from "fastify";
 import type Stripe from "stripe";
+import { withSpan } from "../../lib/tracing.ts";
 import { createStripe } from "./stripe.ts";
 import {
   handleCheckoutCompleted,
   handleInvoicePayment,
   handlePaymentIntentSucceeded,
 } from "./webhook-service.ts";
+
+/**
+ * Marker for handler errors that are permanently terminal — schema
+ * mismatches, missing-customer references, etc — where Stripe
+ * retrying is pointless. Throw this from a handler to ack the event
+ * with 200 (no retry) while still logging the failure.
+ */
+export class StripeWebhookTerminalError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "StripeWebhookTerminalError";
+  }
+}
 
 /**
  * Stripe webhook route plugin.
@@ -68,33 +82,110 @@ export const webhookRoutes: FastifyPluginAsync = async (app) => {
           webhookSecret,
         );
       } catch (err) {
-        request.log.warn({ err }, "Webhook signature verification failed");
+        // Bumped from warn to error — bad signature is either an
+        // attacker probe or a deploy-time secret drift, neither
+        // benign.
+        request.log.error({ err }, "stripe_webhook_signature_failed");
         return reply.status(400).send({ error: "Invalid signature" });
       }
 
       request.log.info(
         { type: event.type, id: event.id },
-        "Stripe webhook received",
+        "stripe_webhook_received",
       );
 
-      switch (event.type) {
-        case "checkout.session.completed":
-        case "checkout.session.async_payment_succeeded":
-          await onCheckoutCompleted(event.data.object, event.created);
-          break;
-        case "invoice.payment_succeeded":
-          await onInvoicePayment(event.data.object, event.created);
-          break;
-        case "payment_intent.succeeded":
-          await onPaymentIntentSucceeded(event.data.object, event.created);
-          break;
-        default:
-          request.log.info(
-            { type: event.type },
-            "Unhandled webhook event type",
-          );
+      // Idempotency: Stripe delivers each event at-least-once and
+      // retries any 5xx for ~3 days. We claim the event with INSERT
+      // (or bump `attempts` on conflict) and only short-circuit when
+      // a previous attempt actually finished (`processed_at` set).
+      // A retry after a mid-handler crash will re-execute — better
+      // than silently dropping events because the marker row exists
+      // but no work was done (#179).
+      const claim = await app.db
+        .insertInto("stripe_webhook_event")
+        .values({
+          id: event.id,
+          type: event.type,
+          received_at: new Date(),
+          attempts: 1,
+        })
+        .onConflict((oc) =>
+          oc.column("id").doUpdateSet((eb) => ({
+            attempts: eb("stripe_webhook_event.attempts", "+", 1),
+          })),
+        )
+        .returning(["processed_at", "attempts"])
+        .executeTakeFirst();
+
+      if (claim?.processed_at) {
+        request.log.info(
+          {
+            eventId: event.id,
+            type: event.type,
+            attempts: claim.attempts,
+          },
+          "stripe_webhook_duplicate_skipped",
+        );
+        return reply.send({ received: true, duplicate: true });
       }
 
+      const markProcessed = async () => {
+        await app.db
+          .updateTable("stripe_webhook_event")
+          .set({ processed_at: new Date() })
+          .where("id", "=", event.id)
+          .execute();
+      };
+
+      try {
+        switch (event.type) {
+          case "checkout.session.completed":
+          case "checkout.session.async_payment_succeeded":
+            await withSpan(
+              "stripe.checkout.completed",
+              { eventId: event.id, eventType: event.type },
+              () => onCheckoutCompleted(event.data.object, event.created),
+            );
+            break;
+          case "invoice.payment_succeeded":
+            await withSpan(
+              "stripe.invoice.payment",
+              { eventId: event.id },
+              () => onInvoicePayment(event.data.object, event.created),
+            );
+            break;
+          case "payment_intent.succeeded":
+            await withSpan(
+              "stripe.payment_intent.succeeded",
+              { eventId: event.id },
+              () =>
+                onPaymentIntentSucceeded(event.data.object, event.created),
+            );
+            break;
+          default:
+            request.log.info(
+              { type: event.type },
+              "stripe_webhook_unhandled_event",
+            );
+        }
+      } catch (err) {
+        if (err instanceof StripeWebhookTerminalError) {
+          // Don't 5xx — Stripe would retry indefinitely. Log, mark
+          // processed (so retries don't reopen the event), and ack.
+          request.log.error(
+            { err, eventId: event.id, type: event.type },
+            "stripe_webhook_terminal_error",
+          );
+          await markProcessed();
+          return reply.send({ received: true, terminalError: true });
+        }
+        // Retryable — leave processed_at NULL so Stripe's next
+        // delivery reclaims and re-runs. Rethrow → Fastify 500 →
+        // Stripe retries with backoff.
+        throw err;
+      }
+
+      await markProcessed();
       return { received: true };
     });
   });

--- a/apps/api/src/features/payments/webhook.ts
+++ b/apps/api/src/features/payments/webhook.ts
@@ -158,8 +158,7 @@ export const webhookRoutes: FastifyPluginAsync = async (app) => {
             await withSpan(
               "stripe.payment_intent.succeeded",
               { eventId: event.id },
-              () =>
-                onPaymentIntentSucceeded(event.data.object, event.created),
+              () => onPaymentIntentSucceeded(event.data.object, event.created),
             );
             break;
           default:

--- a/apps/api/src/features/play-cricket/api-client.ts
+++ b/apps/api/src/features/play-cricket/api-client.ts
@@ -12,6 +12,24 @@ export interface PlayCricketApiConfig {
   siteId: string;
 }
 
+/**
+ * Static-message error so NR Errors view groups all Play Cricket
+ * failures together (path / status / bodyPreview live as properties,
+ * not in the message string). The original parse error is chained
+ * via `cause` when wrapping a JSON.parse failure.
+ */
+export class PlayCricketApiError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly status: number,
+    public readonly bodyPreview: string,
+    options?: { cause?: unknown },
+  ) {
+    super("play_cricket_api_error", options);
+    this.name = "PlayCricketApiError";
+  }
+}
+
 async function fetchPlayCricket(
   config: PlayCricketApiConfig,
   path: string,
@@ -28,16 +46,14 @@ async function fetchPlayCricket(
   const res = await fetch(url);
   const body = await res.text();
   if (!res.ok) {
-    throw new Error(
-      `Play Cricket API error (HTTP ${res.status}): ${body.slice(0, 500)}`,
-    );
+    throw new PlayCricketApiError(path, res.status, body.slice(0, 500));
   }
   try {
     return JSON.parse(body) as unknown;
-  } catch {
-    throw new Error(
-      `Play Cricket API returned non-JSON (HTTP ${res.status}): ${body.slice(0, 500)}`,
-    );
+  } catch (err) {
+    throw new PlayCricketApiError(path, res.status, body.slice(0, 500), {
+      cause: err,
+    });
   }
 }
 

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
 import {
   seedTestUser,
   startTestContainer,
@@ -9,6 +10,8 @@ import {
 import type { PlayCricketApiClient } from "./api-client.ts";
 import type { RvClient } from "./rv-client.ts";
 import { ingestRvDataForMatch } from "./rv-ingest.ts";
+
+const log = createNoopLogger();
 import type {
   RvBall,
   RvMatchOverview as RvMatchOverviewT,
@@ -468,7 +471,7 @@ describe("play-cricket sync (integration)", () => {
       }),
     });
 
-    const sync = runSync(ctx.db, api);
+    const sync = runSync(ctx.db, api, null, log);
     await sync({ siteId: SITE_ID });
 
     const teams = await ctx.db
@@ -497,7 +500,7 @@ describe("play-cricket sync (integration)", () => {
       getMatchDetail: vi.fn().mockResolvedValue(makeMatchDetail(matchId)),
     });
 
-    const sync = runSync(ctx.db, api);
+    const sync = runSync(ctx.db, api, null, log);
     const result = await sync({ siteId: SITE_ID });
 
     expect(result.matchesProcessed).toBe(1);
@@ -562,7 +565,7 @@ describe("play-cricket sync (integration)", () => {
       getMatchDetail: vi.fn().mockResolvedValue(makeMatchDetail(matchId)),
     });
 
-    const sync = runSync(ctx.db, api);
+    const sync = runSync(ctx.db, api, null, log);
     await sync({ siteId: SITE_ID });
 
     const result = await ctx.db
@@ -586,7 +589,7 @@ describe("play-cricket sync (integration)", () => {
   it("logs sync to play_cricket_sync_log", async () => {
     const api = createMockApi();
 
-    const sync = runSync(ctx.db, api);
+    const sync = runSync(ctx.db, api, null, log);
     await sync({ siteId: SITE_ID });
 
     const logs = await ctx.db
@@ -627,7 +630,7 @@ describe("play-cricket sync (integration)", () => {
         .mockResolvedValue({ matches: [makeMatchSummary(matchId, oldDatePc)] }),
     });
 
-    const sync = runSync(ctx.db, api);
+    const sync = runSync(ctx.db, api, null, log);
     const result = await sync({ siteId: SITE_ID });
 
     expect(result.matchesProcessed).toBe(0);
@@ -651,7 +654,7 @@ describe("play-cricket sync (integration)", () => {
       }),
     });
 
-    const sync = runSync(ctx.db, api);
+    const sync = runSync(ctx.db, api, null, log);
     const result = await sync({ siteId: SITE_ID });
 
     expect(result.matchesProcessed).toBe(1);
@@ -677,7 +680,7 @@ describe("play-cricket sync (integration)", () => {
       getMatchDetail: vi.fn().mockResolvedValue(matchDetail),
     });
 
-    const sync = runSync(ctx.db, api);
+    const sync = runSync(ctx.db, api, null, log);
     await sync({ siteId: SITE_ID });
 
     const result = await ctx.db
@@ -823,7 +826,7 @@ describe("ingestRvDataForMatch (integration)", () => {
       balls: [[], [ball1, ball2, wicket], []],
     });
 
-    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
 
     expect(wrote).toBe(true);
 
@@ -885,14 +888,14 @@ describe("ingestRvDataForMatch (integration)", () => {
       match: makeOverview(),
       balls: [[], [initial], []],
     });
-    await ingestRvDataForMatch(ctx.db, rvFirst, matchId, "2026-05-02");
+    await ingestRvDataForMatch(ctx.db, rvFirst, matchId, "2026-05-02", log);
 
     const rvSecond = makeMockRv({
       mapping: { rvMatchId: "7464451" },
       match: makeOverview(),
       balls: [[], [corrected], []],
     });
-    await ingestRvDataForMatch(ctx.db, rvSecond, matchId, "2026-05-02");
+    await ingestRvDataForMatch(ctx.db, rvSecond, matchId, "2026-05-02", log);
 
     const balls = await ctx.db
       .selectFrom("match_ball")
@@ -909,7 +912,7 @@ describe("ingestRvDataForMatch (integration)", () => {
     await seedMatchResult(matchId);
 
     const rv = makeMockRv({ mapping: null });
-    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
 
     expect(wrote).toBe(false);
     expect(rv.calls.mapping).toBe(1);
@@ -931,7 +934,7 @@ describe("ingestRvDataForMatch (integration)", () => {
       mapping: { rvMatchId: "7464451" },
       match: null,
     });
-    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
 
     expect(wrote).toBe(false);
     expect(rv.calls.match).toBe(1);
@@ -946,7 +949,7 @@ describe("ingestRvDataForMatch (integration)", () => {
       mapping: { rvMatchId: "7464451" },
       match: makeOverview({ MatchTeams: [] }),
     });
-    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
 
     expect(wrote).toBe(false);
     expect(rv.calls.balls).toBe(0);
@@ -965,7 +968,7 @@ describe("ingestRvDataForMatch (integration)", () => {
       balls: [[], [makeBall(0, 1)], []],
     });
 
-    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
 
     const balls = await ctx.db
       .selectFrom("match_ball")
@@ -995,7 +998,7 @@ describe("ingestRvDataForMatch (integration)", () => {
       balls: [[], [nb, wd, b, lb, none], []],
     });
 
-    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
 
     const balls = await ctx.db
       .selectFrom("match_ball")
@@ -1040,7 +1043,7 @@ describe("ingestRvDataForMatch (integration)", () => {
       balls: [[], balls, []],
     });
 
-    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
 
     const stored = await ctx.db
       .selectFrom("match_ball")
@@ -1093,7 +1096,7 @@ describe("ingestRvDataForMatch (integration)", () => {
       balls: [[], [initial, revised], []],
     });
 
-    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02");
+    await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
 
     const stored = await ctx.db
       .selectFrom("match_ball")

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -10,14 +10,14 @@ import {
 import type { PlayCricketApiClient } from "./api-client.ts";
 import type { RvClient } from "./rv-client.ts";
 import { ingestRvDataForMatch } from "./rv-ingest.ts";
-
-const log = createNoopLogger();
 import type {
   RvBall,
   RvMatchOverview as RvMatchOverviewT,
 } from "./rv-schemas.ts";
 import { getMatchDetail, getPlayerCareerStats, getTeams } from "./service.ts";
 import { runSync } from "./sync.ts";
+
+const log = createNoopLogger();
 
 // Mock RV client for the ingest tests below — wired with the same
 // curried-deps pattern as the real createRvClient. Each method returns
@@ -826,7 +826,13 @@ describe("ingestRvDataForMatch (integration)", () => {
       balls: [[], [ball1, ball2, wicket], []],
     });
 
-    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
+    const wrote = await ingestRvDataForMatch(
+      ctx.db,
+      rv,
+      matchId,
+      "2026-05-02",
+      log,
+    );
 
     expect(wrote).toBe(true);
 
@@ -912,7 +918,13 @@ describe("ingestRvDataForMatch (integration)", () => {
     await seedMatchResult(matchId);
 
     const rv = makeMockRv({ mapping: null });
-    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
+    const wrote = await ingestRvDataForMatch(
+      ctx.db,
+      rv,
+      matchId,
+      "2026-05-02",
+      log,
+    );
 
     expect(wrote).toBe(false);
     expect(rv.calls.mapping).toBe(1);
@@ -934,7 +946,13 @@ describe("ingestRvDataForMatch (integration)", () => {
       mapping: { rvMatchId: "7464451" },
       match: null,
     });
-    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
+    const wrote = await ingestRvDataForMatch(
+      ctx.db,
+      rv,
+      matchId,
+      "2026-05-02",
+      log,
+    );
 
     expect(wrote).toBe(false);
     expect(rv.calls.match).toBe(1);
@@ -949,7 +967,13 @@ describe("ingestRvDataForMatch (integration)", () => {
       mapping: { rvMatchId: "7464451" },
       match: makeOverview({ MatchTeams: [] }),
     });
-    const wrote = await ingestRvDataForMatch(ctx.db, rv, matchId, "2026-05-02", log);
+    const wrote = await ingestRvDataForMatch(
+      ctx.db,
+      rv,
+      matchId,
+      "2026-05-02",
+      log,
+    );
 
     expect(wrote).toBe(false);
     expect(rv.calls.balls).toBe(0);

--- a/apps/api/src/features/play-cricket/rv-client.test.ts
+++ b/apps/api/src/features/play-cricket/rv-client.test.ts
@@ -179,7 +179,10 @@ describe("createRvClient.getMatchMapping", () => {
       fetch: fetchMock as unknown as typeof fetch,
     });
 
-    await expect(client.getMatchMapping("123")).rejects.toThrow(/HTTP 401/);
+    await expect(client.getMatchMapping("123")).rejects.toMatchObject({
+      name: "RvApiError",
+      status: 401,
+    });
   });
 });
 

--- a/apps/api/src/features/play-cricket/rv-client.ts
+++ b/apps/api/src/features/play-cricket/rv-client.ts
@@ -1,4 +1,11 @@
 import crypto from "node:crypto";
+import {
+  RvBallsResponse,
+  RvMappingInfo,
+  RvMatchOverview,
+  type RvBall,
+  type RvMatchOverview as RvMatchOverviewType,
+} from "./rv-schemas.ts";
 
 /**
  * Static-message errors so NR Errors view groups RV failures
@@ -27,13 +34,6 @@ export class RvApiTimeoutError extends Error {
     this.name = "RvApiTimeoutError";
   }
 }
-import {
-  RvBallsResponse,
-  RvMappingInfo,
-  RvMatchOverview,
-  type RvBall,
-  type RvMatchOverview as RvMatchOverviewType,
-} from "./rv-schemas.ts";
 
 // ResultsVault read-only client. Reverse-engineered from InteractSport's
 // Match Centre SPA — see BALL_BY_BALL_FETCHING.md (local, gitignored) for

--- a/apps/api/src/features/play-cricket/rv-client.ts
+++ b/apps/api/src/features/play-cricket/rv-client.ts
@@ -1,4 +1,32 @@
 import crypto from "node:crypto";
+
+/**
+ * Static-message errors so NR Errors view groups RV failures
+ * together. Variable values (path / status / bodyPreview / timeout)
+ * live as properties.
+ */
+export class RvApiError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly status: number,
+    public readonly bodyPreview: string,
+    options?: { cause?: unknown },
+  ) {
+    super("rv_api_error", options);
+    this.name = "RvApiError";
+  }
+}
+
+export class RvApiTimeoutError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly timeoutMs: number,
+    options?: { cause?: unknown },
+  ) {
+    super("rv_api_timeout", options);
+    this.name = "RvApiTimeoutError";
+  }
+}
 import {
   RvBallsResponse,
   RvMappingInfo,
@@ -130,10 +158,7 @@ export function createRvClient(config: RvClientConfig): RvClient {
       });
     } catch (err) {
       if (ac.signal.aborted) {
-        throw new Error(
-          `ResultsVault API timeout (${String(timeoutMs)}ms) for ${url.pathname}`,
-          { cause: err },
-        );
+        throw new RvApiTimeoutError(url.pathname, timeoutMs, { cause: err });
       }
       throw err;
     } finally {
@@ -142,17 +167,15 @@ export function createRvClient(config: RvClientConfig): RvClient {
     if (res.status === 404) return { status: 404, body: null };
     const text = await res.text();
     if (!res.ok) {
-      throw new Error(
-        `ResultsVault API error (HTTP ${String(res.status)}) for ${url.pathname}: ${text.slice(0, 300)}`,
-      );
+      throw new RvApiError(url.pathname, res.status, text.slice(0, 300));
     }
     let parsed: unknown;
     try {
       parsed = JSON.parse(text);
-    } catch {
-      throw new Error(
-        `ResultsVault API returned non-JSON for ${url.pathname}: ${text.slice(0, 300)}`,
-      );
+    } catch (err) {
+      throw new RvApiError(url.pathname, res.status, text.slice(0, 300), {
+        cause: err,
+      });
     }
     return { status: res.status, body: parsed };
   }

--- a/apps/api/src/features/play-cricket/rv-ingest.ts
+++ b/apps/api/src/features/play-cricket/rv-ingest.ts
@@ -1,4 +1,5 @@
 import type { DB } from "@percy-main/db";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import type { RvClient } from "./rv-client.ts";
 import { parseMsDate } from "./rv-client.ts";
@@ -39,6 +40,7 @@ export async function ingestRvDataForMatch(
   rv: RvClient,
   pcMatchId: string,
   matchDateIso: string,
+  log: FastifyBaseLogger,
 ): Promise<boolean> {
   const mapping = await rv.getMatchMapping(pcMatchId);
   if (!mapping) return false;
@@ -74,6 +76,7 @@ export async function ingestRvDataForMatch(
         rvMatchId: mapping.rvMatchId,
         rvResultId: String(team.result_id),
         anchorMs: anchor?.getTime() ?? null,
+        log,
       });
     }
   }
@@ -189,6 +192,7 @@ interface UpsertBallsContext {
   rvMatchId: string;
   rvResultId: string;
   anchorMs: number | null;
+  log: FastifyBaseLogger;
 }
 
 async function upsertBalls(
@@ -223,8 +227,15 @@ async function upsertBalls(
       // store null and surface a warning so we notice and add the
       // mapping. Match + ball coordinates are enough to find the row in
       // RV later for verification.
-      console.warn(
-        `[rv-ingest] unmapped extras_type ${JSON.stringify(b.extras_type)} on match=${ctx.matchId} innings=${String(b.innings_number)} over=${String(b.over_no)} ball=${String(b.ball_no)}`,
+      ctx.log.warn(
+        {
+          extrasType: b.extras_type,
+          matchId: ctx.matchId,
+          innings: b.innings_number,
+          over: b.over_no,
+          ball: b.ball_no,
+        },
+        "rv_ingest_unmapped_extras_type",
       );
     }
     return {

--- a/apps/api/src/features/play-cricket/sync.test.ts
+++ b/apps/api/src/features/play-cricket/sync.test.ts
@@ -1,6 +1,7 @@
 import type { DB } from "@percy-main/db";
 import type { Kysely } from "kysely";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
 import type { PlayCricketApiClient } from "./api-client.ts";
 import {
   didBat,
@@ -9,6 +10,8 @@ import {
   parseDismissalType,
   runSync,
 } from "./sync.ts";
+
+const log = createNoopLogger();
 
 // --- Helper tests ---
 
@@ -169,7 +172,7 @@ describe("runSync", () => {
   });
 
   it("returns zero matches when no matches exist", async () => {
-    const sync = runSync(mockDb, mockApi);
+    const sync = runSync(mockDb, mockApi, null, log);
     const result = await sync({ siteId: "134" });
 
     expect(result.matchesProcessed).toBe(0);
@@ -181,7 +184,7 @@ describe("runSync", () => {
   });
 
   it("syncs extra seasons", async () => {
-    const sync = runSync(mockDb, mockApi);
+    const sync = runSync(mockDb, mockApi, null, log);
     await sync({ siteId: "134", extraSeasons: [2024, 2025] });
 
     /* eslint-disable @typescript-eslint/unbound-method -- vi.fn() mocks */
@@ -220,7 +223,7 @@ describe("runSync", () => {
     // Mark it as already processed
     mockSelectExecute.mockResolvedValueOnce([{ match_id: "12345" }]);
 
-    const sync = runSync(mockDb, mockApi);
+    const sync = runSync(mockDb, mockApi, null, log);
     const result = await sync({ siteId: "134" });
 
     expect(result.matchesProcessed).toBe(0);
@@ -281,7 +284,7 @@ describe("runSync", () => {
     // Mark it as already processed
     mockSelectExecute.mockResolvedValueOnce([{ match_id: "12345" }]);
 
-    const sync = runSync(mockDb, mockApi);
+    const sync = runSync(mockDb, mockApi, null, log);
     await sync({ siteId: "134" });
 
     // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock
@@ -293,7 +296,7 @@ describe("runSync", () => {
       getTeams: vi.fn().mockRejectedValue(new Error("Unauthorized")),
     });
 
-    const sync = runSync(mockDb, mockApi);
+    const sync = runSync(mockDb, mockApi, null, log);
     const result = await sync({ siteId: "134" });
 
     expect(result.errors).toHaveLength(1);
@@ -302,7 +305,7 @@ describe("runSync", () => {
   });
 
   it("logs sync result to play_cricket_sync_log", async () => {
-    const sync = runSync(mockDb, mockApi);
+    const sync = runSync(mockDb, mockApi, null, log);
     await sync({ siteId: "134" });
 
     // Should have called insertInto for the sync log

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -577,6 +577,12 @@ async function syncMatches(
         try {
           await ingestRvDataForMatch(db, rv, matchId, matchDateIso, log);
         } catch (rvErr) {
+          // Log via Pino so the stack + cause survive (the array push
+          // stringifies and loses both — kept for the DB log row).
+          log.error(
+            { err: rvErr, matchId },
+            "play_cricket_sync_rv_ingest_failed",
+          );
           errors.push(
             `RV ingest failed for match ${matchId}: ${
               rvErr instanceof Error ? rvErr.message : String(rvErr)
@@ -587,6 +593,7 @@ async function syncMatches(
 
       matchesProcessed++;
     } catch (err) {
+      log.error({ err, matchId }, "play_cricket_sync_match_failed");
       const msg = `Error processing match ${matchId}: ${err instanceof Error ? err.message : String(err)}`;
       errors.push(msg);
     }
@@ -641,12 +648,26 @@ export function runSync(
         const season = String(new Date().getFullYear());
         await calculateFantasyScores(db)(season);
       } catch (scoringErr) {
-        result.errors.push(`Fantasy scoring failed: ${String(scoringErr)}`);
+        // Log via Pino so the stack survives — the array push
+        // String()s the error and loses the trace.
+        log.error(
+          { err: scoringErr },
+          "play_cricket_sync_fantasy_scoring_failed",
+        );
+        result.errors.push(
+          `Fantasy scoring failed: ${
+            scoringErr instanceof Error ? scoringErr.message : String(scoringErr)
+          }`,
+        );
       }
 
       return result;
     } catch (err) {
-      // Try to log the failure
+      // Top-level sync failure. Log via Pino BEFORE the DB write so
+      // the breadcrumb survives even if the DB itself is the cause
+      // of the failure.
+      log.error({ err }, "play_cricket_sync_failed");
+
       try {
         await db
           .insertInto("play_cricket_sync_log")
@@ -656,11 +677,19 @@ export function runSync(
             completed_at: new Date().toISOString(),
             season: new Date().getFullYear(),
             matches_processed: 0,
-            errors: JSON.stringify([String(err)]),
+            errors: JSON.stringify([
+              err instanceof Error ? err.message : String(err),
+            ]),
           })
           .execute();
-      } catch {
-        // Swallow logging failure
+      } catch (logErr) {
+        // The DB write itself failed. Surface it instead of swallowing
+        // — without this, an outage that takes down both the sync and
+        // the log table is invisible.
+        log.error(
+          { err: logErr, originalErr: err },
+          "play_cricket_sync_log_write_failed",
+        );
       }
 
       throw err;

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -656,7 +656,9 @@ export function runSync(
         );
         result.errors.push(
           `Fantasy scoring failed: ${
-            scoringErr instanceof Error ? scoringErr.message : String(scoringErr)
+            scoringErr instanceof Error
+              ? scoringErr.message
+              : String(scoringErr)
           }`,
         );
       }

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -1,4 +1,5 @@
 import type { DB } from "@percy-main/db";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 
 import type { z } from "zod";
@@ -351,6 +352,7 @@ async function syncMatches(
   rv: RvClient | null,
   config: SyncConfig,
   startTime: number,
+  log: FastifyBaseLogger,
 ): Promise<SyncResult> {
   const { siteId } = config;
   const errors: string[] = [];
@@ -573,7 +575,7 @@ async function syncMatches(
       // up once the result lands.
       if (rv && shouldWriteResult) {
         try {
-          await ingestRvDataForMatch(db, rv, matchId, matchDateIso);
+          await ingestRvDataForMatch(db, rv, matchId, matchDateIso, log);
         } catch (rvErr) {
           errors.push(
             `RV ingest failed for match ${matchId}: ${
@@ -607,6 +609,7 @@ export function runSync(
   db: Kysely<DB>,
   api: PlayCricketApiClient,
   rv: RvClient | null = null,
+  log: FastifyBaseLogger,
 ) {
   return async (config: SyncConfig): Promise<SyncResult> => {
     const logId = crypto.randomUUID();
@@ -614,7 +617,7 @@ export function runSync(
     const startTime = Date.now();
 
     try {
-      const result = await syncMatches(db, api, rv, config, startTime);
+      const result = await syncMatches(db, api, rv, config, startTime, log);
 
       // Log the sync
       await db

--- a/apps/api/src/features/scout/agent.test.ts
+++ b/apps/api/src/features/scout/agent.test.ts
@@ -4,6 +4,7 @@ import type { Kysely } from "kysely";
 import { describe, expect, it } from "vitest";
 import type { Config } from "../../config.ts";
 import type { ScoutReportStore } from "../../lib/s3-scout-reports.ts";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 import { createScoutAgent } from "./agent.ts";
 
@@ -39,6 +40,7 @@ function makeAgent(mode: "chat" | "debrief" | "scout" = "chat") {
     mode,
     scoutReports: stubScoutReports,
     thinkingMode: "thinking",
+    logger: createNoopLogger(),
   });
 }
 

--- a/apps/api/src/features/scout/agent.ts
+++ b/apps/api/src/features/scout/agent.ts
@@ -63,7 +63,7 @@ export interface ScoutAgentDeps {
   // the assistant's prose. The route wraps streamText in createUIMessageStream
   // and passes the resulting writer down.
   writer: UIMessageStreamWriter;
-  logger?: FastifyBaseLogger;
+  logger: FastifyBaseLogger;
   // Fact-RAG dependencies. Optional so the agent can boot without a Voyage
   // API key — the fact_record / fact_retrieve tools are simply omitted in
   // that case. userId is the authenticated caller; threadId is attached to

--- a/apps/api/src/features/scout/attachments/service.ts
+++ b/apps/api/src/features/scout/attachments/service.ts
@@ -184,121 +184,125 @@ export function commitAttachment(deps: AttachmentDeps) {
       "scout.attachment.commit",
       { attachmentId: input.attachmentId, threadId: input.threadId },
       async () => {
-    const row = await loadOwnedRow(deps, input);
+        const row = await loadOwnedRow(deps, input);
 
-    // Idempotent: re-calling on a 'ready' row is a no-op. Failed rows can
-    // be retried by re-uploading from scratch (FE removes the chip first).
-    if (row.processing_state === "ready") {
-      return rowToSummary(row);
-    }
-    if (row.processing_state !== "awaiting-upload") {
-      throw new AttachmentInvalidStateError(
-        row.processing_state as ProcessingState,
-      );
-    }
-    if (!row.pending_key) {
-      // Defensive: mint always sets pending_key. If we hit this branch,
-      // the row is corrupt — fail closed rather than silently re-upload.
-      throw new AttachmentInvalidStateError("failed");
-    }
+        // Idempotent: re-calling on a 'ready' row is a no-op. Failed rows can
+        // be retried by re-uploading from scratch (FE removes the chip first).
+        if (row.processing_state === "ready") {
+          return rowToSummary(row);
+        }
+        if (row.processing_state !== "awaiting-upload") {
+          throw new AttachmentInvalidStateError(
+            row.processing_state as ProcessingState,
+          );
+        }
+        if (!row.pending_key) {
+          // Defensive: mint always sets pending_key. If we hit this branch,
+          // the row is corrupt — fail closed rather than silently re-upload.
+          throw new AttachmentInvalidStateError("failed");
+        }
 
-    // Race guard: only the first concurrent caller flips
-    // awaiting-upload → processing. Subsequent callers find 0 affected
-    // rows and bail with the row's current state (likely 'processing' or
-    // 'ready') so we never run derive twice or clobber a sibling's ready
-    // row with our own failure.
-    const claimResult = await deps.db
-      .updateTable("scout_attachment")
-      .set({ processing_state: "processing" satisfies ProcessingState })
-      .where("id", "=", row.id)
-      .where(
-        "processing_state",
-        "=",
-        "awaiting-upload" satisfies ProcessingState,
-      )
-      .executeTakeFirst();
-    if (Number(claimResult.numUpdatedRows) === 0) {
-      // Another caller has already claimed this attachment. Re-load and
-      // either return the ready summary (idempotent) or surface the
-      // current state.
-      const fresh = await loadOwnedRow(deps, input);
-      if (fresh.processing_state === "ready") return rowToSummary(fresh);
-      throw new AttachmentInvalidStateError(
-        fresh.processing_state as ProcessingState,
-      );
-    }
+        // Race guard: only the first concurrent caller flips
+        // awaiting-upload → processing. Subsequent callers find 0 affected
+        // rows and bail with the row's current state (likely 'processing' or
+        // 'ready') so we never run derive twice or clobber a sibling's ready
+        // row with our own failure.
+        const claimResult = await deps.db
+          .updateTable("scout_attachment")
+          .set({ processing_state: "processing" satisfies ProcessingState })
+          .where("id", "=", row.id)
+          .where(
+            "processing_state",
+            "=",
+            "awaiting-upload" satisfies ProcessingState,
+          )
+          .executeTakeFirst();
+        if (Number(claimResult.numUpdatedRows) === 0) {
+          // Another caller has already claimed this attachment. Re-load and
+          // either return the ready summary (idempotent) or surface the
+          // current state.
+          const fresh = await loadOwnedRow(deps, input);
+          if (fresh.processing_state === "ready") return rowToSummary(fresh);
+          throw new AttachmentInvalidStateError(
+            fresh.processing_state as ProcessingState,
+          );
+        }
 
-    try {
-      const head = await deps.store.headPending(row.pending_key);
-      if (!head) {
-        throw new AttachmentMissingError();
-      }
-      if (head.contentLength !== row.size_bytes) {
-        throw new AttachmentSizeMismatchError(
-          row.size_bytes,
-          head.contentLength,
-        );
-      }
+        try {
+          const head = await deps.store.headPending(row.pending_key);
+          if (!head) {
+            throw new AttachmentMissingError();
+          }
+          if (head.contentLength !== row.size_bytes) {
+            throw new AttachmentSizeMismatchError(
+              row.size_bytes,
+              head.contentLength,
+            );
+          }
 
-      const bytes = await deps.store.getPending(row.pending_key);
-      const contentHash = createHash("sha256").update(bytes).digest("hex");
+          const bytes = await deps.store.getPending(row.pending_key);
+          const contentHash = createHash("sha256").update(bytes).digest("hex");
 
-      const derived = await deps.derive({
-        kind: row.kind as AttachmentKind,
-        contentHash,
-        contentType: row.content_type,
-        bytes,
-      });
+          const derived = await deps.derive({
+            kind: row.kind as AttachmentKind,
+            contentHash,
+            contentType: row.content_type,
+            bytes,
+          });
 
-      const ext = extensionForContentType(row.content_type);
-      const permanentKey = await deps.store.copyToPermanent(
-        row.pending_key,
-        row.thread_id,
-        row.id,
-        ext,
-        row.content_type,
-      );
+          const ext = extensionForContentType(row.content_type);
+          const permanentKey = await deps.store.copyToPermanent(
+            row.pending_key,
+            row.thread_id,
+            row.id,
+            ext,
+            row.content_type,
+          );
 
-      const updated = await deps.db
-        .updateTable("scout_attachment")
-        .set({
-          processing_state: "ready" satisfies ProcessingState,
-          derived_text: derived.derivedText,
-          content_hash: contentHash,
-          s3_key: permanentKey,
-        })
-        .where("id", "=", row.id)
-        .returningAll()
-        .executeTakeFirstOrThrow();
+          const updated = await deps.db
+            .updateTable("scout_attachment")
+            .set({
+              processing_state: "ready" satisfies ProcessingState,
+              derived_text: derived.derivedText,
+              content_hash: contentHash,
+              s3_key: permanentKey,
+            })
+            .where("id", "=", row.id)
+            .returningAll()
+            .executeTakeFirstOrThrow();
 
-      // Best-effort: 24h S3 lifecycle reaps the object if this fails.
-      void deps.store
-        .deletePending(row.pending_key)
-        .catch((err: unknown) =>
-          deps.log.warn(
-            { err, key: row.pending_key, kind: "s3_cleanup" },
-            "s3_cleanup_failed",
-          ),
-        );
+          // Best-effort: 24h S3 lifecycle reaps the object if this fails.
+          void deps.store
+            .deletePending(row.pending_key)
+            .catch((err: unknown) =>
+              deps.log.warn(
+                { err, key: row.pending_key, kind: "s3_cleanup" },
+                "s3_cleanup_failed",
+              ),
+            );
 
-      return rowToSummary(updated);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      // Only flip to failed if we still own the row (state = 'processing').
-      // A concurrent caller that won the claim race is responsible for its
-      // own state — without this guard, a late-failing call could overwrite
-      // a sibling's 'ready' state.
-      await deps.db
-        .updateTable("scout_attachment")
-        .set({
-          processing_state: "failed" satisfies ProcessingState,
-          processing_error: message.slice(0, 500),
-        })
-        .where("id", "=", row.id)
-        .where("processing_state", "=", "processing" satisfies ProcessingState)
-        .execute();
-      throw err;
-    }
+          return rowToSummary(updated);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          // Only flip to failed if we still own the row (state = 'processing').
+          // A concurrent caller that won the claim race is responsible for its
+          // own state — without this guard, a late-failing call could overwrite
+          // a sibling's 'ready' state.
+          await deps.db
+            .updateTable("scout_attachment")
+            .set({
+              processing_state: "failed" satisfies ProcessingState,
+              processing_error: message.slice(0, 500),
+            })
+            .where("id", "=", row.id)
+            .where(
+              "processing_state",
+              "=",
+              "processing" satisfies ProcessingState,
+            )
+            .execute();
+          throw err;
+        }
       },
     );
 }

--- a/apps/api/src/features/scout/attachments/service.ts
+++ b/apps/api/src/features/scout/attachments/service.ts
@@ -1,5 +1,6 @@
 import type { DB } from "@percy-main/db";
 import type { ModelMessage } from "ai";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import { createHash } from "node:crypto";
 import type { z } from "zod";
@@ -57,6 +58,7 @@ export interface AttachmentDeps {
   maxImageBytes: number;
   maxPdfBytes: number;
   uploadUrlExpirySeconds: number;
+  log: FastifyBaseLogger;
 }
 
 export class AttachmentSizeTooLargeError extends Error {
@@ -265,7 +267,14 @@ export function commitAttachment(deps: AttachmentDeps) {
         .executeTakeFirstOrThrow();
 
       // Best-effort: 24h S3 lifecycle reaps the object if this fails.
-      void deps.store.deletePending(row.pending_key).catch(() => undefined);
+      void deps.store
+        .deletePending(row.pending_key)
+        .catch((err: unknown) =>
+          deps.log.warn(
+            { err, key: row.pending_key, kind: "s3_cleanup" },
+            "s3_cleanup_failed",
+          ),
+        );
 
       return rowToSummary(updated);
     } catch (err) {
@@ -322,10 +331,24 @@ export function deleteAttachment(deps: AttachmentDeps) {
 
     // Best-effort: orphaned bytes are tolerated per Track 1 design notes.
     if (row.s3_key) {
-      void deps.store.deletePermanent(row.s3_key).catch(() => undefined);
+      void deps.store
+        .deletePermanent(row.s3_key)
+        .catch((err: unknown) =>
+          deps.log.warn(
+            { err, key: row.s3_key, kind: "s3_cleanup" },
+            "s3_cleanup_failed",
+          ),
+        );
     }
     if (row.pending_key) {
-      void deps.store.deletePending(row.pending_key).catch(() => undefined);
+      void deps.store
+        .deletePending(row.pending_key)
+        .catch((err: unknown) =>
+          deps.log.warn(
+            { err, key: row.pending_key, kind: "s3_cleanup" },
+            "s3_cleanup_failed",
+          ),
+        );
     }
   };
 }

--- a/apps/api/src/features/scout/attachments/service.ts
+++ b/apps/api/src/features/scout/attachments/service.ts
@@ -5,6 +5,7 @@ import type { Kysely } from "kysely";
 import { createHash } from "node:crypto";
 import type { z } from "zod";
 import type { ScoutAttachmentStore } from "../../../lib/s3-scout-attachments.ts";
+import { withSpan } from "../../../lib/tracing.ts";
 import type {
   AttachmentKind,
   attachmentProcessingStateSchema,
@@ -178,7 +179,11 @@ export interface CommitInput {
 }
 
 export function commitAttachment(deps: AttachmentDeps) {
-  return async (input: CommitInput): Promise<AttachmentSummary> => {
+  return async (input: CommitInput): Promise<AttachmentSummary> =>
+    withSpan(
+      "scout.attachment.commit",
+      { attachmentId: input.attachmentId, threadId: input.threadId },
+      async () => {
     const row = await loadOwnedRow(deps, input);
 
     // Idempotent: re-calling on a 'ready' row is a no-op. Failed rows can
@@ -294,7 +299,8 @@ export function commitAttachment(deps: AttachmentDeps) {
         .execute();
       throw err;
     }
-  };
+      },
+    );
 }
 
 export function getAttachment(deps: AttachmentDeps) {

--- a/apps/api/src/features/scout/knowledge/launch.ts
+++ b/apps/api/src/features/scout/knowledge/launch.ts
@@ -8,10 +8,10 @@ import { runIngest, type RunIngestDeps } from "./run-ingest.ts";
  * worker can extract them and create its root span as a child. See
  * launch.ts in scout/report for the full rationale.
  */
-function tracepartEnvOverrides(): { name: string; value: string }[] {
+function tracepartEnvOverrides(): Array<{ name: string; value: string }> {
   const carrier: Record<string, string> = {};
   propagation.inject(context.active(), carrier);
-  const out: { name: string; value: string }[] = [];
+  const out: Array<{ name: string; value: string }> = [];
   if (carrier.traceparent) {
     out.push({ name: "OTEL_TRACEPARENT", value: carrier.traceparent });
   }

--- a/apps/api/src/features/scout/knowledge/launch.ts
+++ b/apps/api/src/features/scout/knowledge/launch.ts
@@ -41,7 +41,7 @@ export async function launchScoutKbIngest({
     // before throwing, so the top-level catch is purely belt-and-braces
     // logging.
     void runIngest(inProcessDeps, documentId).catch((err: unknown) => {
-      inProcessDeps.logger?.error(
+      inProcessDeps.logger.error(
         { err, documentId },
         "scout_kb_in_process_runner_failed",
       );
@@ -97,7 +97,7 @@ export async function launchScoutKbIngest({
     throw new ScoutKbLaunchError("ECS RunTask returned no task ARN");
   }
 
-  inProcessDeps.logger?.info(
+  inProcessDeps.logger.info(
     { documentId, taskArn },
     "scout_kb_worker_launched",
   );

--- a/apps/api/src/features/scout/knowledge/launch.ts
+++ b/apps/api/src/features/scout/knowledge/launch.ts
@@ -1,6 +1,25 @@
 import { ECSClient, RunTaskCommand } from "@aws-sdk/client-ecs";
+import { context, propagation } from "@opentelemetry/api";
 import type { Config } from "../../../config.ts";
 import { runIngest, type RunIngestDeps } from "./run-ingest.ts";
+
+/**
+ * Inject the active OTel context into env-var carriers so the spawned
+ * worker can extract them and create its root span as a child. See
+ * launch.ts in scout/report for the full rationale.
+ */
+function tracepartEnvOverrides(): { name: string; value: string }[] {
+  const carrier: Record<string, string> = {};
+  propagation.inject(context.active(), carrier);
+  const out: { name: string; value: string }[] = [];
+  if (carrier.traceparent) {
+    out.push({ name: "OTEL_TRACEPARENT", value: carrier.traceparent });
+  }
+  if (carrier.tracestate) {
+    out.push({ name: "OTEL_TRACESTATE", value: carrier.tracestate });
+  }
+  return out;
+}
 
 export interface LaunchScoutKbOpts {
   config: Config;
@@ -76,8 +95,20 @@ export async function launchScoutKbIngest({
         containerOverrides: [
           {
             name: "api",
-            command: ["node", "apps/api/dist/scout-knowledge-worker.js"],
-            environment: [{ name: "KB_DOCUMENT_ID", value: documentId }],
+            // Mirror the API's `start` script: --import boots the OTel
+            // SDK before any worker code runs. Without it the SDK is
+            // never registered, the propagator can't extract from env,
+            // and the OTEL_TRACEPARENT injected here would be inert.
+            command: [
+              "node",
+              "--import",
+              "./apps/api/dist/instrumentation.js",
+              "apps/api/dist/scout-knowledge-worker.js",
+            ],
+            environment: [
+              { name: "KB_DOCUMENT_ID", value: documentId },
+              ...tracepartEnvOverrides(),
+            ],
           },
         ],
       },

--- a/apps/api/src/features/scout/knowledge/run-ingest.ts
+++ b/apps/api/src/features/scout/knowledge/run-ingest.ts
@@ -28,7 +28,7 @@ export interface RunIngestDeps {
   anthropicModel: LanguageModel | null;
   scoutKnowledgeBase: S3KnowledgeBaseStore;
   config: Config;
-  logger?: FastifyBaseLogger;
+  logger: FastifyBaseLogger;
 }
 
 export class IngestNotFoundError extends Error {
@@ -64,7 +64,7 @@ export async function runIngest(
     if (!exists) {
       throw new IngestNotFoundError(documentId);
     }
-    logger?.info(
+    logger.info(
       { documentId, status: exists.status },
       "scout_kb_ingest_skipped_non_queued",
     );
@@ -117,7 +117,7 @@ export async function runIngest(
       .where("id", "=", documentId)
       .execute();
 
-    logger?.info(
+    logger.info(
       {
         documentId,
         filename: claimed.filename,
@@ -133,7 +133,7 @@ export async function runIngest(
         : err instanceof Error
           ? err.message
           : String(err);
-    logger?.error(
+    logger.error(
       { err, documentId, filename: claimed.filename },
       "scout_kb_ingest_failed",
     );

--- a/apps/api/src/features/scout/knowledge/service.ts
+++ b/apps/api/src/features/scout/knowledge/service.ts
@@ -280,90 +280,90 @@ export function commitDocument(deps: KbDeps) {
     withSpan("scout.kb.commit", { documentId: id }, async () => {
       const row = await loadRow(deps, id);
 
-    if (row.status === "queued" || row.status === "ingesting") {
-      // Idempotent: already past commit. Surface what we have.
-      if (!row.s3_key || !row.content_hash) {
-        throw new KbDocumentInvalidStateError(row.status);
+      if (row.status === "queued" || row.status === "ingesting") {
+        // Idempotent: already past commit. Surface what we have.
+        if (!row.s3_key || !row.content_hash) {
+          throw new KbDocumentInvalidStateError(row.status);
+        }
+        return {
+          id: row.id,
+          status: row.status,
+          contentHash: row.content_hash,
+          s3Key: row.s3_key,
+        };
       }
-      return {
-        id: row.id,
-        status: row.status,
-        contentHash: row.content_hash,
-        s3Key: row.s3_key,
-      };
-    }
-    if (row.status !== "awaiting-upload" && row.status !== "failed") {
-      throw new KbDocumentInvalidStateError(row.status as DocumentStatus);
-    }
-    if (!row.pending_key) {
-      throw new KbDocumentInvalidStateError(row.status as DocumentStatus);
-    }
+      if (row.status !== "awaiting-upload" && row.status !== "failed") {
+        throw new KbDocumentInvalidStateError(row.status as DocumentStatus);
+      }
+      if (!row.pending_key) {
+        throw new KbDocumentInvalidStateError(row.status as DocumentStatus);
+      }
 
-    const ct = ALLOWED_CONTENT_TYPES[row.content_type];
-    if (!ct) {
-      throw new KbUnsupportedContentTypeError(row.content_type);
-    }
+      const ct = ALLOWED_CONTENT_TYPES[row.content_type];
+      if (!ct) {
+        throw new KbUnsupportedContentTypeError(row.content_type);
+      }
 
-    const head = await deps.store.headPending(row.pending_key);
-    if (!head) {
-      throw new KbUploadMissingError();
-    }
-    if (head.contentLength !== row.size_bytes) {
-      throw new KbUploadSizeMismatchError(row.size_bytes, head.contentLength);
-    }
+      const head = await deps.store.headPending(row.pending_key);
+      if (!head) {
+        throw new KbUploadMissingError();
+      }
+      if (head.contentLength !== row.size_bytes) {
+        throw new KbUploadSizeMismatchError(row.size_bytes, head.contentLength);
+      }
 
-    const bytes = await deps.store.getPending(row.pending_key);
-    const contentHash = createHash("sha256").update(bytes).digest("hex");
+      const bytes = await deps.store.getPending(row.pending_key);
+      const contentHash = createHash("sha256").update(bytes).digest("hex");
 
-    // Hash dedup: another committed (= populated content_hash) doc
-    // with the same bytes already exists.
-    const existing = await deps.db
-      .selectFrom("scout_kb_document")
-      .where("content_hash", "=", contentHash)
-      .where("id", "!=", id)
-      .select(["id"])
-      .executeTakeFirst();
-    if (existing) {
-      throw new KbDuplicateContentError(existing.id);
-    }
+      // Hash dedup: another committed (= populated content_hash) doc
+      // with the same bytes already exists.
+      const existing = await deps.db
+        .selectFrom("scout_kb_document")
+        .where("content_hash", "=", contentHash)
+        .where("id", "!=", id)
+        .select(["id"])
+        .executeTakeFirst();
+      if (existing) {
+        throw new KbDuplicateContentError(existing.id);
+      }
 
-    const permanentKey = await deps.store.copyToPermanent(
-      row.pending_key,
-      id,
-      ct.ext,
-      row.content_type,
-    );
-
-    await deps.db
-      .updateTable("scout_kb_document")
-      .set({
-        status: "queued" satisfies DocumentStatus,
-        content_hash: contentHash,
-        s3_key: permanentKey,
-        pending_key: null,
-        error_message: null,
-        updated_at: new Date(),
-      })
-      .where("id", "=", id)
-      .execute();
-
-    // Best-effort cleanup of the uploads-bucket object. The 24h
-    // lifecycle is the safety net.
-    void deps.store
-      .deletePending(row.pending_key)
-      .catch((err: unknown) =>
-        deps.log.warn(
-          { err, key: row.pending_key, kind: "s3_cleanup" },
-          "s3_cleanup_failed",
-        ),
+      const permanentKey = await deps.store.copyToPermanent(
+        row.pending_key,
+        id,
+        ct.ext,
+        row.content_type,
       );
 
-    return {
-      id,
-      status: "queued",
-      contentHash,
-      s3Key: permanentKey,
-    };
+      await deps.db
+        .updateTable("scout_kb_document")
+        .set({
+          status: "queued" satisfies DocumentStatus,
+          content_hash: contentHash,
+          s3_key: permanentKey,
+          pending_key: null,
+          error_message: null,
+          updated_at: new Date(),
+        })
+        .where("id", "=", id)
+        .execute();
+
+      // Best-effort cleanup of the uploads-bucket object. The 24h
+      // lifecycle is the safety net.
+      void deps.store
+        .deletePending(row.pending_key)
+        .catch((err: unknown) =>
+          deps.log.warn(
+            { err, key: row.pending_key, kind: "s3_cleanup" },
+            "s3_cleanup_failed",
+          ),
+        );
+
+      return {
+        id,
+        status: "queued",
+        contentHash,
+        s3Key: permanentKey,
+      };
     });
 }
 

--- a/apps/api/src/features/scout/knowledge/service.ts
+++ b/apps/api/src/features/scout/knowledge/service.ts
@@ -433,13 +433,13 @@ export function deleteDocument(deps: KbDeps) {
     }
     if (row.pending_key) {
       void deps.store
-      .deletePending(row.pending_key)
-      .catch((err: unknown) =>
-        deps.log.warn(
-          { err, key: row.pending_key, kind: "s3_cleanup" },
-          "s3_cleanup_failed",
-        ),
-      );
+        .deletePending(row.pending_key)
+        .catch((err: unknown) =>
+          deps.log.warn(
+            { err, key: row.pending_key, kind: "s3_cleanup" },
+            "s3_cleanup_failed",
+          ),
+        );
     }
   };
 }

--- a/apps/api/src/features/scout/knowledge/service.ts
+++ b/apps/api/src/features/scout/knowledge/service.ts
@@ -1,4 +1,5 @@
 import type { DB } from "@percy-main/db";
+import type { FastifyBaseLogger } from "fastify";
 import { CompiledQuery, type Kysely, sql } from "kysely";
 import { createHash } from "node:crypto";
 import type { S3KnowledgeBaseStore } from "../../../lib/s3-knowledge-base.ts";
@@ -123,6 +124,7 @@ export interface KbDeps {
   voyage?: VoyageClient;
   maxDocumentBytes: number;
   uploadUrlExpirySeconds: number;
+  log: FastifyBaseLogger;
 }
 
 // ── List ──
@@ -345,7 +347,14 @@ export function commitDocument(deps: KbDeps) {
 
     // Best-effort cleanup of the uploads-bucket object. The 24h
     // lifecycle is the safety net.
-    void deps.store.deletePending(row.pending_key).catch(() => undefined);
+    void deps.store
+      .deletePending(row.pending_key)
+      .catch((err: unknown) =>
+        deps.log.warn(
+          { err, key: row.pending_key, kind: "s3_cleanup" },
+          "s3_cleanup_failed",
+        ),
+      );
 
     return {
       id,
@@ -413,10 +422,24 @@ export function deleteDocument(deps: KbDeps) {
     // Best-effort S3 cleanup. Orphaned bytes are tolerated — Scout
     // is admin-only, low volume.
     if (row.s3_key) {
-      void deps.store.deleteDocument(row.s3_key).catch(() => undefined);
+      void deps.store
+        .deleteDocument(row.s3_key)
+        .catch((err: unknown) =>
+          deps.log.warn(
+            { err, key: row.s3_key, kind: "s3_cleanup" },
+            "s3_cleanup_failed",
+          ),
+        );
     }
     if (row.pending_key) {
-      void deps.store.deletePending(row.pending_key).catch(() => undefined);
+      void deps.store
+      .deletePending(row.pending_key)
+      .catch((err: unknown) =>
+        deps.log.warn(
+          { err, key: row.pending_key, kind: "s3_cleanup" },
+          "s3_cleanup_failed",
+        ),
+      );
     }
   };
 }

--- a/apps/api/src/features/scout/knowledge/service.ts
+++ b/apps/api/src/features/scout/knowledge/service.ts
@@ -3,6 +3,7 @@ import type { FastifyBaseLogger } from "fastify";
 import { CompiledQuery, type Kysely, sql } from "kysely";
 import { createHash } from "node:crypto";
 import type { S3KnowledgeBaseStore } from "../../../lib/s3-knowledge-base.ts";
+import { withSpan } from "../../../lib/tracing.ts";
 import { type FactTags, factTagsSchema } from "../facts/service.ts";
 import { type VoyageClient, toVectorLiteral } from "../facts/voyage.ts";
 
@@ -275,8 +276,9 @@ export interface CommitResult {
 }
 
 export function commitDocument(deps: KbDeps) {
-  return async (id: string): Promise<CommitResult> => {
-    const row = await loadRow(deps, id);
+  return async (id: string): Promise<CommitResult> =>
+    withSpan("scout.kb.commit", { documentId: id }, async () => {
+      const row = await loadRow(deps, id);
 
     if (row.status === "queued" || row.status === "ingesting") {
       // Idempotent: already past commit. Surface what we have.
@@ -362,7 +364,7 @@ export function commitDocument(deps: KbDeps) {
       contentHash,
       s3Key: permanentKey,
     };
-  };
+    });
 }
 
 // ── Patch ──

--- a/apps/api/src/features/scout/report/launch.ts
+++ b/apps/api/src/features/scout/report/launch.ts
@@ -55,7 +55,7 @@ export async function launchScoutReport({
     // are already persisted to the row's error_message before the throw, so
     // a top-level catch here is purely belt-and-braces logging.
     void runReport(inProcessDeps, reportId).catch((err: unknown) => {
-      inProcessDeps.logger?.error(
+      inProcessDeps.logger.error(
         { err, reportId },
         "scout_report_in_process_runner_failed",
       );
@@ -114,7 +114,7 @@ export async function launchScoutReport({
     throw new ScoutReportLaunchError("ECS RunTask returned no task ARN");
   }
 
-  inProcessDeps.logger?.info(
+  inProcessDeps.logger.info(
     { reportId, taskArn },
     "scout_report_worker_launched",
   );

--- a/apps/api/src/features/scout/report/launch.ts
+++ b/apps/api/src/features/scout/report/launch.ts
@@ -14,10 +14,10 @@ import { runReport, type RunReportDeps } from "./run-report.ts";
  * no traceparent is available (instrumentation not booted, or this
  * request runs outside a span).
  */
-function tracepartEnvOverrides(): { name: string; value: string }[] {
+function tracepartEnvOverrides(): Array<{ name: string; value: string }> {
   const carrier: Record<string, string> = {};
   propagation.inject(context.active(), carrier);
-  const out: { name: string; value: string }[] = [];
+  const out: Array<{ name: string; value: string }> = [];
   if (carrier.traceparent) {
     out.push({ name: "OTEL_TRACEPARENT", value: carrier.traceparent });
   }

--- a/apps/api/src/features/scout/report/launch.ts
+++ b/apps/api/src/features/scout/report/launch.ts
@@ -1,6 +1,31 @@
 import { ECSClient, RunTaskCommand } from "@aws-sdk/client-ecs";
+import { context, propagation } from "@opentelemetry/api";
 import type { Config } from "../../../config.ts";
 import { runReport, type RunReportDeps } from "./run-report.ts";
+
+/**
+ * Inject the active OTel context into env-var carriers (traceparent +
+ * tracestate) so the spawned worker can extract them and create its
+ * root span as a child of the API span. Without this the worker spans
+ * land on a separate trace tree in NR and end-to-end latency
+ * correlation is impossible.
+ *
+ * Returns ECS containerOverrides environment entries; empty list when
+ * no traceparent is available (instrumentation not booted, or this
+ * request runs outside a span).
+ */
+function tracepartEnvOverrides(): { name: string; value: string }[] {
+  const carrier: Record<string, string> = {};
+  propagation.inject(context.active(), carrier);
+  const out: { name: string; value: string }[] = [];
+  if (carrier.traceparent) {
+    out.push({ name: "OTEL_TRACEPARENT", value: carrier.traceparent });
+  }
+  if (carrier.tracestate) {
+    out.push({ name: "OTEL_TRACESTATE", value: carrier.tracestate });
+  }
+  return out;
+}
 
 export interface LaunchScoutReportOpts {
   config: Config;
@@ -93,8 +118,20 @@ export async function launchScoutReport({
         containerOverrides: [
           {
             name: "api",
-            command: ["node", "apps/api/dist/scout-report-worker.js"],
-            environment: [{ name: "REPORT_ID", value: reportId }],
+            // Mirror the API's `start` script: --import boots the OTel
+            // SDK before any worker code runs. Without it the SDK is
+            // never registered, the propagator can't extract from env,
+            // and the OTEL_TRACEPARENT injected here would be inert.
+            command: [
+              "node",
+              "--import",
+              "./apps/api/dist/instrumentation.js",
+              "apps/api/dist/scout-report-worker.js",
+            ],
+            environment: [
+              { name: "REPORT_ID", value: reportId },
+              ...tracepartEnvOverrides(),
+            ],
           },
         ],
       },

--- a/apps/api/src/features/scout/report/report-agent.ts
+++ b/apps/api/src/features/scout/report/report-agent.ts
@@ -37,7 +37,7 @@ export interface ReportAgentDeps {
   config: Config;
   voyage?: VoyageClient;
   userId: string;
-  logger?: FastifyBaseLogger;
+  logger: FastifyBaseLogger;
   /** Optional external cancellation signal — combined with the internal
    *  timeout so a worker-level cancel (user clicked Stop on an in-flight
    *  report) aborts the AI SDK loop. */
@@ -232,7 +232,7 @@ Build the report now via the tool surface above. Stop calling tools when you've 
 
   const runOnce = async (extra: string, attempt: number): Promise<void> => {
     const stepStart = Date.now();
-    deps.logger?.info(
+    deps.logger.info(
       {
         matchId: params.matchId,
         attempt,
@@ -259,7 +259,7 @@ Build the report now via the tool surface above. Stop calling tools when you've 
           : AbortSignal.timeout(deps.config.SCOUT_REPORT_TIMEOUT_MS),
         onStepFinish: ({ toolCalls, finishReason }) => {
           stepIndex += 1;
-          deps.logger?.info(
+          deps.logger.info(
             {
               matchId: params.matchId,
               attempt,
@@ -272,7 +272,7 @@ Build the report now via the tool surface above. Stop calling tools when you've 
           );
         },
       });
-      deps.logger?.info(
+      deps.logger.info(
         {
           matchId: params.matchId,
           attempt,
@@ -298,9 +298,9 @@ Build the report now via the tool surface above. Stop calling tools when you've 
         elapsedMs: Date.now() - stepStart,
       };
       if (isCancelled) {
-        deps.logger?.info(logFields, "scout_report_agent_step_cancelled");
+        deps.logger.info(logFields, "scout_report_agent_step_cancelled");
       } else {
-        deps.logger?.error(logFields, "scout_report_agent_step_failed");
+        deps.logger.error(logFields, "scout_report_agent_step_failed");
       }
       if (isTimeout) {
         throw new Error(
@@ -323,7 +323,7 @@ Build the report now via the tool surface above. Stop calling tools when you've 
     // for a long-tail recovery. Hard-fail loud; runReport persists the
     // message to scout_report.error_message so the captain sees it.
     if (assembled.reason === "missing") {
-      deps.logger?.error(
+      deps.logger.error(
         { matchId: params.matchId, missing: assembled.missing },
         "scout_report_agent_missing_sections",
       );
@@ -331,7 +331,7 @@ Build the report now via the tool surface above. Stop calling tools when you've 
         `Report agent finished without calling required sections: ${assembled.missing.join(", ")}.`,
       );
     }
-    deps.logger?.error(
+    deps.logger.error(
       { matchId: params.matchId, schemaError: assembled.message },
       "scout_report_agent_schema_invalid",
     );
@@ -340,7 +340,7 @@ Build the report now via the tool surface above. Stop calling tools when you've 
     );
   }
 
-  deps.logger?.info(
+  deps.logger.info(
     {
       matchId: params.matchId,
       citations: citations.size(),

--- a/apps/api/src/features/scout/report/run-report.ts
+++ b/apps/api/src/features/scout/report/run-report.ts
@@ -21,7 +21,7 @@ export interface RunReportDeps {
   config: Config;
   voyage?: VoyageClient;
   scoutReports: ScoutReportStore;
-  logger?: FastifyBaseLogger;
+  logger: FastifyBaseLogger;
 }
 
 export class ReportCancelledError extends Error {
@@ -99,7 +99,7 @@ export async function runReport(
       .where("id", "=", reportId)
       .executeTakeFirst();
     if (!existing) throw new ReportNotFoundError(reportId);
-    logger?.warn(
+    logger.warn(
       { reportId, status: existing.status },
       "scout_report_worker_skip_already_claimed_or_finished",
     );
@@ -148,7 +148,7 @@ export async function runReport(
         abortController.abort(new ReportCancelledError());
       }
     } catch (err) {
-      logger?.warn({ err, reportId }, "scout_report_flush_failed");
+      logger.warn({ err, reportId }, "scout_report_flush_failed");
     }
   };
 
@@ -231,7 +231,7 @@ export async function runReport(
       try {
         await deps.scoutReports.deleteReport(s3Key);
       } catch (cleanupErr) {
-        logger?.warn(
+        logger.warn(
           { err: cleanupErr, reportId, s3Key },
           "scout_report_s3_cleanup_after_db_failure_also_failed; lifecycle rule will sweep",
         );
@@ -239,7 +239,7 @@ export async function runReport(
       throw updateErr;
     }
 
-    logger?.info(
+    logger.info(
       { reportId, bytes: pdf.length, ms: Date.now() - startedAt },
       "scout_report_generated",
     );
@@ -261,17 +261,17 @@ export async function runReport(
       .where("id", "=", reportId)
       .execute()
       .catch((dbErr: unknown) => {
-        logger?.error(
+        logger.error(
           { err: dbErr, reportId },
           "scout_report_failed_status_update_failed",
         );
       });
 
     if (cancelled) {
-      logger?.info({ reportId }, "scout_report_cancelled");
+      logger.info({ reportId }, "scout_report_cancelled");
       return;
     }
-    logger?.error(
+    logger.error(
       { err, reportId, ms: Date.now() - startedAt },
       "scout_report_failed",
     );

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -755,6 +755,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
               {
                 event: "scout.turn",
                 threadId,
+                userId: user.id,
                 provider: app.config.SCOUT_PROVIDER_CHAT,
                 model: app.config.SCOUT_MODEL_CHAT,
                 inputTokens,

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -681,7 +681,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
           // tools to recover. Voyage errors carry structured detail
           // (status, endpoint, raw body) on the error itself; pino picks
           // them up automatically from the err field.
-          app.log.error(
+          request.log.error(
             { err, threadId },
             "scout: auto-retrieval failed; continuing without fact injection",
           );
@@ -731,7 +731,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
             });
             await bump(threadId);
             if (isAborted) {
-              app.log.warn(
+              request.log.warn(
                 { event: "scout.turn_aborted", threadId },
                 "scout turn aborted; persisted partial assistant message",
               );
@@ -753,7 +753,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
               inputTokens > 0 && cacheRead != null
                 ? Number((cacheRead / (inputTokens + cacheRead)).toFixed(3))
                 : null;
-            app.log.info(
+            request.log.info(
               {
                 event: "scout.turn",
                 threadId,
@@ -770,7 +770,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
               "scout turn complete",
             );
           } catch (err) {
-            app.log.error(
+            request.log.error(
               { err, threadId },
               "scout: failed to persist assistant message",
             );
@@ -804,7 +804,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
             prepareStep: agent.prepareStep,
             providerOptions: agent.providerOptions,
             onError: ({ error }) => {
-              app.log.error(
+              request.log.error(
                 { err: sanitizeError(error) },
                 "scout streamText error",
               );
@@ -838,7 +838,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
           // Returning that to the FE leaks operational state of our account
           // to anyone with Scout access, so we log the full sanitized error
           // server-side and surface a generic string to the UI.
-          app.log.error({ err: sanitizeError(error) }, "scout UI stream error");
+          request.log.error({ err: sanitizeError(error) }, "scout UI stream error");
           return "Scout failed to respond. Please try again.";
         },
       });
@@ -975,7 +975,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
         // as 500. The service has already flipped the row to 'failed' and
         // populated processing_error, so the FE can show a chip with a
         // retry option.
-        app.log.error(
+        request.log.error(
           { err, threadId, attachmentId },
           "scout: attachment commit failed",
         );
@@ -1278,7 +1278,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
         try {
           await app.scoutReports.deleteReport(s3Key);
         } catch (s3Err) {
-          app.log.warn(
+          request.log.warn(
             { err: s3Err, s3Key },
             "scout report S3 delete failed; lifecycle rule will clean up",
           );
@@ -1414,7 +1414,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
             documentId: id,
           });
         } catch (launchErr) {
-          app.log.error(
+          request.log.error(
             { err: launchErr, documentId: id },
             "scout KB worker launch failed",
           );
@@ -1573,7 +1573,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
             documentId: id,
           });
         } catch (launchErr) {
-          app.log.error(
+          request.log.error(
             { err: launchErr, documentId: id },
             "scout KB reingest worker launch failed",
           );
@@ -1700,7 +1700,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
             documentId: result.documentId,
           });
         } catch (launchErr) {
-          app.log.error(
+          request.log.error(
             { err: launchErr, documentId: result.documentId },
             "scout KB bridge worker launch failed",
           );

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -838,7 +838,10 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
           // Returning that to the FE leaks operational state of our account
           // to anyone with Scout access, so we log the full sanitized error
           // server-side and surface a generic string to the UI.
-          request.log.error({ err: sanitizeError(error) }, "scout UI stream error");
+          request.log.error(
+            { err: sanitizeError(error) },
+            "scout UI stream error",
+          );
           return "Scout failed to respond. Please try again.";
         },
       });

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -184,6 +184,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
     maxPdfBytes: app.config.SCOUT_ATTACHMENT_MAX_PDF_BYTES,
     uploadUrlExpirySeconds:
       app.config.SCOUT_ATTACHMENT_UPLOAD_URL_EXPIRY_SECONDS,
+    log: app.log,
   };
   const mintAtt = mintAttachment(attachmentDeps);
   const commitAtt = commitAttachment(attachmentDeps);
@@ -210,6 +211,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
     voyage: kbVoyage,
     maxDocumentBytes: app.config.SCOUT_KB_MAX_DOCUMENT_BYTES,
     uploadUrlExpirySeconds: app.config.SCOUT_KB_UPLOAD_URL_EXPIRY_SECONDS,
+    log: app.log,
   };
   const kbList = listDocuments(kbDeps);
   const kbGet = getDocument(kbDeps);

--- a/apps/api/src/features/scout/tools/generate-report.ts
+++ b/apps/api/src/features/scout/tools/generate-report.ts
@@ -21,7 +21,7 @@ export interface GenerateReportToolDeps {
   writer: UIMessageStreamWriter;
   userId: string;
   threadId: string;
-  logger?: FastifyBaseLogger;
+  logger: FastifyBaseLogger;
 }
 
 const generateReportInputSchema = z.object({

--- a/apps/api/src/features/scout/tools/knowledge.ts
+++ b/apps/api/src/features/scout/tools/knowledge.ts
@@ -59,7 +59,7 @@ export interface KbToolDeps {
   threadId?: string;
   /** Optional UI stream writer; cite_kb streams citation parts when present. */
   writer?: UIMessageStreamWriter;
-  logger?: FastifyBaseLogger;
+  logger: FastifyBaseLogger;
 }
 
 export function createKnowledgeTools(deps: KbToolDeps) {
@@ -73,6 +73,7 @@ export function createKnowledgeTools(deps: KbToolDeps) {
     // route layer and tool layer; we pass dummy non-zero defaults.
     maxDocumentBytes: 1,
     uploadUrlExpirySeconds: 1,
+    log: logger,
   });
 
   return {

--- a/apps/api/src/features/sponsorship/routes.ts
+++ b/apps/api/src/features/sponsorship/routes.ts
@@ -219,7 +219,7 @@ export const sponsorshipRoutes: FastifyPluginAsyncZod = async (app) => {
         }
       }
 
-      return await createGamePayment(data);
+      return await createGamePayment(data, request.log);
     },
   );
 
@@ -259,7 +259,7 @@ export const sponsorshipRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await createPayment(request.body);
+      return await createPayment(request.body, request.log);
     },
   );
 

--- a/apps/api/src/features/sponsorship/service.ts
+++ b/apps/api/src/features/sponsorship/service.ts
@@ -2,6 +2,14 @@ import type { DB } from "@percy-main/db";
 import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import Stripe from "stripe";
+import type {
+  GameSponsorshipManual,
+  GameSponsorshipPayment,
+  PlayerSponsorshipManual,
+  PlayerSponsorshipPayment,
+  SponsorshipList,
+  SponsorshipUpdate,
+} from "./schemas.ts";
 
 /**
  * Cancel a Stripe payment intent, swallowing the expected
@@ -30,14 +38,6 @@ async function cancelPaymentIntentTolerantly(
     throw err;
   }
 }
-import type {
-  GameSponsorshipManual,
-  GameSponsorshipPayment,
-  PlayerSponsorshipManual,
-  PlayerSponsorshipPayment,
-  SponsorshipList,
-  SponsorshipUpdate,
-} from "./schemas.ts";
 
 async function fetchStripePriceInfo(stripe: Stripe, priceId: string) {
   const price = await stripe.prices.retrieve(priceId, {

--- a/apps/api/src/features/sponsorship/service.ts
+++ b/apps/api/src/features/sponsorship/service.ts
@@ -1,6 +1,35 @@
 import type { DB } from "@percy-main/db";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
-import type Stripe from "stripe";
+import Stripe from "stripe";
+
+/**
+ * Cancel a Stripe payment intent, swallowing the expected
+ * "already cancelled / never existed" cases (which Stripe returns as
+ * StripeInvalidRequestError with code payment_intent_unexpected_state
+ * or resource_missing) and logging+rethrowing genuine errors so a
+ * Stripe outage isn't silently masked.
+ */
+async function cancelPaymentIntentTolerantly(
+  stripe: Stripe,
+  paymentIntentId: string,
+  log: FastifyBaseLogger,
+): Promise<void> {
+  try {
+    await stripe.paymentIntents.cancel(paymentIntentId);
+  } catch (err) {
+    if (
+      err instanceof Stripe.errors.StripeInvalidRequestError &&
+      (err.code === "payment_intent_unexpected_state" ||
+        err.code === "resource_missing")
+    ) {
+      // Already cancelled or never existed — expected; nothing to do.
+      return;
+    }
+    log.warn({ err, paymentIntentId }, "stripe_cancel_failed");
+    throw err;
+  }
+}
 import type {
   GameSponsorshipManual,
   GameSponsorshipPayment,
@@ -391,7 +420,7 @@ export function createGameSponsorshipPayment(
   stripe: Stripe,
   gameSponsorshipPriceId: string,
 ) {
-  return async (data: GameSponsorshipPayment) => {
+  return async (data: GameSponsorshipPayment, log: FastifyBaseLogger) => {
     // Validate logo size
     if (data.sponsorLogoDataUrl && data.sponsorLogoDataUrl.length > 150_000) {
       throw Object.assign(new Error("Logo must be under 150KB"), {
@@ -441,11 +470,11 @@ export function createGameSponsorshipPayment(
 
     for (const row of stale) {
       if (row.stripe_payment_intent_id) {
-        try {
-          await stripe.paymentIntents.cancel(row.stripe_payment_intent_id);
-        } catch {
-          // Ignore cancellation errors for already-cancelled intents
-        }
+        await cancelPaymentIntentTolerantly(
+          stripe,
+          row.stripe_payment_intent_id,
+          log,
+        );
       }
       await db
         .deleteFrom("game_sponsorship")
@@ -509,7 +538,7 @@ export function createPlayerSponsorshipPayment(
   stripe: Stripe,
   playerSponsorshipPriceId: string,
 ) {
-  return async (data: PlayerSponsorshipPayment) => {
+  return async (data: PlayerSponsorshipPayment, log: FastifyBaseLogger) => {
     const currentYear = new Date().getFullYear();
 
     // Validate logo size
@@ -566,11 +595,11 @@ export function createPlayerSponsorshipPayment(
 
     for (const row of stale) {
       if (row.stripe_payment_intent_id) {
-        try {
-          await stripe.paymentIntents.cancel(row.stripe_payment_intent_id);
-        } catch {
-          // Ignore cancellation errors for already-cancelled intents
-        }
+        await cancelPaymentIntentTolerantly(
+          stripe,
+          row.stripe_payment_intent_id,
+          log,
+        );
       }
       await db
         .deleteFrom("player_sponsorship")

--- a/apps/api/src/lib/tracing.ts
+++ b/apps/api/src/lib/tracing.ts
@@ -1,0 +1,41 @@
+/**
+ * Thin wrapper around OTel's tracer.startActiveSpan that:
+ *
+ * - Records the wrapped function's thrown error on the span and sets
+ *   the span status to ERROR before re-throwing — without this, an
+ *   exception leaves the span in OK state.
+ * - Always ends the span (even if the function throws) so spans
+ *   don't leak.
+ * - Returns the wrapped function's return value untouched.
+ *
+ * Use for high-value flows (#186) where the auto-instrumentation
+ * doesn't give a useful breakdown — e.g., a multi-step file upload
+ * where mint, S3 PUT, commit, derive each take meaningful time but
+ * collapse into one Fastify span otherwise.
+ */
+import { SpanStatusCode, trace, type Attributes } from "@opentelemetry/api";
+
+const tracer = trace.getTracer("percy-main-api");
+
+export async function withSpan<T>(
+  name: string,
+  attributes: Attributes,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return tracer.startActiveSpan(name, { attributes }, async (span) => {
+    try {
+      const result = await fn();
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (err) {
+      span.recordException(err as Error);
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/apps/api/src/lib/worker-logger.ts
+++ b/apps/api/src/lib/worker-logger.ts
@@ -1,0 +1,44 @@
+/**
+ * Pino-backed FastifyBaseLogger for standalone worker processes
+ * (scout-knowledge-worker, scout-report-worker, migrate). The workers
+ * don't need an HTTP server but several call paths now require a
+ * non-optional `logger: FastifyBaseLogger`. Booting a Fastify instance
+ * just to get its logger gives us the same Pino shape the API code
+ * uses, with no extra dependency.
+ */
+
+import Fastify from "fastify";
+import type { FastifyBaseLogger } from "fastify";
+
+export function createWorkerLogger(name: string): FastifyBaseLogger {
+  // `genReqId` is required by the type but never called outside the
+  // request lifecycle — workers don't have requests.
+  const app = Fastify({
+    logger: {
+      level: process.env.LOG_LEVEL ?? "info",
+      base: { name },
+    },
+  });
+  return app.log;
+}
+
+/**
+ * Silent logger for unit tests. Satisfies FastifyBaseLogger without
+ * emitting anything (or booting Fastify). Use in test fixtures that
+ * need to satisfy a non-optional `logger` dep.
+ */
+export function createNoopLogger(): FastifyBaseLogger {
+  const noop = () => {};
+  const logger = {
+    level: "silent" as const,
+    silent: noop,
+    trace: noop,
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    fatal: noop,
+    child: () => logger,
+  };
+  return logger as unknown as FastifyBaseLogger;
+}

--- a/apps/api/src/lib/worker-logger.ts
+++ b/apps/api/src/lib/worker-logger.ts
@@ -7,8 +7,8 @@
  * uses, with no extra dependency.
  */
 
-import Fastify from "fastify";
 import type { FastifyBaseLogger } from "fastify";
+import Fastify from "fastify";
 
 export function createWorkerLogger(name: string): FastifyBaseLogger {
   // `genReqId` is required by the type but never called outside the

--- a/apps/api/src/lib/worker-logger.ts
+++ b/apps/api/src/lib/worker-logger.ts
@@ -28,7 +28,7 @@ export function createWorkerLogger(name: string): FastifyBaseLogger {
  * need to satisfy a non-optional `logger` dep.
  */
 export function createNoopLogger(): FastifyBaseLogger {
-  const noop = () => {};
+  const noop = () => undefined;
   const logger = {
     level: "silent" as const,
     silent: noop,

--- a/apps/api/src/migrate.ts
+++ b/apps/api/src/migrate.ts
@@ -66,10 +66,7 @@ try {
     process.exit(1);
   }
 
-  logger.info(
-    { count: results?.length ?? 0 },
-    "migrate_complete",
-  );
+  logger.info({ count: results?.length ?? 0 }, "migrate_complete");
   await client.destroy();
   process.exit(0);
 } catch (error) {

--- a/apps/api/src/migrate.ts
+++ b/apps/api/src/migrate.ts
@@ -16,6 +16,9 @@ import {
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import pg from "pg";
+import { createWorkerLogger } from "./lib/worker-logger.ts";
+
+const logger = createWorkerLogger("migrate");
 
 const DATABASE_URL = process.env.DATABASE_URL;
 
@@ -45,29 +48,32 @@ const migrator = new Migrator({
 });
 
 try {
-  console.log("Running database migrations...");
+  logger.info("migrate_started");
 
   const { error, results } = await migrator.migrateToLatest();
 
   results?.forEach((it) => {
     if (it.status === "Success") {
-      console.log(`  ✓ ${it.migrationName}`);
+      logger.info({ migrationName: it.migrationName }, "migrate_step_success");
     } else if (it.status === "Error") {
-      console.error(`  ✗ ${it.migrationName}`);
+      logger.error({ migrationName: it.migrationName }, "migrate_step_failed");
     }
   });
 
   if (error) {
-    console.error("Migration failed:", error);
+    logger.error({ err: error }, "migrate_failed");
     await client.destroy().catch(noop);
     process.exit(1);
   }
 
-  console.log(`Migrations complete (${results?.length ?? 0} applied)`);
+  logger.info(
+    { count: results?.length ?? 0 },
+    "migrate_complete",
+  );
   await client.destroy();
   process.exit(0);
 } catch (error) {
-  console.error("Migration failed:", error);
+  logger.error({ err: error }, "migrate_failed");
   await client.destroy().catch(noop);
   process.exit(1);
 }

--- a/apps/api/src/scout-knowledge-worker.ts
+++ b/apps/api/src/scout-knowledge-worker.ts
@@ -39,17 +39,19 @@ function extractTraceContext() {
   return propagation.extract(ROOT_CONTEXT, carrier);
 }
 
+const logger = createWorkerLogger("scout-knowledge-worker");
+
 const DOCUMENT_ID = process.env.KB_DOCUMENT_ID;
 if (!DOCUMENT_ID) {
-  console.error("Missing required env var: KB_DOCUMENT_ID");
+  logger.error("scout_kb_worker_missing_env: KB_DOCUMENT_ID");
   process.exit(1);
 }
 
 const config = parseConfig(process.env);
 
 if (!config.VOYAGE_API_KEY) {
-  console.error(
-    "Missing required env var: VOYAGE_API_KEY (KB ingest needs embeddings)",
+  logger.error(
+    "scout_kb_worker_missing_env: VOYAGE_API_KEY (KB ingest needs embeddings)",
   );
   process.exit(1);
 }
@@ -68,7 +70,6 @@ const anthropicModel = config.ANTHROPIC_API_KEY
   ? resolveModel("anthropic", config.SCOUT_ATTACHMENT_DERIVE_MODEL).model
   : null;
 const scoutKnowledgeBase = createS3KnowledgeBaseStore(config);
-const logger = createWorkerLogger("scout-knowledge-worker");
 const parentCtx = extractTraceContext();
 
 logger.info({ documentId: DOCUMENT_ID }, "scout_kb_worker_started");

--- a/apps/api/src/scout-knowledge-worker.ts
+++ b/apps/api/src/scout-knowledge-worker.ts
@@ -15,6 +15,7 @@
  * backstop the report worker carries.
  */
 
+import { context, propagation, ROOT_CONTEXT } from "@opentelemetry/api";
 import { createClient } from "@percy-main/db";
 import { parseConfig } from "./config.ts";
 import { createVoyageClient } from "./features/scout/facts/voyage.ts";
@@ -22,6 +23,21 @@ import { runIngest } from "./features/scout/knowledge/run-ingest.ts";
 import { resolveModel } from "./features/scout/provider.ts";
 import { createS3KnowledgeBaseStore } from "./lib/s3-knowledge-base.ts";
 import { createWorkerLogger } from "./lib/worker-logger.ts";
+
+/**
+ * Extract the propagated W3C trace context from env vars set by the
+ * launcher (#197). See scout-report-worker.ts for the full rationale.
+ */
+function extractTraceContext() {
+  const carrier: Record<string, string> = {};
+  if (process.env.OTEL_TRACEPARENT) {
+    carrier.traceparent = process.env.OTEL_TRACEPARENT;
+  }
+  if (process.env.OTEL_TRACESTATE) {
+    carrier.tracestate = process.env.OTEL_TRACESTATE;
+  }
+  return propagation.extract(ROOT_CONTEXT, carrier);
+}
 
 const DOCUMENT_ID = process.env.KB_DOCUMENT_ID;
 if (!DOCUMENT_ID) {
@@ -53,13 +69,16 @@ const anthropicModel = config.ANTHROPIC_API_KEY
   : null;
 const scoutKnowledgeBase = createS3KnowledgeBaseStore(config);
 const logger = createWorkerLogger("scout-knowledge-worker");
+const parentCtx = extractTraceContext();
 
 logger.info({ documentId: DOCUMENT_ID }, "scout_kb_worker_started");
 
 try {
-  await runIngest(
-    { db, voyage, anthropicModel, scoutKnowledgeBase, config, logger },
-    DOCUMENT_ID,
+  await context.with(parentCtx, () =>
+    runIngest(
+      { db, voyage, anthropicModel, scoutKnowledgeBase, config, logger },
+      DOCUMENT_ID,
+    ),
   );
   logger.info({ documentId: DOCUMENT_ID }, "scout_kb_worker_done");
   await db.destroy();

--- a/apps/api/src/scout-knowledge-worker.ts
+++ b/apps/api/src/scout-knowledge-worker.ts
@@ -22,6 +22,7 @@ import { createVoyageClient } from "./features/scout/facts/voyage.ts";
 import { runIngest } from "./features/scout/knowledge/run-ingest.ts";
 import { resolveModel } from "./features/scout/provider.ts";
 import { createS3KnowledgeBaseStore } from "./lib/s3-knowledge-base.ts";
+import { withSpan } from "./lib/tracing.ts";
 import { createWorkerLogger } from "./lib/worker-logger.ts";
 
 /**
@@ -76,9 +77,14 @@ logger.info({ documentId: DOCUMENT_ID }, "scout_kb_worker_started");
 
 try {
   await context.with(parentCtx, () =>
-    runIngest(
-      { db, voyage, anthropicModel, scoutKnowledgeBase, config, logger },
-      DOCUMENT_ID,
+    // Named root span for the whole ingest run so the trace tree
+    // shows scout.kb.ingest as the parent of S3 / DB / Voyage /
+    // Anthropic spans rather than implicit per-call siblings.
+    withSpan("scout.kb.ingest", { documentId: DOCUMENT_ID }, () =>
+      runIngest(
+        { db, voyage, anthropicModel, scoutKnowledgeBase, config, logger },
+        DOCUMENT_ID,
+      ),
     ),
   );
   logger.info({ documentId: DOCUMENT_ID }, "scout_kb_worker_done");

--- a/apps/api/src/scout-knowledge-worker.ts
+++ b/apps/api/src/scout-knowledge-worker.ts
@@ -21,6 +21,7 @@ import { createVoyageClient } from "./features/scout/facts/voyage.ts";
 import { runIngest } from "./features/scout/knowledge/run-ingest.ts";
 import { resolveModel } from "./features/scout/provider.ts";
 import { createS3KnowledgeBaseStore } from "./lib/s3-knowledge-base.ts";
+import { createWorkerLogger } from "./lib/worker-logger.ts";
 
 const DOCUMENT_ID = process.env.KB_DOCUMENT_ID;
 if (!DOCUMENT_ID) {
@@ -51,15 +52,16 @@ const anthropicModel = config.ANTHROPIC_API_KEY
   ? resolveModel("anthropic", config.SCOUT_ATTACHMENT_DERIVE_MODEL).model
   : null;
 const scoutKnowledgeBase = createS3KnowledgeBaseStore(config);
+const logger = createWorkerLogger("scout-knowledge-worker");
 
-console.log(`scout_kb_worker_started documentId=${DOCUMENT_ID}`);
+logger.info({ documentId: DOCUMENT_ID }, "scout_kb_worker_started");
 
 try {
   await runIngest(
-    { db, voyage, anthropicModel, scoutKnowledgeBase, config },
+    { db, voyage, anthropicModel, scoutKnowledgeBase, config, logger },
     DOCUMENT_ID,
   );
-  console.log(`scout_kb_worker_done documentId=${DOCUMENT_ID}`);
+  logger.info({ documentId: DOCUMENT_ID }, "scout_kb_worker_done");
   await db.destroy();
   process.exit(0);
 } catch (err) {
@@ -67,7 +69,7 @@ try {
   // catch is purely about exit code + log. Unhandled errors here mean
   // something outside the pipeline (boot, DB connect) blew up; the
   // row's status is the source of truth for downstream observers.
-  console.error("scout_kb_worker_failed", err);
+  logger.error({ err, documentId: DOCUMENT_ID }, "scout_kb_worker_failed");
   await db.destroy().catch(() => undefined);
   process.exit(1);
 }

--- a/apps/api/src/scout-report-worker.ts
+++ b/apps/api/src/scout-report-worker.ts
@@ -21,6 +21,7 @@ import { createApiClient } from "./features/play-cricket/api-client.ts";
 import { createVoyageClient } from "./features/scout/facts/voyage.ts";
 import { runReport } from "./features/scout/report/run-report.ts";
 import { createScoutReportStore } from "./lib/s3-scout-reports.ts";
+import { withSpan } from "./lib/tracing.ts";
 import { createWorkerLogger } from "./lib/worker-logger.ts";
 
 /**
@@ -98,17 +99,23 @@ logger.info({ reportId: REPORT_ID }, "scout_report_worker_started");
 
 try {
   await context.with(parentCtx, () =>
-    runReport(
-      {
-        db,
-        dbReadonly,
-        playCricket,
-        config,
-        voyage,
-        scoutReports,
-        logger,
-      },
-      REPORT_ID,
+    // Named root span for the whole worker run so the trace tree in
+    // NR shows scout.report.run as the parent of everything (DB,
+    // PlayCricket, Anthropic, S3) rather than implicit per-call
+    // siblings. Attaches reportId for filtering.
+    withSpan("scout.report.run", { reportId: REPORT_ID }, () =>
+      runReport(
+        {
+          db,
+          dbReadonly,
+          playCricket,
+          config,
+          voyage,
+          scoutReports,
+          logger,
+        },
+        REPORT_ID,
+      ),
     ),
   );
   logger.info({ reportId: REPORT_ID }, "scout_report_worker_done");

--- a/apps/api/src/scout-report-worker.ts
+++ b/apps/api/src/scout-report-worker.ts
@@ -14,6 +14,7 @@
  * stalled outside the agent loop.
  */
 
+import { context, propagation, ROOT_CONTEXT } from "@opentelemetry/api";
 import { createClient } from "@percy-main/db";
 import { parseConfig } from "./config.ts";
 import { createApiClient } from "./features/play-cricket/api-client.ts";
@@ -21,6 +22,23 @@ import { createVoyageClient } from "./features/scout/facts/voyage.ts";
 import { runReport } from "./features/scout/report/run-report.ts";
 import { createScoutReportStore } from "./lib/s3-scout-reports.ts";
 import { createWorkerLogger } from "./lib/worker-logger.ts";
+
+/**
+ * Extract the propagated W3C trace context from env vars set by the
+ * launcher (#197). Returns a Context that the rest of the worker
+ * should run inside via context.with(...) so any spans/metrics it
+ * emits are children of the API span that triggered this run.
+ */
+function extractTraceContext() {
+  const carrier: Record<string, string> = {};
+  if (process.env.OTEL_TRACEPARENT) {
+    carrier.traceparent = process.env.OTEL_TRACEPARENT;
+  }
+  if (process.env.OTEL_TRACESTATE) {
+    carrier.tracestate = process.env.OTEL_TRACESTATE;
+  }
+  return propagation.extract(ROOT_CONTEXT, carrier);
+}
 
 const RENDER_MARGIN_MS = 90_000;
 
@@ -70,21 +88,24 @@ const voyage = config.VOYAGE_API_KEY
   : undefined;
 const scoutReports = createScoutReportStore(config);
 const logger = createWorkerLogger("scout-report-worker");
+const parentCtx = extractTraceContext();
 
 logger.info({ reportId: REPORT_ID }, "scout_report_worker_started");
 
 try {
-  await runReport(
-    {
-      db,
-      dbReadonly,
-      playCricket,
-      config,
-      voyage,
-      scoutReports,
-      logger,
-    },
-    REPORT_ID,
+  await context.with(parentCtx, () =>
+    runReport(
+      {
+        db,
+        dbReadonly,
+        playCricket,
+        config,
+        voyage,
+        scoutReports,
+        logger,
+      },
+      REPORT_ID,
+    ),
   );
   logger.info({ reportId: REPORT_ID }, "scout_report_worker_done");
   await db.destroy();

--- a/apps/api/src/scout-report-worker.ts
+++ b/apps/api/src/scout-report-worker.ts
@@ -42,22 +42,26 @@ function extractTraceContext() {
 
 const RENDER_MARGIN_MS = 90_000;
 
+const logger = createWorkerLogger("scout-report-worker");
+
 const REPORT_ID = process.env.REPORT_ID;
 if (!REPORT_ID) {
-  console.error("Missing required env var: REPORT_ID");
+  logger.error("scout_report_worker_missing_env: REPORT_ID");
   process.exit(1);
 }
 
 const config = parseConfig(process.env);
 
 if (!config.PLAY_CRICKET_API_TOKEN || !config.PLAY_CRICKET_SITE_ID) {
-  console.error(
-    "Missing required env vars: PLAY_CRICKET_API_TOKEN / PLAY_CRICKET_SITE_ID",
+  logger.error(
+    "scout_report_worker_missing_env: PLAY_CRICKET_API_TOKEN / PLAY_CRICKET_SITE_ID",
   );
   process.exit(1);
 }
 if (!config.SCOUT_DB_URL) {
-  console.error("Missing required env var: SCOUT_DB_URL (read-only DB role)");
+  logger.error(
+    "scout_report_worker_missing_env: SCOUT_DB_URL (read-only DB role)",
+  );
   process.exit(1);
 }
 
@@ -67,8 +71,9 @@ if (!config.SCOUT_DB_URL) {
 // outside the agent loop (boot, DB connect, render, S3 upload) stalls.
 const HARD_KILL_MS = config.SCOUT_REPORT_TIMEOUT_MS + RENDER_MARGIN_MS;
 setTimeout(() => {
-  console.error(
-    `scout_report_worker_wall_clock_kill reportId=${REPORT_ID} after ${HARD_KILL_MS}ms`,
+  logger.error(
+    { reportId: REPORT_ID, hardKillMs: HARD_KILL_MS },
+    "scout_report_worker_wall_clock_kill",
   );
   process.exit(2);
 }, HARD_KILL_MS).unref();
@@ -87,7 +92,6 @@ const voyage = config.VOYAGE_API_KEY
     })
   : undefined;
 const scoutReports = createScoutReportStore(config);
-const logger = createWorkerLogger("scout-report-worker");
 const parentCtx = extractTraceContext();
 
 logger.info({ reportId: REPORT_ID }, "scout_report_worker_started");

--- a/apps/api/src/scout-report-worker.ts
+++ b/apps/api/src/scout-report-worker.ts
@@ -20,6 +20,7 @@ import { createApiClient } from "./features/play-cricket/api-client.ts";
 import { createVoyageClient } from "./features/scout/facts/voyage.ts";
 import { runReport } from "./features/scout/report/run-report.ts";
 import { createScoutReportStore } from "./lib/s3-scout-reports.ts";
+import { createWorkerLogger } from "./lib/worker-logger.ts";
 
 const RENDER_MARGIN_MS = 90_000;
 
@@ -68,8 +69,9 @@ const voyage = config.VOYAGE_API_KEY
     })
   : undefined;
 const scoutReports = createScoutReportStore(config);
+const logger = createWorkerLogger("scout-report-worker");
 
-console.log(`scout_report_worker_started reportId=${REPORT_ID}`);
+logger.info({ reportId: REPORT_ID }, "scout_report_worker_started");
 
 try {
   await runReport(
@@ -80,10 +82,11 @@ try {
       config,
       voyage,
       scoutReports,
+      logger,
     },
     REPORT_ID,
   );
-  console.log(`scout_report_worker_done reportId=${REPORT_ID}`);
+  logger.info({ reportId: REPORT_ID }, "scout_report_worker_done");
   await db.destroy();
   await dbReadonly.destroy();
   process.exit(0);
@@ -95,7 +98,7 @@ try {
   // the first phase write. ECS will retry per task settings (currently
   // none — the row just stays orphaned and a future operator query can
   // sweep it).
-  console.error("scout_report_worker_failed", err);
+  logger.error({ err, reportId: REPORT_ID }, "scout_report_worker_failed");
   await db.destroy().catch(() => undefined);
   await dbReadonly.destroy().catch(() => undefined);
   process.exit(1);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6,6 +6,24 @@ const config = parseConfig(process.env as Record<string, string>);
 const { client: db, dialect } = createClient(config.DATABASE_URL);
 const app = await buildApp({ db, dialect, config });
 
+// Surface unhandled rejections + uncaught exceptions to NR before the
+// process exits. ECS will restart the task either way; without these
+// the only breadcrumb is the ECS task-stopped event with no stack.
+// fatal() flushes Pino's buffer synchronously before exit so the log
+// line actually lands.
+//
+// Both handlers exit(1) because attaching a listener disables Node's
+// default crash behaviour — without exiting we'd silently keep running
+// in a corrupted state instead of letting ECS restart us cleanly.
+process.on("unhandledRejection", (reason: unknown) => {
+  app.log.fatal({ err: reason }, "unhandled_rejection");
+  process.exit(1);
+});
+process.on("uncaughtException", (err: Error) => {
+  app.log.fatal({ err }, "uncaught_exception");
+  process.exit(1);
+});
+
 try {
   await app.listen({ port: config.PORT, host: config.HOST });
 } catch (err) {

--- a/apps/api/src/sync-runner.ts
+++ b/apps/api/src/sync-runner.ts
@@ -40,10 +40,7 @@ const rv = RV_SHARED_SECRET
   : null;
 
 try {
-  logger.info(
-    { withRv: Boolean(rv) },
-    "play_cricket_sync_started",
-  );
+  logger.info({ withRv: Boolean(rv) }, "play_cricket_sync_started");
 
   const sync = runSync(client, api, rv, logger);
   // Throw out of withSpan if the sync returned a non-empty errors
@@ -69,7 +66,9 @@ try {
       },
     );
   } catch (err) {
-    const syncResult = (err as { syncResult?: { errors: string[]; matchesProcessed: number } }).syncResult;
+    const syncResult = (
+      err as { syncResult?: { errors: string[]; matchesProcessed: number } }
+    ).syncResult;
     if (syncResult) {
       // Treat as completed-with-errors: log + exit 1, span already
       // marked ERROR by withSpan.

--- a/apps/api/src/sync-runner.ts
+++ b/apps/api/src/sync-runner.ts
@@ -10,6 +10,9 @@ import { createClient } from "@percy-main/db";
 import { createApiClient } from "./features/play-cricket/api-client.ts";
 import { createRvClient } from "./features/play-cricket/rv-client.ts";
 import { runSync } from "./features/play-cricket/sync.ts";
+import { createWorkerLogger } from "./lib/worker-logger.ts";
+
+const logger = createWorkerLogger("sync-runner");
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const PLAY_CRICKET_API_TOKEN = process.env.PLAY_CRICKET_API_TOKEN;
@@ -36,26 +39,30 @@ const rv = RV_SHARED_SECRET
   : null;
 
 try {
-  console.log(
-    `Starting Play Cricket sync${rv ? " (with RV ingest)" : " (PC only)"}...`,
+  logger.info(
+    { withRv: Boolean(rv) },
+    "play_cricket_sync_started",
   );
 
-  const sync = runSync(client, api, rv);
+  const sync = runSync(client, api, rv, logger);
   const result = await sync({ siteId: PLAY_CRICKET_SITE_ID });
 
-  console.log(`Sync complete: ${result.matchesProcessed} matches processed`);
+  logger.info(
+    { matchesProcessed: result.matchesProcessed },
+    "play_cricket_sync_complete",
+  );
 
   if (result.errors.length > 0) {
-    console.error(`Sync completed with ${result.errors.length} error(s):`);
-    for (const err of result.errors) {
-      console.error(`  - ${err}`);
-    }
+    logger.error(
+      { errorCount: result.errors.length, errors: result.errors },
+      "play_cricket_sync_completed_with_errors",
+    );
   }
 
   await client.destroy();
   process.exit(result.errors.length > 0 ? 1 : 0);
 } catch (error) {
-  console.error("Sync failed:", error);
+  logger.error({ err: error }, "play_cricket_sync_failed");
   await client.destroy().catch(() => undefined);
   process.exit(1);
 }

--- a/apps/api/src/sync-runner.ts
+++ b/apps/api/src/sync-runner.ts
@@ -10,6 +10,7 @@ import { createClient } from "@percy-main/db";
 import { createApiClient } from "./features/play-cricket/api-client.ts";
 import { createRvClient } from "./features/play-cricket/rv-client.ts";
 import { runSync } from "./features/play-cricket/sync.ts";
+import { withSpan } from "./lib/tracing.ts";
 import { createWorkerLogger } from "./lib/worker-logger.ts";
 
 const logger = createWorkerLogger("sync-runner");
@@ -45,22 +46,52 @@ try {
   );
 
   const sync = runSync(client, api, rv, logger);
-  const result = await sync({ siteId: PLAY_CRICKET_SITE_ID });
+  // Throw out of withSpan if the sync returned a non-empty errors
+  // list — withSpan only marks ERROR on a thrown error, so a
+  // completed-with-errors run would otherwise look successful in
+  // OTel. The thrown PlayCricketSyncErrorsError is caught below to
+  // restore the per-error logging + exit-1 behaviour.
+  let result;
+  try {
+    result = await withSpan(
+      "play_cricket.sync.run",
+      { siteId: PLAY_CRICKET_SITE_ID, withRv: Boolean(rv) },
+      async () => {
+        const r = await sync({ siteId: PLAY_CRICKET_SITE_ID });
+        if (r.errors.length > 0) {
+          const err = new Error(
+            `play_cricket_sync_completed_with_${r.errors.length}_errors`,
+          );
+          (err as Error & { syncResult?: typeof r }).syncResult = r;
+          throw err;
+        }
+        return r;
+      },
+    );
+  } catch (err) {
+    const syncResult = (err as { syncResult?: { errors: string[]; matchesProcessed: number } }).syncResult;
+    if (syncResult) {
+      // Treat as completed-with-errors: log + exit 1, span already
+      // marked ERROR by withSpan.
+      logger.error(
+        { errorCount: syncResult.errors.length, errors: syncResult.errors },
+        "play_cricket_sync_completed_with_errors",
+      );
+      await client.destroy();
+      process.exit(1);
+    }
+    throw err;
+  }
 
+  // Reaching here means errors.length === 0 (otherwise the throw
+  // above would have routed via the catch).
   logger.info(
     { matchesProcessed: result.matchesProcessed },
     "play_cricket_sync_complete",
   );
 
-  if (result.errors.length > 0) {
-    logger.error(
-      { errorCount: result.errors.length, errors: result.errors },
-      "play_cricket_sync_completed_with_errors",
-    );
-  }
-
   await client.destroy();
-  process.exit(result.errors.length > 0 ? 1 : 0);
+  process.exit(0);
 } catch (error) {
   logger.error({ err: error }, "play_cricket_sync_failed");
   await client.destroy().catch(() => undefined);

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button.js";
 import { Input } from "@/components/ui/input.js";
 import { Textarea } from "@/components/ui/textarea.js";
 import { api, callApi } from "@/lib/api-client.js";
+import type { paths } from "@/lib/api.gen.js";
 import { getImageUrl, getPicture } from "@/lib/image-map.js";
 import {
   CURRENT_CONSENT_VERSION,
@@ -196,30 +197,18 @@ function EventPreview({
   );
 }
 
-// /api/games/{matchId} is not yet in the generated OpenAPI spec, so we keep
-// local types and use a direct fetch until the spec is regenerated.
-type Outcome = "W" | "L" | "D" | "T" | "A" | "C" | "N";
-
-interface GameListItem {
-  id: string;
-  home: boolean;
-  team: { name: string };
-  opposition: {
-    club: { name: string };
-    team: { name: string };
-  };
-  league: { name: string };
-  competition: { name: string };
-  when: string | null;
-  outcome: Outcome | null;
-  scoreDescription: string | null;
-  sponsorName: string | null;
-}
+// Use the OpenAPI-generated response type directly per CLAUDE.md
+// (\"Never use raw fetch or define local response type interfaces —
+// types are generated from the OpenAPI spec\"). The component below
+// only reads a subset of these fields.
+type GameListItem = NonNullable<
+  paths["/api/games/{matchId}"]["get"]["responses"][200]["content"]["application/json"]
+>;
 
 async function fetchGame(matchId: string): Promise<GameListItem> {
-  const res = await fetch(`/api/games/${matchId}`, { credentials: "include" });
-  if (!res.ok) throw new Error(res.statusText);
-  return res.json() as Promise<GameListItem>;
+  return await callApi(
+    api.GET("/api/games/{matchId}", { params: { path: { matchId } } }),
+  );
 }
 
 function GamePreview({ playCricketId }: { playCricketId: string }) {

--- a/apps/web/src/components/members/charges.tsx
+++ b/apps/web/src/components/members/charges.tsx
@@ -43,7 +43,10 @@ export function Charges() {
   });
 
   const payMutation = useMutation({
-    mutationFn: () => callApi(api.POST("/api/charges/pay-outstanding")),
+    // Members "Pay outstanding" page intentionally pays everything
+    // unpaid for the user — no chargeIds scope.
+    mutationFn: () =>
+      callApi(api.POST("/api/charges/pay-outstanding", { body: {} })),
     onSuccess: (data) => {
       if (data.clientSecret) {
         const piId = data.clientSecret.split("_secret_")[0];

--- a/apps/web/src/components/route-error.tsx
+++ b/apps/web/src/components/route-error.tsx
@@ -15,7 +15,7 @@ import { isRouteErrorResponse, useLocation, useRouteError } from "react-router";
  */
 export function RouteError() {
   const error = useRouteError();
-  const location = useLocation();
+  const { pathname } = useLocation();
 
   useEffect(() => {
     const err =
@@ -29,15 +29,15 @@ export function RouteError() {
     if (window.newrelic) {
       window.newrelic.noticeError(err, {
         kind: "route_error",
-        route: location.pathname,
+        route: pathname,
         status: isRouteErrorResponse(error) ? error.status : 0,
       });
     } else {
       console.error("route_error (NR not loaded):", err.message, {
-        route: location.pathname,
+        route: pathname,
       });
     }
-  }, [error, location.pathname]);
+  }, [error, pathname]);
 
   if (isRouteErrorResponse(error)) {
     return (

--- a/apps/web/src/components/route-error.tsx
+++ b/apps/web/src/components/route-error.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+import { isRouteErrorResponse, useLocation, useRouteError } from "react-router";
+
+/**
+ * Default errorElement for the route tree (#182). Catches:
+ *   - Render-time exceptions in lazy routes (otherwise: white screen)
+ *   - Loader/action throws (when those land — none today)
+ *   - Route-not-found (404 fallthrough — react-router synthesises a
+ *     Response that this component can render)
+ *
+ * On every render, fires window.newrelic.noticeError with the route
+ * path + status so the failure is filterable in NR Browser. The agent's
+ * automatic uncaught-exception capture would also see this, but
+ * without the route attribute or the chance to render a useful UI.
+ */
+export function RouteError() {
+  const error = useRouteError();
+  const location = useLocation();
+
+  useEffect(() => {
+    const err =
+      error instanceof Error
+        ? error
+        : new Error(
+            typeof error === "object" && error
+              ? JSON.stringify(error)
+              : String(error),
+          );
+    if (window.newrelic) {
+      window.newrelic.noticeError(err, {
+        kind: "route_error",
+        route: location.pathname,
+        status: isRouteErrorResponse(error) ? error.status : 0,
+      });
+    } else {
+      console.error("route_error (NR not loaded):", err.message, {
+        route: location.pathname,
+      });
+    }
+  }, [error, location.pathname]);
+
+  if (isRouteErrorResponse(error)) {
+    return (
+      <div className="mx-auto max-w-md py-16 text-center">
+        <h1 className="text-2xl font-semibold text-stone-700">
+          {error.status === 404 ? "Page not found" : `Error ${error.status}`}
+        </h1>
+        <p className="mt-2 text-sm text-stone-500">
+          {error.status === 404
+            ? "The page you were looking for doesn't exist."
+            : "Something went wrong loading this page. We've been notified."}
+        </p>
+        <a
+          href="/"
+          className="mt-6 inline-block text-sm text-blue-600 underline"
+        >
+          Back to home
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-md py-16 text-center">
+      <h1 className="text-2xl font-semibold text-stone-700">
+        Something went wrong
+      </h1>
+      <p className="mt-2 text-sm text-stone-500">
+        We've been notified and will look into it. Try refreshing the page.
+      </p>
+      <a href="/" className="mt-6 inline-block text-sm text-blue-600 underline">
+        Back to home
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -545,7 +545,13 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody: {
+                content: {
+                    "application/json": {
+                        chargeIds?: string[];
+                    };
+                };
+            };
             responses: {
                 /** @description Default Response */
                 200: {

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -4,6 +4,98 @@
  */
 
 export interface paths {
+    "/health/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok";
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/health/ready": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok" | "unhealthy";
+                            /** @enum {string} */
+                            database: "connected" | "disconnected";
+                        };
+                    };
+                };
+                /** @description Default Response */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok" | "unhealthy";
+                            /** @enum {string} */
+                            database: "connected" | "disconnected";
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -5409,6 +5501,11 @@ export interface paths {
                     content: {
                         "application/json": {
                             sent: number;
+                            failed: number;
+                            failures: {
+                                email: string;
+                                reason: string;
+                            }[];
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -8,6 +8,102 @@
     "schemas": {}
   },
   "paths": {
+    "/health/live": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health/ready": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok",
+                        "unhealthy"
+                      ]
+                    },
+                    "database": {
+                      "type": "string",
+                      "enum": [
+                        "connected",
+                        "disconnected"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "database"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok",
+                        "unhealthy"
+                      ]
+                    },
+                    "database": {
+                      "type": "string",
+                      "enum": [
+                        "connected",
+                        "disconnected"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "database"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "responses": {
@@ -9333,10 +9429,34 @@
                   "properties": {
                     "sent": {
                       "type": "number"
+                    },
+                    "failed": {
+                      "type": "number"
+                    },
+                    "failures": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "email": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "email",
+                          "reason"
+                        ],
+                        "additionalProperties": false
+                      }
                     }
                   },
                   "required": [
-                    "sent"
+                    "sent",
+                    "failed",
+                    "failures"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -641,6 +641,24 @@
     },
     "/api/charges/pay-outstanding": {
       "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "chargeIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Default Response",

--- a/apps/web/src/lib/newrelic.ts
+++ b/apps/web/src/lib/newrelic.ts
@@ -11,6 +11,19 @@
 
 import { BrowserAgent } from "@newrelic/browser-agent/loaders/browser-agent";
 
+// NR Browser agent attaches `newrelic` to window after load. This
+// declaration narrows the type to the methods we actually use.
+declare global {
+  interface Window {
+    newrelic?: {
+      noticeError: (
+        err: Error,
+        attributes?: Record<string, string | number | boolean>,
+      ) => void;
+    };
+  }
+}
+
 const licenseKey = import.meta.env.VITE_NEW_RELIC_LICENSE_KEY as
   | string
   | undefined;
@@ -20,6 +33,68 @@ const applicationID = import.meta.env.VITE_NEW_RELIC_APP_ID as
 const accountID = import.meta.env.VITE_NEW_RELIC_ACCOUNT_ID as
   | string
   | undefined;
+
+/**
+ * Wrap a fetch with a noticeError on non-OK / network failure so S3
+ * presigned PUTs and other raw fetches that can't go through the
+ * typed client still surface in NR Browser.
+ *
+ * Throws on failure so the caller can decide what to do (toast,
+ * retry, etc). Returns the Response on success.
+ */
+export async function noticedFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  attributes: Record<string, string | number | boolean> = {},
+): Promise<Response> {
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  // Try to keep query strings out of NR custom attrs (URLs may carry
+  // S3 presigned-URL query params containing signatures).
+  const path = (() => {
+    try {
+      return new URL(url, window.location.origin).pathname;
+    } catch {
+      return url;
+    }
+  })();
+  const notice = (
+    err: Error,
+    attrs: Record<string, string | number | boolean>,
+  ) => {
+    if (window.newrelic) {
+      window.newrelic.noticeError(err, attrs);
+    } else {
+      // NR Browser agent isn't loaded (local dev, ad-blocker, missing
+      // VITE_NEW_RELIC_LICENSE_KEY). Drop to console so the failure
+      // is at least visible while debugging instead of disappearing
+      // silently.
+      console.error("noticedFetch (NR not loaded):", err.message, attrs);
+    }
+  };
+  try {
+    const res = await fetch(input, init);
+    if (!res.ok) {
+      const err = new Error(
+        `noticed_fetch_failed status=${res.status} ${path}`,
+      );
+      notice(err, { ...attributes, path, status: res.status });
+      throw err;
+    }
+    return res;
+  } catch (err) {
+    if (
+      !(err instanceof Error && err.message.startsWith("noticed_fetch_failed"))
+    ) {
+      notice(err as Error, { ...attributes, path });
+    }
+    throw err;
+  }
+}
 
 if (licenseKey && applicationID && accountID) {
   new BrowserAgent({

--- a/apps/web/src/lib/newrelic.ts
+++ b/apps/web/src/lib/newrelic.ts
@@ -103,7 +103,14 @@ if (licenseKey && applicationID && accountID) {
         enabled: true,
         cors_use_tracecontext_headers: true,
         cors_use_newrelic_header: true,
-        allowed_origins: ["https://api.v2.percymain.org"],
+        // Both production + staging API origins so cross-app traces
+        // light up in either env (#195). Staging may not currently
+        // emit any traces if its frontend NR ingest is unconfigured —
+        // harmless to list it here regardless.
+        allowed_origins: [
+          "https://api.v2.percymain.org",
+          "https://api.staging.v2.percymain.org",
+        ],
       },
       privacy: { cookies_enabled: true },
       ajax: { deny_list: ["bam.eu01.nr-data.net"] },

--- a/apps/web/src/pages/admin/documents-tab.tsx
+++ b/apps/web/src/pages/admin/documents-tab.tsx
@@ -17,6 +17,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
+import { noticedFetch } from "@/lib/newrelic";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
@@ -56,13 +57,17 @@ function CreateDocumentDialog({
       const { uploadUrl, pendingKey } = await callApi(
         api.POST("/api/admin/documents/upload-url"),
       );
-      // Step 2: Upload PDF directly to S3
-      const res = await fetch(uploadUrl, {
-        method: "PUT",
-        body: file,
-        headers: { "Content-Type": "application/pdf" },
-      });
-      if (!res.ok) throw new Error("Failed to upload file");
+      // Step 2: Upload PDF directly to S3 (presigned PUT — bypasses
+      // the typed client; noticedFetch surfaces failures in NR Browser).
+      await noticedFetch(
+        uploadUrl,
+        {
+          method: "PUT",
+          body: file,
+          headers: { "Content-Type": "application/pdf" },
+        },
+        { kind: "documents_s3_put", phase: "create" },
+      );
       // Step 3: Create document record with pending key
       return callApi(
         api.POST("/api/admin/documents", {
@@ -173,13 +178,17 @@ function EditDocumentDialog({
             params: { path: { documentId } },
           }),
         );
-        // Step 2: Upload PDF directly to S3
-        const res = await fetch(upload.uploadUrl, {
-          method: "PUT",
-          body: file,
-          headers: { "Content-Type": "application/pdf" },
-        });
-        if (!res.ok) throw new Error("Failed to upload file");
+        // Step 2: Upload PDF directly to S3 (presigned PUT — bypasses
+        // the typed client; noticedFetch surfaces failures in NR Browser).
+        await noticedFetch(
+          upload.uploadUrl,
+          {
+            method: "PUT",
+            body: file,
+            headers: { "Content-Type": "application/pdf" },
+          },
+          { kind: "documents_s3_put", phase: "update" },
+        );
         pendingKey = upload.pendingKey;
       }
       return callApi(

--- a/apps/web/src/pages/admin/expense-history-tab.tsx
+++ b/apps/web/src/pages/admin/expense-history-tab.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
+import { noticedFetch } from "@/lib/newrelic";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useReducer, useRef, useState } from "react";
 import {
@@ -135,31 +136,37 @@ export function ExpenseHistoryTab() {
   const handleExport = async () => {
     setIsExporting(true);
     try {
-      const response = await fetch(
-        `/api/treasurer/expenses/export?${new URLSearchParams(
-          Object.entries({
-            dateFrom: dateFrom || "",
-            dateTo: dateTo || "",
-            status: status === "all" ? "" : status,
-            expenseType: expenseType === "all" ? "" : expenseType,
-            search: debouncedSearch || "",
-          }).filter(([, v]) => v !== ""),
-        ).toString()}`,
-        { credentials: "include" },
-      );
-      if (!response.ok) {
+      const url = `/api/treasurer/expenses/export?${new URLSearchParams(
+        Object.entries({
+          dateFrom: dateFrom || "",
+          dateTo: dateTo || "",
+          status: status === "all" ? "" : status,
+          expenseType: expenseType === "all" ? "" : expenseType,
+          search: debouncedSearch || "",
+        }).filter(([, v]) => v !== ""),
+      ).toString()}`;
+      let response: Response;
+      try {
+        response = await noticedFetch(
+          url,
+          { credentials: "include" },
+          { kind: "expenses_csv_export" },
+        );
+      } catch {
+        // noticedFetch already noticed the error in NR. Surface to user
+        // and bail.
         alert("Failed to export expenses. Please try again.");
         return;
       }
       const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
+      const blobUrl = URL.createObjectURL(blob);
       const a = document.createElement("a");
-      a.href = url;
+      a.href = blobUrl;
       a.download = "expenses-export.csv";
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      URL.revokeObjectURL(blobUrl);
     } finally {
       setIsExporting(false);
     }

--- a/apps/web/src/pages/content-page.tsx
+++ b/apps/web/src/pages/content-page.tsx
@@ -7,7 +7,7 @@ import {
   type ContentNode,
 } from "@/lib/content.js";
 import { MDXProvider } from "@mdx-js/react";
-import { Fragment, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { IoChevronForward } from "react-icons/io5";
 import { Link, useLocation } from "react-router";
 
@@ -129,6 +129,23 @@ export function Component() {
   const page = contentPageMap.get(path);
 
   useDocumentMeta(page?.title, page?.description);
+
+  // 404s land here because router.tsx's catch-all `path: "*"` routes
+  // unknown paths through ContentPage rather than triggering the
+  // root errorElement (#182). Forward the miss to NR so the not-
+  // found rate is observable.
+  useEffect(() => {
+    if (!page) {
+      if (window.newrelic) {
+        window.newrelic.noticeError(new Error(`route_not_found ${path}`), {
+          kind: "route_not_found",
+          route: path,
+        });
+      } else {
+        console.warn("route_not_found (NR not loaded):", path);
+      }
+    }
+  }, [page, path]);
 
   if (!page) {
     return (

--- a/apps/web/src/pages/membership/membership-junior.tsx
+++ b/apps/web/src/pages/membership/membership-junior.tsx
@@ -254,7 +254,13 @@ function JuniorRegistrationInner() {
   });
 
   const payMutation = useMutation({
-    mutationFn: () => callApi(api.POST("/api/charges/pay-outstanding")),
+    // Junior registration pays only the charge just created for these
+    // dependents — passing chargeIds prevents bundling unrelated
+    // outstanding charges (#93) like a parent's own membership fee.
+    mutationFn: (chargeIds: string[]) =>
+      callApi(
+        api.POST("/api/charges/pay-outstanding", { body: { chargeIds } }),
+      ),
     onSuccess: (data) => {
       if (!data.clientSecret) return;
       const piId = data.clientSecret.split("_secret_")[0];
@@ -289,9 +295,9 @@ function JuniorRegistrationInner() {
     dispatch({ type: "advanceIfValid", next: nextStep });
 
   const handleSubmit = async () => {
-    await addDependentsMutation.mutateAsync(dependents);
+    const result = await addDependentsMutation.mutateAsync(dependents);
     setStep("payment");
-    payMutation.mutate();
+    payMutation.mutate([result.chargeId]);
   };
 
   if (step === "done") {
@@ -953,9 +959,12 @@ function JuniorRegistrationInner() {
               <div className="flex flex-wrap gap-3">
                 <Button
                   type="button"
+                  disabled={!addDependentsMutation.data?.chargeId}
                   onClick={() => {
+                    const chargeId = addDependentsMutation.data?.chargeId;
+                    if (!chargeId) return;
                     dispatch({ type: "setPaymentError", message: null });
-                    payMutation.mutate();
+                    payMutation.mutate([chargeId]);
                   }}
                 >
                   Try Again

--- a/apps/web/src/pages/official/availability.tsx
+++ b/apps/web/src/pages/official/availability.tsx
@@ -1068,7 +1068,7 @@ function NotifyDialog({ requestId }: { requestId: string }) {
                   <ul className="space-y-1 text-xs text-amber-900">
                     {sendMutation.data.failures.map((f) => (
                       <li key={f.email}>
-                        <code>{f.email}</code> — {f.reason}
+                        <code>{f.email}</code>: {f.reason}
                       </li>
                     ))}
                   </ul>

--- a/apps/web/src/pages/official/availability.tsx
+++ b/apps/web/src/pages/official/availability.tsx
@@ -1060,6 +1060,20 @@ function NotifyDialog({ requestId }: { requestId: string }) {
                 Sent {sendMutation.data.sent} email
                 {sendMutation.data.sent !== 1 ? "s" : ""}.
               </p>
+              {sendMutation.data.failed > 0 && (
+                <div className="space-y-2 rounded border border-amber-300 bg-amber-50 p-3">
+                  <p className="text-sm font-medium text-amber-800">
+                    {sendMutation.data.failed} failed:
+                  </p>
+                  <ul className="space-y-1 text-xs text-amber-900">
+                    {sendMutation.data.failures.map((f) => (
+                      <li key={f.email}>
+                        <code>{f.email}</code> — {f.reason}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
               <Button
                 size="sm"
                 variant="outline"

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -84,7 +84,7 @@ function DownloadTeamNewsButton({
   const handleDownload = () => {
     setDownloading(true);
     // Raw fetch: endpoint returns a PNG blob, not JSON — openapi-fetch can't handle binary downloads
-    void fetch(
+    fetch(
       `${API_BASE}/matchday/${encodeURIComponent(matchdayId)}/team-news-image?isHome=${isHome}${matchTime ? `&matchTime=${encodeURIComponent(matchTime)}` : ""}`,
       { credentials: "include" },
     )
@@ -99,6 +99,20 @@ function DownloadTeamNewsButton({
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
+      })
+      .catch((err: unknown) => {
+        const error = err instanceof Error ? err : new Error(String(err));
+        // Surface to NR Browser. Without this, the void-discarded chain
+        // hides failures from observability — the spinner just resets.
+        if (window.newrelic) {
+          window.newrelic.noticeError(error, {
+            kind: "team_news_image_download",
+            matchdayId,
+          });
+        }
+        // No toast library in the web app today (#194); console.error
+        // gives local-dev visibility, NR captures via noticeError.
+        console.error("team_news_image_download failed:", error.message);
       })
       .finally(() => {
         setDownloading(false);

--- a/apps/web/src/pages/scout/attachments/use-attachment-upload.ts
+++ b/apps/web/src/pages/scout/attachments/use-attachment-upload.ts
@@ -1,4 +1,5 @@
 import { api, callApi } from "@/lib/api-client";
+import { noticedFetch } from "@/lib/newrelic";
 import { useState } from "react";
 
 const ACCEPTED_TYPES = [
@@ -112,16 +113,17 @@ export function useAttachmentUpload({
       );
       update(localId, { id: mint.id });
 
-      const putRes = await fetch(mint.uploadUrl, {
-        method: "PUT",
-        body: file,
-        headers: { "Content-Type": contentType },
-      });
-      if (!putRes.ok) {
-        throw new Error(
-          `Upload to S3 failed (${putRes.status} ${putRes.statusText})`,
-        );
-      }
+      // Presigned PUT — bypasses the typed client; noticedFetch
+      // surfaces failures (CORS, status, network) in NR Browser.
+      await noticedFetch(
+        mint.uploadUrl,
+        {
+          method: "PUT",
+          body: file,
+          headers: { "Content-Type": contentType },
+        },
+        { kind: "scout_attachment_s3_put" },
+      );
 
       update(localId, { status: "processing" });
 

--- a/apps/web/src/pages/scout/knowledge-admin.tsx
+++ b/apps/web/src/pages/scout/knowledge-admin.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen.js";
+import { noticedFetch } from "@/lib/newrelic";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useReducer, useState } from "react";
 import {
@@ -227,16 +228,17 @@ function UploadForm({ onUploaded }: UploadFormProps) {
         }),
       );
 
-      const putRes = await fetch(mint.uploadUrl, {
-        method: "PUT",
-        body: file,
-        headers: { "Content-Type": contentType },
-      });
-      if (!putRes.ok) {
-        throw new Error(
-          `S3 upload failed (${putRes.status} ${putRes.statusText})`,
-        );
-      }
+      // Presigned PUT — bypasses the typed client; noticedFetch
+      // surfaces failures (CORS, status, network) in NR Browser.
+      await noticedFetch(
+        mint.uploadUrl,
+        {
+          method: "PUT",
+          body: file,
+          headers: { "Content-Type": contentType },
+        },
+        { kind: "scout_kb_s3_put" },
+      );
 
       await callApi(
         api.POST("/api/scout/knowledge/documents/{id}/commit", {

--- a/apps/web/src/pages/scout/knowledge-admin.tsx
+++ b/apps/web/src/pages/scout/knowledge-admin.tsx
@@ -215,6 +215,10 @@ function UploadForm({ onUploaded }: UploadFormProps) {
       }
       const tags = parseTags(tagsRaw);
 
+      // 3-step sequence — each await depends on the previous result
+      // (mint.uploadUrl → S3 PUT → commit by mint.id), so the
+      // async-parallel lint rule's auto-detection is a false positive.
+      // eslint-disable-next-line react-doctor/async-parallel
       const mint = await callApi(
         api.POST("/api/scout/knowledge/documents", {
           body: {

--- a/apps/web/src/providers/app-providers.tsx
+++ b/apps/web/src/providers/app-providers.tsx
@@ -34,8 +34,7 @@ export function AppProviders({ children }: { children: ReactNode }) {
             noticeQueryError(err, {
               kind: "query",
               queryKey: query.queryKey
-                .map((part) => (typeof part === "string" ? part : ""))
-                .filter(Boolean)
+                .flatMap((part) => (typeof part === "string" ? [part] : []))
                 .join(":"),
             }),
         }),
@@ -45,8 +44,7 @@ export function AppProviders({ children }: { children: ReactNode }) {
               kind: "mutation",
               mutationKey:
                 mutation.options.mutationKey
-                  ?.map((part) => (typeof part === "string" ? part : ""))
-                  .filter(Boolean)
+                  ?.flatMap((part) => (typeof part === "string" ? [part] : []))
                   .join(":") ?? "unknown",
             }),
         }),

--- a/apps/web/src/providers/app-providers.tsx
+++ b/apps/web/src/providers/app-providers.tsx
@@ -1,9 +1,57 @@
 import { ThemeProvider } from "@/hooks/use-theme.js";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  MutationCache,
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
 
+/**
+ * Forward any react-query (or react-query-mutation) error to NR
+ * Browser. Without this, react-query failures bubble to component-
+ * local `error` state and never reach NR — a server 5xx on a query
+ * shows as a toast (or nothing) and is invisible to observability.
+ */
+function noticeQueryError(
+  err: unknown,
+  attrs: Record<string, string | number | boolean>,
+) {
+  const error = err instanceof Error ? err : new Error(String(err));
+  if (window.newrelic) {
+    window.newrelic.noticeError(error, attrs);
+  } else {
+    console.error("react-query (NR not loaded):", error.message, attrs);
+  }
+}
+
 export function AppProviders({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        queryCache: new QueryCache({
+          onError: (err, query) =>
+            noticeQueryError(err, {
+              kind: "query",
+              queryKey: query.queryKey
+                .map((part) => (typeof part === "string" ? part : ""))
+                .filter(Boolean)
+                .join(":"),
+            }),
+        }),
+        mutationCache: new MutationCache({
+          onError: (err, _vars, _ctx, mutation) =>
+            noticeQueryError(err, {
+              kind: "mutation",
+              mutationKey:
+                mutation.options.mutationKey
+                  ?.map((part) => (typeof part === "string" ? part : ""))
+                  .filter(Boolean)
+                  .join(":") ?? "unknown",
+            }),
+        }),
+      }),
+  );
   return (
     <ThemeProvider>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2,12 +2,17 @@ import { createBrowserRouter } from "react-router";
 import { RequireAuth } from "./components/require-auth.js";
 import { RequireRole } from "./components/require-role.js";
 import { RequireVerifiedEmail } from "./components/require-verified-email.js";
+import { RouteError } from "./components/route-error.js";
 import { AuthLayout } from "./layouts/auth-layout.js";
 import { RootLayout } from "./layouts/root-layout.js";
 
 export const router = createBrowserRouter([
   {
     element: <RootLayout />,
+    // Catches render exceptions in any descendant route, plus
+    // route-not-found. Reports to NR with the route path so the white-
+    // screen failure mode is at least observable. (#182)
+    errorElement: <RouteError />,
     children: [
       // Public routes
       {

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -143,7 +143,7 @@ module "ecs" {
   public_subnet_ids        = module.vpc.public_subnet_ids
   ecs_security_group_id    = module.vpc.ecs_security_group_id
   alb_security_group_id    = module.vpc.alb_security_group_id
-  health_check_path        = "/health"
+  health_check_path        = "/health/ready"
   log_retention_days       = 30
   assign_public_ip         = true
   ses_identity_arn         = local.shared.ses_identity_arn

--- a/infra/environments/shared/.terraform.lock.hcl
+++ b/infra/environments/shared/.terraform.lock.hcl
@@ -23,3 +23,29 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
+
+provider "registry.terraform.io/newrelic/newrelic" {
+  version     = "3.87.1"
+  constraints = "~> 3.49"
+  hashes = [
+    "h1:FMp3SFbUBrrIgoh58RSoE5/fQDPrHFuB9hddBbt9pxA=",
+    "zh:0e27c11507438585e9edf621f03ef2850a2fbbb9af93565ab060ce99bd6b7fb9",
+    "zh:12bd328d70d7968fa44387160aeaf6800d09491d6481f05408a7ea351b9d4169",
+    "zh:2614a4b4aa461e0f48c364113dac65a6c9e6ff234b7d62b6b4de998caaab4dbe",
+    "zh:271364fa6a498aa2b48db139ed0112debef8091dcf71207b308ca33dca9819d5",
+    "zh:3874ba4f7b2e0e0523aba23ad47bab56aeb4e4ef431a762f4c38e19d2ff88dfe",
+    "zh:414703fcfeb3d91f0d76ca521ae3f43fdfe8fe12c99a3ae30ab3f4dde0fac774",
+    "zh:5014cab20337bbdf75d3897fe5f7ef45540fa4db61d2dcc87d5a32ddab8afb99",
+    "zh:6224579ce40dd732c828543fdb7151843ed0326ff1bdd04be577c9a91ba9ee88",
+    "zh:6494c8702f1dcfc2b8e4b625bb5b8fe4e3187ea864129d2b8bbc74ec8239c40b",
+    "zh:7614474e06081707f7bab0047dfe49e3f074661fe7193fa494e00082ebc148a7",
+    "zh:81345ebaaa5715fc5a3050c81979f293a5f30f2c1e024fa82d1ae4cd1d3c9128",
+    "zh:a3428ee5fae7e0bd6731c4899e0ece91cd893cd40146fa4a5dc8ef531892cb62",
+    "zh:a68edfdfb0f48bf01e19fbf6a6497b94920505f22b26fdad930126e6d57d0249",
+    "zh:a97fa457c40c43044768a5547ec46e5e57cf0c76a797ed0b02f84b693e6c59e5",
+    "zh:b0fd27ae0d4903e06841bd0981bba404020625b561e3e17aa770e7e49f6faa5d",
+    "zh:f1da5858add70b6a061ed8fa8e3fc2ec17bdc6108033f3abeb5f8b1db5ac25e5",
+    "zh:f8fda37a7573377e056e12ff57d2291d1d564ec3e3d99021a941265fe538ec30",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -911,10 +911,9 @@ resource "newrelic_cloud_aws_integrations" "main" {
   # narrow what gets ingested.
   alb {}
   cloudfront {}
-  cloudwatch_metric_streams {}
   ec2 {}
   ecs {}
-  elasticloadbalancing {}
+  elb {}
   iam {}
   rds {}
   route53 {}

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -586,10 +586,12 @@ resource "aws_sns_topic" "shared_reliability_alarms_us_east_1" {
 # from R53's globally-distributed checkers, so it catches DNS / TLS /
 # edge problems that ALB target health cannot.
 resource "aws_route53_health_check" "api" {
-  fqdn              = "api.v2.${var.domain_name}"
-  port              = 443
-  type              = "HTTPS"
-  resource_path     = "/health"
+  fqdn = "api.v2.${var.domain_name}"
+  port = 443
+  type = "HTTPS"
+  # /health/ready returns 503 on DB outage, so this health check fires
+  # the alarm on a real outage rather than just process death (#193).
+  resource_path     = "/health/ready"
   request_interval  = 30
   failure_threshold = 3
   measure_latency   = false

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = "~> 3.49"
+    }
   }
 
   backend "s3" {
@@ -24,6 +28,14 @@ provider "aws" {
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+}
+
+# New Relic provider — auth via NEW_RELIC_API_KEY env var (set on the
+# CI runner from secrets.NEW_RELIC_API_KEY). Account ID + region come
+# from variables so they're declarative rather than env-dependent.
+provider "newrelic" {
+  account_id = var.newrelic_account_id
+  region     = var.newrelic_region
 }
 
 # -----------------------------------------------------------------------------
@@ -824,4 +836,90 @@ resource "aws_sns_topic_policy" "security_events_us_east_1" {
   provider = aws.us_east_1
   arn      = aws_sns_topic.security_events_us_east_1.arn
   policy   = data.aws_iam_policy_document.security_events_us_east_1_topic.json
+}
+
+
+# -----------------------------------------------------------------------------
+# New Relic ↔ AWS account integration (API poll)
+# -----------------------------------------------------------------------------
+# Cross-account IAM role assumed by NR to poll CloudWatch metrics from
+# AWS namespace dashboards (RDS, ALB, CloudFront, SES, S3, Route 53,
+# etc). API poll over CloudWatch Metric Streams: 5-min granularity but
+# free; revisit when budget allows.
+#
+# The link account resource also tracks the integration in NR so a
+# console-side change shows as drift in the daily drift workflow
+# (#228) rather than silently diverging.
+
+data "aws_iam_policy_document" "newrelic_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+      # New Relic's integration account. Same value across all NR
+      # tenants — they assume into our account using ExternalId for
+      # tenant separation.
+      identifiers = ["arn:aws:iam::754728514883:root"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [tostring(var.newrelic_account_id)]
+    }
+  }
+}
+
+resource "aws_iam_role" "newrelic_integration" {
+  name               = "NewRelicInfrastructure-Integrations"
+  description        = "Allows New Relic to poll CloudWatch on this account"
+  assume_role_policy = data.aws_iam_policy_document.newrelic_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "newrelic_readonly" {
+  role       = aws_iam_role.newrelic_integration.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# Grants the additional permissions NR needs beyond ReadOnlyAccess
+# (mainly billing / budget metadata).
+resource "aws_iam_role_policy_attachment" "newrelic_budgets" {
+  role       = aws_iam_role.newrelic_integration.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSBilling"
+}
+
+# Tell New Relic about the role. NR begins polling CloudWatch via this
+# role on the next poll cycle (every 5 min by default).
+resource "newrelic_cloud_aws_link_account" "main" {
+  account_id             = var.newrelic_account_id
+  arn                    = aws_iam_role.newrelic_integration.arn
+  metric_collection_mode = "PULL"
+  name                   = "percy-main-aws"
+  depends_on = [
+    aws_iam_role_policy_attachment.newrelic_readonly,
+    aws_iam_role_policy_attachment.newrelic_budgets,
+  ]
+}
+
+# Enable the per-service AWS integrations we actually use. Cheap to
+# leave the others off — NR only polls services listed here.
+resource "newrelic_cloud_aws_integrations" "main" {
+  account_id        = var.newrelic_account_id
+  linked_account_id = newrelic_cloud_aws_link_account.main.id
+
+  # Per-service blocks — empty config blocks accept defaults (5-min
+  # poll, all regions). Add tag filters here later if we want to
+  # narrow what gets ingested.
+  alb {}
+  cloudfront {}
+  cloudwatch_metric_streams {}
+  ec2 {}
+  ecs {}
+  elasticloadbalancing {}
+  iam {}
+  rds {}
+  route53 {}
+  s3 {}
+  ses {}
+  sns {}
+  vpc {}
 }

--- a/infra/environments/shared/variables.tf
+++ b/infra/environments/shared/variables.tf
@@ -15,3 +15,18 @@ variable "ses_subdomain" {
   default     = "contact.percymain.org"
   description = "SES sending domain"
 }
+
+variable "newrelic_account_id" {
+  type        = number
+  description = "New Relic account ID for the AWS integration link. Pass via TF_VAR_newrelic_account_id (CI sets from vars.NEW_RELIC_ACCOUNT_ID)."
+}
+
+variable "newrelic_region" {
+  type        = string
+  default     = "EU"
+  description = "New Relic data centre region (US or EU)."
+  validation {
+    condition     = contains(["US", "EU"], var.newrelic_region)
+    error_message = "newrelic_region must be US or EU."
+  }
+}

--- a/infra/modules/ecs-service/main.tf
+++ b/infra/modules/ecs-service/main.tf
@@ -70,8 +70,9 @@ variable "secrets" {
 }
 
 variable "health_check_path" {
-  type    = string
-  default = "/health"
+  type        = string
+  default     = "/health/ready"
+  description = "ALB target group health check path. Defaults to /health/ready (returns 503 on DB outage so the instance drains). Set to /health/live for pure liveness; legacy /health is also still served."
 }
 
 variable "log_retention_days" {

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -814,6 +814,14 @@ export interface Session {
   userId: string;
 }
 
+export interface StripeWebhookEvent {
+  attempts: Generated<number>;
+  id: string;
+  processed_at: Timestamp | null;
+  received_at: Generated<Timestamp>;
+  type: string;
+}
+
 export interface TeamOfficial {
   play_cricket_team_id: string;
   user_id: string;
@@ -908,6 +916,7 @@ export interface DB {
   scout_thread_share: ScoutThreadShare;
   scout_tool_cache: ScoutToolCache;
   session: Session;
+  stripe_webhook_event: StripeWebhookEvent;
   team_official: TeamOfficial;
   twoFactor: TwoFactor;
   user: User;

--- a/packages/db/src/migrations/2026-05-10T00:00:00.000Z.ts
+++ b/packages/db/src/migrations/2026-05-10T00:00:00.000Z.ts
@@ -1,0 +1,37 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Stripe webhook idempotency table (#179).
+ *
+ * Every Stripe webhook event has a globally-unique `event.id`. Stripe
+ * delivers each event at-least-once: a 5xx (or any unhandled
+ * exception) on the receiver triggers exponential backoff retries for
+ * up to ~3 days. Without an idempotency check, every retry re-runs
+ * all side effects in handle{CheckoutCompleted,InvoicePayment,
+ * PaymentIntentSucceeded} — re-creating charges, re-sending emails,
+ * re-firing Slack notifications.
+ *
+ * Two-column claim pattern:
+ *   - `received_at` is set unconditionally on first sight (so we have
+ *     an audit row even for events that crash mid-processing)
+ *   - `processed_at` is set only after handlers finish successfully
+ *     (or terminally fail and we ack); a row whose processed_at IS NULL
+ *     is treated as not-yet-handled, so a Stripe retry after a crash
+ *     re-runs the handler instead of being skipped as a duplicate.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("stripe_webhook_event")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("type", "text", (col) => col.notNull())
+    .addColumn("received_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(db.fn("now")),
+    )
+    .addColumn("processed_at", "timestamptz")
+    .addColumn("attempts", "integer", (col) => col.notNull().defaultTo(0))
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("stripe_webhook_event").execute();
+}


### PR DESCRIPTION
## Summary

Wave 5 of the bug/observability sweep — 10 issues, mostly app-code (TS) with one TF integration:

- **#198** scout launchers/workers: `logger` non-optional in RunIngestDeps / RunReportDeps / ReportAgentDeps / ScoutAgentDeps / GenerateReportDeps; standalone workers use new `createWorkerLogger` helper (Pino via Fastify) and tests use `createNoopLogger`.
- **#196** scout/routes: include `userId` in per-turn `scout.turn` log.
- **#197** Propagate W3C traceparent from API to scout worker tasks. Launcher injects `OTEL_TRACEPARENT`/`OTEL_TRACESTATE` via ECS containerOverrides; worker extracts and runs inside `context.with(...)`. Worker `node` command now includes `--import ./apps/api/dist/instrumentation.js` so the OTel SDK actually boots in ECS.
- **#192** matchday/team-news-image: log image-composition errors at `team_news_image_asset_skipped` / `team_news_image_fetch_failed` instead of silent skip.
- **#191** Stripe paymentIntent cancel: new `cancelPaymentIntentTolerantly` helper distinguishes `payment_intent_unexpected_state` / `resource_missing` (expected) from genuine errors (logged + re-thrown).
- **#190** Log S3 cleanup failures in scout knowledge/attachments at `s3_cleanup_failed` warn — was silent `() => undefined`.
- **#193** Split `/health` → `/health/live` + `/health/ready` (503 on degraded). ALB target group + R53 health check + smoke tests all switched to `/health/ready`. ALB single-task fail-open caveat documented in route doc-comment.
- **#194** Frontend: new `noticedFetch` helper wraps raw S3 PUT fetches with `noticeError` + console.error fallback. Wired into 4 sites (admin expense export, admin documents, scout KB upload, scout chat attachments).
- **#195** Frontend NR Browser `allowed_origins` extended to staging API.
- **#201** NR↔AWS API-poll integration via `newrelic` TF provider in shared: cross-account IAM role + `newrelic_cloud_aws_link_account` + per-service `newrelic_cloud_aws_integrations`. Workflow plumbing for `NEW_RELIC_API_KEY` + `TF_VAR_newrelic_account_id` across all TF workflows.

## Codex review

Run after each wave with findings folded back into the relevant commits — 4 of 4 addressed:

- [High] Worker `node` command now includes `--import` so OTel SDK boots
- [High] NR TF wiring: workflow comment corrected to reflect that NR vars are required, not "tolerated"
- [Medium] ALB single-task fail-open caveat documented in `/health/ready` doc-comment
- [Medium] noticedFetch falls back to `console.error` when `window.newrelic` is undefined

## Test plan

- [ ] CI passes on this PR (lint-test-build, terraform plan for shared + production)
- [ ] After merge, verify scout chat → report flow shows as one trace tree in NR (was two)
- [ ] After merge, verify NR's "AWS" namespace dashboards (RDS / ALB / CloudFront / SES) populate from API-poll
- [ ] After merge, deliberately fail a scout S3 upload (e.g. break presigned URL) and confirm `noticeError` appears in NR Browser
- [ ] After merge, ALB target group health check uses `/health/ready` (verify in console)

## Issue references

Closes #190, #191, #192, #193, #194, #195, #196, #197, #198, #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)