### PR TITLE
feat(matchday): cancel matchday workflow (close without charging)

### DIFF
--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   addPlayer,
   approveExpense,
+  cancelMatchday,
   confirmTeam,
   createMatchday,
   deleteExpense,
@@ -785,6 +786,163 @@ describe("matchday service (integration)", () => {
       for (const item of submitted.items) {
         expect(item.status).toBe("submitted");
       }
+    });
+  });
+
+  describe("cancelMatchday", () => {
+    it("cancels a pending matchday and records the reason", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cancel-pending-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: userId });
+
+      const result = await cancelMatchday(ctx.db)(userId, "admin", matchdayId, {
+        reason: "Rained off",
+      });
+
+      expect(result.success).toBe(true);
+
+      const md = await ctx.db
+        .selectFrom("matchday")
+        .where("id", "=", matchdayId)
+        .selectAll()
+        .executeTakeFirst();
+      expect(md?.status).toBe("cancelled");
+      expect(md?.cancelled_at).not.toBeNull();
+      expect(md?.cancelled_by).toBe(userId);
+      expect(md?.cancelled_reason).toBe("Rained off");
+    });
+
+    it("cancels a confirmed matchday when no charges exist", async () => {
+      // A confirmed matchday with only bursary players has no charges.
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cancel-confirmed-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: userId });
+      const memberId = await seedMember(
+        "Bursary Player",
+        `bursary-${crypto.randomUUID()}@test.com`,
+        "bursary",
+      );
+      await seedFeeRate({ teamId, memberCategory: "senior", amountPence: 500 });
+
+      const { id: playerId } = await addPlayer(ctx.db)(
+        userId,
+        "admin",
+        matchdayId,
+        { memberId, playerName: "Bursary Player" },
+      );
+
+      await confirmTeam(ctx.db)(userId, "admin", matchdayId, {
+        playerStatuses: [{ matchdayPlayerId: playerId, status: "playing" }],
+      });
+
+      const md = await ctx.db
+        .selectFrom("matchday")
+        .where("id", "=", matchdayId)
+        .select(["status"])
+        .executeTakeFirst();
+      expect(md?.status).toBe("confirmed");
+
+      const result = await cancelMatchday(ctx.db)(
+        userId,
+        "admin",
+        matchdayId,
+        {},
+      );
+      expect(result.success).toBe(true);
+
+      const after = await ctx.db
+        .selectFrom("matchday")
+        .where("id", "=", matchdayId)
+        .selectAll()
+        .executeTakeFirst();
+      expect(after?.status).toBe("cancelled");
+    });
+
+    it("blocks cancel when any active match-fee charge exists", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cancel-blocked-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: userId });
+      const memberId = await seedMember(
+        "Paying Player",
+        `paying-${crypto.randomUUID()}@test.com`,
+        "senior",
+      );
+      await seedFeeRate({ teamId, memberCategory: "senior", amountPence: 500 });
+
+      const { id: playerId } = await addPlayer(ctx.db)(
+        userId,
+        "admin",
+        matchdayId,
+        { memberId, playerName: "Paying Player" },
+      );
+
+      await confirmTeam(ctx.db)(userId, "admin", matchdayId, {
+        playerStatuses: [{ matchdayPlayerId: playerId, status: "playing" }],
+      });
+
+      await expect(
+        cancelMatchday(ctx.db)(userId, "admin", matchdayId, {}),
+      ).rejects.toThrow("Cannot cancel");
+
+      // Status unchanged
+      const md = await ctx.db
+        .selectFrom("matchday")
+        .where("id", "=", matchdayId)
+        .select(["status"])
+        .executeTakeFirst();
+      expect(md?.status).toBe("confirmed");
+    });
+
+    it("rejects cancelling a finished matchday", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cancel-finished-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({
+        teamId,
+        createdBy: userId,
+        status: "finished",
+      });
+
+      await expect(
+        cancelMatchday(ctx.db)(userId, "admin", matchdayId, {}),
+      ).rejects.toThrow("finished matchday");
+    });
+
+    it("createMatchday allows re-using the date of a cancelled matchday", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cancel-recreate-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchDate = "2026-08-12";
+
+      // First matchday on this date → cancel it
+      const firstId = await seedMatchday({
+        teamId,
+        createdBy: userId,
+        matchDate,
+      });
+      await cancelMatchday(ctx.db)(userId, "admin", firstId, {});
+
+      // Now re-create on the same date — should succeed
+      const result = await createMatchday(ctx.db)(userId, "admin", {
+        teamId,
+        matchDate,
+        opposition: "Rescheduled CC",
+      });
+      expect(result.id).toBeDefined();
+      expect(result.id).not.toBe(firstId);
     });
   });
 });

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -4,6 +4,7 @@ import { createApiClient } from "../play-cricket/api-client.ts";
 import {
   addPlayerResponseSchema,
   addPlayerSchema,
+  cancelMatchdaySchema,
   confirmTeamSchema,
   createMatchdayResponseSchema,
   createMatchdaySchema,
@@ -36,6 +37,7 @@ import {
 import {
   addPlayer,
   approveExpense,
+  cancelMatchday,
   confirmTeam,
   createMatchday,
   deleteExpense,
@@ -300,6 +302,7 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
   const setRoles = setMatchRoles(app.db);
   const paid = markFeePaid(app.db);
   const finish = finishMatch(app.db, app.send, app.config);
+  const cancel = cancelMatchday(app.db);
 
   // Play-Cricket API client for upcoming matches — wired at registration time
   const upcoming =
@@ -497,6 +500,23 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
         request.body,
         request.log,
       );
+    },
+  );
+
+  app.post(
+    "/matchday/:matchId/cancel",
+    {
+      preHandler: [officialRole],
+      schema: {
+        params: matchIdParamSchema,
+        body: cancelMatchdaySchema,
+        response: { 200: successResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      const role = (user as { role?: string | null }).role ?? "user";
+      return await cancel(user.id, role, request.params.matchId, request.body);
     },
   );
 };

--- a/apps/api/src/features/matchday/schemas.ts
+++ b/apps/api/src/features/matchday/schemas.ts
@@ -19,7 +19,7 @@ export const listMatchesSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
   offset: z.coerce.number().int().min(0).default(0),
   statusFilter: z
-    .enum(["all", "pending", "confirmed", "finished"])
+    .enum(["all", "pending", "confirmed", "finished", "cancelled"])
     .default("all"),
 });
 
