### PR TITLE
restore: switch R53 + ALB health checks back to /health/ready

### DIFF
--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -143,16 +143,7 @@ module "ecs" {
   public_subnet_ids        = module.vpc.public_subnet_ids
   ecs_security_group_id    = module.vpc.ecs_security_group_id
   alb_security_group_id    = module.vpc.alb_security_group_id
-  # HOTFIX 2026-05-11: temporarily reverted to /health (pairs with #275
-  # R53 revert). The /health/ready route only exists in API commits
-  # >= b37094b, and the production API has been stuck on the May 7 image
-  # since b37094b's deploy failed at terraform-shared and never recovered
-  # (Trivy now flags ~30 deps + a Stripe-pattern placeholder in
-  # generate-openapi.js, fixed in #281). Result: ALB polls
-  # /health/ready, gets 404 from old code, both targets unhealthy,
-  # HTTPCode_ELB_5XX_Count alarm fires. Restore /health/ready once
-  # the API is on a build that serves it.
-  health_check_path        = "/health"
+  health_check_path        = "/health/ready"
   log_retention_days       = 30
   assign_public_ip         = true
   ses_identity_arn         = local.shared.ses_identity_arn

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -601,14 +601,9 @@ resource "aws_route53_health_check" "api" {
   fqdn = "api.v2.${var.domain_name}"
   port = 443
   type = "HTTPS"
-  # HOTFIX 2026-05-10: temporarily reverted to /health from /health/ready.
-  # The /health/ready route only exists in API commits >= b37094b, and the
-  # production API is still on the May 7 image (b37094b's deploy failed at
-  # terraform-shared; subsequent CVE buildup blocks the Trivy gate, so we
-  # can't redeploy until the dep bumps land). Once the API is on a build
-  # with /health/ready, restore that path here so the alarm reflects DB
-  # readiness, not just process death (#193).
-  resource_path     = "/health"
+  # /health/ready returns 503 on DB outage, so this health check fires
+  # the alarm on a real outage rather than just process death (#193).
+  resource_path     = "/health/ready"
   request_interval  = 30
   failure_threshold = 3
   measure_latency   = false


### PR DESCRIPTION
## Why

The production API has been redeployed onto task-definition \`production-api:110\` (commit \`dc6209a\` head). The \`/health/ready\` route is live and healthy:

\`\`\`
$ curl -i https://api.v2.percymain.org/health/ready
HTTP/2 200
{"status":"ok","database":"connected"}
\`\`\`

Reverts the two emergency hotfixes that pointed Route 53 (#275) and the production ALB target group (#282) at \`/health\` while the API was stuck on the May 7 image. With the new code shipped, \`/health/ready\` is the better signal — it returns 503 on DB outage so the ALB drains the instance, while \`/health\` always 200s.

## Scope

- \`infra/environments/shared/main.tf\` — R53 health check \`resource_path\` → \`/health/ready\`.
- \`infra/environments/production/main.tf\` — ALB \`health_check_path\` → \`/health/ready\`.

## Not in this PR

- Trivy vulnerability gate stays disabled (#284) until #283 closes.

## Safety

The new image serves both legacy \`/health\` and \`/health/ready\`. If anything goes wrong during apply, the alternative path still 200s, so the alarm just goes back to firing on the OK→ALARM cycle of \`/health/ready\` — not a target-deregistration storm. Verified the target is healthy right now on the deployed task.