### PR TITLE
feat(matchday): surface past unfinished matchdays on team page

### DIFF
--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -14,6 +14,7 @@ import {
   createMatchday,
   deleteExpense,
   getMatch,
+  getPastUnfinishedMatchdays,
   listMatches,
   listPendingExpenses,
   listTeams,
@@ -943,6 +944,69 @@ describe("matchday service (integration)", () => {
       });
       expect(result.id).toBeDefined();
       expect(result.id).not.toBe(firstId);
+    });
+  });
+
+  describe("getPastUnfinishedMatchdays", () => {
+    it("returns only pending/confirmed matchdays whose date is in the past", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `past-unfinished-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+
+      // Past pending — should show
+      const pastPending = await seedMatchday({
+        teamId,
+        createdBy: userId,
+        status: "pending",
+        matchDate: "2026-04-01",
+      });
+      // Past confirmed — should show
+      const pastConfirmed = await seedMatchday({
+        teamId,
+        createdBy: userId,
+        status: "confirmed",
+        matchDate: "2026-04-15",
+      });
+      // Past finished — should NOT show
+      const pastFinished = await seedMatchday({
+        teamId,
+        createdBy: userId,
+        status: "finished",
+        matchDate: "2026-04-20",
+      });
+      // Future pending — should NOT show
+      const futurePending = await seedMatchday({
+        teamId,
+        createdBy: userId,
+        status: "pending",
+        matchDate: "2099-01-01",
+      });
+
+      const result = await getPastUnfinishedMatchdays(ctx.db)(
+        userId,
+        "admin",
+        teamId,
+      );
+
+      const ids = result.map((m) => m.id);
+      expect(ids).toContain(pastPending);
+      expect(ids).toContain(pastConfirmed);
+      expect(ids).not.toContain(pastFinished);
+      expect(ids).not.toContain(futurePending);
+    });
+
+    it("rejects access to a team the official does not officiate", async () => {
+      const { userId: outsiderId } = await seedTestUser(ctx.db, {
+        email: `outsider-${crypto.randomUUID()}@test.com`,
+        role: "official",
+      });
+      const teamId = await seedTeam();
+
+      await expect(
+        getPastUnfinishedMatchdays(ctx.db)(outsiderId, "official", teamId),
+      ).rejects.toThrow("do not have access");
     });
   });
 });

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -19,6 +19,7 @@ import {
   listTeamsResponseSchema,
   markPaidSchema,
   matchIdParamSchema,
+  pastUnfinishedMatchdaysResponseSchema,
   playerIdParamSchema,
   recordExpenseResponseSchema,
   recordExpenseSchema,
@@ -43,6 +44,7 @@ import {
   deleteExpense,
   finishMatch,
   getMatch,
+  getPastUnfinishedMatchdays,
   getTeamNewsData,
   getUpcomingMatches,
   listMatches,
@@ -295,6 +297,7 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
 
   const teams = listTeams(app.db);
   const create = createMatchday(app.db);
+  const pastUnfinished = getPastUnfinishedMatchdays(app.db);
   const search = searchMembers(app.db);
   const add = addPlayer(app.db);
   const removeP = removePlayer(app.db);
@@ -329,6 +332,22 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
       const { user } = getAuthSession(request);
       const role = (user as { role?: string | null }).role ?? "user";
       return await teams(user.id, role);
+    },
+  );
+
+  app.get(
+    "/matchday/teams/:teamId/past-unfinished",
+    {
+      preHandler: [officialRole],
+      schema: {
+        params: teamIdParamSchema,
+        response: { 200: pastUnfinishedMatchdaysResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      const role = (user as { role?: string | null }).role ?? "user";
+      return await pastUnfinished(user.id, role, request.params.teamId);
     },
   );
 

--- a/apps/api/src/features/matchday/schemas.ts
+++ b/apps/api/src/features/matchday/schemas.ts
@@ -282,6 +282,18 @@ const upcomingMatchSchema = z.object({
 
 export const upcomingMatchesResponseSchema = z.array(upcomingMatchSchema);
 
+const pastUnfinishedMatchdaySchema = z.object({
+  id: z.string(),
+  match_date: z.string(),
+  opposition: z.string(),
+  status: z.string(),
+  competition_type: z.string().nullable(),
+});
+
+export const pastUnfinishedMatchdaysResponseSchema = z.array(
+  pastUnfinishedMatchdaySchema,
+);
+
 export const createMatchdayResponseSchema = z.object({
   id: z.string(),
 });

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -460,6 +460,34 @@ export function getUpcomingMatches(
   };
 }
 
+/**
+ * Past unfinished matchdays for a team — matchdays whose match_date is
+ * before today and whose status is still pending or confirmed. Lets
+ * officials find and finish/cancel matchdays they started but never
+ * closed out (the upcoming-matches view only goes forward in time).
+ */
+export function getPastUnfinishedMatchdays(db: Kysely<DB>) {
+  return async (userId: string, role: string, teamId: string) => {
+    const accessibleIds = await getAccessibleTeamIds(db, userId, role);
+    if (!accessibleIds.includes(teamId)) {
+      throwHttpError(403, "You do not have access to this team");
+    }
+
+    const today = formatDate(startOfDay(new Date()), "yyyy-MM-dd");
+
+    const matchdays = await db
+      .selectFrom("matchday")
+      .where("play_cricket_team_id", "=", teamId)
+      .where("status", "in", ["pending", "confirmed"])
+      .where("match_date", "<", today)
+      .select(["id", "match_date", "opposition", "status", "competition_type"])
+      .orderBy("match_date", "desc")
+      .execute();
+
+    return matchdays;
+  };
+}
+
 export function createMatchday(db: Kysely<DB>) {
   return async (userId: string, role: string, data: CreateMatchday) => {
     const accessibleIds = await getAccessibleTeamIds(db, userId, role);

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -4574,6 +4574,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/matchday/teams/{teamId}/past-unfinished": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    teamId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            match_date: string;
+                            opposition: string;
+                            status: string;
+                            competition_type: string | null;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/matchday/teams/{teamId}/upcoming": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -7905,6 +7905,61 @@
         }
       }
     },
+    "/api/matchday/teams/{teamId}/past-unfinished": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "teamId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "match_date": {
+                        "type": "string"
+                      },
+                      "opposition": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "competition_type": {
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "match_date",
+                      "opposition",
+                      "status",
+                      "competition_type"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/matchday/teams/{teamId}/upcoming": {
       "get": {
         "parameters": [

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -363,6 +363,16 @@ function TeamMatchesView({
       ),
   });
 
+  const pastUnfinishedQuery = useQuery({
+    queryKey: ["official", "pastUnfinished", teamId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/matchday/teams/{teamId}/past-unfinished", {
+          params: { path: { teamId } },
+        }),
+      ),
+  });
+
   const createMatchdayMutation = useMutation({
     mutationFn: (input: {
       teamId: string;
@@ -394,6 +404,7 @@ function TeamMatchesView({
   });
 
   const matches = matchesQuery.data ?? [];
+  const pastUnfinished = pastUnfinishedQuery.data ?? [];
 
   return (
     <div className="flex flex-col gap-4">
@@ -403,6 +414,52 @@ function TeamMatchesView({
         </Button>
         <h2 className="text-xl font-semibold">{teamName}</h2>
       </div>
+
+      {pastUnfinished.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Past unfinished matches
+              <span className="ml-2 rounded bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800">
+                {pastUnfinished.length}
+              </span>
+            </CardTitle>
+            <p className="text-sm text-stone-500">
+              These matchdays still need to be finished or cancelled.
+            </p>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2">
+            {pastUnfinished.map((md) => (
+              <div
+                key={md.id}
+                className="flex items-center justify-between rounded border border-stone-200 px-3 py-2"
+              >
+                <div>
+                  <p className="font-medium">vs {md.opposition}</p>
+                  <p className="text-sm text-stone-500">
+                    {format(new Date(md.match_date), "EEEE d MMMM yyyy")}
+                    <span
+                      className={`ml-2 inline-block rounded px-1.5 py-0.5 text-xs font-medium ${
+                        md.status === "confirmed"
+                          ? "bg-green-100 text-green-800"
+                          : "bg-yellow-100 text-yellow-800"
+                      }`}
+                    >
+                      {md.status}
+                    </span>
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => onSelectMatchday(md.id, true, null)}
+                >
+                  Open
+                </Button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
 
       {matchesQuery.isPending && (
         <p className="text-stone-500">Loading matches…</p>


### PR DESCRIPTION
## Summary
- Officials' team page only shows fixtures from today onwards (the upcoming list is filtered by `match_date >= today`). Any matchday left in `pending` or `confirmed` after its match date silently drops off — visible to admins via Game Reports, invisible to officials.
- Adds `GET /api/matchday/teams/:teamId/past-unfinished` returning the team's `pending`/`confirmed` matchdays whose date is before today (sorted newest-first), gated by the same officiates-team access check as the rest of the matchday API.
- Renders a "Past unfinished matches" card above the upcoming list on the team page so officials can open and either finish or cancel them.
- Pairs naturally with #287 (cancel matchday), which lets them clear pending rows that never happened. Independent of that PR — works on its own.

## Test plan
- [x] `pnpm test:integration` — new tests cover the filter (past pending/confirmed in, future and finished out) and the access guard
- [x] `pnpm typecheck` (api + web)
- [x] `pnpm lint`
- [ ] Manual: as an official with a team, leave a matchday in `pending`/`confirmed` past its match_date and confirm it appears in the new section on the team page