### PR TITLE
feat(admin): Edit action on charges (amount + description)

### DIFF
--- a/apps/api/src/features/admin/integration.test.ts
+++ b/apps/api/src/features/admin/integration.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   chasePayment,
   createMember,
+  editCharge,
   findDuplicateMembers,
   getChargeAggregates,
   getMergePreview,
@@ -931,6 +932,132 @@ describe("admin service (integration)", () => {
 
       await expect(
         markChargePaid(ctx.db)(chargeId, { paymentMethod: "cash" }),
+      ).rejects.toThrow("Charge not found or already paid/deleted");
+    });
+  });
+
+  describe("editCharge", () => {
+    it("updates amount and description on an unpaid charge", async () => {
+      const email = `edit-charge-${crypto.randomUUID()}@test.com`;
+      const seed = await seedTestUser(ctx.db, { email });
+      const memberId = seed.memberId ?? "";
+
+      const chargeId = crypto.randomUUID();
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: memberId,
+          description: "Adult match donation",
+          amount_pence: 1500,
+          charge_date: "2026-03-15",
+          created_by: "admin",
+          source: "admin",
+          type: "manual",
+        })
+        .execute();
+
+      const result = await editCharge(ctx.db)(chargeId, {
+        amountPence: 500,
+        description: "Junior match donation",
+      });
+      expect(result).toEqual({ success: true });
+
+      const after = await ctx.db
+        .selectFrom("charge")
+        .where("id", "=", chargeId)
+        .select(["amount_pence", "description"])
+        .executeTakeFirstOrThrow();
+      expect(after.amount_pence).toBe(500);
+      expect(after.description).toBe("Junior match donation");
+    });
+
+    it("throws 404 for an already-paid charge", async () => {
+      const email = `edit-charge-paid-${crypto.randomUUID()}@test.com`;
+      const seed = await seedTestUser(ctx.db, { email });
+      const memberId = seed.memberId ?? "";
+
+      const chargeId = crypto.randomUUID();
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: memberId,
+          description: "Already paid",
+          amount_pence: 1500,
+          charge_date: "2026-03-15",
+          paid_at: new Date().toISOString(),
+          payment_method: "card",
+          created_by: "admin",
+          source: "admin",
+          type: "manual",
+        })
+        .execute();
+
+      await expect(
+        editCharge(ctx.db)(chargeId, {
+          amountPence: 500,
+          description: "Junior",
+        }),
+      ).rejects.toThrow("Charge not found or already paid/deleted");
+    });
+
+    it("throws 404 for a deleted (voided) charge", async () => {
+      const email = `edit-charge-voided-${crypto.randomUUID()}@test.com`;
+      const seed = await seedTestUser(ctx.db, { email });
+      const memberId = seed.memberId ?? "";
+
+      const chargeId = crypto.randomUUID();
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: memberId,
+          description: "Voided",
+          amount_pence: 1500,
+          charge_date: "2026-03-15",
+          deleted_at: new Date().toISOString(),
+          deleted_reason: "raised in error",
+          created_by: "admin",
+          source: "admin",
+          type: "manual",
+        })
+        .execute();
+
+      await expect(
+        editCharge(ctx.db)(chargeId, {
+          amountPence: 500,
+          description: "Junior",
+        }),
+      ).rejects.toThrow("Charge not found or already paid/deleted");
+    });
+
+    it("throws 404 for a charge with payment in flight", async () => {
+      const email = `edit-charge-pending-${crypto.randomUUID()}@test.com`;
+      const seed = await seedTestUser(ctx.db, { email });
+      const memberId = seed.memberId ?? "";
+
+      const chargeId = crypto.randomUUID();
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: memberId,
+          description: "Pending Stripe confirmation",
+          amount_pence: 1500,
+          charge_date: "2026-03-15",
+          payment_confirmed_at: new Date().toISOString(),
+          created_by: "admin",
+          source: "admin",
+          type: "manual",
+        })
+        .execute();
+
+      await expect(
+        editCharge(ctx.db)(chargeId, {
+          amountPence: 500,
+          description: "Junior",
+        }),
       ).rejects.toThrow("Charge not found or already paid/deleted");
     });
   });

