### PR TITLE
feat(admin): Mark Paid action on charges (cash / bank transfer / card)

### DIFF
--- a/apps/api/src/features/admin/integration.test.ts
+++ b/apps/api/src/features/admin/integration.test.ts
@@ -21,6 +21,7 @@ import {
   listContactSubmissions,
   listJuniors,
   listUsers,
+  markChargePaid,
   mergeMembers,
   searchMembersForParentLink,
   searchUsersForLinking,
@@ -815,6 +816,122 @@ describe("admin service (integration)", () => {
       await expect(chasePayment(ctx.db)(chargeId)).rejects.toThrow(
         "Charge not found or already paid/deleted",
       );
+    });
+  });
+
+  describe("markChargePaid", () => {
+    it("marks an unpaid charge as paid with the given payment method", async () => {
+      const email = `mark-paid-${crypto.randomUUID()}@test.com`;
+      const seed = await seedTestUser(ctx.db, { email });
+      const memberId = seed.memberId ?? "";
+
+      const chargeId = crypto.randomUUID();
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: memberId,
+          description: "Cash payment",
+          amount_pence: 1500,
+          charge_date: "2026-03-15",
+          created_by: "admin",
+          source: "admin",
+          type: "manual",
+        })
+        .execute();
+
+      const result = await markChargePaid(ctx.db)(chargeId, {
+        paymentMethod: "cash",
+      });
+      expect(result).toEqual({ success: true });
+
+      const after = await ctx.db
+        .selectFrom("charge")
+        .where("id", "=", chargeId)
+        .select(["paid_at", "payment_method"])
+        .executeTakeFirstOrThrow();
+      expect(after.paid_at).not.toBeNull();
+      expect(after.payment_method).toBe("cash");
+    });
+
+    it("throws 404 for an already-paid charge", async () => {
+      const email = `mark-paid-already-${crypto.randomUUID()}@test.com`;
+      const seed = await seedTestUser(ctx.db, { email });
+      const memberId = seed.memberId ?? "";
+
+      const chargeId = crypto.randomUUID();
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: memberId,
+          description: "Already paid",
+          amount_pence: 1500,
+          charge_date: "2026-03-15",
+          paid_at: new Date().toISOString(),
+          payment_method: "card",
+          created_by: "admin",
+          source: "admin",
+          type: "manual",
+        })
+        .execute();
+
+      await expect(
+        markChargePaid(ctx.db)(chargeId, { paymentMethod: "cash" }),
+      ).rejects.toThrow("Charge not found or already paid/deleted");
+    });
+
+    it("throws 404 for a deleted (voided) charge", async () => {
+      const email = `mark-paid-voided-${crypto.randomUUID()}@test.com`;
+      const seed = await seedTestUser(ctx.db, { email });
+      const memberId = seed.memberId ?? "";
+
+      const chargeId = crypto.randomUUID();
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: memberId,
+          description: "Voided",
+          amount_pence: 1500,
+          charge_date: "2026-03-15",
+          deleted_at: new Date().toISOString(),
+          deleted_reason: "raised in error",
+          created_by: "admin",
+          source: "admin",
+          type: "manual",
+        })
+        .execute();
+
+      await expect(
+        markChargePaid(ctx.db)(chargeId, { paymentMethod: "cash" }),
+      ).rejects.toThrow("Charge not found or already paid/deleted");
+    });
+
+    it("throws 404 for a charge with payment in flight", async () => {
+      const email = `mark-paid-pending-${crypto.randomUUID()}@test.com`;
+      const seed = await seedTestUser(ctx.db, { email });
+      const memberId = seed.memberId ?? "";
+
+      const chargeId = crypto.randomUUID();
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: memberId,
+          description: "Pending Stripe confirmation",
+          amount_pence: 1500,
+          charge_date: "2026-03-15",
+          payment_confirmed_at: new Date().toISOString(),
+          created_by: "admin",
+          source: "admin",
+          type: "manual",
+        })
+        .execute();
+
+      await expect(
+        markChargePaid(ctx.db)(chargeId, { paymentMethod: "cash" }),
+      ).rejects.toThrow("Charge not found or already paid/deleted");
     });
   });
 

