### PR TITLE
fix(matchday): allow marking match fees paid after match finished

### DIFF
--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -17,6 +17,7 @@ import {
   listPendingExpenses,
   listTeams,
   markExpenseReimbursed,
+  markFeePaid,
   recordExpense,
   rejectExpense,
   removePlayer,
@@ -435,6 +436,73 @@ describe("matchday service (integration)", () => {
         expect(charge?.amount_pence).toBe(500);
         expect(charge?.type).toBe("match_fee");
       }
+    });
+  });
+
+  describe("markFeePaid", () => {
+    it("marks an outstanding match fee as paid after the match is finished", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `markpaid-finished-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: userId });
+      const memberId = await seedMember(
+        "Late Payer",
+        `late-${crypto.randomUUID()}@test.com`,
+        "senior",
+      );
+
+      await seedFeeRate({ memberCategory: "senior", amountPence: 700 });
+
+      const { id: playerId } = await addPlayer(ctx.db)(
+        userId,
+        "admin",
+        matchdayId,
+        { memberId, playerName: "Late Payer" },
+      );
+
+      await confirmTeam(ctx.db)(userId, "admin", matchdayId, {
+        playerStatuses: [{ matchdayPlayerId: playerId, status: "playing" }],
+      });
+
+      // Move matchday to "finished" without going through finishMatch
+      // (avoids pulling in the email/render imports for this test).
+      await ctx.db
+        .updateTable("matchday")
+        .set({
+          status: "finished",
+          finished_at: new Date().toISOString(),
+          finished_by: userId,
+          result_type: "W",
+        })
+        .where("id", "=", matchdayId)
+        .execute();
+
+      const result = await markFeePaid(ctx.db)(
+        userId,
+        "admin",
+        matchdayId,
+        playerId,
+        { paymentMethod: "cash" },
+      );
+
+      expect(result.success).toBe(true);
+
+      const player = await ctx.db
+        .selectFrom("matchday_player")
+        .where("id", "=", playerId)
+        .select(["charge_id"])
+        .executeTakeFirst();
+
+      const charge = await ctx.db
+        .selectFrom("charge")
+        .where("id", "=", player?.charge_id ?? "")
+        .selectAll()
+        .executeTakeFirst();
+
+      expect(charge?.paid_at).not.toBeNull();
+      expect(charge?.payment_method).toBe("cash");
     });
   });
 

--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -453,7 +453,7 @@ describe("matchday service (integration)", () => {
         "senior",
       );
 
-      await seedFeeRate({ memberCategory: "senior", amountPence: 700 });
+      await seedFeeRate({ teamId, memberCategory: "senior", amountPence: 700 });
 
       const { id: playerId } = await addPlayer(ctx.db)(
         userId,

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -949,8 +949,9 @@ function MatchdayView({
                         </div>
                       </div>
                       <div className="flex items-center gap-2">
-                        {/* Match fee payment controls for confirmed matchdays */}
-                        {data.matchday.status === "confirmed" &&
+                        {/* Match fee payment controls for confirmed and finished matchdays */}
+                        {(data.matchday.status === "confirmed" ||
+                          data.matchday.status === "finished") &&
                           player.status === "playing" &&
                           player.charge_id &&
                           !player.chargePaidAt && (


### PR DESCRIPTION
## Summary
- Mark-paid UI was only available while a matchday was `confirmed`. Once finished, officials could no longer record cash/bank-transfer payments they collected after the game, leaving outstanding charges they had to chase through the admin Charges tab instead.
- Backend `markFeePaid` already permits any matchday status, so the fix is purely UI: extend the gate to also include `finished`.
- Added an integration test asserting that `markFeePaid` works against a finished matchday (it would have caught a future status-tightening on the API side).

## Test plan
- [x] `pnpm test:integration` — new `markFeePaid` test passes
- [x] `pnpm typecheck` (api + web)
- [x] `pnpm lint`
- [ ] Manual: confirm "Mark Paid" buttons appear on a finished matchday for unpaid playing members and the click flow completes