### PR TITLE
feat(charges): rename match "fee" to "donation" in user-facing copy

### DIFF
--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -775,7 +775,7 @@ export function confirmTeam(db: Kysely<DB>) {
           .values({
             id: chargeId,
             member_id: player.member_id,
-            description: `Match fee - ${matchday.opposition} (${formatDate(new Date(matchday.match_date), "dd/MM/yyyy")})`,
+            description: `Match donation - ${matchday.opposition} (${formatDate(new Date(matchday.match_date), "dd/MM/yyyy")})`,
             amount_pence: rate.amount_pence,
             charge_date: matchday.match_date,
             created_by: userId,
@@ -908,7 +908,7 @@ export function markFeePaid(db: Kysely<DB>) {
     }
 
     if (!player.charge_id) {
-      throwHttpError(400, "No match fee charge found for this player");
+      throwHttpError(400, "No match donation charge found for this player");
     }
 
     await db
@@ -969,7 +969,7 @@ export function cancelMatchday(db: Kysely<DB>) {
     if (existingCharge) {
       throwHttpError(
         400,
-        "Cannot cancel: match fee charges already exist. Void them via the Charges admin first.",
+        "Cannot cancel: match donation charges already exist. Void them via the Charges admin first.",
       );
     }
 
@@ -1100,7 +1100,7 @@ export function finishMatch(
             .values({
               id: chargeId,
               member_id: player.member_id,
-              description: `Match fee - ${matchday.opposition} (${formatDate(new Date(matchday.match_date), "dd/MM/yyyy")})`,
+              description: `Match donation - ${matchday.opposition} (${formatDate(new Date(matchday.match_date), "dd/MM/yyyy")})`,
               amount_pence: rate.amount_pence,
               charge_date: matchday.match_date,
               created_by: userId,

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -94,7 +94,7 @@ const SECTIONS = [
       },
       {
         value: "match-fees",
-        label: "Match Fees",
+        label: "Match Donations",
         render: () => <MatchFeesTab />,
       },
       { value: "fantasy", label: "Fantasy", render: () => <FantasyTab /> },

--- a/apps/web/src/pages/admin/game-reports-tab.tsx
+++ b/apps/web/src/pages/admin/game-reports-tab.tsx
@@ -260,7 +260,9 @@ function MatchdayReport({
             <CardContent>
               <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 <div className="rounded border border-stone-200 p-3">
-                  <p className="text-sm text-stone-500">Match Fee Income</p>
+                  <p className="text-sm text-stone-500">
+                    Match Donation Income
+                  </p>
                   <p className="text-lg font-semibold">
                     {formatPence(data.summary.totalIncoming)}
                   </p>
@@ -336,7 +338,9 @@ function MatchdayReport({
                       <TableHead>Player</TableHead>
                       <TableHead>Status</TableHead>
                       <TableHead>Category</TableHead>
-                      <TableHead className="text-right">Match Fee</TableHead>
+                      <TableHead className="text-right">
+                        Match Donation
+                      </TableHead>
                       <TableHead>Payment</TableHead>
                     </TableRow>
                   </TableHeader>

--- a/apps/web/src/pages/admin/match-fees-tab.tsx
+++ b/apps/web/src/pages/admin/match-fees-tab.tsx
@@ -101,7 +101,7 @@ export function MatchFeesTab() {
     <div className="flex flex-col gap-4">
       <Card>
         <CardHeader>
-          <CardTitle>Add Fee Rate</CardTitle>
+          <CardTitle>Add Donation Rate</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex flex-wrap items-end gap-3">
@@ -227,8 +227,8 @@ export function MatchFeesTab() {
             <p className="text-sm text-stone-500">Loading…</p>
           ) : rates.length === 0 ? (
             <p className="text-sm text-stone-500">
-              No fee rates configured. Add rates above so match fees can be
-              generated when a team is confirmed.
+              No donation rates configured. Add rates above so match donations
+              can be generated when a team is confirmed.
             </p>
           ) : (
             <Table>

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -1224,8 +1224,8 @@ function MatchdayView({
               <CardContent className="p-4">
                 <p className="font-medium">Finish Match</p>
                 <p className="mb-3 text-sm text-stone-500">
-                  Select the match result and finish. Unpaid match fees will
-                  remain as charges and notification emails will be sent.
+                  Select the match result and finish. Unpaid match donations
+                  will remain as charges and notification emails will be sent.
                 </p>
                 <div className="flex items-center gap-3">
                   <Select

--- a/packages/db/src/migrations/2026-05-11T20:43:52.646Z.ts
+++ b/packages/db/src/migrations/2026-05-11T20:43:52.646Z.ts
@@ -1,0 +1,23 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Rename existing match-fee charge descriptions to use "donation" wording.
+ * Treasurer's request for amateur sports club tax/accounts purposes.
+ * Only descriptions starting with the legacy "Match fee - " prefix are
+ * rewritten; trailing "<opposition> (dd/MM/yyyy)" portion is preserved.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE charge
+    SET description = 'Match donation - ' || substring(description from length('Match fee - ') + 1)
+    WHERE description LIKE 'Match fee - %'
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE charge
+    SET description = 'Match fee - ' || substring(description from length('Match donation - ') + 1)
+    WHERE description LIKE 'Match donation - %'
+  `.execute(db);
+}

--- a/packages/email/src/templates/ChargeNotification.tsx
+++ b/packages/email/src/templates/ChargeNotification.tsx
@@ -91,7 +91,7 @@ export const ChargeNotification = email<Props>("New Charge Added", {
   preview: {
     imageBaseUrl: "http://localhost:5173/images",
     name: "Alex",
-    description: "Match fee - Senior XI vs Benwell Hill",
+    description: "Match donation - Senior XI vs Benwell Hill",
     amount: "\u00a35.00",
     chargeDate: "25/02/2026",
     loginUrl: "http://localhost:5173/auth/login",

--- a/packages/email/src/templates/PaymentReminder.tsx
+++ b/packages/email/src/templates/PaymentReminder.tsx
@@ -92,7 +92,7 @@ export const PaymentReminder = email<Props>("Payment Reminder", {
   preview: {
     imageBaseUrl: "http://localhost:5173/images",
     name: "Alex",
-    description: "Match fee - Senior XI vs Benwell Hill",
+    description: "Match donation - Senior XI vs Benwell Hill",
     amount: "\u00a35.00",
     chargeDate: "25/02/2026",
     loginUrl: "http://localhost:5173/auth/login",


### PR DESCRIPTION
## Summary

- Renames all user-visible "match fee" wording to "match donation" — treasurer's request for amateur sports club tax/accounts treatment.
- New charges generated by the matchday workflow get description `Match donation - <opposition> (dd/MM/yyyy)`.
- One-shot migration rewrites existing `charge.description` rows from the legacy `Match fee - %` prefix.

Internal identifiers (`match_fee_rate` table, `match_fee` charge type, `/api/admin/match-fee-rates` route) are deliberately left in place — they are not user-visible and a rename would be a much larger refactor with no user benefit.

## Test plan

- [x] `pnpm --filter api lint && pnpm --filter web lint`
- [x] `pnpm --filter api typecheck && pnpm --filter web typecheck`
- [x] `pnpm --filter api test src/features/matchday`
- [x] `pnpm format` clean
- [ ] CI green
- [ ] Smoke-check: admin → Cricket → "Match Donations" tab still renders rate list and add-rate form
- [ ] Smoke-check: a member's charges list shows existing match donations with the rewritten description

🤖 Generated with [Claude Code](https://claude.com/claude-code)