### PR TITLE
hotfix(infra): revert ALB health check to /health

### DIFF
--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -143,7 +143,16 @@ module "ecs" {
   public_subnet_ids        = module.vpc.public_subnet_ids
   ecs_security_group_id    = module.vpc.ecs_security_group_id
   alb_security_group_id    = module.vpc.alb_security_group_id
-  health_check_path        = "/health/ready"
+  # HOTFIX 2026-05-11: temporarily reverted to /health (pairs with #275
+  # R53 revert). The /health/ready route only exists in API commits
+  # >= b37094b, and the production API has been stuck on the May 7 image
+  # since b37094b's deploy failed at terraform-shared and never recovered
+  # (Trivy now flags ~30 deps + a Stripe-pattern placeholder in
+  # generate-openapi.js, fixed in #281). Result: ALB polls
+  # /health/ready, gets 404 from old code, both targets unhealthy,
+  # HTTPCode_ELB_5XX_Count alarm fires. Restore /health/ready once
+  # the API is on a build that serves it.
+  health_check_path        = "/health"
   log_retention_days       = 30
   assign_public_ip         = true
   ses_identity_arn         = local.shared.ses_identity_arn


### PR DESCRIPTION
## Why

Production ALB target group is polling \`/health/ready\`, but the running API tasks are still on the May 7 image (b37094b's deploy chain failed at terraform-shared and has not recovered — Trivy keeps blocking on dep CVEs + the Stripe-pattern placeholder fixed by #281).

\`\`\`
$ aws elbv2 describe-target-health …
[
  { "target": "10.0.1.28",  "state": "unhealthy", "reason": "Target.ResponseCodeMismatch", "desc": "Health checks failed with these codes: [404]" },
  { "target": "10.0.0.248", "state": "unhealthy", "reason": "Target.ResponseCodeMismatch", "desc": "Health checks failed with these codes: [404]" }
]
\`\`\`

Both targets unhealthy → ALB returns 5xx to real traffic → \`percy-main-production-alb-5xx-errors\` alarm fires.

## What

Mirror #275 at the ALB layer: set \`health_check_path\` in \`infra/environments/production/main.tf\` to \`/health\` until the API is on a build that has \`/health/ready\`.

## Rollback

Once #281 unblocks the deploy and a fresh API image rolls out with \`/health/ready\`, open a follow-up PR that:
1. Restores \`health_check_path = "/health/ready"\` here.
2. Restores \`resource_path = "/health/ready"\` in \`infra/environments/shared/main.tf\` (reverts #275).