### PR TITLE
hotfix(infra): revert R53 health check to /health

### DIFF
--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -601,9 +601,14 @@ resource "aws_route53_health_check" "api" {
   fqdn = "api.v2.${var.domain_name}"
   port = 443
   type = "HTTPS"
-  # /health/ready returns 503 on DB outage, so this health check fires
-  # the alarm on a real outage rather than just process death (#193).
-  resource_path     = "/health/ready"
+  # HOTFIX 2026-05-10: temporarily reverted to /health from /health/ready.
+  # The /health/ready route only exists in API commits >= b37094b, and the
+  # production API is still on the May 7 image (b37094b's deploy failed at
+  # terraform-shared; subsequent CVE buildup blocks the Trivy gate, so we
+  # can't redeploy until the dep bumps land). Once the API is on a build
+  # with /health/ready, restore that path here so the alarm reflects DB
+  # readiness, not just process death (#193).
+  resource_path     = "/health"
   request_interval  = 30
   failure_threshold = 3
   measure_latency   = false


### PR DESCRIPTION
## Why

Production API has been spamming the on-call inbox: R53 health check hits \`/health/ready\` every 30s and gets 404.

## Root cause

\`b37094b\` (#253) bundled two changes:
1. Added \`/health/ready\` route to the API.
2. Switched R53 health check + ALB target group to poll \`/health/ready\`.

\`b37094b\`'s Deploy workflow failed at \`terraform-shared\`, and the chain skipped \`deploy-api\`. A later push (\`bdb39cc\`) succeeded at terraform-shared, so the R53 check is now polling \`/health/ready\` — but the API is still the May 7 image, which doesn't have that route.

Re-running \`Deploy API (manual)\` from current main hits the Trivy gate: 29 CVEs (3 CRITICAL) accumulated since May 7. Clearing those requires landing the dep-bump PRs, which is its own multi-PR effort.

## What this does

Revert the Route 53 health-check \`resource_path\` from \`/health/ready\` to \`/health\` so the check polls a route the deployed API actually serves. Stops the spam.

## Follow-up

Once the API is redeployed with current main code (which has \`/health/ready\`), flip the path back. The ALB target group's path will also need a coordinated update (#263 currently bundles that drift with the AWS provider v6 bump).