### PR TITLE
hotfix(api): replace Stripe-pattern placeholder in generate-openapi

### DIFF
--- a/apps/api/src/generate-openapi.ts
+++ b/apps/api/src/generate-openapi.ts
@@ -12,7 +12,11 @@ import { parseConfig } from "./config.ts";
 const config = parseConfig({
   DATABASE_URL: "postgres://percy:percy@localhost:5433/percy_main",
   API_BASE_URL: "http://localhost:3000",
-  STRIPE_SECRET_KEY: "sk_test_placeholder",
+  // Trivy's stripe-secret-token rule matches any `sk_test_*` literal —
+  // even an obvious placeholder — and fails the deploy. The OpenAPI
+  // generator boots the app but never calls Stripe, so any non-empty
+  // string satisfies z.string() in config.
+  STRIPE_SECRET_KEY: "openapi-generator-placeholder",
   S3_BUCKET: "placeholder",
   S3_DOCUMENTS_BUCKET: "placeholder",
   S3_DOCUMENT_UPLOADS_BUCKET: "placeholder",


### PR DESCRIPTION
## Why

Latest deploy failed at Trivy:

\`\`\`
/app/apps/api/dist/generate-openapi.js (secrets)
CRITICAL: Stripe (stripe-secret-token)
Stripe Secret Key
   13       STRIPE_SECRET_KEY: "sk_test_placeholder",
\`\`\`

Trivy's \`stripe-secret-token\` rule matches **any** literal starting with \`sk_test_\` or \`sk_live_\`. The placeholder in \`generate-openapi.ts\` is obviously a test-mode dummy, but the regex doesn't care.

## What

Change the placeholder to a value that doesn't match the regex. \`generate-openapi.ts\` boots the app to dump the OpenAPI spec; it never calls Stripe. The config schema is just \`z.string()\` so any non-empty string works.

## Tested

\`pnpm --filter api typecheck\` clean; \`pnpm --filter api lint\` clean.