### PR TITLE
feat(charges): link junior members to parent(s); selectable bundle UI

### DIFF
--- a/apps/api/src/features/admin/integration.test.ts
+++ b/apps/api/src/features/admin/integration.test.ts
@@ -391,6 +391,57 @@ describe("admin service (integration)", () => {
       expect(juniorDetail.linkedJuniors).toEqual([]);
     });
 
+    it("rejects a reciprocal link that would create a cycle", async () => {
+      const aSeed = await seedTestUser(ctx.db, {
+        email: `mp-cyc-a-${crypto.randomUUID()}@test.com`,
+      });
+      const bSeed = await seedTestUser(ctx.db, {
+        email: `mp-cyc-b-${crypto.randomUUID()}@test.com`,
+      });
+      // A as parent of B
+      await linkMemberParent(ctx.db)(
+        {
+          memberId: bSeed.memberId ?? "",
+          parentMemberId: aSeed.memberId ?? "",
+        },
+        null,
+      );
+      // B as parent of A → would create cycle
+      await expect(
+        linkMemberParent(ctx.db)(
+          {
+            memberId: aSeed.memberId ?? "",
+            parentMemberId: bSeed.memberId ?? "",
+          },
+          null,
+        ),
+      ).rejects.toThrow("already linked as this member's junior");
+    });
+
+    it("refuses to link an archived (soft-deleted) member", async () => {
+      const liveSeed = await seedTestUser(ctx.db, {
+        email: `mp-live-${crypto.randomUUID()}@test.com`,
+      });
+      const archivedSeed = await seedTestUser(ctx.db, {
+        email: `mp-arc-${crypto.randomUUID()}@test.com`,
+      });
+      await ctx.db
+        .updateTable("member")
+        .set({ deleted_at: new Date().toISOString(), deleted_reason: "test" })
+        .where("id", "=", archivedSeed.memberId ?? "")
+        .execute();
+
+      await expect(
+        linkMemberParent(ctx.db)(
+          {
+            memberId: liveSeed.memberId ?? "",
+            parentMemberId: archivedSeed.memberId ?? "",
+          },
+          null,
+        ),
+      ).rejects.toThrow("Member not found");
+    });
+
     it("rejects self-linking", async () => {
       const seed = await seedTestUser(ctx.db, {
         email: `mp-self-${crypto.randomUUID()}@test.com`,

--- a/apps/api/src/features/admin/integration.test.ts
+++ b/apps/api/src/features/admin/integration.test.ts
@@ -13,15 +13,19 @@ import {
   findDuplicateMembers,
   getChargeAggregates,
   getMergePreview,
+  getUserDetail,
   linkDependentToUser,
+  linkMemberParent,
   linkPlayCricketPlayer,
   listAllCharges,
   listContactSubmissions,
   listJuniors,
   listUsers,
   mergeMembers,
+  searchMembersForParentLink,
   searchUsersForLinking,
   unlinkDependentUser,
+  unlinkMemberParent,
   unlinkPlayCricketPlayer,
 } from "./service.ts";
 
@@ -348,6 +352,124 @@ describe("admin service (integration)", () => {
       await expect(
         unlinkDependentUser(ctx.db)({ dependentId: "non-existent" }),
       ).rejects.toThrow("Dependent not found");
+    });
+  });
+
+  describe("member-parent linking", () => {
+    it("links a junior to a parent and exposes the relationship via getUserDetail", async () => {
+      const parentSeed = await seedTestUser(ctx.db, {
+        email: `mp-parent-${crypto.randomUUID()}@test.com`,
+        name: "Pat Parent",
+      });
+      const juniorSeed = await seedTestUser(ctx.db, {
+        email: `mp-junior-${crypto.randomUUID()}@test.com`,
+        name: "Jamie Junior",
+      });
+
+      await linkMemberParent(ctx.db)(
+        {
+          memberId: juniorSeed.memberId ?? "",
+          parentMemberId: parentSeed.memberId ?? "",
+        },
+        null,
+      );
+
+      const parentDetail = await getUserDetail(ctx.db)(parentSeed.userId);
+      expect(parentDetail.linkedJuniors).toHaveLength(1);
+      expect(parentDetail.linkedJuniors[0]).toMatchObject({
+        memberId: juniorSeed.memberId,
+        name: "Jamie Junior",
+      });
+      expect(parentDetail.linkedParents).toEqual([]);
+
+      const juniorDetail = await getUserDetail(ctx.db)(juniorSeed.userId);
+      expect(juniorDetail.linkedParents).toHaveLength(1);
+      expect(juniorDetail.linkedParents[0]).toMatchObject({
+        memberId: parentSeed.memberId,
+        name: "Pat Parent",
+      });
+      expect(juniorDetail.linkedJuniors).toEqual([]);
+    });
+
+    it("rejects self-linking", async () => {
+      const seed = await seedTestUser(ctx.db, {
+        email: `mp-self-${crypto.randomUUID()}@test.com`,
+      });
+      await expect(
+        linkMemberParent(ctx.db)(
+          {
+            memberId: seed.memberId ?? "",
+            parentMemberId: seed.memberId ?? "",
+          },
+          null,
+        ),
+      ).rejects.toThrow("cannot be their own parent");
+    });
+
+    it("is idempotent — linking twice does not error and produces one row", async () => {
+      const parentSeed = await seedTestUser(ctx.db, {
+        email: `mp-idem-p-${crypto.randomUUID()}@test.com`,
+      });
+      const juniorSeed = await seedTestUser(ctx.db, {
+        email: `mp-idem-j-${crypto.randomUUID()}@test.com`,
+      });
+      const params = {
+        memberId: juniorSeed.memberId ?? "",
+        parentMemberId: parentSeed.memberId ?? "",
+      };
+      await linkMemberParent(ctx.db)(params, null);
+      await linkMemberParent(ctx.db)(params, null);
+
+      const rows = await ctx.db
+        .selectFrom("member_parent_link")
+        .where("member_id", "=", params.memberId)
+        .where("parent_member_id", "=", params.parentMemberId)
+        .select("member_id")
+        .execute();
+      expect(rows).toHaveLength(1);
+    });
+
+    it("unlinks", async () => {
+      const parentSeed = await seedTestUser(ctx.db, {
+        email: `mp-ul-p-${crypto.randomUUID()}@test.com`,
+      });
+      const juniorSeed = await seedTestUser(ctx.db, {
+        email: `mp-ul-j-${crypto.randomUUID()}@test.com`,
+      });
+      const params = {
+        memberId: juniorSeed.memberId ?? "",
+        parentMemberId: parentSeed.memberId ?? "",
+      };
+      await linkMemberParent(ctx.db)(params, null);
+      await unlinkMemberParent(ctx.db)(params);
+
+      const detail = await getUserDetail(ctx.db)(juniorSeed.userId);
+      expect(detail.linkedParents).toEqual([]);
+    });
+
+    it("searches candidate parents by name/email and excludes the junior themselves", async () => {
+      const sharedSurname = `Smithy-${crypto.randomUUID().slice(0, 6)}`;
+      const juniorSeed = await seedTestUser(ctx.db, {
+        email: `mp-search-jr-${crypto.randomUUID()}@test.com`,
+        name: `Junior ${sharedSurname}`,
+      });
+      const parentSeed = await seedTestUser(ctx.db, {
+        email: `mp-search-pa-${crypto.randomUUID()}@test.com`,
+        name: `Adult ${sharedSurname}`,
+      });
+
+      const result = await searchMembersForParentLink(ctx.db)({
+        juniorMemberId: juniorSeed.memberId ?? "",
+        search: sharedSurname,
+      });
+
+      expect(result.juniorName).toBe(`Junior ${sharedSurname}`);
+      expect(result.members.some((m) => m.id === juniorSeed.memberId)).toBe(
+        false,
+      );
+      expect(result.members.some((m) => m.id === parentSeed.memberId)).toBe(
+        true,
+      );
     });
   });
 

--- a/apps/api/src/features/admin/routes.ts
+++ b/apps/api/src/features/admin/routes.ts
@@ -26,6 +26,8 @@ import {
   juniorTeamsResponseSchema,
   linkDependentResponseSchema,
   linkDependentSchema,
+  linkParentResponseSchema,
+  linkParentSchema,
   linkPlayCricketResponseSchema,
   linkSlugResponseSchema,
   listChargesResponseSchema,
@@ -51,6 +53,8 @@ import {
   recordLinkingResponseSchema,
   recordLinkingSchema,
   restoreMemberResponseSchema,
+  searchMembersForParentLinkResponseSchema,
+  searchMembersForParentLinkSchema,
   searchUsersForLinkingResponseSchema,
   searchUsersForLinkingSchema,
   setJuniorManagerTeamsResponseSchema,
@@ -63,6 +67,8 @@ import {
   slugUnlinkSchema,
   unlinkDependentResponseSchema,
   unlinkDependentSchema,
+  unlinkParentResponseSchema,
+  unlinkParentSchema,
   unlinkPlayCricketResponseSchema,
   unlinkSchema,
   unlinkSlugResponseSchema,
@@ -86,6 +92,7 @@ import {
   getRecordLinking,
   getUserDetail,
   linkDependentToUser,
+  linkMemberParent,
   linkPlayCricketPlayer,
   linkSlug,
   listAllCharges,
@@ -95,12 +102,14 @@ import {
   listUsers,
   mergeMembers,
   restoreMember,
+  searchMembersForParentLink,
   searchUsersForLinking,
   sendChargeNotification,
   setJuniorManagerTeams,
   setMemberCategory,
   setOfficialTeams,
   unlinkDependentUser,
+  unlinkMemberParent,
   unlinkPlayCricketPlayer,
   unlinkSlug,
   updateUser,
@@ -131,6 +140,9 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
   const searchForLinking = searchUsersForLinking(app.db);
   const linkDep = linkDependentToUser(app.db);
   const unlinkDep = unlinkDependentUser(app.db);
+  const searchForParent = searchMembersForParentLink(app.db);
+  const linkParent = linkMemberParent(app.db);
+  const unlinkParent = unlinkMemberParent(app.db);
   const listCharges = listAllCharges(app.db);
   const chargeAggregates = getChargeAggregates(app.db);
   const chase = chasePayment(app.db);
@@ -574,6 +586,49 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request) => {
       return await unlinkDep(request.body);
+    },
+  );
+
+  app.get(
+    "/admin/members/parent-search",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        querystring: searchMembersForParentLinkSchema,
+        response: { 200: searchMembersForParentLinkResponseSchema },
+      },
+    },
+    async (request) => {
+      return await searchForParent(request.query);
+    },
+  );
+
+  app.post(
+    "/admin/members/parent-link",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        body: linkParentSchema,
+        response: { 200: linkParentResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await linkParent(request.body, user.id);
+    },
+  );
+
+  app.post(
+    "/admin/members/parent-unlink",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        body: unlinkParentSchema,
+        response: { 200: unlinkParentResponseSchema },
+      },
+    },
+    async (request) => {
+      return await unlinkParent(request.body);
     },
   );
 

--- a/apps/api/src/features/admin/schemas.ts
+++ b/apps/api/src/features/admin/schemas.ts
@@ -344,6 +344,21 @@ export const getUserDetailResponseSchema = z.object({
       name: z.string(),
     }),
   ),
