### PR TITLE
feat(scout): ask_db on deepseek-v4-flash + re-apply scout_readonly on restore

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -87,11 +87,11 @@ SCOUT_PROVIDER_CHAT=deepseek
 SCOUT_MODEL_CHAT=deepseek-v4-pro
 SCOUT_PROVIDER_SUBAGENT=deepseek
 SCOUT_MODEL_SUBAGENT=deepseek-v4-pro
-# DB sub-agent runs the SQL loop behind ask_db. Anthropic Haiku is
-# strong at SQL and cheap; the chat agent can run on DeepSeek
-# independently.
-SCOUT_PROVIDER_DB=anthropic
-SCOUT_MODEL_DB=claude-haiku-4-5-20251001
+# DB sub-agent runs the SQL loop behind ask_db. DeepSeek-Flash is
+# fast, cheap, and handles our SELECT-heavy workload as well as
+# Haiku in practice.
+SCOUT_PROVIDER_DB=deepseek
+SCOUT_MODEL_DB=deepseek-v4-flash
 # Report agent (the loop behind generate_report).
 SCOUT_PROVIDER_REPORT=deepseek
 SCOUT_MODEL_REPORT=deepseek-v4-flash

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -183,11 +183,11 @@ module "ecs" {
     # quality over latency on the long generate_report loop.
     SCOUT_PROVIDER_CHAT           = "deepseek"
     SCOUT_PROVIDER_SUBAGENT       = "deepseek"
-    SCOUT_PROVIDER_DB             = "anthropic"
+    SCOUT_PROVIDER_DB             = "deepseek"
     SCOUT_PROVIDER_REPORT         = "deepseek"
     SCOUT_MODEL_CHAT              = "deepseek-v4-pro"
     SCOUT_MODEL_SUBAGENT          = "deepseek-v4-pro"
-    SCOUT_MODEL_DB                = "claude-haiku-4-5-20251001"
+    SCOUT_MODEL_DB                = "deepseek-v4-flash"
     SCOUT_MODEL_REPORT            = "deepseek-v4"
     SCOUT_ATTACHMENT_DERIVE_MODEL = "claude-haiku-4-5-20251001"
     VOYAGE_EMBED_MODEL            = "voyage-4"

--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -126,11 +126,11 @@ module "ecs" {
     # flash) to favour quality over latency on report runs.
     SCOUT_PROVIDER_CHAT           = "deepseek"
     SCOUT_PROVIDER_SUBAGENT       = "deepseek"
-    SCOUT_PROVIDER_DB             = "anthropic"
+    SCOUT_PROVIDER_DB             = "deepseek"
     SCOUT_PROVIDER_REPORT         = "deepseek"
     SCOUT_MODEL_CHAT              = "deepseek-v4-pro"
     SCOUT_MODEL_SUBAGENT          = "deepseek-v4-pro"
-    SCOUT_MODEL_DB                = "claude-haiku-4-5-20251001"
+    SCOUT_MODEL_DB                = "deepseek-v4-flash"
     SCOUT_MODEL_REPORT            = "deepseek-v4-flash"
     SCOUT_ATTACHMENT_DERIVE_MODEL = "claude-haiku-4-5-20251001"
     VOYAGE_EMBED_MODEL            = "voyage-4"

--- a/scripts/db-restore.sh
+++ b/scripts/db-restore.sh
@@ -65,5 +65,14 @@ echo ""
 # Use psql to execute the dump (which contains SQL statements from pg_dump --clean --if-exists)
 psql "$TARGET_URL" -f "$DUMP_FILE"
 
+# Re-apply the scout_readonly LOGIN + dev password. The migration creates the
+# role as NOLOGIN; setup-scout flips it to LOGIN with the known dev password
+# that apps/api/.env's SCOUT_DB_URL expects. Dumps from prod strip role state
+# (--no-owner --no-privileges), so without this step Scout's sub-agent gets
+# "password authentication failed for scout_readonly" after every restore.
+echo ""
+echo "Reapplying scout_readonly LOGIN + dev password..."
+DATABASE_URL="$TARGET_URL" pnpm --filter @percy-main/db run db:setup-scout
+
 echo ""
 echo "Restore complete."


### PR DESCRIPTION
## Summary
- Flip `SCOUT_PROVIDER_DB` / `SCOUT_MODEL_DB` to `deepseek` / `deepseek-v4-flash` in staging + production (local has been running this way and handles our SELECT-heavy workload as well as Haiku).
- `scripts/db-restore.sh` now reruns `db:setup-scout` after psql, so `scout_readonly` regains LOGIN + the dev password the API expects. Migrations create the role `NOLOGIN`; previously every restore left ask_db broken with "password authentication failed for scout_readonly".
- `.env.example` updated to match.

## Test plan
- [ ] CI green
- [ ] After merge, prod ECS picks up the new env vars (CI applies Terraform)
- [ ] Run a Scout query in prod (e.g. "top run scorer 2025") — ask_db sub-agent now routed through DeepSeek-Flash
- [x] Locally: `./scripts/db-restore.sh <dump>` followed by a Scout query should work without manually running `db:setup-scout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)