--- a/apps/api/src/features/admin/routes.ts
+++ b/apps/api/src/features/admin/routes.ts
@@ -21,6 +21,8 @@ import {
   deleteChargeResponseSchema,
   deleteChargeSchema,
   deleteMatchFeeRateResponseSchema,
+  editChargeResponseSchema,
+  editChargeSchema,
   findDuplicatesResponseSchema,
   getUserDetailResponseSchema,
   juniorTeamsResponseSchema,
@@ -86,6 +88,7 @@ import {
   createMember,
   deleteCharge,
   deleteMatchFeeRate,
+  editCharge,
   findDuplicateMembers,
   getAllJuniorTeams,
   getAllPlayCricketTeams,
@@ -150,6 +153,7 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
   const chargeAggregates = getChargeAggregates(app.db);
   const chase = chasePayment(app.db);
   const markPaid = markChargePaid(app.db);
+  const edit = editCharge(app.db);
   const listContacts = listContactSubmissions(app.db);
   const findDuplicates = findDuplicateMembers(app.db);
   const previewMerge = getMergePreview(app.db);
@@ -531,6 +535,21 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request) => {
       return await markPaid(request.params.chargeId, request.body);
+    },
+  );
+
+  app.post(
+    "/admin/charges/:chargeId/edit",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: chargeIdParamSchema,
+        body: editChargeSchema,
+        response: { 200: editChargeResponseSchema },
+      },
+    },
+    async (request) => {
+      return await edit(request.params.chargeId, request.body);
     },
   );
 