+  linkedParents: z.array(
+    z.object({
+      memberId: z.string(),
+      name: z.string().nullable(),
+      email: z.string(),
+    }),
+  ),
+  linkedJuniors: z.array(
+    z.object({
+      memberId: z.string(),
+      name: z.string().nullable(),
+      email: z.string(),
+      dob: z.string().nullable(),
+    }),
+  ),
 });
 
 export const setMemberCategoryResponseSchema = successResponseSchema;
@@ -436,6 +451,14 @@ export const listChargesResponseSchema = z.object({
       deletedReason: z.string().nullable(),
       memberName: z.string().nullable(),
       memberEmail: z.string(),
+      memberCategory: z.string().nullable(),
+      paidByParents: z.array(
+        z.object({
+          memberId: z.string(),
+          name: z.string().nullable(),
+          email: z.string(),
+        }),
+      ),
       status: chargeStatusSchema,
     }),
   ),
@@ -512,6 +535,37 @@ export const searchUsersForLinkingResponseSchema = z.object({
 
 export const linkDependentResponseSchema = successResponseSchema;
 export const unlinkDependentResponseSchema = successResponseSchema;
+
+export const searchMembersForParentLinkSchema = z.object({
+  juniorMemberId: z.string().min(1),
+  search: z.string().optional(),
+});
+export type SearchMembersForParentLink = z.infer<
+  typeof searchMembersForParentLinkSchema
+>;
+
+export const searchMembersForParentLinkResponseSchema = z.object({
+  juniorName: z.string().nullable(),
+  members: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string().nullable(),
+      email: z.string(),
+      score: z.number(),
+    }),
+  ),
+});
+
+export const linkParentSchema = z.object({
+  memberId: z.string().min(1),
+  parentMemberId: z.string().min(1),
+});
+export type LinkParent = z.infer<typeof linkParentSchema>;
+export const linkParentResponseSchema = successResponseSchema;
+
+export const unlinkParentSchema = linkParentSchema;
+export type UnlinkParent = z.infer<typeof unlinkParentSchema>;
+export const unlinkParentResponseSchema = successResponseSchema;
 
 const duplicateGroupMemberSchema = z.object({
   id: z.string(),

--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -507,12 +507,30 @@ export function linkMemberParent(db: Kysely<DB>) {
       .selectFrom("member")
       .select("id")
       .where("id", "in", [memberId, parentMemberId])
+      .where("deleted_at", "is", null)
       .execute();
     if (found.length !== 2) {
       const error = new Error("Member not found") as Error & {
         statusCode: number;
       };
       error.statusCode = 404;
+      throw error;
+    }
+
+    // Reject the reciprocal case (A↔B). A multi-hop cycle (A→B→C→A)
+    // is theoretically possible but unrealistic under admin-managed
+    // linking; we keep the cheap single-hop guard for now.
+    const reverse = await db
+      .selectFrom("member_parent_link")
+      .where("member_id", "=", parentMemberId)
+      .where("parent_member_id", "=", memberId)
+      .select("member_id")
+      .executeTakeFirst();
+    if (reverse) {
+      const error = new Error(
+        "Cannot link: the proposed parent is already linked as this member's junior",
+      ) as Error & { statusCode: number };
+      error.statusCode = 400;
       throw error;
     }
 

--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -13,6 +13,7 @@ import type {
   CreateCharge,
   CreateMember,
   LinkDependent,
+  LinkParent,
   ListCharges,
   ListContactSubmissions,
   ListJuniors,
@@ -20,9 +21,11 @@ import type {
   MergeMembers,
   MergePreview,
   RecordLinking,
+  SearchMembersForParentLink,
   SearchUsersForLinking,
   Unlink,
   UnlinkDependent,
+  UnlinkParent,
   UpdateUser,
 } from "./schemas.ts";
 
@@ -396,6 +399,37 @@ export function getUserDetail(db: Kysely<DB>) {
       .select(["play_cricket_team.id", "play_cricket_team.name"])
       .execute();
 
+    const linkedParents = member
+      ? await db
+          .selectFrom("member_parent_link")
+          .innerJoin(
+            "member as parent",
+            "parent.id",
+            "member_parent_link.parent_member_id",
+          )
+          .where("member_parent_link.member_id", "=", member.id)
+          .select(["parent.id as memberId", "parent.name", "parent.email"])
+          .execute()
+      : [];
+
+    const linkedJuniors = member
+      ? await db
+          .selectFrom("member_parent_link")
+          .innerJoin(
+            "member as junior",
+            "junior.id",
+            "member_parent_link.member_id",
+          )
+          .where("member_parent_link.parent_member_id", "=", member.id)
+          .select([
+            "junior.id as memberId",
+            "junior.name",
+            "junior.email",
+            "junior.dob",
+          ])
+          .execute()
+      : [];
+
     return {
       user,
       member: member ?? null,
@@ -404,7 +438,116 @@ export function getUserDetail(db: Kysely<DB>) {
       charges,
       juniorManagerTeams,
       officialTeams,
+      linkedParents,
+      linkedJuniors,
     };
+  };
+}
+
+export function searchMembersForParentLink(db: Kysely<DB>) {
+  return async (params: SearchMembersForParentLink) => {
+    const { juniorMemberId, search } = params;
+
+    const junior = await db
+      .selectFrom("member")
+      .select(["id", "name"])
+      .where("id", "=", juniorMemberId)
+      .executeTakeFirst();
+
+    if (!junior) {
+      const error = new Error("Member not found") as Error & {
+        statusCode: number;
+      };
+      error.statusCode = 404;
+      throw error;
+    }
+
+    let query = db
+      .selectFrom("member")
+      .select(["id", "name", "email"])
+      .where("id", "<>", juniorMemberId)
+      .where("deleted_at", "is", null);
+
+    if (search && search.trim().length > 0) {
+      const term = `%${search.trim()}%`;
+      query = query.where((eb) =>
+        eb.or([eb("name", "ilike", term), eb("email", "ilike", term)]),
+      );
+    }
+
+    const members = await query.execute();
+
+    const scored = members
+      .map((m) => ({
+        id: m.id,
+        name: m.name,
+        email: m.email,
+        score: nameSimilarity(junior.name ?? "", m.name ?? ""),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 20);
+
+    return { juniorName: junior.name, members: scored };
+  };
+}
+
+export function linkMemberParent(db: Kysely<DB>) {
+  return async (params: LinkParent, createdBy: string | null) => {
+    const { memberId, parentMemberId } = params;
+
+    if (memberId === parentMemberId) {
+      const error = new Error(
+        "A member cannot be their own parent",
+      ) as Error & { statusCode: number };
+      error.statusCode = 400;
+      throw error;
+    }
+
+    const found = await db
+      .selectFrom("member")
+      .select("id")
+      .where("id", "in", [memberId, parentMemberId])
+      .execute();
+    if (found.length !== 2) {
+      const error = new Error("Member not found") as Error & {
+        statusCode: number;
+      };
+      error.statusCode = 404;
+      throw error;
+    }
+
+    const existing = await db
+      .selectFrom("member_parent_link")
+      .where("member_id", "=", memberId)
+      .where("parent_member_id", "=", parentMemberId)
+      .select("member_id")
+      .executeTakeFirst();
+    if (existing) {
+      return { success: true };
+    }
+
+    await db
+      .insertInto("member_parent_link")
+      .values({
+        member_id: memberId,
+        parent_member_id: parentMemberId,
+        created_by: createdBy,
+      })
+      .execute();
+
+    return { success: true };
+  };
+}
+
+export function unlinkMemberParent(db: Kysely<DB>) {
+  return async (params: UnlinkParent) => {
+    const { memberId, parentMemberId } = params;
+    await db
+      .deleteFrom("member_parent_link")
+      .where("member_id", "=", memberId)
+      .where("parent_member_id", "=", parentMemberId)
+      .execute();
+    return { success: true };
   };
 }
 
@@ -1051,12 +1194,50 @@ export function listAllCharges(db: Kysely<DB>) {
           "charge.deleted_reason",
           "member.name as memberName",
           "member.email as memberEmail",
+          "member.member_category as memberCategory",
         ])
         .orderBy("charge.charge_date", "desc")
         .limit(pageSize)
         .offset(offset)
         .execute(),
     ]);
+
+    // Resolve which parent(s) absorb each charge: a single batched
+    // lookup against member_parent_link for every member appearing on
+    // this page.
+    const memberIds = Array.from(new Set(charges.map((c) => c.member_id)));
+    const parentLinks =
+      memberIds.length > 0
+        ? await db
+            .selectFrom("member_parent_link")
+            .innerJoin(
+              "member as parent",
+              "parent.id",
+              "member_parent_link.parent_member_id",
+            )
+            .where("member_parent_link.member_id", "in", memberIds)
+            .select([
+              "member_parent_link.member_id",
+              "parent.id as parentMemberId",
+              "parent.name as parentName",
+              "parent.email as parentEmail",
+            ])
+            .execute()
+        : [];
+
+    const parentsByMember = new Map<
+      string,
+      Array<{ memberId: string; name: string | null; email: string }>
+    >();
+    for (const link of parentLinks) {
+      const arr = parentsByMember.get(link.member_id) ?? [];
+      arr.push({
+        memberId: link.parentMemberId,
+        name: link.parentName,
+        email: link.parentEmail,
+      });
+      parentsByMember.set(link.member_id, arr);
+    }
 
     return {
       charges: charges.map((c) => ({
@@ -1075,6 +1256,8 @@ export function listAllCharges(db: Kysely<DB>) {
         deletedReason: c.deleted_reason,
         memberName: c.memberName,
         memberEmail: c.memberEmail,
+        memberCategory: c.memberCategory,
+        paidByParents: parentsByMember.get(c.member_id) ?? [],
         status: getChargeStatus(
           c.paid_at,
           c.payment_confirmed_at,

--- a/apps/api/src/features/charges/integration.test.ts
+++ b/apps/api/src/features/charges/integration.test.ts
@@ -466,6 +466,70 @@ describe("charges service (integration)", () => {
       expect(result.chargeIds).toContain(parentChargeId);
     });
 
+    it("does not steal a junior charge's PI while it is mid-flight for another parent", async () => {
+      // Two parents both linked to one junior. Parent A has started
+      // paying — the junior's charge has stripe_payment_intent_id set
+      // and Stripe says the PI is requires_payment_method (the
+      // default state until the cardholder completes the form). When
+      // parent B hits pay-outstanding, we must NOT clear that PI: if
+      // parent A then completes, Stripe succeeds against the original
+      // PI but the charge row would now point at parent B's PI,
+      // breaking confirmation and risking double-payment.
+      const parentAEmail = `parentA-${crypto.randomUUID()}@test.com`;
+      const parentBEmail = `parentB-${crypto.randomUUID()}@test.com`;
+      const juniorEmail = `junior-${crypto.randomUUID()}@test.com`;
+      const { memberId: parentAId } = await seedTestUser(ctx.db, {
+        email: parentAEmail,
+      });
+      const { memberId: parentBId } = await seedTestUser(ctx.db, {
+        email: parentBEmail,
+      });
+      const { memberId: juniorId } = await seedTestUser(ctx.db, {
+        email: juniorEmail,
+      });
+      await ctx.db
+        .insertInto("member_parent_link")
+        .values([
+          { member_id: juniorId ?? "", parent_member_id: parentAId ?? "" },
+          { member_id: juniorId ?? "", parent_member_id: parentBId ?? "" },
+        ])
+        .execute();
+
+      const juniorChargeId = `ch-shared-${crypto.randomUUID()}`;
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: juniorChargeId,
+          member_id: juniorId ?? "",
+          description: "Junior match fee",
+          amount_pence: 500,
+          charge_date: "2026-05-01",
+          created_by: "system",
+          type: "match_fee",
+          source: "matchday",
+          stripe_payment_intent_id: "pi_in_flight_for_A",
+        })
+        .execute();
+
+      mockPaymentIntentsRetrieve.mockResolvedValue({
+        id: "pi_in_flight_for_A",
+        status: "requires_payment_method",
+        metadata: { memberEmail: parentAEmail },
+      });
+
+      await expect(
+        payOutstandingCharges(ctx.db, mockStripe)(parentBEmail),
+      ).rejects.toThrow("No unpaid charges found");
+
+      // Junior's charge still points at parent A's PI, untouched.
+      const charge = await ctx.db
+        .selectFrom("charge")
+        .where("id", "=", juniorChargeId)
+        .select("stripe_payment_intent_id")
+        .executeTakeFirst();
+      expect(charge?.stripe_payment_intent_id).toBe("pi_in_flight_for_A");
+    });
+
     it("confirmPayment confirms charges across the parent + linked juniors", async () => {
       const parentEmail = `parent-conf-${crypto.randomUUID()}@test.com`;
       const juniorEmail = `junior-conf-${crypto.randomUUID()}@test.com`;

--- a/apps/api/src/features/charges/integration.test.ts
+++ b/apps/api/src/features/charges/integration.test.ts
@@ -344,6 +344,177 @@ describe("charges service (integration)", () => {
     });
   });
 
+  describe("parent-junior link routing", () => {
+    async function linkParent(
+      memberId: string,
+      parentMemberId: string,
+    ): Promise<void> {
+      await ctx.db
+        .insertInto("member_parent_link")
+        .values({ member_id: memberId, parent_member_id: parentMemberId })
+        .execute();
+    }
+
+    it("routes a linked junior's charges to the parent with on_behalf_of attribution", async () => {
+      const parentEmail = `parent-${crypto.randomUUID()}@test.com`;
+      const juniorEmail = `junior-${crypto.randomUUID()}@test.com`;
+      const { memberId: parentId } = await seedTestUser(ctx.db, {
+        email: parentEmail,
+        name: "Parent Person",
+      });
+      const { memberId: juniorId } = await seedTestUser(ctx.db, {
+        email: juniorEmail,
+        name: "Junior Person",
+      });
+      await linkParent(juniorId ?? "", parentId ?? "");
+
+      const juniorChargeId = `ch-jr-${crypto.randomUUID()}`;
+      const parentChargeId = `ch-par-${crypto.randomUUID()}`;
+      await ctx.db
+        .insertInto("charge")
+        .values([
+          {
+            id: juniorChargeId,
+            member_id: juniorId ?? "",
+            description: "Junior match fee",
+            amount_pence: 500,
+            charge_date: "2026-05-01",
+            created_by: "system",
+            type: "match_fee",
+            source: "matchday",
+          },
+          {
+            id: parentChargeId,
+            member_id: parentId ?? "",
+            description: "Parent fee",
+            amount_pence: 1500,
+            charge_date: "2026-04-15",
+            created_by: "system",
+            type: "manual",
+            source: "admin",
+          },
+        ])
+        .execute();
+
+      const parentCharges = await getMyCharges(ctx.db)(parentEmail);
+      const juniorCharges = await getMyCharges(ctx.db)(juniorEmail);
+
+      expect(parentCharges).toHaveLength(2);
+      const fromJunior = parentCharges.find((c) => c.id === juniorChargeId);
+      const own = parentCharges.find((c) => c.id === parentChargeId);
+      expect(fromJunior?.on_behalf_of).toEqual({
+        memberId: juniorId,
+        name: "Junior Person",
+      });
+      expect(own?.on_behalf_of).toBeNull();
+
+      expect(juniorCharges).toEqual([]);
+    });
+
+    it("bundles linked-junior charges into the parent's pay-outstanding", async () => {
+      const parentEmail = `parent-pay-${crypto.randomUUID()}@test.com`;
+      const juniorEmail = `junior-pay-${crypto.randomUUID()}@test.com`;
+      const { memberId: parentId } = await seedTestUser(ctx.db, {
+        email: parentEmail,
+      });
+      const { memberId: juniorId } = await seedTestUser(ctx.db, {
+        email: juniorEmail,
+      });
+      await linkParent(juniorId ?? "", parentId ?? "");
+
+      const juniorChargeId = `ch-jrpay-${crypto.randomUUID()}`;
+      const parentChargeId = `ch-parpay-${crypto.randomUUID()}`;
+      await ctx.db
+        .insertInto("charge")
+        .values([
+          {
+            id: juniorChargeId,
+            member_id: juniorId ?? "",
+            description: "Junior match fee",
+            amount_pence: 500,
+            charge_date: "2026-05-01",
+            created_by: "system",
+            type: "match_fee",
+            source: "matchday",
+          },
+          {
+            id: parentChargeId,
+            member_id: parentId ?? "",
+            description: "Parent membership",
+            amount_pence: 5000,
+            charge_date: "2026-04-15",
+            created_by: "system",
+            type: "membership",
+            source: "admin",
+          },
+        ])
+        .execute();
+
+      mockPaymentIntentsCreate.mockResolvedValue({
+        id: "pi_household_bundle",
+        client_secret: "pi_household_bundle_secret",
+      });
+
+      const result = await payOutstandingCharges(
+        ctx.db,
+        mockStripe,
+      )(parentEmail);
+
+      expect(result.totalAmountPence).toBe(5500);
+      expect(result.chargeIds).toHaveLength(2);
+      expect(result.chargeIds).toContain(juniorChargeId);
+      expect(result.chargeIds).toContain(parentChargeId);
+    });
+
+    it("confirmPayment confirms charges across the parent + linked juniors", async () => {
+      const parentEmail = `parent-conf-${crypto.randomUUID()}@test.com`;
+      const juniorEmail = `junior-conf-${crypto.randomUUID()}@test.com`;
+      const { memberId: parentId } = await seedTestUser(ctx.db, {
+        email: parentEmail,
+      });
+      const { memberId: juniorId } = await seedTestUser(ctx.db, {
+        email: juniorEmail,
+      });
+      await linkParent(juniorId ?? "", parentId ?? "");
+
+      const pi = `pi_${crypto.randomUUID()}`;
+      const juniorChargeId = `ch-cjr-${crypto.randomUUID()}`;
+      const parentChargeId = `ch-cpar-${crypto.randomUUID()}`;
+      await ctx.db
+        .insertInto("charge")
+        .values([
+          {
+            id: juniorChargeId,
+            member_id: juniorId ?? "",
+            description: "Junior fee",
+            amount_pence: 500,
+            charge_date: "2026-05-01",
+            created_by: "system",
+            type: "match_fee",
+            source: "matchday",
+            stripe_payment_intent_id: pi,
+          },
+          {
+            id: parentChargeId,
+            member_id: parentId ?? "",
+            description: "Parent fee",
+            amount_pence: 1000,
+            charge_date: "2026-04-15",
+            created_by: "system",
+            type: "manual",
+            source: "admin",
+            stripe_payment_intent_id: pi,
+          },
+        ])
+        .execute();
+
+      await confirmPayment(ctx.db)(parentEmail, pi);
+
+      const parentCharges = await getMyCharges(ctx.db)(parentEmail);
+      expect(parentCharges.every((c) => c.payment_confirmed_at)).toBe(true);
+    });
+  });
+
   describe("confirmPayment", () => {
     it("updates matching unpaid charges with a payment confirmation", async () => {
       const email = `confirm-${crypto.randomUUID()}@test.com`;

--- a/apps/api/src/features/charges/routes.test.ts
+++ b/apps/api/src/features/charges/routes.test.ts
@@ -10,6 +10,7 @@ const { mockExecuteTakeFirst, mockExecute, mockQueryBuilder } = vi.hoisted(
     const mockQueryBuilder = {
       selectFrom: vi.fn().mockReturnThis(),
       updateTable: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       selectAll: vi.fn().mockReturnThis(),
@@ -44,6 +45,7 @@ describe("charges service", () => {
     vi.clearAllMocks();
     mockQueryBuilder.selectFrom.mockReturnValue(mockQueryBuilder);
     mockQueryBuilder.updateTable.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.innerJoin.mockReturnValue(mockQueryBuilder);
     mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
     mockQueryBuilder.select.mockReturnValue(mockQueryBuilder);
     mockQueryBuilder.selectAll.mockReturnValue(mockQueryBuilder);
@@ -67,16 +69,31 @@ describe("charges service", () => {
 
     it("returns charges ordered by date desc", async () => {
       const charges = [
-        { id: "c1", charge_date: "2026-03-14", amount: 50 },
-        { id: "c2", charge_date: "2026-02-01", amount: 25 },
+        {
+          id: "c1",
+          member_id: "member-1",
+          charge_date: "2026-03-14",
+          amount: 50,
+        },
+        {
+          id: "c2",
+          member_id: "member-1",
+          charge_date: "2026-02-01",
+          amount: 25,
+        },
       ];
 
       mockExecuteTakeFirst.mockResolvedValue({ id: "member-1" });
-      mockExecute.mockResolvedValue(charges);
+      mockExecute
+        .mockResolvedValueOnce([]) // parents
+        .mockResolvedValueOnce([]) // linked juniors
+        .mockResolvedValueOnce(charges);
 
       const result = await getMyCharges(db)("user@example.com");
 
-      expect(result).toEqual(charges);
+      expect(result).toEqual(
+        charges.map((c) => ({ ...c, on_behalf_of: null })),
+      );
       expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
         "charge_date",
         "desc",
@@ -85,7 +102,10 @@ describe("charges service", () => {
 
     it("excludes soft-deleted charges", async () => {
       mockExecuteTakeFirst.mockResolvedValue({ id: "member-1" });
-      mockExecute.mockResolvedValue([]);
+      mockExecute
+        .mockResolvedValueOnce([]) // parents
+        .mockResolvedValueOnce([]) // linked juniors
+        .mockResolvedValueOnce([]);
 
       await getMyCharges(db)("user@example.com");
 
@@ -108,7 +128,10 @@ describe("charges service", () => {
 
     it("updates matching charges", async () => {
       mockExecuteTakeFirst.mockResolvedValue({ id: "member-1" });
-      mockExecute.mockResolvedValue([]);
+      mockExecute
+        .mockResolvedValueOnce([]) // parents
+        .mockResolvedValueOnce([]) // linked juniors
+        .mockResolvedValueOnce([]);
 
       await confirmPayment(db)("user@example.com", "pi_abc");
 
@@ -127,7 +150,10 @@ describe("charges service", () => {
 
     it("ignores already-confirmed charges", async () => {
       mockExecuteTakeFirst.mockResolvedValue({ id: "member-1" });
-      mockExecute.mockResolvedValue([]);
+      mockExecute
+        .mockResolvedValueOnce([]) // parents
+        .mockResolvedValueOnce([]) // linked juniors
+        .mockResolvedValueOnce([]);
 
       await confirmPayment(db)("user@example.com", "pi_abc");
 
@@ -155,7 +181,10 @@ describe("charges service", () => {
 
     it("throws when no unpaid charges exist", async () => {
       mockExecuteTakeFirst.mockResolvedValue({ id: "member-1" });
-      mockExecute.mockResolvedValue([]);
+      mockExecute
+        .mockResolvedValueOnce([]) // parents
+        .mockResolvedValueOnce([]) // linked juniors
+        .mockResolvedValueOnce([]);
 
       await expect(
         payOutstandingCharges(db, mockStripe)("user@example.com"),

--- a/apps/api/src/features/charges/schemas.ts
+++ b/apps/api/src/features/charges/schemas.ts
@@ -40,6 +40,12 @@ const chargeSchema = z.object({
   deleted_reason: z.string().nullable(),
   created_at: z.string(),
   created_by: z.string(),
+  // Set when the charge belongs to a linked junior member rather than
+  // the authenticated user — used to label "For [Junior name]" in the
+  // user-facing charges list.
+  on_behalf_of: z
+    .object({ memberId: z.string(), name: z.string().nullable() })
+    .nullable(),
 });
 
 export const chargesResponseSchema = z.object({

--- a/apps/api/src/features/charges/service.ts
+++ b/apps/api/src/features/charges/service.ts
@@ -135,17 +135,25 @@ export function payOutstandingCharges(db: Kysely<DB>, stripe: Stripe) {
       }
 
       // Charges with an existing PI might be retryable if the PI was
-      // abandoned/expired. Check Stripe and clear stale ones so they
+      // abandoned/cancelled. Check Stripe and clear stale ones so they
       // can be bundled into a new PI.
+      //
+      // For linked-junior charges (shared between multiple parents),
+      // only clear if the existing PI was started by THIS user — a
+      // mid-flight PI started by the other parent must not be
+      // overwritten or we'd risk double-charging (their PI succeeds
+      // against an unrelated charge row). `canceled` is always safe
+      // to clear because the PI cannot succeed.
       for (const charge of unpaidCharges) {
         if (!charge.stripe_payment_intent_id) continue;
         const pi = await stripe.paymentIntents.retrieve(
           charge.stripe_payment_intent_id,
         );
-        if (
-          pi.status === "requires_payment_method" ||
-          pi.status === "canceled"
-        ) {
+        const startedByThisUser = pi.metadata?.memberEmail === email;
+        const shouldClear =
+          pi.status === "canceled" ||
+          (pi.status === "requires_payment_method" && startedByThisUser);
+        if (shouldClear) {
           await trx
             .updateTable("charge")
             .set({ stripe_payment_intent_id: null })

--- a/apps/api/src/features/charges/service.ts
+++ b/apps/api/src/features/charges/service.ts
@@ -2,6 +2,56 @@ import type { DB } from "@percy-main/db";
 import type { Kysely } from "kysely";
 import type Stripe from "stripe";
 
+export interface ChargeOnBehalfOf {
+  memberId: string;
+  name: string | null;
+}
+
+/**
+ * Resolve which member rows a given member can see (and pay) charges
+ * for. A member with parent links is treated as a junior whose charges
+ * are routed to their parent(s) — they see nothing themselves. A
+ * member who is named as a parent_member_id in any link absorbs those
+ * juniors' charges into their own list.
+ */
+async function getVisibleMembers(db: Kysely<DB>, memberId: string) {
+  const parents = await db
+    .selectFrom("member_parent_link")
+    .where("member_id", "=", memberId)
+    .select("parent_member_id")
+    .execute();
+
+  const juniors = await db
+    .selectFrom("member_parent_link")
+    .innerJoin("member", "member.id", "member_parent_link.member_id")
+    .where("member_parent_link.parent_member_id", "=", memberId)
+    .select(["member.id", "member.name"])
+    .execute();
+
+  const ownVisible = parents.length === 0;
+  const ids = [...(ownVisible ? [memberId] : []), ...juniors.map((j) => j.id)];
+  const juniorNameById = new Map(juniors.map((j) => [j.id, j.name]));
+
+  return { ids, juniorNameById };
+}
+
+function attributeOnBehalfOf<T extends { member_id: string }>(
+  charges: T[],
+  selfMemberId: string,
+  juniorNameById: Map<string, string | null>,
+): Array<T & { on_behalf_of: ChargeOnBehalfOf | null }> {
+  return charges.map((c) => ({
+    ...c,
+    on_behalf_of:
+      c.member_id === selfMemberId
+        ? null
+        : {
+            memberId: c.member_id,
+            name: juniorNameById.get(c.member_id) ?? null,
+          },
+  }));
+}
+
 export function getMyCharges(db: Kysely<DB>) {
   return async (email: string) => {
     const member = await db
@@ -14,15 +64,20 @@ export function getMyCharges(db: Kysely<DB>) {
       return [];
     }
 
+    const { ids, juniorNameById } = await getVisibleMembers(db, member.id);
+    if (ids.length === 0) {
+      return [];
+    }
+
     const charges = await db
       .selectFrom("charge")
-      .where("member_id", "=", member.id)
+      .where("member_id", "in", ids)
       .where("deleted_at", "is", null)
       .selectAll()
       .orderBy("charge_date", "desc")
       .execute();
 
-    return charges;
+    return attributeOnBehalfOf(charges, member.id, juniorNameById);
   };
 }
 
@@ -42,17 +97,24 @@ export function payOutstandingCharges(db: Kysely<DB>, stripe: Stripe) {
       throw error;
     }
 
-    // Use a transaction with FOR UPDATE to prevent concurrent requests
-    // from creating duplicate PaymentIntents for the same charges
     return await db.transaction().execute(async (trx) => {
+      const { ids: visibleIds } = await getVisibleMembers(trx, member.id);
+      if (visibleIds.length === 0) {
+        const error = new Error("No unpaid charges found") as Error & {
+          statusCode: number;
+        };
+        error.statusCode = 400;
+        throw error;
+      }
+
       // When scopeChargeIds is provided (#93 — junior registration
       // pays only the charge it created), narrow the bundle. The
       // member_id WHERE still applies, so a malicious client passing
-      // someone else's chargeIds can only affect rows it already
-      // owned.
+      // someone else's chargeIds can only affect rows owned by a
+      // member they are entitled to pay for (self or linked junior).
       let query = trx
         .selectFrom("charge")
-        .where("member_id", "=", member.id)
+        .where("member_id", "in", visibleIds)
         .where("deleted_at", "is", null)
         .where("paid_at", "is", null)
         .where("payment_confirmed_at", "is", null);
@@ -93,7 +155,6 @@ export function payOutstandingCharges(db: Kysely<DB>, stripe: Stripe) {
         }
       }
 
-      // Only include charges that are now unlinked
       const payableCharges = unpaidCharges.filter(
         (c) => !c.stripe_payment_intent_id,
       );
@@ -123,7 +184,6 @@ export function payOutstandingCharges(db: Kysely<DB>, stripe: Stripe) {
         },
       });
 
-      // Link charges to the payment intent within the same transaction
       await trx
         .updateTable("charge")
         .set({ stripe_payment_intent_id: paymentIntent.id })
@@ -155,10 +215,15 @@ export function confirmPayment(db: Kysely<DB>) {
       throw error;
     }
 
+    const { ids: visibleIds } = await getVisibleMembers(db, member.id);
+    if (visibleIds.length === 0) {
+      return;
+    }
+
     await db
       .updateTable("charge")
       .set({ payment_confirmed_at: new Date().toISOString() })
-      .where("member_id", "=", member.id)
+      .where("member_id", "in", visibleIds)
       .where("stripe_payment_intent_id", "=", paymentIntentId)
       .where("paid_at", "is", null)
       .where("payment_confirmed_at", "is", null)

--- a/apps/web/src/components/members/charges.tsx
+++ b/apps/web/src/components/members/charges.tsx
@@ -6,8 +6,10 @@ import {
   Card,
   CardContent,
   CardDescription,
+  CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -19,7 +21,7 @@ import {
 import { api, callApi } from "@/lib/api-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatDate } from "date-fns";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 const currencyFormatter = new Intl.NumberFormat("en-GB", {
   style: "currency",
@@ -27,6 +29,17 @@ const currencyFormatter = new Intl.NumberFormat("en-GB", {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
+
+type ChargeRow = NonNullable<
+  NonNullable<ReturnType<typeof useChargesQuery>["data"]>
+>["charges"][number];
+
+function useChargesQuery() {
+  return useQuery({
+    queryKey: ["myCharges"],
+    queryFn: () => callApi(api.GET("/api/charges")),
+  });
+}
 
 export function Charges() {
   const queryClient = useQueryClient();
@@ -37,16 +50,41 @@ export function Charges() {
     paymentIntentId: string;
   } | null>(null);
 
-  const query = useQuery({
-    queryKey: ["myCharges"],
-    queryFn: () => callApi(api.GET("/api/charges")),
-  });
+  const query = useChargesQuery();
+  const charges = query.data?.charges;
+
+  const unpaidCharges = useMemo(
+    () => charges?.filter((c) => !c.paid_at && !c.payment_confirmed_at) ?? [],
+    [charges],
+  );
+  const historyCharges = useMemo(
+    () =>
+      charges?.filter(
+        (c) => c.paid_at !== null || c.payment_confirmed_at !== null,
+      ) ?? [],
+    [charges],
+  );
+
+  // Track explicit deselections rather than selections so new unpaid
+  // charges arriving (e.g. on a refresh) are selected by default
+  // without needing an effect to sync state.
+  const [deselectedIds, setDeselectedIds] = useState<Set<string>>(new Set());
+
+  const selectedIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const c of unpaidCharges) {
+      if (!deselectedIds.has(c.id)) ids.add(c.id);
+    }
+    return ids;
+  }, [unpaidCharges, deselectedIds]);
 
   const payMutation = useMutation({
-    // Members "Pay outstanding" page intentionally pays everything
-    // unpaid for the user — no chargeIds scope.
-    mutationFn: () =>
-      callApi(api.POST("/api/charges/pay-outstanding", { body: {} })),
+    mutationFn: (chargeIds: string[]) =>
+      callApi(
+        api.POST("/api/charges/pay-outstanding", {
+          body: { chargeIds },
+        }),
+      ),
     onSuccess: (data) => {
       if (data.clientSecret) {
         const piId = data.clientSecret.split("_secret_")[0];
@@ -56,15 +94,12 @@ export function Charges() {
           paymentIntentId: piId,
         });
       }
-      // Refresh charges so any newly-attached payment intent state is visible.
       void queryClient.invalidateQueries({ queryKey: ["myCharges"] });
     },
     onError: () => {
       setPaymentError("Failed to create payment. Please try again.");
     },
   });
-
-  const charges = query.data?.charges;
 
   if (query.isLoading) {
     return null;
@@ -78,14 +113,6 @@ export function Charges() {
       </div>
     );
   }
-
-  const unpaidCharges = charges.filter(
-    (c) => !c.paid_at && !c.payment_confirmed_at,
-  );
-  const totalOutstandingPence = unpaidCharges.reduce(
-    (sum, c) => sum + c.amount_pence,
-    0,
-  );
 
   if (paymentData) {
     return (
@@ -113,70 +140,192 @@ export function Charges() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-6">
       <h2 className="text-h4 mb-0">Payments</h2>
 
-      {unpaidCharges.length > 0 && (
-        <Card>
-          <CardContent className="flex items-center justify-between pt-6">
-            <div>
-              <CardTitle className="text-base">
-                Outstanding balance:{" "}
-                {currencyFormatter.format(totalOutstandingPence / 100)}
-              </CardTitle>
-              <CardDescription>
-                {unpaidCharges.length} unpaid{" "}
-                {unpaidCharges.length === 1 ? "payment" : "payments"}
-              </CardDescription>
-            </div>
-            <Button
-              onClick={() => {
-                setPaymentError(null);
-                payMutation.mutate();
-              }}
-              disabled={payMutation.isPending}
-            >
-              {payMutation.isPending
-                ? "Processing…"
-                : "Pay Outstanding Balance"}
-            </Button>
-          </CardContent>
-          {paymentError && (
-            <CardContent className="pt-0">
-              <Alert variant="destructive">
-                <AlertDescription>{paymentError}</AlertDescription>
-              </Alert>
-            </CardContent>
-          )}
-        </Card>
-      )}
+      <OutstandingSection
+        unpaidCharges={unpaidCharges}
+        selectedIds={selectedIds}
+        onToggleCharge={(id, checked) =>
+          setDeselectedIds((prev) => {
+            const next = new Set(prev);
+            if (checked) next.delete(id);
+            else next.add(id);
+            return next;
+          })
+        }
+        onToggleAll={(checked) =>
+          setDeselectedIds(
+            checked ? new Set() : new Set(unpaidCharges.map((c) => c.id)),
+          )
+        }
+        onPay={() => {
+          setPaymentError(null);
+          payMutation.mutate(Array.from(selectedIds));
+        }}
+        isPending={payMutation.isPending}
+        error={paymentError}
+      />
 
+      <HistorySection historyCharges={historyCharges} />
+    </div>
+  );
+}
+
+function OutstandingSection({
+  unpaidCharges,
+  selectedIds,
+  onToggleCharge,
+  onToggleAll,
+  onPay,
+  isPending,
+  error,
+}: {
+  unpaidCharges: ChargeRow[];
+  selectedIds: Set<string>;
+  onToggleCharge: (id: string, checked: boolean) => void;
+  onToggleAll: (checked: boolean) => void;
+  onPay: () => void;
+  isPending: boolean;
+  error: string | null;
+}) {
+  if (unpaidCharges.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Outstanding payments</CardTitle>
+          <CardDescription>You&apos;re all paid up.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const selectedCharges = unpaidCharges.filter((c) => selectedIds.has(c.id));
+  const totalSelectedPence = selectedCharges.reduce(
+    (sum, c) => sum + c.amount_pence,
+    0,
+  );
+  const allSelected = selectedIds.size === unpaidCharges.length;
+  const noneSelected = selectedIds.size === 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          Outstanding payments ({unpaidCharges.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10">
+                <Checkbox
+                  aria-label="Select all unpaid charges"
+                  checked={allSelected}
+                  onCheckedChange={(checked) => onToggleAll(checked === true)}
+                />
+              </TableHead>
+              <TableHead>Date</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead className="text-right">Amount</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {unpaidCharges.map((charge) => (
+              <TableRow key={charge.id}>
+                <TableCell>
+                  <Checkbox
+                    aria-label={`Select charge ${charge.description}`}
+                    checked={selectedIds.has(charge.id)}
+                    onCheckedChange={(checked) =>
+                      onToggleCharge(charge.id, checked === true)
+                    }
+                  />
+                </TableCell>
+                <TableCell>
+                  {formatDate(charge.charge_date, "dd/MM/yyyy")}
+                </TableCell>
+                <TableCell>
+                  <div>{charge.description}</div>
+                  {charge.on_behalf_of && (
+                    <div className="text-xs text-stone-500">
+                      For {charge.on_behalf_of.name ?? "linked junior"}
+                    </div>
+                  )}
+                </TableCell>
+                <TableCell className="text-right">
+                  {currencyFormatter.format(charge.amount_pence / 100)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+
+        <div className="flex items-center justify-between border-t border-stone-200 pt-4">
+          <div>
+            <p className="text-sm text-stone-500">
+              Paying {selectedCharges.length} of {unpaidCharges.length}: total
+            </p>
+            <p className="text-h5 mb-0">
+              {currencyFormatter.format(totalSelectedPence / 100)}
+            </p>
+          </div>
+          <Button
+            onClick={onPay}
+            disabled={isPending || noneSelected}
+            size="lg"
+          >
+            {isPending ? "Processing…" : "Pay selected"}
+          </Button>
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function HistorySection({ historyCharges }: { historyCharges: ChargeRow[] }) {
+  if (historyCharges.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-sm font-semibold text-stone-700">Payment history</h3>
       <Table>
         <TableHeader>
           <TableRow>
             <TableHead>Date</TableHead>
             <TableHead>Description</TableHead>
-            <TableHead>Amount</TableHead>
+            <TableHead className="text-right">Amount</TableHead>
             <TableHead>Status</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
-          {charges.map((charge) => (
+          {historyCharges.map((charge) => (
             <TableRow key={charge.id}>
               <TableCell>
                 {formatDate(charge.charge_date, "dd/MM/yyyy")}
               </TableCell>
-              <TableCell>{charge.description}</TableCell>
               <TableCell>
+                <div>{charge.description}</div>
+                {charge.on_behalf_of && (
+                  <div className="text-xs text-stone-500">
+                    For {charge.on_behalf_of.name ?? "linked junior"}
+                  </div>
+                )}
+              </TableCell>
+              <TableCell className="text-right">
                 {currencyFormatter.format(charge.amount_pence / 100)}
               </TableCell>
               <TableCell>
                 {charge.paid_at ? (
                   <Badge variant="success">Paid</Badge>
-                ) : charge.payment_confirmed_at ? (
-                  <Badge variant="info">Pending</Badge>
                 ) : (
-                  <Badge variant="warning">Unpaid</Badge>
+                  <Badge variant="info">Pending</Badge>
                 )}
               </TableCell>
             </TableRow>

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -515,6 +515,10 @@ export interface paths {
                                 deleted_reason: string | null;
                                 created_at: string;
                                 created_by: string;
+                                on_behalf_of: {
+                                    memberId: string;
+                                    name: string | null;
+                                } | null;
                             }[];
                         };
                     };
@@ -6107,6 +6111,17 @@ export interface paths {
                                 id: string;
                                 name: string;
                             }[];
+                            linkedParents: {
+                                memberId: string;
+                                name: string | null;
+                                email: string;
+                            }[];
+                            linkedJuniors: {
+                                memberId: string;
+                                name: string | null;
+                                email: string;
+                                dob: string | null;
+                            }[];
                         };
                     };
                 };
@@ -6954,6 +6969,12 @@ export interface paths {
                                 deletedReason: string | null;
                                 memberName: string | null;
                                 memberEmail: string;
+                                memberCategory: string | null;
+                                paidByParents: {
+                                    memberId: string;
+                                    name: string | null;
+                                    email: string;
+                                }[];
                                 /** @enum {string} */
                                 status: "paid" | "pending" | "unpaid" | "abandoned" | "deleted";
                             }[];
@@ -7287,6 +7308,140 @@ export interface paths {
                 content: {
                     "application/json": {
                         dependentId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/members/parent-search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    juniorMemberId: string;
+                    search?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            juniorName: string | null;
+                            members: {
+                                id: string;
+                                name: string | null;
+                                email: string;
+                                score: number;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/members/parent-link": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        memberId: string;
+                        parentMemberId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/members/parent-unlink": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        memberId: string;
+                        parentMemberId: string;
                     };
                 };
             };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -604,6 +604,24 @@
                           },
                           "created_by": {
                             "type": "string"
+                          },
+                          "on_behalf_of": {
+                            "nullable": true,
+                            "type": "object",
+                            "properties": {
+                              "memberId": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "memberId",
+                              "name"
+                            ],
+                            "additionalProperties": false
                           }
                         },
                         "required": [
@@ -622,7 +640,8 @@
                           "deleted_by",
                           "deleted_reason",
                           "created_at",
-                          "created_by"
+                          "created_by",
+                          "on_behalf_of"
                         ],
                         "additionalProperties": false
                       }
@@ -10751,6 +10770,59 @@
                         ],
                         "additionalProperties": false
                       }
+                    },
+                    "linkedParents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "memberId": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "memberId",
+                          "name",
+                          "email"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "linkedJuniors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "memberId": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "dob": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "memberId",
+                          "name",
+                          "email",
+                          "dob"
+                        ],
+                        "additionalProperties": false
+                      }
                     }
                   },
                   "required": [
@@ -10760,7 +10832,9 @@
                     "dependents",
                     "charges",
                     "juniorManagerTeams",
-                    "officialTeams"
+                    "officialTeams",
+                    "linkedParents",
+                    "linkedJuniors"
                   ],
                   "additionalProperties": false
                 }
@@ -11866,6 +11940,34 @@
                           "memberEmail": {
                             "type": "string"
                           },
+                          "memberCategory": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "paidByParents": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "memberId": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "email": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "memberId",
+                                "name",
+                                "email"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
                           "status": {
                             "type": "string",
                             "enum": [
@@ -11893,6 +11995,8 @@
                           "deletedReason",
                           "memberName",
                           "memberEmail",
+                          "memberCategory",
+                          "paidByParents",
                           "status"
                         ],
                         "additionalProperties": false
@@ -12462,6 +12566,178 @@
                 },
                 "required": [
                   "dependentId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/members/parent-search": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "query",
+            "name": "juniorMemberId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "juniorName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "members": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "score": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email",
+                          "score"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "juniorName",
+                    "members"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/members/parent-link": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "memberId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "parentMemberId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "memberId",
+                  "parentMemberId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/members/parent-unlink": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "memberId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "parentMemberId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "memberId",
+                  "parentMemberId"
                 ]
               }
             }

--- a/apps/web/src/pages/admin/charges-tab.tsx
+++ b/apps/web/src/pages/admin/charges-tab.tsx
@@ -348,10 +348,30 @@ export function ChargesTab() {
                     <TableCell>{formatDate(charge.chargeDate)}</TableCell>
                     <TableCell>
                       <div className="flex flex-col">
-                        <span className="font-medium">{charge.memberName}</span>
+                        <div className="flex items-center gap-1.5">
+                          <span className="font-medium">
+                            {charge.memberName}
+                          </span>
+                          {charge.memberCategory === "junior" && (
+                            <Badge
+                              variant="outline"
+                              className="border-amber-300 text-xs text-amber-700"
+                            >
+                              Junior
+                            </Badge>
+                          )}
+                        </div>
                         <span className="text-xs text-stone-500">
                           {charge.memberEmail}
                         </span>
+                        {charge.paidByParents.length > 0 && (
+                          <span className="mt-0.5 text-xs text-blue-700">
+                            Paid by{" "}
+                            {charge.paidByParents
+                              .map((p) => p.name ?? p.email)
+                              .join(", ")}
+                          </span>
+                        )}
                       </div>
                     </TableCell>
                     <TableCell>

--- a/apps/web/src/pages/admin/member-detail-modal.tsx
+++ b/apps/web/src/pages/admin/member-detail-modal.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -24,7 +25,7 @@ import {
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   buildDependentFields,
   buildMemberDetailFields,
@@ -91,7 +92,15 @@ function MemberDetailContent({
   data: UserDetail;
   userId: string;
 }) {
-  const { user, member, membership, dependents, charges } = data;
+  const {
+    user,
+    member,
+    membership,
+    dependents,
+    charges,
+    linkedParents,
+    linkedJuniors,
+  } = data;
 
   return (
     <div className="space-y-6">
@@ -131,8 +140,23 @@ function MemberDetailContent({
 
       <hr />
 
-      {/* 6. Junior Members */}
-      <JuniorMembersSection dependents={dependents} />
+      {/* 6a. Linked parents (admin-managed) */}
+      {member && (
+        <>
+          <LinkedParentsSection
+            userId={userId}
+            memberId={member.id}
+            linkedParents={linkedParents}
+          />
+          <hr />
+        </>
+      )}
+
+      {/* 6b. Junior Members (self-registered dependents + linked juniors) */}
+      <JuniorMembersSection
+        dependents={dependents}
+        linkedJuniors={linkedJuniors}
+      />
 
       <hr />
 
@@ -440,24 +464,76 @@ function MembershipSection({
 
 function JuniorMembersSection({
   dependents,
+  linkedJuniors,
 }: {
   dependents: UserDetail["dependents"];
+  linkedJuniors: UserDetail["linkedJuniors"];
 }) {
+  const total = dependents.length + linkedJuniors.length;
   return (
     <section>
       <h3 className="mb-3 text-sm font-semibold text-stone-900">
-        Junior Members ({dependents.length})
+        Junior Members ({total})
       </h3>
-      {dependents.length === 0 ? (
+      {total === 0 ? (
         <p className="text-sm text-stone-500">No junior members.</p>
       ) : (
-        <div className="space-y-3">
-          {dependents.map((dep) => (
-            <DependentCard key={dep.id} dependent={dep} />
-          ))}
+        <div className="space-y-4">
+          {dependents.length > 0 && (
+            <div className="space-y-3">
+              <p className="text-xs font-medium tracking-wide text-stone-500 uppercase">
+                Registered dependents
+              </p>
+              {dependents.map((dep) => (
+                <DependentCard key={dep.id} dependent={dep} />
+              ))}
+            </div>
+          )}
+          {linkedJuniors.length > 0 && (
+            <div className="space-y-3">
+              <p className="text-xs font-medium tracking-wide text-stone-500 uppercase">
+                Linked junior members
+              </p>
+              {linkedJuniors.map((j) => (
+                <LinkedJuniorCard key={j.memberId} junior={j} />
+              ))}
+            </div>
+          )}
         </div>
       )}
     </section>
+  );
+}
+
+function LinkedJuniorCard({
+  junior,
+}: {
+  junior: UserDetail["linkedJuniors"][number];
+}) {
+  return (
+    <div className="rounded-md border border-stone-200 bg-stone-50 p-3">
+      <div className="mb-1 flex items-center gap-2">
+        <span className="font-semibold">{junior.name ?? "(no name)"}</span>
+        <Badge
+          variant="outline"
+          className="border-blue-300 text-xs text-blue-700"
+        >
+          Linked account
+        </Badge>
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+        <div>
+          <span className="text-stone-500">Email</span>
+          <p>{junior.email}</p>
+        </div>
+        {junior.dob && (
+          <div>
+            <span className="text-stone-500">DOB</span>
+            <p>{junior.dob}</p>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -977,6 +1053,221 @@ function ChargeRow({
         )}
       </TableCell>
     </TableRow>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* 6a. Linked Parents Section                                          */
+/* ------------------------------------------------------------------ */
+
+function LinkedParentsSection({
+  userId,
+  memberId,
+  linkedParents,
+}: {
+  userId: string;
+  memberId: string;
+  linkedParents: UserDetail["linkedParents"];
+}) {
+  const queryClient = useQueryClient();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const unlinkMutation = useMutation({
+    mutationFn: (parentMemberId: string) =>
+      callApi(
+        api.POST("/api/admin/members/parent-unlink", {
+          body: { memberId, parentMemberId },
+        }),
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["admin", "userDetail", userId],
+      });
+    },
+  });
+
+  return (
+    <section>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-stone-900">
+          Linked Parents ({linkedParents.length})
+        </h3>
+        <Button size="sm" variant="outline" onClick={() => setPickerOpen(true)}>
+          Link to parent
+        </Button>
+      </div>
+      <p className="mb-3 text-xs text-stone-500">
+        Charges raised against this member will surface on the linked
+        parent(s)&apos; outstanding payments instead of this member&apos;s.
+      </p>
+      {linkedParents.length === 0 ? (
+        <p className="text-sm text-stone-500">No linked parents.</p>
+      ) : (
+        <div className="space-y-2">
+          {linkedParents.map((p) => (
+            <div
+              key={p.memberId}
+              className="flex items-center justify-between rounded-md border border-stone-200 p-3 text-sm"
+            >
+              <div>
+                <span className="font-medium">{p.name ?? "(no name)"}</span>
+                <span className="ml-2 text-stone-500">{p.email}</span>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => unlinkMutation.mutate(p.memberId)}
+                disabled={unlinkMutation.isPending}
+                className="border-red-300 text-red-700 hover:bg-red-50"
+              >
+                Unlink
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {pickerOpen && (
+        <ParentLinkDialog
+          userId={userId}
+          memberId={memberId}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+    </section>
+  );
+}
+
+function ParentLinkDialog({
+  userId,
+  memberId,
+  onClose,
+}: {
+  userId: string;
+  memberId: string;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebounced(search);
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [search]);
+
+  const candidatesQuery = useQuery({
+    queryKey: ["admin", "parentSearch", memberId, debounced],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/members/parent-search", {
+          params: {
+            query: {
+              juniorMemberId: memberId,
+              ...(debounced ? { search: debounced } : {}),
+            },
+          },
+        }),
+      ),
+  });
+
+  const linkMutation = useMutation({
+    mutationFn: (parentMemberId: string) =>
+      callApi(
+        api.POST("/api/admin/members/parent-link", {
+          body: { memberId, parentMemberId },
+        }),
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["admin", "userDetail", userId],
+      });
+      onClose();
+    },
+  });
+
+  const members = candidatesQuery.data?.members ?? [];
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Link to parent</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-stone-500">
+          Pick a parent member. Once linked, this member&apos;s charges will
+          surface on the parent&apos;s outstanding payments list.
+        </p>
+
+        <Input
+          type="text"
+          placeholder="Search by name or email…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="mt-2"
+        />
+
+        {candidatesQuery.isLoading && (
+          <p className="text-sm text-stone-500">Searching…</p>
+        )}
+        {candidatesQuery.error && (
+          <p className="text-sm text-red-600">Failed to search members.</p>
+        )}
+
+        <div className="flex max-h-72 flex-col gap-1 overflow-y-auto">
+          {members.length === 0 && !candidatesQuery.isLoading && (
+            <p className="py-2 text-center text-sm text-stone-500">
+              No matching members.
+            </p>
+          )}
+          {members.map((m) => (
+            <div
+              key={m.id}
+              className="flex items-center justify-between rounded px-3 py-2 hover:bg-stone-50"
+            >
+              <div>
+                <span className="font-medium">{m.name ?? "(no name)"}</span>
+                <span className="ml-2 text-xs text-stone-500">{m.email}</span>
+                {m.score >= 0.7 && (
+                  <Badge
+                    variant="outline"
+                    className="ml-2 border-green-300 text-green-700"
+                  >
+                    Strong match
+                  </Badge>
+                )}
+                {m.score >= 0.4 && m.score < 0.7 && (
+                  <Badge
+                    variant="outline"
+                    className="ml-2 border-yellow-300 text-yellow-700"
+                  >
+                    Possible match
+                  </Badge>
+                )}
+              </div>
+              <Button
+                size="sm"
+                onClick={() => linkMutation.mutate(m.id)}
+                disabled={linkMutation.isPending}
+              >
+                Link
+              </Button>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -583,6 +583,13 @@ export interface Member {
   title: string | null;
 }
 
+export interface MemberParentLink {
+  created_at: Generated<string>;
+  created_by: string | null;
+  member_id: string;
+  parent_member_id: string;
+}
+
 export interface Membership {
   created_at: Generated<string>;
   dependent_id: string | null;
@@ -900,6 +907,7 @@ export interface DB {
   matchday_expense: MatchdayExpense;
   matchday_player: MatchdayPlayer;
   member: Member;
+  member_parent_link: MemberParentLink;
   membership: Membership;
   passkey: Passkey;
   play_cricket_match_cache: PlayCricketMatchCache;

--- a/packages/db/src/migrations/2026-05-11T19:23:30.293Z.ts
+++ b/packages/db/src/migrations/2026-05-11T19:23:30.293Z.ts
@@ -1,0 +1,44 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Link a member (typically a junior who self-registered) to one or more
+ * parent members. Used so that charges raised against the junior surface
+ * on the parent's "to pay" list instead of the junior's, and so that
+ * payOutstandingCharges bundles them together. Many-to-many to support
+ * two-parent households. Admin-managed only — no self-service linking.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("member_parent_link")
+    .addColumn("member_id", "text", (col) =>
+      col.notNull().references("member.id").onDelete("cascade"),
+    )
+    .addColumn("parent_member_id", "text", (col) =>
+      col.notNull().references("member.id").onDelete("cascade"),
+    )
+    .addColumn("created_at", "text", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("created_by", "text", (col) =>
+      col.references("user.id").onDelete("set null"),
+    )
+    .addPrimaryKeyConstraint("member_parent_link_pkey", [
+      "member_id",
+      "parent_member_id",
+    ])
+    .addCheckConstraint(
+      "member_parent_link_no_self_check",
+      sql`member_id <> parent_member_id`,
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("idx_member_parent_link_parent")
+    .on("member_parent_link")
+    .column("parent_member_id")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("member_parent_link").execute();
+}


### PR DESCRIPTION
## Summary
- Admins can link a member (typically a self-registered junior) to one or more parent members via a new "Linked parents" section in the member detail modal, with the same fuzzy-search pattern used elsewhere.
- Once linked, charges raised against the junior surface on the parent's "outstanding payments" instead of the junior's. `payOutstandingCharges` bundles parent + linked juniors; junior list hides them.
- Admin charges tab now flags junior members with a badge and shows "Paid by [parent]" when a linked parent will absorb the fee.
- Members "Payments" page is split into a selectable **Outstanding payments** card (one checkbox per unpaid charge, default all selected, deselections persist across refresh) and a separate **Payment history** table.

## Data model
New `member_parent_link` junction `(member_id, parent_member_id)` with ON DELETE CASCADE and a self-link CHECK. Many-to-many to support two-parent households.

## Notes
- Charges keep their original `member_id` so audit trail / matchday → player linkage stays intact; routing happens at read time via `getVisibleMembers`.
- A new `on_behalf_of: { memberId, name } \| null` is added to the user-facing charge response so the parent's list can show "For [Junior name]".
- Linking is admin-only — no self-service from the junior or parent.

## Test plan
- [x] `pnpm --filter api test` — 451 unit tests pass
- [x] `pnpm --filter api test:integration` — admin + charges suites including 5 new admin parent-link tests and 3 new charges parent-link routing tests
- [x] `pnpm --filter web test` — 514 tests pass
- [x] `pnpm lint`, `pnpm format`, `pnpm --filter web build` — clean
- [ ] Manual: admin links a junior → parent → confirm junior's `/charges` is empty, parent's bundle includes them, "Pay selected" with a subset works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)