--- a/apps/api/src/features/admin/routes.ts
+++ b/apps/api/src/features/admin/routes.ts
@@ -40,6 +40,8 @@ import {
   listJuniorsSchema,
   listUsersResponseSchema,
   listUsersSchema,
+  markChargePaidResponseSchema,
+  markChargePaidSchema,
   matchFeeRatesResponseSchema,
   matchdayIdParamSchema,
   matchdayReportResponseSchema,
@@ -100,6 +102,7 @@ import {
   listJuniors,
   listMatchFeeRates,
   listUsers,
+  markChargePaid,
   mergeMembers,
   restoreMember,
   searchMembersForParentLink,
@@ -146,6 +149,7 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
   const listCharges = listAllCharges(app.db);
   const chargeAggregates = getChargeAggregates(app.db);
   const chase = chasePayment(app.db);
+  const markPaid = markChargePaid(app.db);
   const listContacts = listContactSubmissions(app.db);
   const findDuplicates = findDuplicateMembers(app.db);
   const previewMerge = getMergePreview(app.db);
@@ -512,6 +516,21 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request) => {
       return await chase(request.body.chargeId);
+    },
+  );
+
+  app.post(
+    "/admin/charges/:chargeId/mark-paid",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: chargeIdParamSchema,
+        body: markChargePaidSchema,
+        response: { 200: markChargePaidResponseSchema },
+      },
+    },
+    async (request) => {
+      return await markPaid(request.params.chargeId, request.body);
     },
   );
 

--- a/apps/api/src/features/admin/schemas.ts
+++ b/apps/api/src/features/admin/schemas.ts
@@ -141,6 +141,12 @@ export const chasePaymentSchema = z.object({
   chargeId: z.string(),
 });
 
+export const markChargePaidSchema = z.object({
+  paymentMethod: z.enum(["cash", "bank_transfer", "card"]),
+});
+
+export type MarkChargePaid = z.infer<typeof markChargePaidSchema>;
+
 export type ListCharges = z.infer<typeof listChargesSchema>;
 export type ChargeAggregates = z.infer<typeof chargeAggregatesSchema>;
 export type ChasePayment = z.infer<typeof chasePaymentSchema>;
@@ -481,6 +487,8 @@ export const chargeAggregatesResponseSchema = z.object({
 });
 
 export const chasePaymentResponseSchema = successResponseSchema;