--- a/apps/api/src/features/admin/schemas.ts
+++ b/apps/api/src/features/admin/schemas.ts
@@ -147,6 +147,13 @@ export const markChargePaidSchema = z.object({
 
 export type MarkChargePaid = z.infer<typeof markChargePaidSchema>;
 
+export const editChargeSchema = z.object({
+  amountPence: z.number().int().min(0).max(1_000_000),
+  description: z.string().min(1).max(500),
+});
+
+export type EditCharge = z.infer<typeof editChargeSchema>;
+
 export type ListCharges = z.infer<typeof listChargesSchema>;
 export type ChargeAggregates = z.infer<typeof chargeAggregatesSchema>;
 export type ChasePayment = z.infer<typeof chasePaymentSchema>;
@@ -489,6 +496,8 @@ export const chargeAggregatesResponseSchema = z.object({
 export const chasePaymentResponseSchema = successResponseSchema;
 
 export const markChargePaidResponseSchema = successResponseSchema;
+
+export const editChargeResponseSchema = successResponseSchema;
 
 export const listContactSubmissionsResponseSchema = z.object({
   submissions: z.array(

--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -1387,6 +1387,35 @@ export function markChargePaid(db: Kysely<DB>) {
   };
 }
 
+export function editCharge(db: Kysely<DB>) {
+  return async (
+    chargeId: string,
+    data: { amountPence: number; description: string },
+  ) => {
+    const result = await db
+      .updateTable("charge")
+      .set({
+        amount_pence: data.amountPence,
+        description: data.description,
+      })
+      .where("id", "=", chargeId)
+      .where("paid_at", "is", null)
+      .where("payment_confirmed_at", "is", null)
+      .where("deleted_at", "is", null)
+      .executeTakeFirst();
+
+    if (result.numUpdatedRows === 0n) {
+      const error = new Error(
+        "Charge not found or already paid/deleted",
+      ) as Error & { statusCode: number };
+      error.statusCode = 404;
+      throw error;
+    }
+
+    return { success: true };
+  };
+}
+
 export function chasePayment(db: Kysely<DB>) {
   return async (chargeId: string) => {
     const charge = await db

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -7132,6 +7132,52 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/charges/{chargeId}/edit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    chargeId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        amountPence: number;
+                        description: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/contact-submissions": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -12206,6 +12206,67 @@
         }
       }
     },
+    "/api/admin/charges/{chargeId}/edit": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amountPence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1000000
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "amountPence",
+                  "description"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "chargeId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/contact-submissions": {
       "get": {
         "parameters": [

--- a/apps/web/src/pages/admin/charges-tab.tsx
+++ b/apps/web/src/pages/admin/charges-tab.tsx
@@ -87,7 +87,13 @@ export function ChargesTab() {
   type ConfirmAction =
     | { kind: "chase"; chargeId: string }
     | { kind: "void"; chargeId: string; reason: string }
-    | { kind: "markPaid"; chargeId: string; paymentMethod: PaymentMethod };
+    | { kind: "markPaid"; chargeId: string; paymentMethod: PaymentMethod }
+    | {
+        kind: "edit";
+        chargeId: string;
+        amountPence: number;
+        description: string;
+      };
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(
     null,
   );
@@ -188,6 +194,30 @@ export function ChargesTab() {
         api.POST("/api/admin/charges/{chargeId}/mark-paid", {
           params: { path: { chargeId: input.chargeId } },
           body: { paymentMethod: input.paymentMethod },
+        }),
+      ),
+    onSuccess: () => {
+      setConfirmAction(null);
+      void queryClient.invalidateQueries({ queryKey: ["admin", "charges"] });
+      void queryClient.invalidateQueries({
+        queryKey: ["admin", "chargeAggregates"],
+      });
+    },
+  });
+
+  const editMutation = useMutation({
+    mutationFn: (input: {
+      chargeId: string;
+      amountPence: number;
+      description: string;
+    }) =>
+      callApi(
+        api.POST("/api/admin/charges/{chargeId}/edit", {
+          params: { path: { chargeId: input.chargeId } },
+          body: {
+            amountPence: input.amountPence,
+            description: input.description,
+          },
         }),
       ),
     onSuccess: () => {
@@ -452,6 +482,18 @@ export function ChargesTab() {
                               Mark paid…
                             </DropdownMenuItem>
                             <DropdownMenuItem
+                              onSelect={() =>
+                                setConfirmAction({
+                                  kind: "edit",
+                                  chargeId: charge.id,
+                                  amountPence: charge.amountPence,
+                                  description: charge.description,
+                                })
+                              }
+                            >
+                              Edit…
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
                               className="text-red-700 focus:bg-red-50 focus:text-red-800"
                               onSelect={() =>
                                 setConfirmAction({
@@ -549,6 +591,26 @@ export function ChargesTab() {
         isPending={markPaidMutation.isPending}
         isError={markPaidMutation.isError}
       />
+
+      <EditChargeDialog
+        action={confirmAction?.kind === "edit" ? confirmAction : null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmAction(null);
+        }}
+        onAmountChange={(amountPence) =>
+          setConfirmAction((prev) =>
+            prev?.kind === "edit" ? { ...prev, amountPence } : prev,
+          )
+        }
+        onDescriptionChange={(description) =>
+          setConfirmAction((prev) =>
+            prev?.kind === "edit" ? { ...prev, description } : prev,
+          )
+        }
+        onConfirm={(input) => editMutation.mutate(input)}
+        isPending={editMutation.isPending}
+        isError={editMutation.isError}
+      />
     </div>
   );
 }
@@ -632,6 +694,115 @@ function MarkPaidConfirmDialog({
             }}
           >
             {isPending ? "Marking…" : "Mark paid"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditChargeDialog({
+  action,
+  onOpenChange,
+  onAmountChange,
+  onDescriptionChange,
+  onConfirm,
+  isPending,
+  isError,
+}: {
+  action: {
+    chargeId: string;
+    amountPence: number;
+    description: string;
+  } | null;
+  onOpenChange: (open: boolean) => void;
+  onAmountChange: (amountPence: number) => void;
+  onDescriptionChange: (description: string) => void;
+  onConfirm: (input: {
+    chargeId: string;
+    amountPence: number;
+    description: string;
+  }) => void;
+  isPending: boolean;
+  isError: boolean;
+}) {
+  const amountPounds =
+    action !== null ? (action.amountPence / 100).toFixed(2) : "";
+  const canSave =
+    action !== null &&
+    action.description.trim() !== "" &&
+    action.amountPence >= 0;
+
+  return (
+    <Dialog open={action !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit charge</DialogTitle>
+          <DialogDescription>
+            Use this to correct a charge raised with the wrong category (for
+            example, an adult match donation applied to a junior). The member
+            and date are unchanged.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-4 flex flex-col gap-3">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="edit-charge-amount" className="text-sm font-medium">
+              Amount (£)
+            </Label>
+            <Input
+              id="edit-charge-amount"
+              type="number"
+              step="0.01"
+              min="0"
+              value={amountPounds}
+              onChange={(e) => {
+                const parsed = Number.parseFloat(e.target.value);
+                onAmountChange(
+                  Number.isFinite(parsed) ? Math.round(parsed * 100) : 0,
+                );
+              }}
+              className="w-32"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label
+              htmlFor="edit-charge-description"
+              className="text-sm font-medium"
+            >
+              Description
+            </Label>
+            <Input
+              id="edit-charge-description"
+              type="text"
+              value={action?.description ?? ""}
+              onChange={(e) => onDescriptionChange(e.target.value)}
+              maxLength={500}
+            />
+          </div>
+        </div>
+        {isError && (
+          <p className="mt-2 text-sm text-red-600">
+            Failed to save. The charge may have been paid or voided in the
+            meantime.
+          </p>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={!canSave || isPending}
+            onClick={() => {
+              if (action) {
+                onConfirm({
+                  chargeId: action.chargeId,
+                  amountPence: action.amountPence,
+                  description: action.description.trim(),
+                });
+              }
+            }}
+          >
+            {isPending ? "Saving…" : "Save"}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
- New \"Edit…\" row action on the charges admin tab, between Mark paid and Void.
- Dialog edits the £ amount and description, pre-filled from the existing charge. Member, date, and type stay immutable — those are rarely wrong and would balloon the dialog.
- Eligibility mirrors Mark paid: unpaid + non-deleted only. Reject already-paid, deleted, or Stripe-pending charges with 404.

Use case: a charge was raised with the wrong member category (e.g. adult match donation applied to a junior) and the treasurer wants to correct it before it gets chased or paid.

## Test plan
- [x] 4 new integration tests for `editCharge` service: happy path, paid charge → 404, voided charge → 404, payment-in-flight → 404. All pass.
- [x] Web typecheck + lint green
- [ ] CI green
- [ ] Smoke test the dialog on staging (or local): edit an unpaid charge's amount → row updates, aggregates re-fetched
- [ ] Try editing a paid charge via the API directly — should 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)