### PR TITLE
hotfix(ci): correct + extend Terraform state-lock auto-release

### DIFF
--- a/.github/actions/tf-unlock/action.yml
+++ b/.github/actions/tf-unlock/action.yml
@@ -1,0 +1,79 @@
+name: Release stale Terraform state lock
+description: >
+  Force-unlock a Terraform state lock left behind by a cancelled or
+  killed CI run. Intended to run with `if: always() && <plan-outcome
+  != success>` after a terraform plan or apply step — terraform
+  releases its own lock on success, so the only locks this step ever
+  finds are stale.
+
+inputs:
+  environment:
+    description: TF environment name (matches infra/environments/<name>/).
+    required: true
+  bucket:
+    description: S3 state bucket name.
+    required: false
+    default: percy-main-terraform-state-bucket
+  table:
+    description: DynamoDB lock table name.
+    required: false
+    default: percy-main-terraform-locks
+  region:
+    description: AWS region for DynamoDB calls.
+    required: false
+    default: eu-west-2
+
+runs:
+  using: composite
+  steps:
+    - name: Force-unlock if a CI runner left a stale lock
+      shell: bash
+      working-directory: infra/environments/${{ inputs.environment }}
+      env:
+        BUCKET: ${{ inputs.bucket }}
+        TABLE: ${{ inputs.table }}
+        REGION: ${{ inputs.region }}
+        ENV: ${{ inputs.environment }}
+      run: |
+        # The s3 backend's DynamoDB lock row uses LockID = "<bucket>/<key>"
+        # (no -md5 suffix; that suffix is the separate state-digest row
+        # whose Info field is always None).
+        KEY="${BUCKET}/${ENV}/terraform.tfstate"
+
+        # Don't suppress stderr from get-item — IAM / table / region
+        # errors should be visible, not silently masked as "no lock".
+        # When the item is absent, get-item returns 0 with empty
+        # output, which we handle below.
+        set +e
+        OUT=$(aws dynamodb get-item \
+          --region "$REGION" \
+          --table-name "$TABLE" \
+          --key "{\"LockID\":{\"S\":\"$KEY\"}}" \
+          --query 'Item.Info.S' --output text)
+        STATUS=$?
+        set -e
+        if [ $STATUS -ne 0 ]; then
+          echo "::warning::aws dynamodb get-item failed (exit $STATUS) — cannot check for stale lock."
+          exit 0
+        fi
+        if [ -z "$OUT" ] || [ "$OUT" = "None" ]; then
+          echo "No state lock held — nothing to do."
+          exit 0
+        fi
+
+        LOCK_ID=$(jq -r '.ID' <<<"$OUT")
+        LOCK_WHO=$(jq -r '.Who' <<<"$OUT")
+        LOCK_CREATED=$(jq -r '.Created' <<<"$OUT")
+
+        # Only release locks held by GitHub Actions runners. A lock held
+        # by a real person (someone running terraform locally during an
+        # incident) is never something CI should clobber.
+        case "$LOCK_WHO" in
+          runner@*) ;;
+          *)
+            echo "Lock holder $LOCK_WHO is not a CI runner — refusing to force-unlock."
+            exit 0 ;;
+        esac
+
+        echo "Force-unlocking stale CI lock $LOCK_ID (held by $LOCK_WHO since $LOCK_CREATED)"
+        terraform force-unlock -force "$LOCK_ID"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,9 +109,22 @@ jobs:
         # the PR's plan comment; this records the apply-time plan in
         # the run summary so any drift between PR plan and apply is
         # auditable post hoc. See ADR 035.
+        # -lock-timeout: queue briefly behind a concurrent in-flight
+        # PR plan rather than failing instantly on lock contention.
         run: |
-          terraform plan -no-color -out=tfplan 2>&1 | tee plan.txt
+          terraform plan -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
           exit ${PIPESTATUS[0]}
+
+      - name: Release stale state lock if plan didn't release its own
+        # Belt-and-braces against a runner being killed mid-plan.
+        # cancel-in-progress is false on this workflow but a job can
+        # still die from runner OOM / GH outage / 6h timeout / manual
+        # cancellation. On success terraform releases the lock itself
+        # — this only runs on the failure paths.
+        if: always() && steps.plan.outcome != 'success'
+        uses: ./.github/actions/tf-unlock
+        with:
+          environment: shared
 
       - name: Plan summary
         if: always()
@@ -128,8 +141,14 @@ jobs:
         id: apply
         working-directory: infra/environments/shared
         run: |
-          terraform apply -auto-approve -no-color tfplan 2>&1 | tee apply.log
+          terraform apply -auto-approve -lock-timeout=2m -no-color tfplan 2>&1 | tee apply.log
           exit ${PIPESTATUS[0]}
+
+      - name: Release stale state lock if apply didn't release its own
+        if: always() && steps.apply.outcome != 'success'
+        uses: ./.github/actions/tf-unlock
+        with:
+          environment: shared
 
       - name: Apply summary
         if: always()
@@ -210,8 +229,14 @@ jobs:
         id: plan
         working-directory: infra/environments/production
         run: |
-          terraform plan -no-color -out=tfplan 2>&1 | tee plan.txt
+          terraform plan -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
           exit ${PIPESTATUS[0]}
+
+      - name: Release stale state lock if plan didn't release its own
+        if: always() && steps.plan.outcome != 'success'
+        uses: ./.github/actions/tf-unlock
+        with:
+          environment: production
 
       - name: Plan summary
         if: always()
@@ -228,8 +253,14 @@ jobs:
         id: apply
         working-directory: infra/environments/production
         run: |
-          terraform apply -auto-approve -no-color tfplan 2>&1 | tee apply.log
+          terraform apply -auto-approve -lock-timeout=2m -no-color tfplan 2>&1 | tee apply.log
           exit ${PIPESTATUS[0]}