+
+export const markChargePaidResponseSchema = successResponseSchema;
 
 export const listContactSubmissionsResponseSchema = z.object({
   submissions: z.array(

--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -1358,6 +1358,35 @@ export function getChargeAggregates(db: Kysely<DB>) {
   };
 }
 
+export function markChargePaid(db: Kysely<DB>) {
+  return async (
+    chargeId: string,
+    data: { paymentMethod: "cash" | "bank_transfer" | "card" },
+  ) => {
+    const result = await db
+      .updateTable("charge")
+      .set({
+        paid_at: new Date().toISOString(),
+        payment_method: data.paymentMethod,
+      })
+      .where("id", "=", chargeId)
+      .where("paid_at", "is", null)
+      .where("payment_confirmed_at", "is", null)
+      .where("deleted_at", "is", null)
+      .executeTakeFirst();
+
+    if (result.numUpdatedRows === 0n) {
+      const error = new Error(
+        "Charge not found or already paid/deleted",
+      ) as Error & { statusCode: number };
+      error.statusCode = 404;
+      throw error;
+    }
+
+    return { success: true };
+  };
+}
+
 export function chasePayment(db: Kysely<DB>) {
   return async (chargeId: string) => {
     const charge = await db

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -7086,6 +7086,52 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/charges/{chargeId}/mark-paid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    chargeId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        paymentMethod: "cash" | "bank_transfer" | "card";
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/contact-submissions": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -12148,6 +12148,64 @@
         }
       }
     },
+    "/api/admin/charges/{chargeId}/mark-paid": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "paymentMethod": {
+                    "type": "string",
+                    "enum": [
+                      "cash",
+                      "bank_transfer",
+                      "card"
+                    ]
+                  }
+                },
+                "required": [
+                  "paymentMethod"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "chargeId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/contact-submissions": {
       "get": {
         "parameters": [

--- a/apps/web/src/pages/admin/charges-tab.tsx
+++ b/apps/web/src/pages/admin/charges-tab.tsx
@@ -83,9 +83,11 @@ export function ChargesTab() {
     search,
     debouncedSearch,
   } = filters;
+  type PaymentMethod = "cash" | "bank_transfer" | "card";
   type ConfirmAction =
     | { kind: "chase"; chargeId: string }
-    | { kind: "void"; chargeId: string; reason: string };
+    | { kind: "void"; chargeId: string; reason: string }
+    | { kind: "markPaid"; chargeId: string; paymentMethod: PaymentMethod };
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(
     null,
   );
@@ -169,6 +171,23 @@ export function ChargesTab() {
         api.DELETE("/api/admin/charges/{chargeId}", {
           params: { path: { chargeId: input.chargeId } },
           body: { reason: input.reason },
+        }),
+      ),
+    onSuccess: () => {
+      setConfirmAction(null);
+      void queryClient.invalidateQueries({ queryKey: ["admin", "charges"] });
+      void queryClient.invalidateQueries({
+        queryKey: ["admin", "chargeAggregates"],
+      });
+    },
+  });
+
+  const markPaidMutation = useMutation({
+    mutationFn: (input: { chargeId: string; paymentMethod: PaymentMethod }) =>
+      callApi(
+        api.POST("/api/admin/charges/{chargeId}/mark-paid", {
+          params: { path: { chargeId: input.chargeId } },
+          body: { paymentMethod: input.paymentMethod },
         }),
       ),
     onSuccess: () => {
@@ -422,6 +441,17 @@ export function ChargesTab() {
                               Chase
                             </DropdownMenuItem>
                             <DropdownMenuItem
+                              onSelect={() =>
+                                setConfirmAction({
+                                  kind: "markPaid",
+                                  chargeId: charge.id,
+                                  paymentMethod: "cash",
+                                })
+                              }
+                            >
+                              Mark paid…
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
                               className="text-red-700 focus:bg-red-50 focus:text-red-800"
                               onSelect={() =>
                                 setConfirmAction({
@@ -504,7 +534,108 @@ export function ChargesTab() {
         isPending={voidMutation.isPending}
         isError={voidMutation.isError}
       />
+
+      <MarkPaidConfirmDialog
+        action={confirmAction?.kind === "markPaid" ? confirmAction : null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmAction(null);
+        }}
+        onPaymentMethodChange={(paymentMethod) =>
+          setConfirmAction((prev) =>
+            prev?.kind === "markPaid" ? { ...prev, paymentMethod } : prev,
+          )
+        }
+        onConfirm={(input) => markPaidMutation.mutate(input)}
+        isPending={markPaidMutation.isPending}
+        isError={markPaidMutation.isError}
+      />
     </div>
+  );
+}
+
+type PaymentMethod = "cash" | "bank_transfer" | "card";
+
+const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
+  cash: "Cash",
+  bank_transfer: "Bank transfer",
+  card: "Card",
+};
+
+function MarkPaidConfirmDialog({
+  action,
+  onOpenChange,
+  onPaymentMethodChange,
+  onConfirm,
+  isPending,
+  isError,
+}: {
+  action: { chargeId: string; paymentMethod: PaymentMethod } | null;
+  onOpenChange: (open: boolean) => void;
+  onPaymentMethodChange: (paymentMethod: PaymentMethod) => void;
+  onConfirm: (input: {
+    chargeId: string;
+    paymentMethod: PaymentMethod;
+  }) => void;
+  isPending: boolean;
+  isError: boolean;
+}) {
+  return (
+    <Dialog open={action !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Mark this charge as paid?</DialogTitle>
+          <DialogDescription>
+            Records the charge as paid outside Stripe, for cash or bank
+            transfers collected directly. No payment confirmation email is sent.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-4 flex flex-col gap-2">
+          <Label htmlFor="mark-paid-method" className="text-sm font-medium">
+            Payment method
+          </Label>
+          <Select
+            value={action?.paymentMethod ?? "cash"}
+            onValueChange={(v) => onPaymentMethodChange(v as PaymentMethod)}
+          >
+            <SelectTrigger id="mark-paid-method" className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(PAYMENT_METHOD_LABELS) as PaymentMethod[]).map(
+                (m) => (
+                  <SelectItem key={m} value={m}>
+                    {PAYMENT_METHOD_LABELS[m]}
+                  </SelectItem>
+                ),
+              )}
+            </SelectContent>
+          </Select>
+        </div>
+        {isError && (
+          <p className="mt-2 text-sm text-red-600">
+            Failed to mark paid. Try again.
+          </p>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={!action || isPending}
+            onClick={() => {
+              if (action) {
+                onConfirm({
+                  chargeId: action.chargeId,
+                  paymentMethod: action.paymentMethod,
+                });
+              }
+            }}
+          >
+            {isPending ? "Marking…" : "Mark paid"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a third row action on the admin charges tab alongside **Chase** and **Void**: **Mark paid…** Used for recording manual payments collected outside Stripe — typically cash collected by the captain on matchday, or a member-initiated bank transfer.

- New API: `POST /api/admin/charges/{chargeId}/mark-paid` (admin only). Body: `{ paymentMethod: "cash" | "bank_transfer" | "card" }`. Sets `paid_at = now` + `payment_method`.
- Rejects already-paid, soft-deleted, and Stripe-pending charges (`payment_confirmed_at IS NOT NULL`) so we don't double-collect.
- New dropdown item and confirm dialog with a payment-method select (defaults to **Cash**).
- Charges list + aggregates queries invalidated on success.

No email is sent — the user has already paid externally.

## Test plan

- [x] `pnpm --filter api lint && pnpm --filter web lint`
- [x] `pnpm --filter api typecheck && pnpm --filter web typecheck`
- [x] Unit tests (`pnpm --filter api test`) green
- [x] Integration tests for the new service: success, already-paid 404, deleted 404, pending 404
- [ ] CI green
- [ ] Smoke-check: admin → Charges → triple-dot on an unpaid charge → Mark paid → Cash → row flips to Paid, Outstanding total drops by amount

🤖 Generated with [Claude Code](https://claude.com/claude-code)