@@ -119,6 +119,12 @@ export const finishMatchSchema = z.object({
   resultType: resultTypeSchema,
 });
 
+// ── Cancel matchday schemas ──
+
+export const cancelMatchdaySchema = z.object({
+  reason: z.string().trim().min(1).max(500).optional(),
+});
+
 // ── Expense approval workflow schemas ──
 
 export const expenseStatusSchema = z.enum([
@@ -167,6 +173,9 @@ const matchdayItemSchema = z.object({
   result_confirmed_at: z.string().nullable(),
   result_confirmed_by: z.string().nullable(),
   result_source: z.string().nullable(),
+  cancelled_at: z.string().nullable(),
+  cancelled_by: z.string().nullable(),
+  cancelled_reason: z.string().nullable(),
 });
 
 export const listMatchesResponseSchema = z.object({
@@ -313,3 +322,4 @@ export type SubmitExpense = z.infer<typeof submitExpenseSchema>;
 export type RejectExpense = z.infer<typeof rejectExpenseSchema>;
 export type ListPendingExpenses = z.infer<typeof listPendingExpensesSchema>;
 export type FinishMatch = z.infer<typeof finishMatchSchema>;
+export type CancelMatchday = z.infer<typeof cancelMatchdaySchema>;

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -12,6 +12,7 @@ import type { S3Uploader } from "../../lib/s3-upload.ts";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 import type {
   AddPlayer,
+  CancelMatchday,
   ConfirmTeam,
   CreateMatchday,
   FinishMatch,
@@ -431,10 +432,13 @@ export function getUpcomingMatches(
         return dateA.getTime() - dateB.getTime();
       });
 
-    // Check which matches already have a matchday record
+    // Check which matches already have a matchday record. Cancelled
+    // matchdays are hidden so a rescheduled fixture surfaces as
+    // creatable again.
     const existingMatchdays = await db
       .selectFrom("matchday")
       .where("play_cricket_team_id", "=", teamId)
+      .where("status", "!=", "cancelled")
       .selectAll()
       .execute();
 
@@ -463,11 +467,14 @@ export function createMatchday(db: Kysely<DB>) {
       throwHttpError(403, "You do not have access to this team");
     }
 
-    // Check no existing matchday for this team + date
+    // Check no existing matchday for this team + date. A previously
+    // cancelled matchday is ignored so a rescheduled fixture on the
+    // same date can be re-created.
     const existing = await db
       .selectFrom("matchday")
       .where("play_cricket_team_id", "=", data.teamId)
       .where("match_date", "=", data.matchDate)
+      .where("status", "!=", "cancelled")
       .select("id")
       .executeTakeFirst();
 
@@ -884,6 +891,69 @@ export function markFeePaid(db: Kysely<DB>) {
       })
       .where("id", "=", player.charge_id)
       .where("paid_at", "is", null)
+      .execute();
+
+    return { success: true };
+  };
+}
+
+export function cancelMatchday(db: Kysely<DB>) {
+  return async (
+    userId: string,
+    role: string,
+    matchdayId: string,
+    data: CancelMatchday,
+  ) => {
+    const matchday = await db
+      .selectFrom("matchday")
+      .where("id", "=", matchdayId)
+      .select(["id", "play_cricket_team_id", "status"])
+      .executeTakeFirst();
+
+    if (!matchday) throwHttpError(404, "Matchday not found");
+
+    const accessibleIds = await getAccessibleTeamIds(db, userId, role);
+    if (!accessibleIds.includes(matchday.play_cricket_team_id)) {
+      throwHttpError(403, "You do not have access to this matchday");
+    }
+
+    if (matchday.status !== "pending" && matchday.status !== "confirmed") {
+      throwHttpError(
+        400,
+        matchday.status === "cancelled"
+          ? "Matchday is already cancelled"
+          : "Cannot cancel a finished matchday",
+      );
+    }
+
+    // Block if any non-deleted match-fee charge already exists. The
+    // user-facing rule is "close off without charging" — if charges
+    // already exist, treasurer needs to void/refund them through the
+    // normal flow first.
+    const existingCharge = await db
+      .selectFrom("matchday_player")
+      .innerJoin("charge", "charge.id", "matchday_player.charge_id")
+      .where("matchday_player.matchday_id", "=", matchdayId)
+      .where("charge.deleted_at", "is", null)
+      .select("charge.id")
+      .executeTakeFirst();
+
+    if (existingCharge) {
+      throwHttpError(
+        400,
+        "Cannot cancel: match fee charges already exist. Void them via the Charges admin first.",
+      );
+    }
+
+    await db
+      .updateTable("matchday")
+      .set({
+        status: "cancelled",
+        cancelled_at: new Date().toISOString(),
+        cancelled_by: userId,
+        cancelled_reason: data.reason ?? null,
+      })
+      .where("id", "=", matchdayId)
       .execute();
 
     return { success: true };

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -3971,7 +3971,7 @@ export interface paths {
                     teamId?: string;
                     limit?: number;
                     offset?: number;
-                    statusFilter?: "all" | "pending" | "confirmed" | "finished";
+                    statusFilter?: "all" | "pending" | "confirmed" | "finished" | "cancelled";
                 };
                 header?: never;
                 path?: never;
@@ -4004,6 +4004,9 @@ export interface paths {
                                 result_confirmed_at: string | null;
                                 result_confirmed_by: string | null;
                                 result_source: string | null;
+                                cancelled_at: string | null;
+                                cancelled_by: string | null;
+                                cancelled_reason: string | null;
                             }[];
                         };
                     };
@@ -4092,6 +4095,9 @@ export interface paths {
                                 result_confirmed_at: string | null;
                                 result_confirmed_by: string | null;
                                 result_source: string | null;
+                                cancelled_at: string | null;
+                                cancelled_by: string | null;
+                                cancelled_reason: string | null;
                             };
                             team: {
                                 id: string;
@@ -4922,6 +4928,51 @@ export interface paths {
                             success: boolean;
                             emailsSent: number;
                             emailErrors: string[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/matchday/{matchId}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    matchId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        reason?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -649,6 +649,7 @@
                 "type": "object",
                 "properties": {
                   "chargeIds": {
+                    "minItems": 1,
                     "type": "array",
                     "items": {
                       "type": "string"
@@ -6833,7 +6834,8 @@
                 "all",
                 "pending",
                 "confirmed",
-                "finished"
+                "finished",
+                "cancelled"
               ]
             },
             "in": "query",
@@ -6914,6 +6916,18 @@
                           "result_source": {
                             "nullable": true,
                             "type": "string"
+                          },
+                          "cancelled_at": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "cancelled_by": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "cancelled_reason": {
+                            "nullable": true,
+                            "type": "string"
                           }
                         },
                         "required": [
@@ -6933,7 +6947,10 @@
                           "result_type",
                           "result_confirmed_at",
                           "result_confirmed_by",
-                          "result_source"
+                          "result_source",
+                          "cancelled_at",
+                          "cancelled_by",
+                          "cancelled_reason"
                         ],
                         "additionalProperties": false
                       }
@@ -7090,6 +7107,18 @@
                         "result_source": {
                           "nullable": true,
                           "type": "string"
+                        },
+                        "cancelled_at": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "cancelled_by": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "cancelled_reason": {
+                          "nullable": true,
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -7109,7 +7138,10 @@
                         "result_type",
                         "result_confirmed_at",
                         "result_confirmed_by",
-                        "result_source"
+                        "result_source",
+                        "cancelled_at",
+                        "cancelled_by",
+                        "cancelled_reason"
                       ],
                       "additionalProperties": false
                     },
@@ -8364,6 +8396,58 @@
                     "success",
                     "emailsSent",
                     "emailErrors"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/matchday/{matchId}/cancel": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "matchId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/pages/admin/game-reports-tab.tsx
+++ b/apps/web/src/pages/admin/game-reports-tab.tsx
@@ -136,7 +136,9 @@ export function GameReportsTab() {
                             ? "bg-yellow-100 text-yellow-800"
                             : matchday.status === "confirmed"
                               ? "bg-green-100 text-green-800"
-                              : "bg-stone-100 text-stone-800"
+                              : matchday.status === "cancelled"
+                                ? "bg-red-100 text-red-800"
+                                : "bg-stone-100 text-stone-800"
                         }`}
                       >
                         {matchday.status}

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -656,6 +656,21 @@ function MatchdayView({
     },
   });
 
+  const cancelMatchdayMutation = useMutation({
+    mutationFn: (reason: string | undefined) =>
+      callApi(
+        api.POST("/api/matchday/{matchId}/cancel", {
+          params: { path: { matchId: matchdayId } },
+          body: reason ? { reason } : {},
+        }),
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["official", "matchday", matchdayId],
+      });
+    },
+  });
+
   const setRolesMutation = useMutation({
     mutationFn: (input: {
       captainPlayerId: string | null;
@@ -770,7 +785,9 @@ function MatchdayView({
                     ? "bg-yellow-100 text-yellow-800"
                     : data.matchday.status === "confirmed"
                       ? "bg-green-100 text-green-800"
-                      : "bg-stone-100 text-stone-800"
+                      : data.matchday.status === "cancelled"
+                        ? "bg-red-100 text-red-800"
+                        : "bg-stone-100 text-stone-800"
                 }`}
               >
                 {data.matchday.status}
@@ -1218,9 +1235,111 @@ function MatchdayView({
               </CardContent>
             </Card>
           )}
+
+          {/* Cancel matchday — available while pending or confirmed */}
+          {(data.matchday.status === "pending" ||
+            data.matchday.status === "confirmed") &&
+            !confirmingTeam && (
+              <CancelMatchdaySection
+                matchdayStatus={data.matchday.status}
+                onCancel={(reason) => cancelMatchdayMutation.mutate(reason)}
+                isPending={cancelMatchdayMutation.isPending}
+                error={
+                  cancelMatchdayMutation.error instanceof Error
+                    ? cancelMatchdayMutation.error.message
+                    : null
+                }
+              />
+            )}
+
+          {/* Cancelled status message */}
+          {data.matchday.status === "cancelled" && (
+            <Card>
+              <CardContent className="p-4">
+                <p className="text-sm text-stone-500">
+                  This match was cancelled.
+                  {data.matchday.cancelled_at &&
+                    ` On ${format(new Date(data.matchday.cancelled_at), "dd/MM/yyyy HH:mm")}.`}
+                  {data.matchday.cancelled_reason &&
+                    ` Reason: ${data.matchday.cancelled_reason}.`}
+                </p>
+              </CardContent>
+            </Card>
+          )}
         </>
       )}
     </div>
