### PR TITLE
hotfix(infra): NR billing role policy ARN (AWSBillingReadOnlyAccess)

### DIFF
--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -881,10 +881,15 @@ resource "aws_iam_role_policy_attachment" "newrelic_readonly" {
 }
 
 # Grants the additional permissions NR needs beyond ReadOnlyAccess
-# (mainly billing / budget metadata).
+# (mainly billing / budget metadata). The previous ARN ("AWSBilling")
+# does not exist as an AWS-managed policy; AWSBillingReadOnlyAccess
+# is the read-only managed policy that NR's docs recommend for the
+# billing integration. We're not yet enabling NR's `billing {}` block
+# in newrelic_cloud_aws_integrations, but attaching this now means
+# enabling billing later is a one-line change to that resource.
 resource "aws_iam_role_policy_attachment" "newrelic_budgets" {
   role       = aws_iam_role.newrelic_integration.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSBilling"
+  policy_arn = "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
 }
 
 # Tell New Relic about the role. NR begins polling CloudWatch via this


### PR DESCRIPTION
## Summary

deploy.yml's terraform-shared apply died on:

```
Error: attaching IAM Policy (arn:aws:iam::aws:policy/AWSBilling) to IAM Role
(NewRelicInfrastructure-Integrations): NoSuchEntity: Policy does not exist
or is not attachable.
```

There is no AWS-managed policy named `AWSBilling`. Per `aws iam list-policies --scope AWS`, the billing-related managed policies are `job-function/Billing` (write) and `AWSBillingReadOnlyAccess` (read). NR's docs (verified via context7) recommend `AWSBillingReadOnlyAccess` for the billing integration.

Local `terraform plan` against shared: `3 to add, 0 to change, 0 to destroy` (the previous failed apply already created the IAM role; this completes the attachment + linked-account + integrations resources).

## Test plan

- [x] Local `terraform plan` against shared succeeds with the new ARN
- [ ] CI green
- [ ] After merge: deploy.yml's terraform-shared apply succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)