+
+      - name: Release stale state lock if apply didn't release its own
+        if: always() && steps.apply.outcome != 'success'
+        uses: ./.github/actions/tf-unlock
+        with:
+          environment: production
 
       - name: Apply summary
         if: always()

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -48,10 +48,6 @@ jobs:
         working-directory: infra/environments/${{ matrix.environment }}
         run: terraform init
 
-      - name: Record job start (for stale-lock detection)
-        id: jobstart
-        run: echo "ts=$(date -u +%s)" >> "$GITHUB_OUTPUT"
-
       - name: Terraform Plan
         id: plan
         working-directory: infra/environments/${{ matrix.environment }}
@@ -65,45 +61,19 @@ jobs:
           exit ${PIPESTATUS[0]}
         continue-on-error: true
 
-      - name: Release stale state lock left by cancelled plan
+      - name: Release stale state lock if plan didn't release its own
         # cancel-in-progress above SIGKILLs an in-flight terraform when
-        # a new commit lands, leaving the DynamoDB lock orphaned forever.
-        # Run unconditionally: on success terraform already released the
-        # lock so this no-ops; on cancel/fail it cleans up our own mess.
-        # Guards against clobbering an unrelated active lock by checking
-        # both that the holder is a CI runner AND that the lock predates
-        # this job's start time.
-        if: always()
-        working-directory: infra/environments/${{ matrix.environment }}
-        env:
-          JOB_START_TS: ${{ steps.jobstart.outputs.ts }}
-        run: |
-          KEY="percy-main-terraform-state-bucket/${{ matrix.environment }}/terraform.tfstate-md5"
-          INFO=$(aws dynamodb get-item \
-            --region "${AWS_REGION}" \
-            --table-name percy-main-terraform-locks \
-            --key "{\"LockID\":{\"S\":\"$KEY\"}}" \
-            --query 'Item.Info.S' --output text 2>/dev/null) || INFO=""
-          if [ -z "$INFO" ] || [ "$INFO" = "None" ]; then
-            echo "No state lock held — nothing to do."
-            exit 0
-          fi
-          LOCK_ID=$(jq -r '.ID' <<<"$INFO")
-          LOCK_WHO=$(jq -r '.Who' <<<"$INFO")
-          LOCK_CREATED=$(jq -r '.Created' <<<"$INFO")
-          case "$LOCK_WHO" in
-            runner@*) ;;
-            *)
-              echo "Lock holder $LOCK_WHO is not a CI runner — leaving alone."
-              exit 0 ;;
-          esac
-          LOCK_TS=$(date -u -d "$LOCK_CREATED" +%s 2>/dev/null || echo 0)
-          if [ "$LOCK_TS" -ge "$JOB_START_TS" ]; then
-            echo "Lock was created at/after this job started ($LOCK_CREATED ≥ $JOB_START_TS) — likely active, leaving alone."
-            exit 0
-          fi
-          echo "Stale CI lock $LOCK_ID (held by $LOCK_WHO since $LOCK_CREATED) — force-unlocking."
-          terraform force-unlock -force "$LOCK_ID"
+        # a new commit lands, leaving the DynamoDB lock orphaned. On
+        # plan SUCCESS terraform releases the lock itself, so we only
+        # need to clean up on the non-success paths — gating on
+        # outcome != success also avoids clobbering an active lock
+        # acquired by a concurrent run after this job started (the
+        # TOCTOU concern that the previous timestamp guard tried to
+        # address, less reliably).
+        if: always() && steps.plan.outcome != 'success'
+        uses: ./.github/actions/tf-unlock
+        with:
+          environment: ${{ matrix.environment }}
 
       - name: Plan summary
         if: always()


### PR DESCRIPTION
## Summary

Fixes the broken state-lock auto-release that left main's deploy stuck on a stale lock after batch-3 merged. Three bugs in the original implementation, plus deploy.yml had no cleanup at all:

| # | Bug | Effect |
|---|---|---|
| A | DynamoDB key used `-md5` suffix | get-item read the digest row (always `Info=None`); cleanup was a no-op every run |
| B | deploy.yml had no cleanup step | When PR plan got cancelled by merge, lock was orphaned; deploy.yml hit it |
| C | `JOB_START_TS` guard was inverted | A lock created by THIS job has `Created > JOB_START_TS` so the guard would skip cleanup of our own orphaned lock — defeating the step |

Other bugs caught in the review: `2>/dev/null` on get-item swallowed IAM errors as "no lock"; deploy.yml's plan/apply had no `-lock-timeout` so a concurrent PR plan would fail it instantly.

## Redesign

- **Reusable composite action** at `.github/actions/tf-unlock/`. Both workflows call it.
- **Gated on `if: always() && steps.<plan|apply>.outcome != 'success'`** — terraform releases its own lock on success, so this step only runs on the failure paths. Eliminates the cross-job TOCTOU concern that the timestamp guard was trying (and failing) to handle.
- **Dropped the timestamp guard.** Kept the `runner@*` hostname check so we never clobber a developer's local-terraform lock during an incident.
- **Surfaced AWS errors** by removing `2>/dev/null` — IAM/table/region misconfig now warns instead of silently passing as "no lock held".
- **Added `-lock-timeout=2m`** to both plan and apply in deploy.yml.

## Test plan

- [x] Stale lock from the broken deploy manually force-unlocked locally to unblock prod (already done; that's separate from this PR)
- [ ] CI green
- [ ] After merge: trigger a deploy and verify the state-lock cleanup steps appear in the run summary as no-ops on the success path
- [ ] Future cancelled PR plan should leave the cleanup step visible in the cancelled run's logs, releasing the lock for the next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)