+  );
+}
+
+function CancelMatchdaySection({
+  matchdayStatus,
+  onCancel,
+  isPending,
+  error,
+}: {
+  matchdayStatus: string;
+  onCancel: (reason: string | undefined) => void;
+  isPending: boolean;
+  error: string | null;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [reason, setReason] = useState("");
+
+  return (
+    <Card>
+      {confirming ? (
+        <CardContent className="flex flex-col gap-3 p-4">
+          <p className="text-sm font-medium text-stone-800">
+            Cancel this matchday?
+          </p>
+          <p className="text-sm text-stone-500">
+            The matchday will be closed without raising any fees. This cannot be
+            undone from the official panel.
+          </p>
+          <Input
+            placeholder="Reason (optional, e.g. rained off)"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            maxLength={500}
+          />
+          <div className="flex gap-2">
+            <Button
+              variant="destructive"
+              disabled={isPending}
+              onClick={() => onCancel(reason.trim() || undefined)}
+            >
+              {isPending ? "Cancelling…" : "Confirm cancellation"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setConfirming(false);
+                setReason("");
+              }}
+            >
+              Back
+            </Button>
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+        </CardContent>
+      ) : (
+        <CardContent className="flex items-center justify-between p-4">
+          <p className="text-sm text-stone-500">
+            Need to call off this match?{" "}
+            {matchdayStatus === "confirmed" &&
+              "Cancellation is blocked once match-fee charges have been created."}
+          </p>
+          <Button
+            variant="outline"
+            className="text-red-700 hover:bg-red-50 hover:text-red-800"
+            onClick={() => setConfirming(true)}
+          >
+            Cancel Matchday
+          </Button>
+        </CardContent>
+      )}
+    </Card>
   );
 }
 

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -414,6 +414,9 @@ export interface MatchBall {
 }
 
 export interface Matchday {
+  cancelled_at: string | null;
+  cancelled_by: string | null;
+  cancelled_reason: string | null;
   competition_type: string | null;
   confirmed_at: string | null;
   confirmed_by: string | null;

--- a/packages/db/src/migrations/2026-05-11T14:23:49.000Z.ts
+++ b/packages/db/src/migrations/2026-05-11T14:23:49.000Z.ts
@@ -1,0 +1,37 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Cancel-matchday workflow: terminal "cancelled" status distinct from
+ * "finished". Used when a fixture is called off and no fees should be
+ * raised. Cancel is only permitted before any active charges exist on
+ * the matchday; the service enforces that guard.
+ *
+ * `cancelled_at` / `cancelled_by` are populated when status flips to
+ * "cancelled"; `cancelled_reason` is optional free text for the audit
+ * trail (rain, opposition withdrew, etc.).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("matchday")
+    .addColumn("cancelled_at", "text")
+    .execute();
+
+  await db.schema
+    .alterTable("matchday")
+    .addColumn("cancelled_by", "text", (col) => col.references("user.id"))
+    .execute();
+
+  await db.schema
+    .alterTable("matchday")
+    .addColumn("cancelled_reason", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable("matchday").dropColumn("cancelled_at").execute();
+  await db.schema.alterTable("matchday").dropColumn("cancelled_by").execute();
+  await db.schema
+    .alterTable("matchday")
+    .dropColumn("cancelled_reason")
+    .execute();
+}


### PR DESCRIPTION
## Summary
- Adds a terminal `cancelled` status to matchdays so officials can close off rained-off / abandoned fixtures without raising fee charges. Today, "Finish Match" always submits expenses and emails outstanding fees, leaving no clean exit for a cancelled fixture.
- `cancelMatchday` is allowed only from `pending` or `confirmed`, and is blocked if any active (non-deleted) match-fee charge already exists — treasurer must void/refund through the Charges admin first.
- Cancelled rows still appear in admin → Cricket → Game Reports (red badge) for the audit trail.
- A future fixture rescheduled to the same date is unblocked: `createMatchday` + the upcoming-matches view both ignore previously cancelled rows.

## DB migration
- Adds `cancelled_at`, `cancelled_by`, `cancelled_reason` to `matchday`. CI applies on merge to `main`.

## Test plan
- [x] `pnpm test:integration` — 5 new tests pass (pending cancel, confirmed-no-charges cancel, blocked-by-charge, finished-cannot-cancel, re-create-on-cancelled-date)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Manual: create matchday → cancel from pending; confirm with bursary-only player → cancel; confirm with paying player → cancel attempt should fail with the "void via Charges admin" message
- [ ] Manual: cancelled matchday shows red "cancelled" badge in admin → Cricket → Game Reports