### PR TITLE
feat: financial relief workflow

### DIFF
--- a/FINANCIAL_RELIEF_PLAN.md
+++ b/FINANCIAL_RELIEF_PLAN.md
@@ -1,0 +1,379 @@
+# Financial Relief — Implementation Plan
+
+Percy Main currently has an informal escape hatch — setting `member.member_category = "bursary"` causes the matchday flow to skip charge generation at `apps/api/src/features/matchday/service.ts:761` and `:1086`. This works operationally but leaves no record of who was supported, for what, or at what value. That makes "we provided £4,000 of financial relief this year" impossible to produce, and it can't distinguish full vs partial relief, expiry, or membership vs match donations.
+
+This plan formalises the workflow on top of the existing `charge` model: members submit a structured request → an admin decides → approved relief is recorded as a grant → future eligible **match-fee** charges are still generated at full value but immediately marked **relieved** with a `relieved_at / relieved_by / relieved_reason / relief_grant_id` audit set (matching the existing `deleted_at / deleted_by / deleted_reason` triplet). Relieved charges are not debt, do not surface as outstanding to the member, do not enter Stripe bundles, but **do** carry their `amount_pence` so totals are summable.
+
+## Scope decisions (v1)
+
+- **Match-fee relief is the v1 auto-forgiveness path.** Match charges are generated server-side after the matchday is confirmed; relief slots cleanly into that flow.
+- **Membership relief is admin-applied, not auto-applied.** Real membership purchases go through Stripe checkout and arrive in the system as already-paid charge rows via the webhook (`apps/api/src/features/payments/webhook-service.ts`, charge `type IN ('membership','junior_membership','junior_registration')`). There is no pre-pay moment to intercept. For v1, an approved grant with `covers_membership` triggers an admin-side **"Apply membership relief"** action that creates a relieved charge of the appropriate amount **and** extends the member's `membership.paid_until` — the equivalent of a free renewal. The action is gated by `requireRole("admin")` and recorded as a relief event. Partial membership relief in v1 reduces this action to "admin creates a relieved charge for the waived portion only; member pays the rest through normal Stripe checkout"; admins are guided to record this via the existing `createCharge` + the new "Apply" action.
+- **No retrospective refunds.** Already-paid charges are not refunded by the relief flow. If an admin needs to refund, that's a manual Stripe operation outside this feature.
+
+## Product principles applied
+
+- **Dignity / low friction**: short form, no uploads, no income disclosure, "Prefer not to say" available everywhere, helper copy borrowed verbatim from the brief.
+- **Reuse existing patterns**: form via `react-hook-form` + Zod (as junior registration / incident report), admin tab as a new sub-tab under `/admin?section=finance`, audit columns on `charge` mirroring `deleted_at/by/reason`, `requireRole("admin")` middleware, React Query hooks, OpenAPI-generated client.
+- **Smallest coherent slice**: one new feature folder, three new tables, four new columns on `charge`, one member page, one admin sub-tab, two emails. Defer CSV export, anonymised public reports, and refunds.
+- **No new roles**: full application details restricted to existing `admin` role. Captains see a neutral `"waived"` charge status on the officials' matchday view — never the application text, the grant note, or the partial amount.
+
+## Data model
+
+### New migration: `2026-05-12T*-financial-relief.ts`
+
+```sql
+-- The application form, one row per submission.
+CREATE TABLE financial_relief_request (
+  id                          TEXT PRIMARY KEY,
+  submitted_by_user_id        TEXT NOT NULL REFERENCES "user"(id),
+  member_id                   TEXT NOT NULL REFERENCES member(id),
+  status                      TEXT NOT NULL DEFAULT 'submitted',
+    -- submitted | in_review | more_info_needed | approved | declined | withdrawn | expired
+  requested_membership_full    BOOLEAN NOT NULL,
+  requested_membership_partial BOOLEAN NOT NULL,
+  requested_match_fees         BOOLEAN NOT NULL,
+  partial_amount_pence         INTEGER,
+  reason_category              TEXT,
+  reason_text                  TEXT,                   -- capped at 2000 chars in Zod
+  duration                     TEXT,
+  duration_other_text          TEXT,
+  contribution_ability         TEXT,
+  contribution_amount_pence    INTEGER,
+  volunteer_options            JSONB NOT NULL DEFAULT '[]',
+  volunteer_notes              TEXT,
+  contact_preference           TEXT NOT NULL,
+  privacy_acknowledged_at      TIMESTAMPTZ NOT NULL,
+  declaration_confirmed_at     TIMESTAMPTZ NOT NULL,
+  withdrawn_at                 TIMESTAMPTZ,
+  withdrawn_reason             TEXT,
+  created_at                   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX financial_relief_request_member_id_idx ON financial_relief_request(member_id);
+-- Hard DB-level guarantee: one open request per member.
+CREATE UNIQUE INDEX financial_relief_request_one_open_uidx
+  ON financial_relief_request(member_id)
+  WHERE status IN ('submitted','in_review','more_info_needed');
+
+-- The grant produced when an admin approves a request. Declines are NEVER persisted
+-- as grants — they live on the request row + an event. A request can be re-decided
+-- (e.g. extended) by closing the old grant and opening a new one.
+CREATE TABLE financial_relief_grant (
+  id                          TEXT PRIMARY KEY,
+  request_id                  TEXT NOT NULL REFERENCES financial_relief_request(id),
+  member_id                   TEXT NOT NULL REFERENCES member(id),
+  decision                    TEXT NOT NULL,            -- approved_full | approved_partial | approved_temporary
+  covers_membership           BOOLEAN NOT NULL,
+  covers_match_fees           BOOLEAN NOT NULL,
+  membership_partial_pence    INTEGER,                  -- if set, member contributes this portion of membership; NULL = full membership relief
+  effective_from              DATE NOT NULL,
+  effective_to_exclusive      DATE,                     -- NULL = open-ended; otherwise grant inactive on this date
+  admin_notes                 TEXT,                     -- private to admins, never returned to non-admin endpoints
+  member_facing_note          TEXT,                     -- the only admin-authored text shown to the member
+  decided_by                  TEXT NOT NULL REFERENCES "user"(id),
+  decided_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  closed_at                   TIMESTAMPTZ,
+  closed_by                   TEXT REFERENCES "user"(id),
+  closed_reason               TEXT
+);
+-- Hard DB-level guarantee: one active grant per member.
+CREATE UNIQUE INDEX financial_relief_grant_one_active_uidx
+  ON financial_relief_grant(member_id) WHERE closed_at IS NULL;
+
+-- Admin decision history / status transitions.
+CREATE TABLE financial_relief_event (
+  id            TEXT PRIMARY KEY,
+  request_id    TEXT NOT NULL REFERENCES financial_relief_request(id),
+  event_type    TEXT NOT NULL,
+    -- status_changed | note_added | more_info_requested | grant_created | grant_closed
+    -- | declined | withdrawn | membership_relief_applied
+  from_status   TEXT,
+  to_status     TEXT,
+  note          TEXT,
+  actor_user_id TEXT NOT NULL REFERENCES "user"(id),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX financial_relief_event_request_id_idx ON financial_relief_event(request_id, created_at);
+
+-- Relief columns on charge. Mirrors the deleted_at/by/reason triplet.
+-- original_amount_pence is set ONLY on the partial-relief case, so that the
+-- "value retained for reporting" invariant holds without sibling rows.
+ALTER TABLE charge
+  ADD COLUMN relieved_at            TIMESTAMPTZ,
+  ADD COLUMN relieved_by            TEXT REFERENCES "user"(id),
+  ADD COLUMN relieved_reason        TEXT,
+  ADD COLUMN relief_grant_id        TEXT REFERENCES financial_relief_grant(id),
+  ADD COLUMN original_amount_pence  INTEGER,
+  ADD CONSTRAINT charge_relief_consistent CHECK (
+    (relieved_at IS NULL AND relieved_by IS NULL AND relieved_reason IS NULL AND original_amount_pence IS NULL)
+    OR (relieved_at IS NOT NULL AND relieved_by IS NOT NULL AND relieved_reason IS NOT NULL)
+  );
+CREATE INDEX charge_relieved_at_idx ON charge(relieved_at) WHERE relieved_at IS NOT NULL;
+```
+
+**Reporting value for a relieved row** = `COALESCE(original_amount_pence, amount_pence)` when the charge was partially relieved (the original total), else `amount_pence` (full forgiveness). Aggregate queries use that expression.
+
+**Reason categories** (closed enum, from brief):
+`cost_of_living | low_income | temporary_change | multiple_family | unemployment | caring | other_personal | prefer_not_to_say`
+
+**Volunteer option keys** (closed list):
+`ground_work | scoring | umpiring | junior_sessions | womens_girls | bbq_kitchen | fundraising | social_media | admin | matchday_setup | transport | other | none`
+
+After the migration: `pnpm run db:types`.
+
+### Why not just flip `member_category = "bursary"`?
+
+- Cannot report total value waived — the charges never exist.
+- Cannot distinguish full vs partial relief, expiry, or applied-vs-active.
+- Hides the rationale; future admins have no audit.
+
+The hard-skip at `matchday/service.ts:761` and `:1086` is deleted in Phase 5 (no live bursary members today; the `bursary` category value remains allowed as a member_category but stops short-circuiting charge generation).
+
+## Charge type taxonomy (verified against current code)
+
+| Type                  | Where created                               | Relief coverage flag       |
+| --------------------- | ------------------------------------------- | -------------------------- |
+| `match_fee`           | `matchday/service.ts:774`, `:1099`          | `covers_match_fees`        |
+| `membership`          | `payments/webhook-service.ts` (post-Stripe) | `covers_membership` \*     |
+| `junior_membership`   | `payments/webhook-service.ts`               | `covers_membership` \*     |
+| `junior_registration` | `junior/service.ts:131`                     | `covers_membership` \*     |
+| `manual`              | `admin/service.ts` `createCharge`           | neither (admin discretion) |
+
+\* Membership-family charges arrive **already paid** via Stripe webhook, so they're not auto-forgiven on creation. The "Apply membership relief" admin action is the manual path described in _Scope decisions_.
+
+## API — new feature folder `apps/api/src/features/financial-relief/`
+
+### Routes
+
+| Verb | Path                                                      | Auth                   | Purpose                                                           |
+| ---- | --------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------- |
+| GET  | `/api/financial-relief/eligible-members`                  | `requireAuth`          | Returns self + linked juniors (id, name)                          |
+| GET  | `/api/financial-relief/me`                                | `requireAuth`          | Caller's open/recent request + active grant summary               |
+| POST | `/api/financial-relief/requests`                          | `requireAuth`          | Submit a new request                                              |
+| POST | `/api/financial-relief/requests/:id/withdraw`             | `requireAuth` (owner)  | Member withdraws their own pending request                        |
+| GET  | `/api/admin/financial-relief/requests`                    | `requireRole("admin")` | Paginated list with filters                                       |
+| GET  | `/api/admin/financial-relief/requests/:id`                | `requireRole("admin")` | Full detail + events + linked grant                               |
+| POST | `/api/admin/financial-relief/requests/:id/status`         | `requireRole("admin")` | Transition (in_review, more_info, decline)                        |
+| POST | `/api/admin/financial-relief/requests/:id/decide`         | `requireRole("admin")` | Approve → creates grant + forgives match charges                  |
+| POST | `/api/admin/financial-relief/grants/:id/close`            | `requireRole("admin")` | Close an active grant                                             |
+| POST | `/api/admin/financial-relief/grants/:id/apply-membership` | `requireRole("admin")` | One-shot: create relieved membership charge + extend `paid_until` |
+| GET  | `/api/admin/financial-relief/report`                      | `requireRole("admin")` | Aggregated totals for a date range                                |
+
+### Submitter ownership (server-side)
+
+The form's `memberId` field is **never trusted** from the client. The submit endpoint resolves the caller's user → member, then computes the allowed set:
+
+- The caller's own member id
+- Any member id where `member_parent_link.parent_member_id = caller.memberId` (juniors they're a parent for)
+
+The same set powers `/eligible-members`. Submitting with a `memberId` outside that set returns 403.
+
+### Service: decision flow (concurrency-safe)
+
+```typescript
+export function decideFinancialReliefRequest(db: Kysely<DB>, stripe: Stripe, send: SendEmail) {
+  return async (adminUserId: string, requestId: string, data: Decide) => {
+    return await db.transaction().execute(async (trx) => {
+      // 1. Lock the member row to serialise concurrent decisions for the same member.
+      const member = await trx
+        .selectFrom("member")
+        .where("id", "=", data.memberId)
+        .selectAll()
+        .forUpdate()
+        .executeTakeFirstOrThrow();
+      if (member.deleted_at) throwHttpError(400, "Cannot grant relief to an archived member");
+
+      // 2. Close any existing active grant — UNIQUE INDEX protects us either way.
+      await trx.updateTable("financial_relief_grant")
+        .set({ closed_at: now(), closed_by: adminUserId, closed_reason: "superseded" })
+        .where("member_id", "=", data.memberId).where("closed_at", "is", null).execute();
+
+      // 3. Insert new grant. If a race slipped past the lock, the partial UNIQUE INDEX rejects it.
+      const grantId = crypto.randomUUID();
+      await trx.insertInto("financial_relief_grant").values({...}).execute();
+
+      // 4. Forgive existing unpaid, undeleted, unrelieved match-fee charges with no live Stripe PI.
+      //    Crucially: for each candidate row, retrieve the PI and SKIP if it is in flight
+      //    (status in ['requires_action','processing','succeeded','requires_capture']).
+      //    Only forgive when PI is null OR status in ['canceled','requires_payment_method'].
+      const candidates = await trx.selectFrom("charge")
+        .where("member_id", "=", data.memberId)
+        .where("type", "=", "match_fee")
+        .where("deleted_at", "is", null)
+        .where("relieved_at", "is", null)
+        .where("paid_at", "is", null)
+        .where("payment_confirmed_at", "is", null)
+        .where("charge_date", ">=", data.effectiveFrom)
+        .selectAll().forUpdate().execute();
+
+      for (const c of candidates) {
+        if (c.stripe_payment_intent_id) {
+          const pi = await stripe.paymentIntents.retrieve(c.stripe_payment_intent_id);
+          if (!["canceled", "requires_payment_method"].includes(pi.status)) continue;
+          // Safe to detach.
+          await trx.updateTable("charge")
+            .set({ stripe_payment_intent_id: null })
+            .where("id", "=", c.id).execute();
+        }
+        await trx.updateTable("charge")
+          .set({ relieved_at: now(), relieved_by: adminUserId,
+                 relieved_reason: "financial relief", relief_grant_id: grantId })
+          .where("id", "=", c.id).execute();
+      }
+
+      // 5. Insert event row, update request status, send email (best-effort).
+    });
+  };
+}
+```
+
+The **at-creation** helper used by `matchday/service.ts:774` and `:1099` looks up the active grant inside the same transaction that creates the charge — no race with the decide flow because both take the member row lock.
+
+### Visibility rules in existing endpoints (all must change)
+
+| Endpoint                                                                                          | Change                                                                              |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `charges/service.ts` `getMyCharges`                                                               | Add `WHERE relieved_at IS NULL`                                                     |
+| `charges/service.ts` `payOutstandingCharges`                                                      | Add `WHERE relieved_at IS NULL`                                                     |
+| `charges/service.ts` `confirmPayment`                                                             | Add `WHERE relieved_at IS NULL` so a race can't mark a now-relieved row as paid     |
+| `payments/webhook-service.ts` `payment_intent.succeeded` reconciliation                           | Add `WHERE relieved_at IS NULL` to the update; if the row is relieved, log and skip |
+| `admin/service.ts` `listAllCharges`                                                               | Extend `chargeStatusSchema` with `"relieved"`; surface it; filter chip              |
+| `admin/service.ts` `getChargeAggregates`                                                          | Treat relieved as its own bucket (not paid / unpaid)                                |
+| `admin/service.ts` `markChargePaid`, `editCharge`, `chasePayment`, `deleteCharge`                 | Add `WHERE relieved_at IS NULL` guard; admin must close the grant before editing    |
+| `matchday/service.ts` finish-emails query for unpaid match fees                                   | Add `WHERE relieved_at IS NULL`                                                     |
+| `matchday/service.ts` `getOfficialMatchday` (`:205`) + `matchday/schemas.ts:185` (`chargePaidAt`) | Replace `chargePaidAt` with a small enum field `chargeStatus: 'unpaid'              | 'paid' | 'waived'`— captain sees`waived` (neutral, no relief language) and **never** the application text, grant note, or partial amount |
+| `treasurer-tab` outstanding-payments aggregation                                                  | Exclude relieved from "outstanding"                                                 |
+| `matchday/service.ts` cancellation guard (`:964`)                                                 | Currently throws if any non-deleted charges exist — change to also skip relieved    |
+| `admin/service.ts` member archive (`archiveMember`)                                               | Close any active grant; force-decline any open request; insert event                |
+
+### Schemas (Zod)
+
+All in `financial-relief/schemas.ts`. Public ones are also exported from `packages/shared` so the form on the SPA can reuse them. Closed enums (`reasonCategorySchema`, `volunteerOptionSchema`, `durationSchema`, `contactPreferenceSchema`) live in `packages/shared/src/financial-relief.ts` alongside their human labels.
+
+After schema changes: `pnpm run openapi:generate`.
+
+## Frontend
+
+### Member-facing
+
+- **Route**: `/members/financial-relief` (new page under `apps/web/src/pages/members/financial-relief.tsx`). Linked from the existing members area dashboard with a single understated line: "Need help with fees? Request financial relief." No prominent visual treatment — dignity by default.
+- **Form**: `react-hook-form` + `@hookform/resolvers/zod`, shadcn `Form` / `Input` / `Textarea` / `Checkbox` / `RadioGroup`. Pattern mirrors the junior registration form. Section copy verbatim from the brief.
+- **Member-being-supported selector**: query the new `GET /api/financial-relief/eligible-members` to populate the choices. Server enforces ownership regardless of what the client posts.
+- **Submission**: `useMutation` → POST `/api/financial-relief/requests`. On success, navigate to a confirmation screen with the privacy reassurance copy, not a toast.
+- **Status view**: at the top of the page, if there's an open or recently-decided request, show the status pill (Submitted / In review / More information needed / Approved / Declined / Withdrawn / Expired) and the `member_facing_note` if set. Approval copy never restates billing mechanics ("Match donations for the 2026 season are waived.").
+
+### Admin-facing
+
+- **Tab**: new sub-tab under the **Finance** section in `admin-panel.tsx:64`, accessed via `/admin?section=finance&sub=financial-relief`, label "Financial Relief". Sits next to Charges / Sponsorships / Expenses.
+- **List** (`financial-relief-tab.tsx`): follows `charges-tab.tsx` for structure.
+  - `useReducer` for filters; URL state via `useSearchParams` (project convention: persist filters, pagination, status in the URL).
+  - Columns: Submitted, Member, Account holder, Requested types (badges), Status pill, Decided by, Actions.
+  - Filters: status (multi), date range, search (member name).
+  - Row click opens a side panel with the full application, decision controls, the event log, and (if an active grant exists) the "Apply membership relief" button.
+- **Decide dialog**: shadcn `Dialog`. Fields: decision (approved_full / approved_partial / approved_temporary), covered types (checkboxes), `membership_partial_pence` (only when partial + membership), effective from (defaults to today), `effective_to_exclusive` (defaults to next 1 Apr — start of season), admin notes (private), member-facing note (shown verbatim to member). Submitting runs the mutation and refreshes.
+- **Decline path**: separate "Decline" action on the side panel — does NOT create a grant. Records `event_type='declined'` and sets `request.status='declined'`.
+- **Apply membership relief**: form with `effectiveDate` (defaults today), `targetPaidUntil` (defaults end of season), and `amountPence` (defaults to current season's membership fee for that category). On submit, creates a relieved `charge` row with `type='membership'` and the supplied amount, and upserts a `membership` row extending `paid_until` to `targetPaidUntil`. Recorded as `event_type='membership_relief_applied'`.
+
+### Reporting
+
+A panel inside the new admin tab — not a separate dashboard — with two date inputs and a "Summarise" button calling `GET /api/admin/financial-relief/report`. Returns:
+
+```typescript
+{
+  totalForgivenPence: number,                       // sum of reporting-value across relieved charges in range
+  byReliefType: { membershipPence: number, matchFeePence: number },
+  bySection: { juniors: Bucket, womens_girls: Bucket, senior: Bucket, other: Bucket },
+  membersSupported: number,                         // distinct member_id with at least one relieved charge in range
+  forgivenChargeCount: number
+}
+// Bucket = { pence: number; count: number; members: number }
+```
+
+Section is derived from the owning matchday team's `play_cricket_team.is_junior` plus opposition string (women/girls heuristic) for match fees; from `member.member_category` for membership. CSV export deferred.
+
+## Notifications
+
+Two new React Email templates:
+
+- `FinancialReliefReceived.tsx` — to submitter; "We've received your request. We'll be in touch within X days."
+- `FinancialReliefDecision.tsx` — to submitter; renders the approval/decline with `member_facing_note` only (never `admin_notes` or `reason_text`).
+
+Email subject lines do not include the words "financial relief" — they read "Your request to Percy Main CC" so a glance at an inbox preview doesn't out the member.
+
+A Slack post on submission, mirroring `incident-report/service.ts:27`, gated on `config.slackWebhookUrl`. Slack payload includes member name, requested types, and admin URL — **not** the reason text or full form contents.
+
+## Privacy & access
+
+- Full `financial_relief_request` rows are only returned by `requireRole("admin")` endpoints.
+- The officials' matchday view shows `chargeStatus = 'waived'` — never the word "relief", the application reason, the grant note, or the partial amount.
+- `member_facing_note` is the only admin-authored text that ever reaches the member.
+- Slack notifications carry no reason text.
+- Logs never log the request body of submit / decide endpoints; we log request IDs only.
+
+## Tests
+
+**Integration tests** (`financial-relief/integration.test.ts`, real PostgreSQL via testcontainers):
+
+- Submit succeeds for own member; rejected (403) for a member id outside the eligible set.
+- Submit twice while the first is open → second rejected by the unique partial index.
+- Withdraw: owner can; non-owner cannot; decided request cannot.
+- Approve full match relief → grant exists, request `approved`, existing unpaid match-fee charges have `relieved_at` set, **paid** match-fee charges untouched, **membership** charges untouched.
+- Approve when an in-flight Stripe PI exists for one of the candidate charges → that charge is NOT forgiven; remainder are; event records the skip count.
+- Race: two concurrent `decide` calls for the same member → exactly one succeeds (the other hits the unique index or the row lock).
+- New matchday charge generation after approval → row created with `relieved_at` set in the same transaction.
+- `getMyCharges` excludes relieved; `payOutstandingCharges` cannot bundle relieved; `confirmPayment` cannot flip a now-relieved row to paid (race).
+- Webhook `payment_intent.succeeded` for a now-relieved charge: skipped, logged, not paid.
+- Officials' matchday view shows `chargeStatus='waived'`; full application is not retrievable from this endpoint.
+- Closing a grant: future matchday charges are no longer auto-forgiven; previously relieved are untouched.
+- Member archival: active grant is closed; open request is force-declined; new submissions for the archived member are rejected.
+- Apply membership relief: creates a relieved `charge` row with reporting value preserved, extends `membership.paid_until`, logs an event.
+- Cancellation of a matchday with only relieved charges no longer blocks (current guard would).
+- Admin `editCharge` / `markChargePaid` / `chasePayment` / `deleteCharge` reject on a relieved row.
+- Aggregate report: forgiven totals match the sum of reporting-values across the date range; not double-counted; declined requests do not contribute.
+
+**Service unit tests** for the at-creation helper edge cases — no active grant, expired grant (today >= `effective_to_exclusive`), type not covered, in-flight PI, deleted member.
+
+**Frontend tests** — reducer tests (`*-tab.reducer.test.ts` pattern) and one React Testing Library smoke for the form.
+
+## Build sequence (phased)
+
+1. **Migration + types**: add migration (including the two unique partial indexes and the relief check constraint), run `pnpm run db:types`.
+2. **API skeleton**: feature folder, schemas, service stubs returning 501. Register routes. Regenerate OpenAPI. `/api/financial-relief/eligible-members` lands here.
+3. **Member submit + me + withdraw**: implement these + receipt email. Integration tests for these only.
+4. **Admin list + detail + status transitions + decline path**: read endpoints + status transitions + decline (no grant). Admin tab list view.
+5. **Decision flow + payment lifecycle changes**: implement `decide` with the locking + PI checks; add `applyReliefIfAny` to the two matchday charge-creation sites; add `relieved_at IS NULL` guards to `getMyCharges`, `payOutstandingCharges`, `confirmPayment`, the webhook reconciliation, finish-emails, all admin charge actions, the treasurer outstanding sums, and the matchday cancellation guard. Hook in member archival. Delete the bursary hard-skip. Frontend decide dialog. Decision email.
+6. **Captain visibility**: change `getOfficialMatchday` to return `chargeStatus` enum; update the schema (`matchday/schemas.ts:185`) and the officials' UI.
+7. **Apply-membership-relief admin action**: backend action + admin button + integration tests.
+8. **Reporting endpoint + panel**: aggregates query (using `COALESCE(original_amount_pence, amount_pence)`), simple admin panel.
+
+Each phase is a separate PR. Phases 1–6 are the minimum to satisfy the acceptance criteria; 7–8 are quality-of-life.
+
+## ADR
+
+Add `docs/adrs/NNN-financial-relief.md`:
+
+- **Decision**: relief as an additive grant + per-charge audit columns on the existing `charge` table; match-fee relief is auto-applied at charge creation, membership relief is an explicit admin action.
+- **Rejected**: (a) extending `member_category` only — loses reporting and history; (b) parallel `relief_ledger` table — duplicates `charge` state; (c) auto-forgiving membership at webhook time — webhook fires post-payment, no charge to forgive.
+- **Consequences**: `chargeStatusSchema` gains `"relieved"` (admin) / `"waived"` (officials); the unpaid bursary hard-skip in `matchday/service.ts` is removed; `original_amount_pence` is set only for partial relief so reporting can sum `COALESCE(original_amount_pence, amount_pence)`.
+
+## Acceptance-criteria mapping
+
+| Criterion                                                                  | Where satisfied                                                      |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Logged-in member can submit a financial relief request                     | `POST /api/financial-relief/requests`, member page                   |
+| Member can submit for self and linked juniors only                         | `/eligible-members` + server-side ownership check                    |
+| One open request per member                                                | Unique partial index `financial_relief_request_one_open_uidx`        |
+| Admin can review and decide the request                                    | Admin tab + `decide` / `status` / decline endpoints                  |
+| Approved relief can be tied to future eligible match charges               | At-creation helper called from `matchday/service.ts:774`, `:1099`    |
+| Eligible future charges marked relieved                                    | `relieved_at/by/reason/relief_grant_id` columns                      |
+| Forgiven charges retain monetary value for reporting                       | `amount_pence` unchanged on full; `original_amount_pence` on partial |
+| Forgiven charges do not appear as unpaid debt                              | `relieved_at IS NULL` guards everywhere                              |
+| In-flight Stripe payments cannot be relieved out from under                | PI status check in `decide`; webhook reconciliation guard            |
+| Concurrent admin decisions can't double-grant                              | Member row lock + unique partial index                               |
+| Full request details visible only to admin                                 | `requireRole("admin")` on detail endpoints                           |
+| Captains see neutral match fee status only, not full application or reason | `chargeStatus = 'waived'` in officials' matchday endpoint            |
+| Admin/reporting can show total value over a period                         | `/api/admin/financial-relief/report`                                 |
+| Public-facing reports aggregate/anonymised                                 | Report response has totals only                                      |
+| Matchday cancellation does not break on relieved charges                   | Cancellation guard excludes relieved                                 |
+| Member archival closes grants + open requests                              | `archiveMember` hook                                                 |
+| Membership relief covered (v1: admin-applied)                              | `/grants/:id/apply-membership` endpoint                              |

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -40,6 +40,7 @@ import { contactRoutes } from "./features/contact/routes.ts";
 import { cricketLeaderboardRoutes } from "./features/cricket-leaderboard/routes.ts";
 import { documentRoutes } from "./features/documents/routes.ts";
 import { fantasyRoutes } from "./features/fantasy/routes.ts";
+import { financialReliefRoutes } from "./features/financial-relief/routes.ts";
 import { gamesRoutes } from "./features/games/routes.ts";
 import { healthRoutes } from "./features/health/routes.ts";
 import { incidentReportRoutes } from "./features/incident-report/routes.ts";
@@ -274,6 +275,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(scoutRoutes, { prefix: "/api" });
   await app.register(contactRoutes, { prefix: "/api" });
   await app.register(incidentReportRoutes, { prefix: "/api" });
+  await app.register(financialReliefRoutes, { prefix: "/api" });
   await app.register(marketingRoutes, { prefix: "/api" });
   await app.register(webhookRoutes, { prefix: "/api" });
   await app.register(ogImageRoutes, { prefix: "/api" });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -172,7 +172,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   app.decorate("send", send);
 
   // Create and decorate the auth instance
-  const auth = createAuth(config, dialect, send, app.log);
+  const auth = createAuth(config, dialect, db, send, app.log);
   app.decorate("auth", auth);
 
   // Create and decorate the S3 uploader (receipt images)

--- a/apps/api/src/features/admin/schemas.ts
+++ b/apps/api/src/features/admin/schemas.ts
@@ -13,6 +13,7 @@ const chargeStatusSchema = z.enum([
   "unpaid",
   "abandoned",
   "deleted",
+  "relieved",
 ]);
 
 // --- Request schemas ---
@@ -110,7 +111,7 @@ export const listChargesSchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(100).default(20),
   status: z
-    .enum(["all", "unpaid", "pending", "paid", "abandoned"])
+    .enum(["all", "unpaid", "pending", "paid", "abandoned", "relieved"])
     .default("all"),
   showDeleted: z.coerce.boolean().default(false),
   dateFrom: z.string().optional(),
@@ -492,6 +493,7 @@ export const listChargesResponseSchema = z.object({
       source: z.string(),
       deletedAt: z.string().nullable(),
       deletedReason: z.string().nullable(),
+      relievedAt: z.string().nullable(),
       memberName: z.string().nullable(),
       memberEmail: z.string(),
       memberCategory: z.string().nullable(),

--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -11,6 +11,7 @@ import {
 } from "@percy-main/shared/auth/permissions";
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
+import { closeReliefForArchivedMember } from "../financial-relief/service.ts";
 import type {
   AddMatchFeeRate,
   ChargeAggregates,
@@ -207,6 +208,7 @@ export function sendChargeNotification(db: Kysely<DB>) {
       .where("paid_at", "is", null)
       .where("payment_confirmed_at", "is", null)
       .where("deleted_at", "is", null)
+      .where("relieved_at", "is", null)
       .selectAll()
       .execute();
 
@@ -636,6 +638,18 @@ export function archiveMember(db: Kysely<DB>) {
         .execute(),
     ]);
 
+    // Close any open financial relief: archived members shouldn't have
+    // an active grant generating relieved charges, nor an open request
+    // waiting on a committee decision.
+    const member = await db
+      .selectFrom("member")
+      .where("email", "=", user.email)
+      .select("id")
+      .executeTakeFirst();
+    if (member) {
+      await closeReliefForArchivedMember(db)(userId, member.id);
+    }
+
     return { success: true };
   };
 }
@@ -741,6 +755,9 @@ export function deleteCharge(db: Kysely<DB>) {
       .where("id", "=", chargeId)
       .where("paid_at", "is", null)
       .where("payment_confirmed_at", "is", null)
+      // Relieved charges have a live grant audit. Close the grant first
+      // if you really need to soft-delete one.
+      .where("relieved_at", "is", null)
       .executeTakeFirst();
 
     if (result.numUpdatedRows === 0n) {
@@ -1018,9 +1035,14 @@ function getChargeStatus(
   stripePaymentIntentId: string | null,
   abandonedCutoff: string,
   createdAt: string,
-): "paid" | "pending" | "unpaid" | "abandoned" | "deleted" {
+  relievedAt: string | null,
+): "paid" | "pending" | "unpaid" | "abandoned" | "deleted" | "relieved" {
   if (deletedAt) return "deleted";
+  // Relieved is a settled state, but a paid relieved charge means the
+  // member paid before the grant landed — report it as paid so refunds
+  // can be triaged separately.
   if (paidAt) return "paid";
+  if (relievedAt) return "relieved";
   if (paymentConfirmedAt) return "pending";
   if (stripePaymentIntentId && createdAt < abandonedCutoff) return "abandoned";
   return "unpaid";
@@ -1049,12 +1071,15 @@ export function listAllCharges(db: Kysely<DB>) {
         q = q
           .where("charge.payment_confirmed_at", "is not", null)
           .where("charge.paid_at", "is", null)
-          .where("charge.deleted_at", "is", null);
+          .where("charge.deleted_at", "is", null)
+          .where("charge.relieved_at", "is", null);
       } else if (status === "unpaid") {
         q = q
           .where("charge.paid_at", "is", null)
           .where("charge.payment_confirmed_at", "is", null)
           .where("charge.deleted_at", "is", null)
+          // Relieved charges are not unpaid debt.
+          .where("charge.relieved_at", "is", null)
           .where((eb) =>
             eb.or([
               eb("charge.stripe_payment_intent_id", "is", null),
@@ -1067,7 +1092,12 @@ export function listAllCharges(db: Kysely<DB>) {
           .where("charge.paid_at", "is", null)
           .where("charge.payment_confirmed_at", "is", null)
           .where("charge.deleted_at", "is", null)
+          .where("charge.relieved_at", "is", null)
           .where("charge.created_at", "<", abandonedCutoff);
+      } else if (status === "relieved") {
+        q = q
+          .where("charge.relieved_at", "is not", null)
+          .where("charge.deleted_at", "is", null);
       }
 
       if (dateFrom) {
@@ -1112,6 +1142,7 @@ export function listAllCharges(db: Kysely<DB>) {
           "charge.source",
           "charge.deleted_at",
           "charge.deleted_reason",
+          "charge.relieved_at",
           "member.name as memberName",
           "member.email as memberEmail",
           "member.member_category as memberCategory",
@@ -1178,6 +1209,7 @@ export function listAllCharges(db: Kysely<DB>) {
         memberEmail: c.memberEmail,
         memberCategory: c.memberCategory,
         paidByParents: parentsByMember.get(c.member_id) ?? [],
+        relievedAt: c.relieved_at,
         status: getChargeStatus(
           c.paid_at,
           c.payment_confirmed_at,
@@ -1185,6 +1217,7 @@ export function listAllCharges(db: Kysely<DB>) {
           c.stripe_payment_intent_id,
           abandonedCutoff,
           c.created_at,
+          c.relieved_at,
         ),
       })),
       total: Number(countResult.total),
@@ -1275,6 +1308,9 @@ export function markChargePaid(db: Kysely<DB>) {
       .where("paid_at", "is", null)
       .where("payment_confirmed_at", "is", null)
       .where("deleted_at", "is", null)
+      // A relieved charge isn't unpaid debt; admin must close the grant
+      // first if they want to revert.
+      .where("relieved_at", "is", null)
       .executeTakeFirst();
 
     if (result.numUpdatedRows === 0n) {
@@ -1304,6 +1340,7 @@ export function editCharge(db: Kysely<DB>) {
       .where("paid_at", "is", null)
       .where("payment_confirmed_at", "is", null)
       .where("deleted_at", "is", null)
+      .where("relieved_at", "is", null)
       .executeTakeFirst();
 
     if (result.numUpdatedRows === 0n) {
@@ -1327,6 +1364,7 @@ export function chasePayment(db: Kysely<DB>) {
       .where("charge.paid_at", "is", null)
       .where("charge.payment_confirmed_at", "is", null)
       .where("charge.deleted_at", "is", null)
+      .where("charge.relieved_at", "is", null)
       .select([
         "charge.id",
         "charge.description",

--- a/apps/api/src/features/auth/auth.ts
+++ b/apps/api/src/features/auth/auth.ts
@@ -1,18 +1,20 @@
 import { dash } from "@better-auth/infra";
 import { passkey } from "@better-auth/passkey";
+import type { DB } from "@percy-main/db";
 import { ResetPassword, VerifyEmail, type Email } from "@percy-main/email";
 import { ac, roles } from "@percy-main/shared/auth/permissions";
 import { render } from "@react-email/render";
 import { betterAuth } from "better-auth";
 import { admin, twoFactor } from "better-auth/plugins";
 import type { FastifyBaseLogger } from "fastify";
-import type { PostgresDialect } from "kysely";
+import { type Kysely, type PostgresDialect } from "kysely";
 import { createElement } from "react";
 import type { Config } from "../../config.ts";
 
 export function createAuth(
   config: Config,
   dialect: PostgresDialect,
+  db: Kysely<DB>,
   send: (email: Email) => Promise<void>,
   log: FastifyBaseLogger,
 ) {
@@ -77,6 +79,49 @@ export function createAuth(
           );
           throw err;
         }
+      },
+    },
+    databaseHooks: {
+      user: {
+        create: {
+          // Every new user gets a paired `member` row keyed by email. This
+          // turns the legacy "members are only created when an admin
+          // creates one, or when a junior signs up for the first time"
+          // model into a 1:1 link from sign-up onwards, so flows like
+          // financial relief that look up the caller's member record
+          // don't have to handle a brand-new user with no member row.
+          //
+          // Idempotent: if a member row already exists for this email
+          // (e.g. a junior parent created one ahead of registering, or
+          // the admin pre-created the member), we leave it alone.
+          after: async (user) => {
+            try {
+              const existing = await db
+                .selectFrom("member")
+                .where("email", "=", user.email)
+                .select("id")
+                .executeTakeFirst();
+              if (existing) return;
+              await db
+                .insertInto("member")
+                .values({
+                  id: crypto.randomUUID(),
+                  email: user.email,
+                  // Mirror the user's display name into the member row
+                  // so the relief form's "Who is this for?" shows the
+                  // right thing on day 0. The Details tab can still
+                  // edit it later.
+                  name: user.name ?? null,
+                })
+                .execute();
+            } catch (err) {
+              log.error(
+                { event: "auth.member-link", err, userId: user.id },
+                "auth_member_link_failed",
+              );
+            }
+          },
+        },
       },
     },
     emailVerification: {

--- a/apps/api/src/features/charges/service.ts
+++ b/apps/api/src/features/charges/service.ts
@@ -73,6 +73,9 @@ export function getMyCharges(db: Kysely<DB>) {
       .selectFrom("charge")
       .where("member_id", "in", ids)
       .where("deleted_at", "is", null)
+      // Relieved charges are settled by the club — they should never
+      // appear on the member's "to pay" list.
+      .where("relieved_at", "is", null)
       .selectAll()
       .orderBy("charge_date", "desc")
       .execute();
@@ -116,6 +119,7 @@ export function payOutstandingCharges(db: Kysely<DB>, stripe: Stripe) {
         .selectFrom("charge")
         .where("member_id", "in", visibleIds)
         .where("deleted_at", "is", null)
+        .where("relieved_at", "is", null)
         .where("paid_at", "is", null)
         .where("payment_confirmed_at", "is", null);
       if (scopeChargeIds && scopeChargeIds.length > 0) {
@@ -235,6 +239,9 @@ export function confirmPayment(db: Kysely<DB>) {
       .where("stripe_payment_intent_id", "=", paymentIntentId)
       .where("paid_at", "is", null)
       .where("payment_confirmed_at", "is", null)
+      // A relief approval mid-flight must not be silently overwritten
+      // by a confirmPayment race.
+      .where("relieved_at", "is", null)
       .execute();
   };
 }

--- a/apps/api/src/features/financial-relief/apply-relief.ts
+++ b/apps/api/src/features/financial-relief/apply-relief.ts
@@ -1,0 +1,64 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely, Transaction } from "kysely";
+
+/**
+ * Helper invoked at every charge-creation site that may be eligible
+ * for auto-forgiveness. Currently auto-applies only to match_fee
+ * charges — membership-family charges go through Stripe checkout and
+ * arrive already paid, so relief there is admin-applied via the
+ * `/grants/:id/apply-membership` action.
+ *
+ * Run this inside the same transaction that just inserted the charge.
+ * It looks up the member's active grant for `chargeDate` and, if the
+ * grant covers `match_fee`, flips the relief audit columns on the
+ * row to mark it forgiven from the start. The charge keeps its full
+ * `amount_pence` so reporting sums correctly.
+ *
+ * No-op if there is no active grant, the grant doesn't cover this
+ * charge's type, or the grant's date window doesn't include
+ * `chargeDate`.
+ */
+export function applyReliefIfAny(trx: Transaction<DB> | Kysely<DB>) {
+  return async (args: {
+    chargeId: string;
+    memberId: string;
+    type: string;
+    chargeDate: string;
+  }) => {
+    if (args.type !== "match_fee") return { applied: false };
+
+    const grant = await trx
+      .selectFrom("financial_relief_grant")
+      .where("member_id", "=", args.memberId)
+      .where("closed_at", "is", null)
+      // `effective_from` / `effective_to_exclusive` are DATE columns.
+      // Kysely types them as Timestamp (Date | string); the cast keeps
+      // string comparison legal at the type level — Postgres compares
+      // ISO-formatted dates lexicographically just fine.
+      .where("effective_from", "<=", args.chargeDate as unknown as Date)
+      .where((eb) =>
+        eb.or([
+          eb("effective_to_exclusive", "is", null),
+          eb("effective_to_exclusive", ">", args.chargeDate as unknown as Date),
+        ]),
+      )
+      .select(["id", "covers_match_fees", "decided_by"])
+      .executeTakeFirst();
+
+    if (!grant) return { applied: false };
+    if (!grant.covers_match_fees) return { applied: false };
+
+    await trx
+      .updateTable("charge")
+      .set({
+        relieved_at: new Date().toISOString(),
+        relieved_by: grant.decided_by,
+        relieved_reason: "financial relief",
+        relief_grant_id: grant.id,
+      })
+      .where("id", "=", args.chargeId)
+      .execute();
+
+    return { applied: true, grantId: grant.id };
+  };
+}

--- a/apps/api/src/features/financial-relief/integration.test.ts
+++ b/apps/api/src/features/financial-relief/integration.test.ts
@@ -8,9 +8,13 @@ import {
 } from "../../test/containers.ts";
 import type { SubmitReliefRequest } from "./schemas.ts";
 import {
+  declineReliefRequest,
   getEligibleMembers,
   getMyReliefStatus,
+  getReliefRequestDetail,
+  listReliefRequestsForAdmin,
   submitReliefRequest,
+  transitionReliefRequestStatus,
   withdrawReliefRequest,
 } from "./service.ts";
 
@@ -276,6 +280,110 @@ describe("financial-relief (integration)", () => {
     expect(events).toHaveLength(1);
     expect(events[0].event_type).toBe("withdrawn");
     expect(events[0].to_status).toBe("withdrawn");
+  });
+
+  it("admin list returns open requests first, then closed by recency", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const a = await seedMember();
+    const b = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id: aId } = await submit(
+      a.userId,
+      a.email,
+      validSubmission({ memberId: a.memberId }),
+      log,
+    );
+    const { id: bId } = await submit(
+      b.userId,
+      b.email,
+      validSubmission({ memberId: b.memberId }),
+      log,
+    );
+    await declineReliefRequest(ctx.db)(admin.userId, aId, {
+      memberFacingNote: null,
+      adminNote: "Insufficient grounds",
+    });
+
+    const result = await listReliefRequestsForAdmin(ctx.db)({
+      page: 1,
+      pageSize: 100,
+      status: "all",
+    });
+    const ours = result.items.filter((i) => [aId, bId].includes(i.id));
+    expect(ours.findIndex((i) => i.id === bId)).toBeLessThan(
+      ours.findIndex((i) => i.id === aId),
+    );
+  });
+
+  it("admin status transition records an event and updates the status", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    await transitionReliefRequestStatus(ctx.db)(admin.userId, id, {
+      toStatus: "more_info_needed",
+      note: "Could you confirm whether the junior plays Saturday matches?",
+    });
+
+    const detail = await getReliefRequestDetail(ctx.db)(id);
+    expect(detail.request.status).toBe("more_info_needed");
+    const moreInfo = detail.events.filter(
+      (e) => e.eventType === "more_info_requested",
+    );
+    expect(moreInfo).toHaveLength(1);
+    expect(moreInfo[0].toStatus).toBe("more_info_needed");
+  });
+
+  it("admin decline transitions, stores member-facing note, and blocks re-decline", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    await declineReliefRequest(ctx.db)(admin.userId, id, {
+      memberFacingNote: "Sorry, we've used up this season's relief budget.",
+      adminNote: "Reapply next season.",
+    });
+
+    const detail = await getReliefRequestDetail(ctx.db)(id);
+    expect(detail.request.status).toBe("declined");
+    expect(detail.grant).toBeNull();
+    const declines = detail.events.filter((e) => e.eventType === "declined");
+    expect(declines).toHaveLength(1);
+    expect(declines[0].note).toBe(
+      "Sorry, we've used up this season's relief budget.",
+    );
+
+    await expect(
+      declineReliefRequest(ctx.db)(admin.userId, id, {
+        memberFacingNote: null,
+        adminNote: null,
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
   });
 
   it("getMyReliefStatus returns the caller's own and linked-junior requests", async () => {

--- a/apps/api/src/features/financial-relief/integration.test.ts
+++ b/apps/api/src/features/financial-relief/integration.test.ts
@@ -17,6 +17,7 @@ import {
   declineReliefRequest,
   getEligibleMembers,
   getMyReliefStatus,
+  getReliefReport,
   getReliefRequestDetail,
   listReliefRequestsForAdmin,
   submitReliefRequest,
@@ -941,6 +942,143 @@ describe("financial-relief (integration)", () => {
         description: "Senior membership (relief)",
       }),
     ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("getReliefReport aggregates forgiven charges into type + section buckets", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const memberA = await seedMember();
+    const memberB = await seedMember();
+
+    // Seed teams: one junior, one senior.
+    const juniorTeam = `team-${crypto.randomUUID()}`;
+    const seniorTeam = `team-${crypto.randomUUID()}`;
+    await ctx.db
+      .insertInto("play_cricket_team")
+      .values([
+        {
+          id: juniorTeam,
+          name: "U13",
+          site_id: "site",
+          is_junior: true,
+        },
+        { id: seniorTeam, name: "1st XI", site_id: "site", is_junior: false },
+      ])
+      .execute();
+
+    const juniorMd = `m-${crypto.randomUUID()}`;
+    const seniorMd = `m-${crypto.randomUUID()}`;
+    await ctx.db
+      .insertInto("matchday")
+      .values([
+        {
+          id: juniorMd,
+          play_cricket_team_id: juniorTeam,
+          match_date: "2026-05-01",
+          opposition: "Junior Foo",
+          status: "confirmed",
+          created_by: admin.userId,
+        },
+        {
+          id: seniorMd,
+          play_cricket_team_id: seniorTeam,
+          match_date: "2026-05-02",
+          opposition: "Senior Bar",
+          status: "confirmed",
+          created_by: admin.userId,
+        },
+      ])
+      .execute();
+
+    // Seed three relieved charges. relieved_at is set to a far-future
+    // date so the report query window can isolate them from charges
+    // relieved by other tests in this file.
+    const reliefDate = "2099-05-15T12:00:00.000Z";
+    const charges = [
+      {
+        id: `c1-${crypto.randomUUID()}`,
+        member_id: memberA.memberId,
+        amount: 500,
+        type: "match_fee",
+        matchdayId: juniorMd,
+        chargeDate: "2026-05-01",
+        original: null as number | null,
+      },
+      {
+        id: `c2-${crypto.randomUUID()}`,
+        member_id: memberB.memberId,
+        amount: 800,
+        type: "match_fee",
+        matchdayId: seniorMd,
+        chargeDate: "2026-05-02",
+        original: null,
+      },
+      {
+        id: `c3-${crypto.randomUUID()}`,
+        member_id: memberA.memberId,
+        amount: 1000,
+        type: "membership",
+        matchdayId: null as string | null,
+        chargeDate: "2026-05-03",
+        // Partial: original was 5000, member paid 1000, waived 4000.
+        // Reporting value should report the original.
+        original: 5000,
+      },
+    ];
+    for (const c of charges) {
+      await ctx.db
+        .insertInto("charge")
+        .values({
+          id: c.id,
+          member_id: c.member_id,
+          description: `desc ${c.id}`,
+          amount_pence: c.amount,
+          charge_date: c.chargeDate,
+          created_by: admin.userId,
+          type: c.type,
+          source: "matchday",
+          relieved_at: reliefDate,
+          relieved_by: admin.userId,
+          relieved_reason: "financial relief",
+          ...(c.original ? { original_amount_pence: c.original } : {}),
+        })
+        .execute();
+      if (c.matchdayId) {
+        await ctx.db
+          .insertInto("matchday_player")
+          .values({
+            id: `mp-${crypto.randomUUID()}`,
+            matchday_id: c.matchdayId,
+            member_id: c.member_id,
+            player_name: "x",
+            status: "playing",
+            charge_id: c.id,
+          })
+          .execute();
+      }
+    }
+
+    const report = await getReliefReport(ctx.db)({
+      dateFrom: "2099-01-01T00:00:00Z",
+      dateTo: "2099-12-31T23:59:59Z",
+    });
+
+    // Reporting value: 500 + 800 + 5000 = 6300
+    expect(report.totalForgivenPence).toBe(6300);
+    expect(report.byReliefType.matchFeePence).toBe(1300);
+    expect(report.byReliefType.membershipPence).toBe(5000);
+    expect(report.forgivenChargeCount).toBe(3);
+    expect(report.membersSupported).toBe(2);
+
+    // Sections: junior match fee in 'juniors', senior in 'senior',
+    // senior-membership in 'senior'.
+    expect(report.bySection.juniors.pence).toBe(500);
+    expect(report.bySection.juniors.count).toBe(1);
+    expect(report.bySection.juniors.members).toBe(1);
+    expect(report.bySection.senior.pence).toBe(800 + 5000);
+    expect(report.bySection.senior.count).toBe(2);
+    expect(report.bySection.senior.members).toBe(2);
+    expect(report.bySection.womensGirls.pence).toBe(0);
+    expect(report.bySection.other.pence).toBe(0);
   });
 
   it("officials' matchday view reports a relieved match-fee as 'waived' and leaks no application detail", async () => {

--- a/apps/api/src/features/financial-relief/integration.test.ts
+++ b/apps/api/src/features/financial-relief/integration.test.ts
@@ -6,8 +6,12 @@ import {
   stopTestContainer,
   type TestContext,
 } from "../../test/containers.ts";
+import { applyReliefIfAny } from "./apply-relief.ts";
 import type { SubmitReliefRequest } from "./schemas.ts";
 import {
+  closeReliefForArchivedMember,
+  closeReliefGrant,
+  decideReliefRequest,
   declineReliefRequest,
   getEligibleMembers,
   getMyReliefStatus,
@@ -314,7 +318,9 @@ describe("financial-relief (integration)", () => {
       pageSize: 100,
       status: "all",
     });
-    const ours = result.items.filter((i) => [aId, bId].includes(i.id));
+    const ours = result.items.filter((i) =>
+      ([aId, bId] as string[]).includes(i.id),
+    );
     expect(ours.findIndex((i) => i.id === bId)).toBeLessThan(
       ours.findIndex((i) => i.id === aId),
     );
@@ -384,6 +390,430 @@ describe("financial-relief (integration)", () => {
         adminNote: null,
       }),
     ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("decide approves, creates a grant, forgives existing unpaid match-fee charges, and skips paid/in-flight ones", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id: requestId } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+
+    // Seed three match-fee charges for this member:
+    //   - "unpaidNoPI"  — pure unpaid, expect relieved
+    //   - "unpaidLivePI" — has a non-cancelled PI, expect skipped
+    //   - "paid"        — already paid, expect untouched
+    const today = "2026-05-12";
+    const ids = {
+      unpaidNoPI: `charge-no-pi-${crypto.randomUUID()}`,
+      unpaidLivePI: `charge-live-pi-${crypto.randomUUID()}`,
+      paid: `charge-paid-${crypto.randomUUID()}`,
+    };
+    await ctx.db
+      .insertInto("charge")
+      .values([
+        {
+          id: ids.unpaidNoPI,
+          member_id: member.memberId,
+          description: "Match donation - Foo",
+          amount_pence: 500,
+          charge_date: today,
+          created_by: admin.userId,
+          type: "match_fee",
+          source: "matchday",
+        },
+        {
+          id: ids.unpaidLivePI,
+          member_id: member.memberId,
+          description: "Match donation - Bar",
+          amount_pence: 500,
+          charge_date: today,
+          created_by: admin.userId,
+          type: "match_fee",
+          source: "matchday",
+          stripe_payment_intent_id: "pi_live_test",
+        },
+        {
+          id: ids.paid,
+          member_id: member.memberId,
+          description: "Match donation - Baz",
+          amount_pence: 500,
+          charge_date: today,
+          created_by: admin.userId,
+          type: "match_fee",
+          source: "matchday",
+          paid_at: new Date().toISOString(),
+        },
+      ])
+      .execute();
+
+    // Stub Stripe so the live-PI charge is reported as "processing" and
+    // we skip relieving it.
+    const stripeStub = {
+      paymentIntents: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: "pi_live_test",
+          status: "processing",
+        }),
+      },
+    } as unknown as import("stripe").default;
+
+    const decide = decideReliefRequest(ctx.db, {
+      stripe: stripeStub,
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const result = await decide(
+      admin.userId,
+      requestId,
+      {
+        decision: "approved_temporary",
+        coversMembership: false,
+        coversMatchFees: true,
+        membershipPartialPence: null,
+        effectiveFrom: today,
+        effectiveToExclusive: null,
+        adminNotes: null,
+        memberFacingNote: "Match donations are waived this season.",
+      },
+      log,
+    );
+
+    expect(result.forgivenChargeCount).toBe(1);
+
+    const charges = await ctx.db
+      .selectFrom("charge")
+      .where("id", "in", [ids.unpaidNoPI, ids.unpaidLivePI, ids.paid])
+      .select(["id", "relieved_at", "paid_at"])
+      .execute();
+    const byId = new Map(charges.map((c) => [c.id, c]));
+    expect(byId.get(ids.unpaidNoPI)?.relieved_at).not.toBeNull();
+    expect(byId.get(ids.unpaidLivePI)?.relieved_at).toBeNull();
+    expect(byId.get(ids.paid)?.relieved_at).toBeNull();
+    expect(byId.get(ids.paid)?.paid_at).not.toBeNull();
+
+    const detail = await getReliefRequestDetail(ctx.db)(requestId);
+    expect(detail.request.status).toBe("approved");
+    expect(detail.grant?.coversMatchFees).toBe(true);
+  });
+
+  it("a second concurrent decide for the same member is rejected by the unique index", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const { id: r1 } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+
+    const stripeStub = {
+      paymentIntents: { retrieve: vi.fn() },
+    } as unknown as import("stripe").default;
+    const decide = decideReliefRequest(ctx.db, {
+      stripe: stripeStub,
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const body = {
+      decision: "approved_full" as const,
+      coversMembership: false,
+      coversMatchFees: true,
+      membershipPartialPence: null,
+      effectiveFrom: "2026-05-12",
+      effectiveToExclusive: null,
+      adminNotes: null,
+      memberFacingNote: null,
+    };
+    await decide(admin.userId, r1, body, log);
+
+    // Re-decide on the same closed request must reject.
+    await expect(decide(admin.userId, r1, body, log)).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+
+  it("applyReliefIfAny auto-forgives a new match-fee charge when an active grant covers it", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const { id: requestId } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    const stripeStub = {
+      paymentIntents: { retrieve: vi.fn() },
+    } as unknown as import("stripe").default;
+    await decideReliefRequest(ctx.db, {
+      stripe: stripeStub,
+      baseUrl: "https://percymain.org",
+      send,
+    })(
+      admin.userId,
+      requestId,
+      {
+        decision: "approved_temporary",
+        coversMembership: false,
+        coversMatchFees: true,
+        membershipPartialPence: null,
+        effectiveFrom: "2026-05-01",
+        effectiveToExclusive: null,
+        adminNotes: null,
+        memberFacingNote: null,
+      },
+      log,
+    );
+
+    // Insert a new match-fee charge after the grant — applyReliefIfAny
+    // should flip the relief audit columns inside the same trx.
+    const chargeId = `c-${crypto.randomUUID()}`;
+    await ctx.db.transaction().execute(async (trx) => {
+      await trx
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: member.memberId,
+          description: "Match donation - Future",
+          amount_pence: 500,
+          charge_date: "2026-06-01",
+          created_by: admin.userId,
+          type: "match_fee",
+          source: "matchday",
+        })
+        .execute();
+      await applyReliefIfAny(trx)({
+        chargeId,
+        memberId: member.memberId,
+        type: "match_fee",
+        chargeDate: "2026-06-01",
+      });
+    });
+
+    const row = await ctx.db
+      .selectFrom("charge")
+      .where("id", "=", chargeId)
+      .select(["relieved_at", "relieved_reason", "amount_pence"])
+      .executeTakeFirstOrThrow();
+    expect(row.relieved_at).not.toBeNull();
+    expect(row.relieved_reason).toBe("financial relief");
+    // Reporting value preserved.
+    expect(row.amount_pence).toBe(500);
+  });
+
+  it("applyReliefIfAny does nothing for membership charges (admin-applied path)", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const { id: requestId } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    const stripeStub = {
+      paymentIntents: { retrieve: vi.fn() },
+    } as unknown as import("stripe").default;
+    await decideReliefRequest(ctx.db, {
+      stripe: stripeStub,
+      baseUrl: "https://percymain.org",
+      send,
+    })(
+      admin.userId,
+      requestId,
+      {
+        decision: "approved_temporary",
+        coversMembership: true,
+        coversMatchFees: false,
+        membershipPartialPence: null,
+        effectiveFrom: "2026-05-01",
+        effectiveToExclusive: null,
+        adminNotes: null,
+        memberFacingNote: null,
+      },
+      log,
+    );
+
+    const chargeId = `c-${crypto.randomUUID()}`;
+    await ctx.db
+      .insertInto("charge")
+      .values({
+        id: chargeId,
+        member_id: member.memberId,
+        description: "Membership renewal",
+        amount_pence: 5000,
+        charge_date: "2026-06-01",
+        created_by: admin.userId,
+        type: "membership",
+        source: "stripe",
+      })
+      .execute();
+    const result = await applyReliefIfAny(ctx.db)({
+      chargeId,
+      memberId: member.memberId,
+      type: "membership",
+      chargeDate: "2026-06-01",
+    });
+    expect(result.applied).toBe(false);
+    const row = await ctx.db
+      .selectFrom("charge")
+      .where("id", "=", chargeId)
+      .select(["relieved_at"])
+      .executeTakeFirstOrThrow();
+    expect(row.relieved_at).toBeNull();
+  });
+
+  it("closing a grant stops future charges being auto-forgiven; previously forgiven are untouched", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const { id: requestId } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    const stripeStub = {
+      paymentIntents: { retrieve: vi.fn() },
+    } as unknown as import("stripe").default;
+    const decideResult = await decideReliefRequest(ctx.db, {
+      stripe: stripeStub,
+      baseUrl: "https://percymain.org",
+      send,
+    })(
+      admin.userId,
+      requestId,
+      {
+        decision: "approved_temporary",
+        coversMembership: false,
+        coversMatchFees: true,
+        membershipPartialPence: null,
+        effectiveFrom: "2026-05-01",
+        effectiveToExclusive: null,
+        adminNotes: null,
+        memberFacingNote: null,
+      },
+      log,
+    );
+
+    // Forgive a charge under the active grant.
+    const beforeId = `c-${crypto.randomUUID()}`;
+    await ctx.db
+      .insertInto("charge")
+      .values({
+        id: beforeId,
+        member_id: member.memberId,
+        description: "Match donation - Before close",
+        amount_pence: 500,
+        charge_date: "2026-06-01",
+        created_by: admin.userId,
+        type: "match_fee",
+        source: "matchday",
+      })
+      .execute();
+    await applyReliefIfAny(ctx.db)({
+      chargeId: beforeId,
+      memberId: member.memberId,
+      type: "match_fee",
+      chargeDate: "2026-06-01",
+    });
+
+    await closeReliefGrant(ctx.db)(admin.userId, decideResult.grantId, {
+      reason: "Season ended",
+    });
+
+    // After-close charge: should NOT be auto-forgiven.
+    const afterId = `c-${crypto.randomUUID()}`;
+    await ctx.db
+      .insertInto("charge")
+      .values({
+        id: afterId,
+        member_id: member.memberId,
+        description: "Match donation - After close",
+        amount_pence: 500,
+        charge_date: "2026-07-01",
+        created_by: admin.userId,
+        type: "match_fee",
+        source: "matchday",
+      })
+      .execute();
+    await applyReliefIfAny(ctx.db)({
+      chargeId: afterId,
+      memberId: member.memberId,
+      type: "match_fee",
+      chargeDate: "2026-07-01",
+    });
+
+    const rows = await ctx.db
+      .selectFrom("charge")
+      .where("id", "in", [beforeId, afterId])
+      .select(["id", "relieved_at"])
+      .execute();
+    const by = new Map(rows.map((r) => [r.id, r]));
+    expect(by.get(beforeId)?.relieved_at).not.toBeNull();
+    expect(by.get(afterId)?.relieved_at).toBeNull();
+  });
+
+  it("archival closes active grants and force-declines open requests", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const { id: openRequestId } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+
+    await closeReliefForArchivedMember(ctx.db)(admin.userId, member.memberId);
+
+    const row = await ctx.db
+      .selectFrom("financial_relief_request")
+      .where("id", "=", openRequestId)
+      .select(["status"])
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("declined");
+
+    const events = await ctx.db
+      .selectFrom("financial_relief_event")
+      .where("request_id", "=", openRequestId)
+      .where("event_type", "=", "declined")
+      .selectAll()
+      .execute();
+    expect(events).toHaveLength(1);
+    expect(events[0].note).toBe("member archived");
   });
 
   it("getMyReliefStatus returns the caller's own and linked-junior requests", async () => {

--- a/apps/api/src/features/financial-relief/integration.test.ts
+++ b/apps/api/src/features/financial-relief/integration.test.ts
@@ -1,0 +1,308 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import type { SubmitReliefRequest } from "./schemas.ts";
+import {
+  getEligibleMembers,
+  getMyReliefStatus,
+  submitReliefRequest,
+  withdrawReliefRequest,
+} from "./service.ts";
+
+const log = createNoopLogger();
+
+// We're not testing email rendering — keep the test focused on DB state.
+vi.mock("@react-email/render", () => ({
+  render: vi.fn().mockResolvedValue("<html></html>"),
+}));
+
+let ctx: TestContext;
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestContainer(ctx);
+});
+
+function validSubmission(
+  overrides: Partial<SubmitReliefRequest>,
+): SubmitReliefRequest {
+  return {
+    memberId: "",
+    requestedMembershipFull: false,
+    requestedMembershipPartial: false,
+    requestedMatchFees: true,
+    partialAmountPence: null,
+    reasonCategory: "cost_of_living",
+    reasonText: "Things are tight at the moment.",
+    duration: "season",
+    durationOtherText: null,
+    contributionAbility: "yes_reduced",
+    contributionAmountPence: 1000,
+    volunteerOptions: ["scoring", "matchday_setup"],
+    volunteerNotes: "Happy to help most Saturday afternoons.",
+    contactPreference: "email",
+    privacyAcknowledged: true,
+    declarationConfirmed: true,
+    ...overrides,
+  };
+}
+
+async function linkJunior(
+  juniorMemberId: string,
+  parentMemberId: string,
+  createdBy: string,
+) {
+  await ctx.db
+    .insertInto("member_parent_link")
+    .values({
+      member_id: juniorMemberId,
+      parent_member_id: parentMemberId,
+      created_by: createdBy,
+    })
+    .execute();
+}
+
+async function seedMember(overrides: Parameters<typeof seedTestUser>[1] = {}) {
+  const result = await seedTestUser(ctx.db, overrides);
+  if (!result.memberId) {
+    throw new Error("Expected seedTestUser to create a member");
+  }
+  return { ...result, memberId: result.memberId };
+}
+
+describe("financial-relief (integration)", () => {
+  it("getEligibleMembers returns self plus linked juniors", async () => {
+    const parent = await seedMember();
+    const junior = await seedMember();
+    await linkJunior(junior.memberId, parent.memberId, parent.userId);
+
+    const result = await getEligibleMembers(ctx.db)(parent.email);
+
+    const ids = result.members.map((m) => m.memberId).sort();
+    expect(ids).toEqual([parent.memberId, junior.memberId].sort());
+    const self = result.members.find((m) => m.relationship === "self");
+    const linked = result.members.find((m) => m.relationship === "junior");
+    expect(self?.memberId).toBe(parent.memberId);
+    expect(linked?.memberId).toBe(junior.memberId);
+  });
+
+  it("submit succeeds for own member id", async () => {
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+
+    const row = await ctx.db
+      .selectFrom("financial_relief_request")
+      .where("id", "=", id)
+      .selectAll()
+      .executeTakeFirst();
+    expect(row?.status).toBe("submitted");
+    expect(row?.member_id).toBe(member.memberId);
+    expect(row?.submitted_by_user_id).toBe(member.userId);
+    expect(row?.requested_match_fees).toBe(true);
+    expect(row?.reason_category).toBe("cost_of_living");
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it("submit succeeds for a linked junior member id", async () => {
+    const parent = await seedMember();
+    const junior = await seedMember();
+    await linkJunior(junior.memberId, parent.memberId, parent.userId);
+
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    const { id } = await submit(
+      parent.userId,
+      parent.email,
+      validSubmission({ memberId: junior.memberId }),
+      log,
+    );
+
+    const row = await ctx.db
+      .selectFrom("financial_relief_request")
+      .where("id", "=", id)
+      .select(["member_id"])
+      .executeTakeFirst();
+    expect(row?.member_id).toBe(junior.memberId);
+  });
+
+  it("submit rejects (403) a member id outside the caller's eligible set", async () => {
+    const caller = await seedMember();
+    const stranger = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    await expect(
+      submit(
+        caller.userId,
+        caller.email,
+        validSubmission({ memberId: stranger.memberId }),
+        log,
+      ),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("submit rejects (409) when an open request already exists", async () => {
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    await expect(
+      submit(
+        member.userId,
+        member.email,
+        validSubmission({ memberId: member.memberId }),
+        log,
+      ),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("submit succeeds again after the prior request is withdrawn", async () => {
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const withdraw = withdrawReliefRequest(ctx.db);
+
+    const { id: firstId } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    await withdraw(member.userId, member.email, firstId, {
+      reason: "Changed mind",
+    });
+
+    await expect(
+      submit(
+        member.userId,
+        member.email,
+        validSubmission({ memberId: member.memberId }),
+        log,
+      ),
+    ).resolves.toHaveProperty("id");
+  });
+
+  it("withdraw is rejected (403) for a non-owner non-parent", async () => {
+    const owner = await seedMember();
+    const stranger = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const withdraw = withdrawReliefRequest(ctx.db);
+
+    const { id } = await submit(
+      owner.userId,
+      owner.email,
+      validSubmission({ memberId: owner.memberId }),
+      log,
+    );
+
+    await expect(
+      withdraw(stranger.userId, stranger.email, id, { reason: null }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("withdraw transitions the request and records an event", async () => {
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const withdraw = withdrawReliefRequest(ctx.db);
+
+    const { id } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    await withdraw(member.userId, member.email, id, { reason: "Got a bonus" });
+
+    const row = await ctx.db
+      .selectFrom("financial_relief_request")
+      .where("id", "=", id)
+      .select(["status", "withdrawn_at", "withdrawn_reason"])
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("withdrawn");
+    expect(row.withdrawn_at).not.toBeNull();
+    expect(row.withdrawn_reason).toBe("Got a bonus");
+
+    const events = await ctx.db
+      .selectFrom("financial_relief_event")
+      .where("request_id", "=", id)
+      .selectAll()
+      .execute();
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe("withdrawn");
+    expect(events[0].to_status).toBe("withdrawn");
+  });
+
+  it("getMyReliefStatus returns the caller's own and linked-junior requests", async () => {
+    const parent = await seedMember();
+    const junior = await seedMember();
+    await linkJunior(junior.memberId, parent.memberId, parent.userId);
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+
+    await submit(
+      parent.userId,
+      parent.email,
+      validSubmission({ memberId: parent.memberId }),
+      log,
+    );
+    await submit(
+      parent.userId,
+      parent.email,
+      validSubmission({ memberId: junior.memberId }),
+      log,
+    );
+
+    const { requests } = await getMyReliefStatus(ctx.db)(parent.email);
+    const ids = requests.map((r) => r.memberId).sort();
+    expect(ids).toEqual([parent.memberId, junior.memberId].sort());
+  });
+});

--- a/apps/api/src/features/financial-relief/integration.test.ts
+++ b/apps/api/src/features/financial-relief/integration.test.ts
@@ -6,6 +6,7 @@ import {
   stopTestContainer,
   type TestContext,
 } from "../../test/containers.ts";
+import { getMatch } from "../matchday/service.ts";
 import { applyReliefIfAny } from "./apply-relief.ts";
 import type { SubmitReliefRequest } from "./schemas.ts";
 import {
@@ -814,6 +815,75 @@ describe("financial-relief (integration)", () => {
       .execute();
     expect(events).toHaveLength(1);
     expect(events[0].note).toBe("member archived");
+  });
+
+  it("officials' matchday view reports a relieved match-fee as 'waived' and leaks no application detail", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+
+    // Seed a minimal matchday + a relieved match-fee charge for this member.
+    const teamId = `team-${crypto.randomUUID()}`;
+    await ctx.db
+      .insertInto("play_cricket_team")
+      .values({ id: teamId, name: "Test Team", site_id: "site" })
+      .execute();
+
+    const matchdayId = `m-${crypto.randomUUID()}`;
+    await ctx.db
+      .insertInto("matchday")
+      .values({
+        id: matchdayId,
+        play_cricket_team_id: teamId,
+        match_date: "2026-05-12",
+        opposition: "Foo",
+        status: "confirmed",
+        created_by: admin.userId,
+      })
+      .execute();
+
+    const chargeId = `c-${crypto.randomUUID()}`;
+    await ctx.db
+      .insertInto("charge")
+      .values({
+        id: chargeId,
+        member_id: member.memberId,
+        description: "Match donation - Foo",
+        amount_pence: 500,
+        charge_date: "2026-05-12",
+        created_by: admin.userId,
+        type: "match_fee",
+        source: "matchday",
+        relieved_at: new Date().toISOString(),
+        relieved_by: admin.userId,
+        relieved_reason: "financial relief",
+      })
+      .execute();
+
+    const playerId = `p-${crypto.randomUUID()}`;
+    await ctx.db
+      .insertInto("matchday_player")
+      .values({
+        id: playerId,
+        matchday_id: matchdayId,
+        member_id: member.memberId,
+        player_name: member.name,
+        status: "playing",
+        charge_id: chargeId,
+      })
+      .execute();
+
+    // role='admin' bypasses the team_official check so the test
+    // doesn't have to seed an official row.
+    const detail = await getMatch(ctx.db)(admin.userId, "admin", matchdayId);
+    expect(detail).toBeTruthy();
+    if (!detail) throw new Error("getMatch returned null");
+    const player = detail.players.find((p) => p.id === playerId);
+    expect(player?.chargeStatus).toBe("waived");
+    // Crucially: the officials' endpoint must NOT expose relief audit
+    // columns, the application reason, or the grant note.
+    expect(Object.keys(player ?? {})).not.toContain("chargeRelievedAt");
+    expect(Object.keys(player ?? {})).not.toContain("relieved_at");
+    expect(Object.keys(player ?? {})).not.toContain("reason_text");
   });
 
   it("getMyReliefStatus returns the caller's own and linked-junior requests", async () => {

--- a/apps/api/src/features/financial-relief/integration.test.ts
+++ b/apps/api/src/features/financial-relief/integration.test.ts
@@ -10,6 +10,7 @@ import { getMatch } from "../matchday/service.ts";
 import { applyReliefIfAny } from "./apply-relief.ts";
 import type { SubmitReliefRequest } from "./schemas.ts";
 import {
+  applyMembershipRelief,
   closeReliefForArchivedMember,
   closeReliefGrant,
   decideReliefRequest,
@@ -815,6 +816,131 @@ describe("financial-relief (integration)", () => {
       .execute();
     expect(events).toHaveLength(1);
     expect(events[0].note).toBe("member archived");
+  });
+
+  it("applyMembershipRelief creates a relieved membership charge and extends paid_until", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const { id: requestId } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    const stripeStub = {
+      paymentIntents: { retrieve: vi.fn() },
+    } as unknown as import("stripe").default;
+    const decide = await decideReliefRequest(ctx.db, {
+      stripe: stripeStub,
+      baseUrl: "https://percymain.org",
+      send,
+    })(
+      admin.userId,
+      requestId,
+      {
+        decision: "approved_temporary",
+        coversMembership: true,
+        coversMatchFees: false,
+        membershipPartialPence: null,
+        effectiveFrom: "2026-05-01",
+        effectiveToExclusive: null,
+        adminNotes: null,
+        memberFacingNote: null,
+      },
+      log,
+    );
+
+    const { chargeId } = await applyMembershipRelief(ctx.db)(
+      admin.userId,
+      decide.grantId,
+      {
+        amountPence: 5000,
+        effectiveDate: "2026-05-12",
+        membershipPaidUntil: "2027-03-31",
+        membershipType: "senior_player",
+        description: "Senior membership (relief)",
+      },
+    );
+
+    const charge = await ctx.db
+      .selectFrom("charge")
+      .where("id", "=", chargeId)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(charge.type).toBe("membership");
+    expect(charge.amount_pence).toBe(5000);
+    expect(charge.relieved_at).not.toBeNull();
+    expect(charge.relief_grant_id).toBe(decide.grantId);
+
+    const membership = await ctx.db
+      .selectFrom("membership")
+      .where("member_id", "=", member.memberId)
+      .where("type", "=", "senior_player")
+      .select(["paid_until"])
+      .executeTakeFirstOrThrow();
+    expect(membership.paid_until).toContain("2027-03-31");
+
+    // Event audit row.
+    const event = await ctx.db
+      .selectFrom("financial_relief_event")
+      .where("request_id", "=", requestId)
+      .where("event_type", "=", "membership_relief_applied")
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(event.note).toContain("senior_player");
+  });
+
+  it("applyMembershipRelief rejects when the grant does not cover membership or is closed", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const { id: requestId } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({ memberId: member.memberId }),
+      log,
+    );
+    const stripeStub = {
+      paymentIntents: { retrieve: vi.fn() },
+    } as unknown as import("stripe").default;
+    const decide = await decideReliefRequest(ctx.db, {
+      stripe: stripeStub,
+      baseUrl: "https://percymain.org",
+      send,
+    })(
+      admin.userId,
+      requestId,
+      {
+        decision: "approved_temporary",
+        coversMembership: false,
+        coversMatchFees: true,
+        membershipPartialPence: null,
+        effectiveFrom: "2026-05-01",
+        effectiveToExclusive: null,
+        adminNotes: null,
+        memberFacingNote: null,
+      },
+      log,
+    );
+
+    await expect(
+      applyMembershipRelief(ctx.db)(admin.userId, decide.grantId, {
+        amountPence: 5000,
+        effectiveDate: "2026-05-12",
+        membershipPaidUntil: "2027-03-31",
+        membershipType: "senior_player",
+        description: "Senior membership (relief)",
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
   });
 
   it("officials' matchday view reports a relieved match-fee as 'waived' and leaks no application detail", async () => {

--- a/apps/api/src/features/financial-relief/routes.ts
+++ b/apps/api/src/features/financial-relief/routes.ts
@@ -269,8 +269,8 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
         response: { 200: reliefReportResponseSchema },
       },
     },
-    async () => {
-      return await report();
+    async (request) => {
+      return await report(request.query);
     },
   );
 };

--- a/apps/api/src/features/financial-relief/routes.ts
+++ b/apps/api/src/features/financial-relief/routes.ts
@@ -1,5 +1,9 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
-import { getAuthSession, requirePermission } from "../auth/middleware.ts";
+import {
+  getAuthSession,
+  requireAuth,
+  requirePermission,
+} from "../auth/middleware.ts";
 import { createStripe } from "../payments/stripe.ts";
 import {
   applyMembershipReliefResponseSchema,
@@ -75,6 +79,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.get(
     "/financial-relief/eligible-members",
     {
+      preHandler: [requireAuth],
       schema: { response: { 200: eligibleMembersResponseSchema } },
     },
     async (request) => {
@@ -86,6 +91,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.get(
     "/financial-relief/me",
     {
+      preHandler: [requireAuth],
       schema: { response: { 200: myReliefStatusResponseSchema } },
     },
     async (request) => {
@@ -97,6 +103,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     "/financial-relief/requests",
     {
+      preHandler: [requireAuth],
       schema: {
         body: submitReliefRequestSchema,
         response: { 200: submitReliefRequestResponseSchema },
@@ -116,6 +123,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     "/financial-relief/requests/:requestId/withdraw",
     {
+      preHandler: [requireAuth],
       schema: {
         params: requestIdParamSchema,
         body: withdrawRequestSchema,

--- a/apps/api/src/features/financial-relief/routes.ts
+++ b/apps/api/src/features/financial-relief/routes.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { getAuthSession, requireRole } from "../auth/middleware.ts";
+import { createStripe } from "../payments/stripe.ts";
 import {
   applyMembershipReliefResponseSchema,
   applyMembershipReliefSchema,
@@ -42,6 +43,9 @@ import {
 
 // eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
 export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
+  const stripe = createStripe({
+    stripeSecretKey: app.config.STRIPE_SECRET_KEY,
+  });
   const eligible = getEligibleMembers(app.db);
   const submit = submitReliefRequest(app.db, {
     baseUrl: app.config.BASE_URL,
@@ -53,7 +57,11 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   const getDetail = getReliefRequestDetail(app.db);
   const transition = transitionReliefRequestStatus(app.db);
   const decline = declineReliefRequest(app.db);
-  const decide = decideReliefRequest(app.db);
+  const decide = decideReliefRequest(app.db, {
+    stripe,
+    baseUrl: app.config.BASE_URL,
+    send: app.send,
+  });
   const closeGrant = closeReliefGrant(app.db);
   const applyMembership = applyMembershipRelief(app.db);
   const report = getReliefReport(app.db);
@@ -201,8 +209,14 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
         response: { 200: decideReliefRequestResponseSchema },
       },
     },
-    async () => {
-      return await decide();
+    async (request) => {
+      const session = getAuthSession(request);
+      return await decide(
+        session.user.id,
+        request.params.requestId,
+        request.body,
+        request.log,
+      );
     },
   );
 
@@ -216,8 +230,13 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
         response: { 200: closeGrantResponseSchema },
       },
     },
-    async () => {
-      return await closeGrant();
+    async (request) => {
+      const session = getAuthSession(request);
+      return await closeGrant(
+        session.user.id,
+        request.params.grantId,
+        request.body,
+      );
     },
   );
 

--- a/apps/api/src/features/financial-relief/routes.ts
+++ b/apps/api/src/features/financial-relief/routes.ts
@@ -1,5 +1,5 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
-import { getAuthSession, requireRole } from "../auth/middleware.ts";
+import { getAuthSession, requirePermission } from "../auth/middleware.ts";
 import { createStripe } from "../payments/stripe.ts";
 import {
   applyMembershipReliefResponseSchema,
@@ -46,6 +46,10 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   const stripe = createStripe({
     stripeSecretKey: app.config.STRIPE_SECRET_KEY,
   });
+  // Relief is admin-side finance work. Anyone with `finance:manage`
+  // (finance_admin role, superadmin, legacy admin) can decide / close
+  // grants / apply membership / view the report.
+  const financeManage = requirePermission("finance", "manage");
   const eligible = getEligibleMembers(app.db);
   const submit = submitReliefRequest(app.db, {
     baseUrl: app.config.BASE_URL,
@@ -134,7 +138,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.get(
     "/admin/financial-relief/requests",
     {
-      preHandler: [requireRole("admin")],
+      preHandler: [financeManage],
       schema: {
         querystring: listReliefRequestsSchema,
         response: { 200: listReliefRequestsResponseSchema },
@@ -148,7 +152,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.get(
     "/admin/financial-relief/requests/:requestId",
     {
-      preHandler: [requireRole("admin")],
+      preHandler: [financeManage],
       schema: {
         params: requestIdParamSchema,
         response: { 200: reliefRequestDetailResponseSchema },
@@ -162,7 +166,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     "/admin/financial-relief/requests/:requestId/status",
     {
-      preHandler: [requireRole("admin")],
+      preHandler: [financeManage],
       schema: {
         params: requestIdParamSchema,
         body: transitionStatusSchema,
@@ -182,7 +186,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     "/admin/financial-relief/requests/:requestId/decline",
     {
-      preHandler: [requireRole("admin")],
+      preHandler: [financeManage],
       schema: {
         params: requestIdParamSchema,
         body: declineRequestSchema,
@@ -202,7 +206,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     "/admin/financial-relief/requests/:requestId/decide",
     {
-      preHandler: [requireRole("admin")],
+      preHandler: [financeManage],
       schema: {
         params: requestIdParamSchema,
         body: decideReliefRequestSchema,
@@ -223,7 +227,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     "/admin/financial-relief/grants/:grantId/close",
     {
-      preHandler: [requireRole("admin")],
+      preHandler: [financeManage],
       schema: {
         params: grantIdParamSchema,
         body: closeGrantSchema,
@@ -243,7 +247,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.post(
     "/admin/financial-relief/grants/:grantId/apply-membership",
     {
-      preHandler: [requireRole("admin")],
+      preHandler: [financeManage],
       schema: {
         params: grantIdParamSchema,
         body: applyMembershipReliefSchema,
@@ -263,7 +267,7 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   app.get(
     "/admin/financial-relief/report",
     {
-      preHandler: [requireRole("admin")],
+      preHandler: [financeManage],
       schema: {
         querystring: reliefReportSchema,
         response: { 200: reliefReportResponseSchema },

--- a/apps/api/src/features/financial-relief/routes.ts
+++ b/apps/api/src/features/financial-relief/routes.ts
@@ -43,7 +43,10 @@ import {
 // eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
 export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
   const eligible = getEligibleMembers(app.db);
-  const submit = submitReliefRequest(app.db);
+  const submit = submitReliefRequest(app.db, {
+    baseUrl: app.config.BASE_URL,
+    send: app.send,
+  });
   const myStatus = getMyReliefStatus(app.db);
   const withdraw = withdrawReliefRequest(app.db);
   const listAdmin = listReliefRequestsForAdmin(app.db);
@@ -74,8 +77,8 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
       schema: { response: { 200: myReliefStatusResponseSchema } },
     },
     async (request) => {
-      getAuthSession(request);
-      return await myStatus();
+      const session = getAuthSession(request);
+      return await myStatus(session.user.email);
     },
   );
 
@@ -88,8 +91,13 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      getAuthSession(request);
-      return await submit();
+      const session = getAuthSession(request);
+      return await submit(
+        session.user.id,
+        session.user.email,
+        request.body,
+        request.log,
+      );
     },
   );
 
@@ -103,8 +111,13 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      getAuthSession(request);
-      return await withdraw();
+      const session = getAuthSession(request);
+      return await withdraw(
+        session.user.id,
+        session.user.email,
+        request.params.requestId,
+        request.body,
+      );
     },
   );
 

--- a/apps/api/src/features/financial-relief/routes.ts
+++ b/apps/api/src/features/financial-relief/routes.ts
@@ -1,0 +1,229 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { getAuthSession, requireRole } from "../auth/middleware.ts";
+import {
+  applyMembershipReliefResponseSchema,
+  applyMembershipReliefSchema,
+  closeGrantResponseSchema,
+  closeGrantSchema,
+  decideReliefRequestResponseSchema,
+  decideReliefRequestSchema,
+  declineRequestResponseSchema,
+  declineRequestSchema,
+  eligibleMembersResponseSchema,
+  grantIdParamSchema,
+  listReliefRequestsResponseSchema,
+  listReliefRequestsSchema,
+  myReliefStatusResponseSchema,
+  reliefReportResponseSchema,
+  reliefReportSchema,
+  reliefRequestDetailResponseSchema,
+  requestIdParamSchema,
+  submitReliefRequestResponseSchema,
+  submitReliefRequestSchema,
+  transitionStatusResponseSchema,
+  transitionStatusSchema,
+  withdrawRequestResponseSchema,
+  withdrawRequestSchema,
+} from "./schemas.ts";
+import {
+  applyMembershipRelief,
+  closeReliefGrant,
+  decideReliefRequest,
+  declineReliefRequest,
+  getEligibleMembers,
+  getMyReliefStatus,
+  getReliefReport,
+  getReliefRequestDetail,
+  listReliefRequestsForAdmin,
+  submitReliefRequest,
+  transitionReliefRequestStatus,
+  withdrawReliefRequest,
+} from "./service.ts";
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
+  const eligible = getEligibleMembers(app.db);
+  const submit = submitReliefRequest(app.db);
+  const myStatus = getMyReliefStatus(app.db);
+  const withdraw = withdrawReliefRequest(app.db);
+  const listAdmin = listReliefRequestsForAdmin(app.db);
+  const getDetail = getReliefRequestDetail(app.db);
+  const transition = transitionReliefRequestStatus(app.db);
+  const decline = declineReliefRequest(app.db);
+  const decide = decideReliefRequest(app.db);
+  const closeGrant = closeReliefGrant(app.db);
+  const applyMembership = applyMembershipRelief(app.db);
+  const report = getReliefReport(app.db);
+
+  // --- Member-facing ---
+
+  app.get(
+    "/financial-relief/eligible-members",
+    {
+      schema: { response: { 200: eligibleMembersResponseSchema } },
+    },
+    async (request) => {
+      const session = getAuthSession(request);
+      return await eligible(session.user.email);
+    },
+  );
+
+  app.get(
+    "/financial-relief/me",
+    {
+      schema: { response: { 200: myReliefStatusResponseSchema } },
+    },
+    async (request) => {
+      getAuthSession(request);
+      return await myStatus();
+    },
+  );
+
+  app.post(
+    "/financial-relief/requests",
+    {
+      schema: {
+        body: submitReliefRequestSchema,
+        response: { 200: submitReliefRequestResponseSchema },
+      },
+    },
+    async (request) => {
+      getAuthSession(request);
+      return await submit();
+    },
+  );
+
+  app.post(
+    "/financial-relief/requests/:requestId/withdraw",
+    {
+      schema: {
+        params: requestIdParamSchema,
+        body: withdrawRequestSchema,
+        response: { 200: withdrawRequestResponseSchema },
+      },
+    },
+    async (request) => {
+      getAuthSession(request);
+      return await withdraw();
+    },
+  );
+
+  // --- Admin ---
+
+  app.get(
+    "/admin/financial-relief/requests",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        querystring: listReliefRequestsSchema,
+        response: { 200: listReliefRequestsResponseSchema },
+      },
+    },
+    async () => {
+      return await listAdmin();
+    },
+  );
+
+  app.get(
+    "/admin/financial-relief/requests/:requestId",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: requestIdParamSchema,
+        response: { 200: reliefRequestDetailResponseSchema },
+      },
+    },
+    async () => {
+      return await getDetail();
+    },
+  );
+
+  app.post(
+    "/admin/financial-relief/requests/:requestId/status",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: requestIdParamSchema,
+        body: transitionStatusSchema,
+        response: { 200: transitionStatusResponseSchema },
+      },
+    },
+    async () => {
+      return await transition();
+    },
+  );
+
+  app.post(
+    "/admin/financial-relief/requests/:requestId/decline",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: requestIdParamSchema,
+        body: declineRequestSchema,
+        response: { 200: declineRequestResponseSchema },
+      },
+    },
+    async () => {
+      return await decline();
+    },
+  );
+
+  app.post(
+    "/admin/financial-relief/requests/:requestId/decide",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: requestIdParamSchema,
+        body: decideReliefRequestSchema,
+        response: { 200: decideReliefRequestResponseSchema },
+      },
+    },
+    async () => {
+      return await decide();
+    },
+  );
+
+  app.post(
+    "/admin/financial-relief/grants/:grantId/close",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: grantIdParamSchema,
+        body: closeGrantSchema,
+        response: { 200: closeGrantResponseSchema },
+      },
+    },
+    async () => {
+      return await closeGrant();
+    },
+  );
+
+  app.post(
+    "/admin/financial-relief/grants/:grantId/apply-membership",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        params: grantIdParamSchema,
+        body: applyMembershipReliefSchema,
+        response: { 200: applyMembershipReliefResponseSchema },
+      },
+    },
+    async () => {
+      return await applyMembership();
+    },
+  );
+
+  app.get(
+    "/admin/financial-relief/report",
+    {
+      preHandler: [requireRole("admin")],
+      schema: {
+        querystring: reliefReportSchema,
+        response: { 200: reliefReportResponseSchema },
+      },
+    },
+    async () => {
+      return await report();
+    },
+  );
+};

--- a/apps/api/src/features/financial-relief/routes.ts
+++ b/apps/api/src/features/financial-relief/routes.ts
@@ -250,8 +250,13 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
         response: { 200: applyMembershipReliefResponseSchema },
       },
     },
-    async () => {
-      return await applyMembership();
+    async (request) => {
+      const session = getAuthSession(request);
+      return await applyMembership(
+        session.user.id,
+        request.params.grantId,
+        request.body,
+      );
     },
   );
 

--- a/apps/api/src/features/financial-relief/routes.ts
+++ b/apps/api/src/features/financial-relief/routes.ts
@@ -132,8 +132,8 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
         response: { 200: listReliefRequestsResponseSchema },
       },
     },
-    async () => {
-      return await listAdmin();
+    async (request) => {
+      return await listAdmin(request.query);
     },
   );
 
@@ -146,8 +146,8 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
         response: { 200: reliefRequestDetailResponseSchema },
       },
     },
-    async () => {
-      return await getDetail();
+    async (request) => {
+      return await getDetail(request.params.requestId);
     },
   );
 
@@ -161,8 +161,13 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
         response: { 200: transitionStatusResponseSchema },
       },
     },
-    async () => {
-      return await transition();
+    async (request) => {
+      const session = getAuthSession(request);
+      return await transition(
+        session.user.id,
+        request.params.requestId,
+        request.body,
+      );
     },
   );
 
@@ -176,8 +181,13 @@ export const financialReliefRoutes: FastifyPluginAsyncZod = async (app) => {
         response: { 200: declineRequestResponseSchema },
       },
     },
-    async () => {
-      return await decline();
+    async (request) => {
+      const session = getAuthSession(request);
+      return await decline(
+        session.user.id,
+        request.params.requestId,
+        request.body,
+      );
     },
   );
 

--- a/apps/api/src/features/financial-relief/schemas.ts
+++ b/apps/api/src/features/financial-relief/schemas.ts
@@ -1,0 +1,314 @@
+import {
+  contactPreferenceSchema,
+  contributionAbilitySchema,
+  durationSchema,
+  grantDecisionSchema,
+  reasonCategorySchema,
+  requestStatusSchema,
+  volunteerOptionSchema,
+} from "@percy-main/shared";
+import { z } from "zod";
+
+const successResponseSchema = z.object({ success: z.boolean() });
+const idResponseSchema = z.object({ id: z.string() });
+
+// --- Member-facing requests ----------------------------------------------
+
+export const submitReliefRequestSchema = z
+  .object({
+    memberId: z.string().min(1),
+    requestedMembershipFull: z.boolean(),
+    requestedMembershipPartial: z.boolean(),
+    requestedMatchFees: z.boolean(),
+    partialAmountPence: z.number().int().nonnegative().nullable().optional(),
+    reasonCategory: reasonCategorySchema.nullable().optional(),
+    reasonText: z.string().max(2000).nullable().optional(),
+    duration: durationSchema.nullable().optional(),
+    durationOtherText: z.string().max(500).nullable().optional(),
+    contributionAbility: contributionAbilitySchema.nullable().optional(),
+    contributionAmountPence: z
+      .number()
+      .int()
+      .nonnegative()
+      .nullable()
+      .optional(),
+    volunteerOptions: z.array(volunteerOptionSchema).default([]),
+    volunteerNotes: z.string().max(2000).nullable().optional(),
+    contactPreference: contactPreferenceSchema,
+    privacyAcknowledged: z.literal(true),
+    declarationConfirmed: z.literal(true),
+  })
+  .refine(
+    (data) =>
+      data.requestedMembershipFull ||
+      data.requestedMembershipPartial ||
+      data.requestedMatchFees,
+    {
+      message: "Select at least one type of support",
+      path: ["requestedMatchFees"],
+    },
+  );
+
+export type SubmitReliefRequest = z.infer<typeof submitReliefRequestSchema>;
+
+export const withdrawRequestSchema = z.object({
+  reason: z.string().max(500).nullable().optional(),
+});
+export type WithdrawRequest = z.infer<typeof withdrawRequestSchema>;
+
+// --- Params --------------------------------------------------------------
+
+export const requestIdParamSchema = z.object({ requestId: z.string().min(1) });
+export type RequestIdParam = z.infer<typeof requestIdParamSchema>;
+
+export const grantIdParamSchema = z.object({ grantId: z.string().min(1) });
+export type GrantIdParam = z.infer<typeof grantIdParamSchema>;
+
+// --- Admin queries -------------------------------------------------------
+
+export const listReliefRequestsSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+  status: z
+    .union([requestStatusSchema, z.literal("all")])
+    .default("all")
+    .optional(),
+  search: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+});
+export type ListReliefRequests = z.infer<typeof listReliefRequestsSchema>;
+
+// --- Admin status transitions / decline ----------------------------------
+
+export const transitionStatusSchema = z.object({
+  toStatus: z.enum(["in_review", "more_info_needed"]),
+  note: z.string().max(2000).nullable().optional(),
+});
+export type TransitionStatus = z.infer<typeof transitionStatusSchema>;
+
+export const declineRequestSchema = z.object({
+  memberFacingNote: z.string().max(2000).nullable().optional(),
+  adminNote: z.string().max(2000).nullable().optional(),
+});
+export type DeclineRequest = z.infer<typeof declineRequestSchema>;
+
+// --- Admin decide --------------------------------------------------------
+
+export const decideReliefRequestSchema = z
+  .object({
+    decision: grantDecisionSchema,
+    coversMembership: z.boolean(),
+    coversMatchFees: z.boolean(),
+    membershipPartialPence: z
+      .number()
+      .int()
+      .nonnegative()
+      .nullable()
+      .optional(),
+    effectiveFrom: z.string().min(1), // ISO date
+    effectiveToExclusive: z.string().nullable().optional(),
+    adminNotes: z.string().max(4000).nullable().optional(),
+    memberFacingNote: z.string().max(2000).nullable().optional(),
+  })
+  .refine((d) => d.coversMembership || d.coversMatchFees, {
+    message: "Approval must cover at least one of membership or match fees",
+    path: ["coversMatchFees"],
+  });
+export type DecideReliefRequest = z.infer<typeof decideReliefRequestSchema>;
+
+// --- Close grant ---------------------------------------------------------
+
+export const closeGrantSchema = z.object({
+  reason: z.string().min(1).max(500),
+});
+export type CloseGrant = z.infer<typeof closeGrantSchema>;
+
+// --- Apply membership relief --------------------------------------------
+
+export const applyMembershipReliefSchema = z.object({
+  amountPence: z.number().int().nonnegative(),
+  effectiveDate: z.string().min(1), // ISO date for the synthetic charge
+  membershipPaidUntil: z.string().min(1), // ISO date
+  membershipType: z.string().min(1).max(100),
+  description: z.string().min(1).max(500),
+});
+export type ApplyMembershipRelief = z.infer<typeof applyMembershipReliefSchema>;
+
+// --- Reporting -----------------------------------------------------------
+
+export const reliefReportSchema = z.object({
+  dateFrom: z.string().min(1),
+  dateTo: z.string().min(1),
+});
+export type ReliefReport = z.infer<typeof reliefReportSchema>;
+
+// --- Response schemas ----------------------------------------------------
+
+export const eligibleMembersResponseSchema = z.object({
+  members: z.array(
+    z.object({
+      memberId: z.string(),
+      name: z.string().nullable(),
+      relationship: z.enum(["self", "junior"]),
+    }),
+  ),
+});
+
+const myRequestSummarySchema = z.object({
+  id: z.string(),
+  memberId: z.string(),
+  memberName: z.string().nullable(),
+  status: requestStatusSchema,
+  requestedMembershipFull: z.boolean(),
+  requestedMembershipPartial: z.boolean(),
+  requestedMatchFees: z.boolean(),
+  createdAt: z.string(),
+  memberFacingNote: z.string().nullable(),
+  activeGrant: z
+    .object({
+      decision: grantDecisionSchema,
+      coversMembership: z.boolean(),
+      coversMatchFees: z.boolean(),
+      effectiveFrom: z.string(),
+      effectiveToExclusive: z.string().nullable(),
+    })
+    .nullable(),
+});
+
+export const myReliefStatusResponseSchema = z.object({
+  requests: z.array(myRequestSummarySchema),
+});
+
+const adminRequestRowSchema = z.object({
+  id: z.string(),
+  memberId: z.string(),
+  memberName: z.string().nullable(),
+  memberEmail: z.string(),
+  submittedByUserId: z.string(),
+  submittedByName: z.string().nullable(),
+  submittedByEmail: z.string(),
+  status: requestStatusSchema,
+  requestedMembershipFull: z.boolean(),
+  requestedMembershipPartial: z.boolean(),
+  requestedMatchFees: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  decidedAt: z.string().nullable(),
+  decidedByName: z.string().nullable(),
+});
+
+export const listReliefRequestsResponseSchema = z.object({
+  items: z.array(adminRequestRowSchema),
+  total: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+
+const eventSchema = z.object({
+  id: z.string(),
+  eventType: z.string(),
+  fromStatus: z.string().nullable(),
+  toStatus: z.string().nullable(),
+  note: z.string().nullable(),
+  actorUserId: z.string(),
+  actorName: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const grantDetailSchema = z.object({
+  id: z.string(),
+  decision: grantDecisionSchema,
+  coversMembership: z.boolean(),
+  coversMatchFees: z.boolean(),
+  membershipPartialPence: z.number().nullable(),
+  effectiveFrom: z.string(),
+  effectiveToExclusive: z.string().nullable(),
+  adminNotes: z.string().nullable(),
+  memberFacingNote: z.string().nullable(),
+  decidedBy: z.string(),
+  decidedByName: z.string().nullable(),
+  decidedAt: z.string(),
+  closedAt: z.string().nullable(),
+  closedBy: z.string().nullable(),
+  closedReason: z.string().nullable(),
+});
+
+export const reliefRequestDetailResponseSchema = z.object({
+  request: z.object({
+    id: z.string(),
+    memberId: z.string(),
+    memberName: z.string().nullable(),
+    memberEmail: z.string(),
+    submittedByUserId: z.string(),
+    submittedByName: z.string().nullable(),
+    submittedByEmail: z.string(),
+    status: requestStatusSchema,
+    requestedMembershipFull: z.boolean(),
+    requestedMembershipPartial: z.boolean(),
+    requestedMatchFees: z.boolean(),
+    partialAmountPence: z.number().nullable(),
+    reasonCategory: z.string().nullable(),
+    reasonText: z.string().nullable(),
+    duration: z.string().nullable(),
+    durationOtherText: z.string().nullable(),
+    contributionAbility: z.string().nullable(),
+    contributionAmountPence: z.number().nullable(),
+    volunteerOptions: z.array(z.string()),
+    volunteerNotes: z.string().nullable(),
+    contactPreference: z.string(),
+    privacyAcknowledgedAt: z.string(),
+    declarationConfirmedAt: z.string(),
+    withdrawnAt: z.string().nullable(),
+    withdrawnReason: z.string().nullable(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  }),
+  events: z.array(eventSchema),
+  grant: grantDetailSchema.nullable(),
+});
+
+export const submitReliefRequestResponseSchema = idResponseSchema;
+export const transitionStatusResponseSchema = successResponseSchema;
+export const declineRequestResponseSchema = successResponseSchema;
+export const decideReliefRequestResponseSchema = z.object({
+  grantId: z.string(),
+  forgivenChargeCount: z.number(),
+});
+export const closeGrantResponseSchema = successResponseSchema;
+export const withdrawRequestResponseSchema = successResponseSchema;
+export const applyMembershipReliefResponseSchema = z.object({
+  chargeId: z.string(),
+});
+
+export const reliefReportResponseSchema = z.object({
+  totalForgivenPence: z.number(),
+  byReliefType: z.object({
+    membershipPence: z.number(),
+    matchFeePence: z.number(),
+  }),
+  bySection: z.object({
+    juniors: z.object({
+      pence: z.number(),
+      count: z.number(),
+      members: z.number(),
+    }),
+    womensGirls: z.object({
+      pence: z.number(),
+      count: z.number(),
+      members: z.number(),
+    }),
+    senior: z.object({
+      pence: z.number(),
+      count: z.number(),
+      members: z.number(),
+    }),
+    other: z.object({
+      pence: z.number(),
+      count: z.number(),
+      members: z.number(),
+    }),
+  }),
+  membersSupported: z.number(),
+  forgivenChargeCount: z.number(),
+});

--- a/apps/api/src/features/financial-relief/service.ts
+++ b/apps/api/src/features/financial-relief/service.ts
@@ -1,11 +1,28 @@
 import type { DB } from "@percy-main/db";
+import { FinancialReliefReceived, type Email } from "@percy-main/email";
+import type { RequestStatus } from "@percy-main/shared";
+import { render } from "@react-email/render";
+import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
+import { createElement } from "react";
+import type { SubmitReliefRequest, WithdrawRequest } from "./schemas.ts";
 
 async function notImplemented(): Promise<never> {
   const err = new Error("Not implemented") as Error & { statusCode: number };
   err.statusCode = 501;
   await Promise.resolve();
   throw err;
+}
+
+function httpError(statusCode: number, message: string): never {
+  const err = new Error(message) as Error & { statusCode: number };
+  err.statusCode = statusCode;
+  throw err;
+}
+
+interface SubmitDeps {
+  baseUrl: string;
+  send: (email: Email) => Promise<void>;
 }
 
 /**
@@ -57,16 +74,277 @@ export function getEligibleMembers(db: Kysely<DB>) {
   };
 }
 
-export function submitReliefRequest(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+async function resolveCallerMemberIds(
+  db: Kysely<DB>,
+  email: string,
+): Promise<{ selfMemberId: string; allowed: Set<string> }> {
+  const self = await db
+    .selectFrom("member")
+    .where("email", "=", email)
+    .where("deleted_at", "is", null)
+    .select(["id"])
+    .executeTakeFirst();
+  if (!self) httpError(403, "No member record found for this account");
+
+  const juniors = await db
+    .selectFrom("member_parent_link")
+    .innerJoin("member", "member.id", "member_parent_link.member_id")
+    .where("member_parent_link.parent_member_id", "=", self.id)
+    .where("member.deleted_at", "is", null)
+    .select(["member.id"])
+    .execute();
+
+  return {
+    selfMemberId: self.id,
+    allowed: new Set([self.id, ...juniors.map((j) => j.id)]),
+  };
 }
 
-export function getMyReliefStatus(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+export function submitReliefRequest(db: Kysely<DB>, deps: SubmitDeps) {
+  return async (
+    userId: string,
+    userEmail: string,
+    data: SubmitReliefRequest,
+    log: FastifyBaseLogger,
+  ) => {
+    const { allowed } = await resolveCallerMemberIds(db, userEmail);
+    if (!allowed.has(data.memberId)) {
+      httpError(
+        403,
+        "You can only request relief for yourself or a linked junior",
+      );
+    }
+
+    const targetMember = await db
+      .selectFrom("member")
+      .where("id", "=", data.memberId)
+      .where("deleted_at", "is", null)
+      .select(["id", "email", "name"])
+      .executeTakeFirst();
+    if (!targetMember) httpError(404, "Member not found");
+
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    try {
+      await db
+        .insertInto("financial_relief_request")
+        .values({
+          id,
+          submitted_by_user_id: userId,
+          member_id: data.memberId,
+          status: "submitted",
+          requested_membership_full: data.requestedMembershipFull,
+          requested_membership_partial: data.requestedMembershipPartial,
+          requested_match_fees: data.requestedMatchFees,
+          partial_amount_pence: data.partialAmountPence ?? null,
+          reason_category: data.reasonCategory ?? null,
+          reason_text: data.reasonText ?? null,
+          duration: data.duration ?? null,
+          duration_other_text: data.durationOtherText ?? null,
+          contribution_ability: data.contributionAbility ?? null,
+          contribution_amount_pence: data.contributionAmountPence ?? null,
+          volunteer_options: JSON.stringify(data.volunteerOptions),
+          volunteer_notes: data.volunteerNotes ?? null,
+          contact_preference: data.contactPreference,
+          privacy_acknowledged_at: now,
+          declaration_confirmed_at: now,
+        })
+        .execute();
+    } catch (err: unknown) {
+      // Partial unique index `financial_relief_request_one_open_uidx`
+      // rejects a second open request for the same member.
+      if (
+        err instanceof Error &&
+        err.message.includes("financial_relief_request_one_open_uidx")
+      ) {
+        httpError(409, "There is already an open request for this member");
+      }
+      throw err;
+    }
+
+    // Best-effort receipt email — never blocks submission.
+    try {
+      await deps.send({
+        to: userEmail,
+        subject: FinancialReliefReceived.subject,
+        html: await render(
+          createElement(FinancialReliefReceived.component, {
+            imageBaseUrl: `${deps.baseUrl}/images`,
+            recipientName: targetMember.name ?? "there",
+          }),
+        ),
+      });
+    } catch (err) {
+      log.error(
+        { err, requestId: id },
+        "financial_relief_receipt_email_failed",
+      );
+    }
+
+    return { id };
+  };
 }
 
-export function withdrawReliefRequest(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+export function getMyReliefStatus(db: Kysely<DB>) {
+  return async (userEmail: string) => {
+    const { allowed } = await resolveCallerMemberIds(db, userEmail).catch(
+      () => ({
+        allowed: new Set<string>(),
+      }),
+    );
+    if (allowed.size === 0) return { requests: [] };
+
+    const memberIds = [...allowed];
+
+    // Surface the caller's submissions for themselves and any junior they
+    // can speak for. We omit free-text reason so it's never re-displayed
+    // even if a parent shares their screen — the member dashboard never
+    // shows the application narrative.
+    const requests = await db
+      .selectFrom("financial_relief_request as r")
+      .innerJoin("member as m", "m.id", "r.member_id")
+      .where("r.member_id", "in", memberIds)
+      .where((eb) =>
+        eb.or([
+          eb("r.status", "in", [
+            "submitted",
+            "in_review",
+            "more_info_needed",
+            "approved",
+          ]),
+          // Recently-decided declines/withdrawals: keep visible for 30 days.
+          eb.and([
+            eb("r.status", "in", ["declined", "withdrawn", "expired"]),
+            eb(
+              "r.updated_at",
+              ">=",
+              new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+            ),
+          ]),
+        ]),
+      )
+      .select([
+        "r.id",
+        "r.member_id as memberId",
+        "m.name as memberName",
+        "r.status",
+        "r.requested_membership_full as requestedMembershipFull",
+        "r.requested_membership_partial as requestedMembershipPartial",
+        "r.requested_match_fees as requestedMatchFees",
+        "r.created_at as createdAt",
+      ])
+      .orderBy("r.created_at", "desc")
+      .execute();
+
+    // Pull active grants for these members so the UI can show a
+    // "current support" summary alongside the request that produced it.
+    const grants = await db
+      .selectFrom("financial_relief_grant as g")
+      .where("g.member_id", "in", memberIds)
+      .where("g.closed_at", "is", null)
+      .select([
+        "g.request_id",
+        "g.decision",
+        "g.covers_membership",
+        "g.covers_match_fees",
+        "g.effective_from",
+        "g.effective_to_exclusive",
+        "g.member_facing_note",
+      ])
+      .execute();
+    const grantByRequest = new Map(grants.map((g) => [g.request_id, g]));
+
+    return {
+      requests: requests.map((r) => {
+        const grant = grantByRequest.get(r.id);
+        return {
+          id: r.id,
+          memberId: r.memberId,
+          memberName: r.memberName,
+          status: r.status as RequestStatus,
+          requestedMembershipFull: r.requestedMembershipFull,
+          requestedMembershipPartial: r.requestedMembershipPartial,
+          requestedMatchFees: r.requestedMatchFees,
+          createdAt: toIsoString(r.createdAt),
+          memberFacingNote: grant?.member_facing_note ?? null,
+          activeGrant: grant
+            ? {
+                decision: grant.decision as
+                  | "approved_full"
+                  | "approved_partial"
+                  | "approved_temporary",
+                coversMembership: grant.covers_membership,
+                coversMatchFees: grant.covers_match_fees,
+                effectiveFrom: toIsoString(grant.effective_from),
+                effectiveToExclusive: grant.effective_to_exclusive
+                  ? toIsoString(grant.effective_to_exclusive)
+                  : null,
+              }
+            : null,
+        };
+      }),
+    };
+  };
+}
+
+export function withdrawReliefRequest(db: Kysely<DB>) {
+  return async (
+    userId: string,
+    userEmail: string,
+    requestId: string,
+    data: WithdrawRequest,
+  ) => {
+    const { allowed } = await resolveCallerMemberIds(db, userEmail);
+
+    const request = await db
+      .selectFrom("financial_relief_request")
+      .where("id", "=", requestId)
+      .select(["id", "member_id", "submitted_by_user_id", "status"])
+      .executeTakeFirst();
+    if (!request) httpError(404, "Request not found");
+
+    // Ownership: the caller must either be the submitter, or be entitled
+    // to act on behalf of the supported member (parent of a junior).
+    const isOwner =
+      request.submitted_by_user_id === userId || allowed.has(request.member_id);
+    if (!isOwner) httpError(403, "You cannot withdraw this request");
+
+    if (
+      !["submitted", "in_review", "more_info_needed"].includes(request.status)
+    ) {
+      httpError(400, "This request cannot be withdrawn in its current state");
+    }
+
+    const now = new Date().toISOString();
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .updateTable("financial_relief_request")
+        .set({
+          status: "withdrawn",
+          withdrawn_at: now,
+          withdrawn_reason: data.reason ?? null,
+          updated_at: now,
+        })
+        .where("id", "=", requestId)
+        .execute();
+
+      await trx
+        .insertInto("financial_relief_event")
+        .values({
+          id: crypto.randomUUID(),
+          request_id: requestId,
+          event_type: "withdrawn",
+          from_status: request.status,
+          to_status: "withdrawn",
+          note: data.reason ?? null,
+          actor_user_id: userId,
+        })
+        .execute();
+    });
+
+    return { success: true };
+  };
 }
 
 export function listReliefRequestsForAdmin(_db: Kysely<DB>) {
@@ -99,4 +377,8 @@ export function applyMembershipRelief(_db: Kysely<DB>) {
 
 export function getReliefReport(_db: Kysely<DB>) {
   return async () => await notImplemented();
+}
+
+function toIsoString(v: unknown): string {
+  return v instanceof Date ? v.toISOString() : String(v);
 }

--- a/apps/api/src/features/financial-relief/service.ts
+++ b/apps/api/src/features/financial-relief/service.ts
@@ -5,7 +5,13 @@ import { render } from "@react-email/render";
 import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import { createElement } from "react";
-import type { SubmitReliefRequest, WithdrawRequest } from "./schemas.ts";
+import type {
+  DeclineRequest,
+  ListReliefRequests,
+  SubmitReliefRequest,
+  TransitionStatus,
+  WithdrawRequest,
+} from "./schemas.ts";
 
 async function notImplemented(): Promise<never> {
   const err = new Error("Not implemented") as Error & { statusCode: number };
@@ -347,20 +353,349 @@ export function withdrawReliefRequest(db: Kysely<DB>) {
   };
 }
 
-export function listReliefRequestsForAdmin(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+export function listReliefRequestsForAdmin(db: Kysely<DB>) {
+  return async (params: ListReliefRequests) => {
+    const offset = (params.page - 1) * params.pageSize;
+
+    let baseQuery = db
+      .selectFrom("financial_relief_request as r")
+      .innerJoin("member as m", "m.id", "r.member_id")
+      .innerJoin("user as u", "u.id", "r.submitted_by_user_id");
+
+    if (params.status && params.status !== "all") {
+      baseQuery = baseQuery.where("r.status", "=", params.status);
+    }
+    if (params.dateFrom) {
+      baseQuery = baseQuery.where(
+        "r.created_at",
+        ">=",
+        new Date(params.dateFrom),
+      );
+    }
+    if (params.dateTo) {
+      baseQuery = baseQuery.where(
+        "r.created_at",
+        "<=",
+        new Date(params.dateTo),
+      );
+    }
+    if (params.search) {
+      const like = `%${params.search}%`;
+      baseQuery = baseQuery.where((eb) =>
+        eb.or([
+          eb("m.name", "ilike", like),
+          eb("m.email", "ilike", like),
+          eb("u.name", "ilike", like),
+          eb("u.email", "ilike", like),
+        ]),
+      );
+    }
+
+    const [{ total }, rows, grants] = await Promise.all([
+      baseQuery
+        .select((eb) => eb.fn.countAll<string>().as("total"))
+        .executeTakeFirstOrThrow(),
+      baseQuery
+        .leftJoin("financial_relief_grant as g", (join) =>
+          join.onRef("g.request_id", "=", "r.id"),
+        )
+        .leftJoin("user as decider", "decider.id", "g.decided_by")
+        .select([
+          "r.id",
+          "r.member_id as memberId",
+          "m.name as memberName",
+          "m.email as memberEmail",
+          "r.submitted_by_user_id as submittedByUserId",
+          "u.name as submittedByName",
+          "u.email as submittedByEmail",
+          "r.status",
+          "r.requested_membership_full as requestedMembershipFull",
+          "r.requested_membership_partial as requestedMembershipPartial",
+          "r.requested_match_fees as requestedMatchFees",
+          "r.created_at as createdAt",
+          "r.updated_at as updatedAt",
+          "g.decided_at as decidedAt",
+          "decider.name as decidedByName",
+        ])
+        // Open requests first; within each group, newest first.
+        .orderBy(
+          (eb) =>
+            eb
+              .case()
+              .when("r.status", "in", [
+                "submitted",
+                "in_review",
+                "more_info_needed",
+              ])
+              .then(0)
+              .else(1)
+              .end(),
+          "asc",
+        )
+        .orderBy("r.created_at", "desc")
+        .limit(params.pageSize)
+        .offset(offset)
+        .execute(),
+      // Empty array — grants are loaded inline via leftJoin above. Kept
+      // as a placeholder so future event/grant lookups can join without
+      // a second N+1.
+      Promise.resolve([] as never[]),
+    ]);
+    void grants;
+
+    return {
+      items: rows.map((r) => ({
+        id: r.id,
+        memberId: r.memberId,
+        memberName: r.memberName,
+        memberEmail: r.memberEmail,
+        submittedByUserId: r.submittedByUserId,
+        submittedByName: r.submittedByName,
+        submittedByEmail: r.submittedByEmail,
+        status: r.status as RequestStatus,
+        requestedMembershipFull: r.requestedMembershipFull,
+        requestedMembershipPartial: r.requestedMembershipPartial,
+        requestedMatchFees: r.requestedMatchFees,
+        createdAt: toIsoString(r.createdAt),
+        updatedAt: toIsoString(r.updatedAt),
+        decidedAt: r.decidedAt ? toIsoString(r.decidedAt) : null,
+        decidedByName: r.decidedByName,
+      })),
+      total: Number(total),
+      page: params.page,
+      pageSize: params.pageSize,
+    };
+  };
 }
 
-export function getReliefRequestDetail(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+export function getReliefRequestDetail(db: Kysely<DB>) {
+  return async (requestId: string) => {
+    const request = await db
+      .selectFrom("financial_relief_request as r")
+      .innerJoin("member as m", "m.id", "r.member_id")
+      .innerJoin("user as u", "u.id", "r.submitted_by_user_id")
+      .where("r.id", "=", requestId)
+      .select([
+        "r.id",
+        "r.member_id as memberId",
+        "m.name as memberName",
+        "m.email as memberEmail",
+        "r.submitted_by_user_id as submittedByUserId",
+        "u.name as submittedByName",
+        "u.email as submittedByEmail",
+        "r.status",
+        "r.requested_membership_full as requestedMembershipFull",
+        "r.requested_membership_partial as requestedMembershipPartial",
+        "r.requested_match_fees as requestedMatchFees",
+        "r.partial_amount_pence as partialAmountPence",
+        "r.reason_category as reasonCategory",
+        "r.reason_text as reasonText",
+        "r.duration",
+        "r.duration_other_text as durationOtherText",
+        "r.contribution_ability as contributionAbility",
+        "r.contribution_amount_pence as contributionAmountPence",
+        "r.volunteer_options as volunteerOptions",
+        "r.volunteer_notes as volunteerNotes",
+        "r.contact_preference as contactPreference",
+        "r.privacy_acknowledged_at as privacyAcknowledgedAt",
+        "r.declaration_confirmed_at as declarationConfirmedAt",
+        "r.withdrawn_at as withdrawnAt",
+        "r.withdrawn_reason as withdrawnReason",
+        "r.created_at as createdAt",
+        "r.updated_at as updatedAt",
+      ])
+      .executeTakeFirst();
+    if (!request) httpError(404, "Request not found");
+
+    const events = await db
+      .selectFrom("financial_relief_event as e")
+      .leftJoin("user as u", "u.id", "e.actor_user_id")
+      .where("e.request_id", "=", requestId)
+      .select([
+        "e.id",
+        "e.event_type as eventType",
+        "e.from_status as fromStatus",
+        "e.to_status as toStatus",
+        "e.note",
+        "e.actor_user_id as actorUserId",
+        "u.name as actorName",
+        "e.created_at as createdAt",
+      ])
+      .orderBy("e.created_at", "asc")
+      .execute();
+
+    const grant = await db
+      .selectFrom("financial_relief_grant as g")
+      .leftJoin("user as decider", "decider.id", "g.decided_by")
+      .where("g.request_id", "=", requestId)
+      .where("g.closed_at", "is", null)
+      .select([
+        "g.id",
+        "g.decision",
+        "g.covers_membership as coversMembership",
+        "g.covers_match_fees as coversMatchFees",
+        "g.membership_partial_pence as membershipPartialPence",
+        "g.effective_from as effectiveFrom",
+        "g.effective_to_exclusive as effectiveToExclusive",
+        "g.admin_notes as adminNotes",
+        "g.member_facing_note as memberFacingNote",
+        "g.decided_by as decidedBy",
+        "decider.name as decidedByName",
+        "g.decided_at as decidedAt",
+        "g.closed_at as closedAt",
+        "g.closed_by as closedBy",
+        "g.closed_reason as closedReason",
+      ])
+      .executeTakeFirst();
+
+    return {
+      request: {
+        ...request,
+        status: request.status as RequestStatus,
+        volunteerOptions: Array.isArray(request.volunteerOptions)
+          ? (request.volunteerOptions as string[])
+          : [],
+        privacyAcknowledgedAt: toIsoString(request.privacyAcknowledgedAt),
+        declarationConfirmedAt: toIsoString(request.declarationConfirmedAt),
+        withdrawnAt: request.withdrawnAt
+          ? toIsoString(request.withdrawnAt)
+          : null,
+        createdAt: toIsoString(request.createdAt),
+        updatedAt: toIsoString(request.updatedAt),
+      },
+      events: events.map((e) => ({
+        ...e,
+        createdAt: toIsoString(e.createdAt),
+      })),
+      grant: grant
+        ? {
+            id: grant.id,
+            decision: grant.decision as
+              | "approved_full"
+              | "approved_partial"
+              | "approved_temporary",
+            coversMembership: grant.coversMembership,
+            coversMatchFees: grant.coversMatchFees,
+            membershipPartialPence: grant.membershipPartialPence,
+            effectiveFrom: toIsoString(grant.effectiveFrom),
+            effectiveToExclusive: grant.effectiveToExclusive
+              ? toIsoString(grant.effectiveToExclusive)
+              : null,
+            adminNotes: grant.adminNotes,
+            memberFacingNote: grant.memberFacingNote,
+            decidedBy: grant.decidedBy,
+            decidedByName: grant.decidedByName,
+            decidedAt: toIsoString(grant.decidedAt),
+            closedAt: grant.closedAt ? toIsoString(grant.closedAt) : null,
+            closedBy: grant.closedBy,
+            closedReason: grant.closedReason,
+          }
+        : null,
+    };
+  };
 }
 
-export function transitionReliefRequestStatus(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+export function transitionReliefRequestStatus(db: Kysely<DB>) {
+  return async (
+    adminUserId: string,
+    requestId: string,
+    data: TransitionStatus,
+  ) => {
+    const current = await db
+      .selectFrom("financial_relief_request")
+      .where("id", "=", requestId)
+      .select(["id", "status"])
+      .executeTakeFirst();
+    if (!current) httpError(404, "Request not found");
+
+    // Only meaningful from an "open" state — moving away from a decided/
+    // declined/withdrawn/expired request loses the audit story.
+    if (
+      !["submitted", "in_review", "more_info_needed"].includes(current.status)
+    ) {
+      httpError(400, "Cannot transition a closed request");
+    }
+    if (current.status === data.toStatus) {
+      return { success: true };
+    }
+
+    const now = new Date().toISOString();
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .updateTable("financial_relief_request")
+        .set({ status: data.toStatus, updated_at: now })
+        .where("id", "=", requestId)
+        .execute();
+
+      await trx
+        .insertInto("financial_relief_event")
+        .values({
+          id: crypto.randomUUID(),
+          request_id: requestId,
+          event_type:
+            data.toStatus === "more_info_needed"
+              ? "more_info_requested"
+              : "status_changed",
+          from_status: current.status,
+          to_status: data.toStatus,
+          note: data.note ?? null,
+          actor_user_id: adminUserId,
+        })
+        .execute();
+    });
+
+    return { success: true };
+  };
 }
 
-export function declineReliefRequest(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+export function declineReliefRequest(db: Kysely<DB>) {
+  return async (
+    adminUserId: string,
+    requestId: string,
+    data: DeclineRequest,
+  ) => {
+    const current = await db
+      .selectFrom("financial_relief_request")
+      .where("id", "=", requestId)
+      .select(["id", "status"])
+      .executeTakeFirst();
+    if (!current) httpError(404, "Request not found");
+
+    if (
+      !["submitted", "in_review", "more_info_needed"].includes(current.status)
+    ) {
+      httpError(400, "Cannot decline a request that has already been closed");
+    }
+
+    const now = new Date().toISOString();
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .updateTable("financial_relief_request")
+        .set({ status: "declined", updated_at: now })
+        .where("id", "=", requestId)
+        .execute();
+
+      // Member-facing note is stored on a synthetic event row that the
+      // member-facing API surfaces. (Grants are reserved for approvals;
+      // we don't want a row that says "declined grant".)
+      await trx
+        .insertInto("financial_relief_event")
+        .values({
+          id: crypto.randomUUID(),
+          request_id: requestId,
+          event_type: "declined",
+          from_status: current.status,
+          to_status: "declined",
+          note:
+            data.memberFacingNote ??
+            (data.adminNote ? `[admin] ${data.adminNote}` : null),
+          actor_user_id: adminUserId,
+        })
+        .execute();
+    });
+
+    return { success: true };
+  };
 }
 
 export function decideReliefRequest(_db: Kysely<DB>) {

--- a/apps/api/src/features/financial-relief/service.ts
+++ b/apps/api/src/features/financial-relief/service.ts
@@ -1,11 +1,18 @@
 import type { DB } from "@percy-main/db";
-import { FinancialReliefReceived, type Email } from "@percy-main/email";
+import {
+  FinancialReliefDecision,
+  FinancialReliefReceived,
+  type Email,
+} from "@percy-main/email";
 import type { RequestStatus } from "@percy-main/shared";
 import { render } from "@react-email/render";
 import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import { createElement } from "react";
+import type Stripe from "stripe";
 import type {
+  CloseGrant,
+  DecideReliefRequest,
   DeclineRequest,
   ListReliefRequests,
   SubmitReliefRequest,
@@ -698,12 +705,308 @@ export function declineReliefRequest(db: Kysely<DB>) {
   };
 }
 
-export function decideReliefRequest(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+interface DecideDeps {
+  stripe: Stripe;
+  baseUrl: string;
+  send: (email: Email) => Promise<void>;
 }
 
-export function closeReliefGrant(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+export function decideReliefRequest(db: Kysely<DB>, deps: DecideDeps) {
+  return async (
+    adminUserId: string,
+    requestId: string,
+    data: DecideReliefRequest,
+    log: FastifyBaseLogger,
+  ) => {
+    const request = await db
+      .selectFrom("financial_relief_request as r")
+      .innerJoin("member as m", "m.id", "r.member_id")
+      .innerJoin("user as u", "u.id", "r.submitted_by_user_id")
+      .where("r.id", "=", requestId)
+      .select([
+        "r.id",
+        "r.member_id",
+        "r.status",
+        "u.email as submitterEmail",
+        "m.name as memberName",
+      ])
+      .executeTakeFirst();
+    if (!request) httpError(404, "Request not found");
+    if (
+      !["submitted", "in_review", "more_info_needed"].includes(request.status)
+    ) {
+      httpError(400, "This request has already been closed");
+    }
+
+    const result = await db.transaction().execute(async (trx) => {
+      // Lock the member row so two concurrent decides for the same
+      // member serialise — second one sees the new active grant and
+      // aborts. The UNIQUE INDEX is a belt-and-braces backstop.
+      const member = await trx
+        .selectFrom("member")
+        .where("id", "=", request.member_id)
+        .select(["id", "deleted_at"])
+        .forUpdate()
+        .executeTakeFirstOrThrow();
+      if (member.deleted_at) {
+        httpError(400, "Cannot grant relief to an archived member");
+      }
+
+      // Close any existing active grant for this member (superseded).
+      await trx
+        .updateTable("financial_relief_grant")
+        .set({
+          closed_at: new Date().toISOString(),
+          closed_by: adminUserId,
+          closed_reason: "superseded",
+        })
+        .where("member_id", "=", request.member_id)
+        .where("closed_at", "is", null)
+        .execute();
+
+      const grantId = crypto.randomUUID();
+      try {
+        await trx
+          .insertInto("financial_relief_grant")
+          .values({
+            id: grantId,
+            request_id: requestId,
+            member_id: request.member_id,
+            decision: data.decision,
+            covers_membership: data.coversMembership,
+            covers_match_fees: data.coversMatchFees,
+            membership_partial_pence: data.membershipPartialPence ?? null,
+            effective_from: data.effectiveFrom,
+            effective_to_exclusive: data.effectiveToExclusive ?? null,
+            admin_notes: data.adminNotes ?? null,
+            member_facing_note: data.memberFacingNote ?? null,
+            decided_by: adminUserId,
+          })
+          .execute();
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.message.includes("financial_relief_grant_one_active_uidx")
+        ) {
+          httpError(
+            409,
+            "Another active grant exists for this member; close it first",
+          );
+        }
+        throw err;
+      }
+
+      const now = new Date().toISOString();
+      await trx
+        .updateTable("financial_relief_request")
+        .set({ status: "approved", updated_at: now })
+        .where("id", "=", requestId)
+        .execute();
+
+      await trx
+        .insertInto("financial_relief_event")
+        .values({
+          id: crypto.randomUUID(),
+          request_id: requestId,
+          event_type: "grant_created",
+          from_status: request.status,
+          to_status: "approved",
+          note: null,
+          actor_user_id: adminUserId,
+        })
+        .execute();
+
+      // Retroactively forgive unpaid match-fee charges issued on or
+      // after `effective_from`, with no live Stripe PI. A PI in
+      // 'requires_action' / 'processing' / 'succeeded' could result in
+      // money landing — we skip those rather than relieve them out
+      // from under a successful payment.
+      let forgivenCount = 0;
+      if (data.coversMatchFees) {
+        const candidates = await trx
+          .selectFrom("charge")
+          .where("member_id", "=", request.member_id)
+          .where("type", "=", "match_fee")
+          .where("deleted_at", "is", null)
+          .where("relieved_at", "is", null)
+          .where("paid_at", "is", null)
+          .where("payment_confirmed_at", "is", null)
+          .where("charge_date", ">=", data.effectiveFrom)
+          .select(["id", "stripe_payment_intent_id"])
+          .forUpdate()
+          .execute();
+
+        for (const c of candidates) {
+          if (c.stripe_payment_intent_id) {
+            try {
+              const pi = await deps.stripe.paymentIntents.retrieve(
+                c.stripe_payment_intent_id,
+              );
+              if (
+                !["canceled", "requires_payment_method"].includes(pi.status)
+              ) {
+                continue;
+              }
+              await trx
+                .updateTable("charge")
+                .set({ stripe_payment_intent_id: null })
+                .where("id", "=", c.id)
+                .execute();
+            } catch (err) {
+              log.error(
+                { err, chargeId: c.id, requestId },
+                "financial_relief_pi_retrieve_failed",
+              );
+              continue;
+            }
+          }
+
+          await trx
+            .updateTable("charge")
+            .set({
+              relieved_at: now,
+              relieved_by: adminUserId,
+              relieved_reason: "financial relief",
+              relief_grant_id: grantId,
+            })
+            .where("id", "=", c.id)
+            .where("relieved_at", "is", null)
+            .execute();
+          forgivenCount += 1;
+        }
+      }
+
+      return { grantId, forgivenChargeCount: forgivenCount };
+    });
+
+    // Best-effort decision email.
+    try {
+      await deps.send({
+        to: request.submitterEmail,
+        subject: FinancialReliefDecision.subject,
+        html: await render(
+          createElement(FinancialReliefDecision.component, {
+            imageBaseUrl: `${deps.baseUrl}/images`,
+            recipientName: request.memberName ?? "there",
+            outcome: "approved",
+            memberFacingNote: data.memberFacingNote ?? null,
+          }),
+        ),
+      });
+    } catch (err) {
+      log.error({ err, requestId }, "financial_relief_decision_email_failed");
+    }
+
+    return result;
+  };
+}
+
+export function closeReliefGrant(db: Kysely<DB>) {
+  return async (adminUserId: string, grantId: string, data: CloseGrant) => {
+    const grant = await db
+      .selectFrom("financial_relief_grant")
+      .where("id", "=", grantId)
+      .select(["id", "request_id", "closed_at"])
+      .executeTakeFirst();
+    if (!grant) httpError(404, "Grant not found");
+    if (grant.closed_at) httpError(400, "Grant is already closed");
+
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .updateTable("financial_relief_grant")
+        .set({
+          closed_at: new Date().toISOString(),
+          closed_by: adminUserId,
+          closed_reason: data.reason,
+        })
+        .where("id", "=", grantId)
+        .where("closed_at", "is", null)
+        .execute();
+
+      await trx
+        .insertInto("financial_relief_event")
+        .values({
+          id: crypto.randomUUID(),
+          request_id: grant.request_id,
+          event_type: "grant_closed",
+          from_status: null,
+          to_status: null,
+          note: data.reason,
+          actor_user_id: adminUserId,
+        })
+        .execute();
+    });
+
+    return { success: true };
+  };
+}
+
+/**
+ * Cleanup hook for admin/service.ts archiveMember. Closes any active
+ * grant for the archived member and force-declines any open relief
+ * request. Pass the same Kysely instance the archive runs against.
+ */
+export function closeReliefForArchivedMember(db: Kysely<DB>) {
+  return async (adminUserId: string, memberId: string) => {
+    const now = new Date().toISOString();
+    await db.transaction().execute(async (trx) => {
+      const openGrants = await trx
+        .selectFrom("financial_relief_grant")
+        .where("member_id", "=", memberId)
+        .where("closed_at", "is", null)
+        .select(["id", "request_id"])
+        .execute();
+      for (const g of openGrants) {
+        await trx
+          .updateTable("financial_relief_grant")
+          .set({
+            closed_at: now,
+            closed_by: adminUserId,
+            closed_reason: "member archived",
+          })
+          .where("id", "=", g.id)
+          .execute();
+        await trx
+          .insertInto("financial_relief_event")
+          .values({
+            id: crypto.randomUUID(),
+            request_id: g.request_id,
+            event_type: "grant_closed",
+            from_status: null,
+            to_status: null,
+            note: "member archived",
+            actor_user_id: adminUserId,
+          })
+          .execute();
+      }
+
+      const openRequests = await trx
+        .selectFrom("financial_relief_request")
+        .where("member_id", "=", memberId)
+        .where("status", "in", ["submitted", "in_review", "more_info_needed"])
+        .select(["id", "status"])
+        .execute();
+      for (const r of openRequests) {
+        await trx
+          .updateTable("financial_relief_request")
+          .set({ status: "declined", updated_at: now })
+          .where("id", "=", r.id)
+          .execute();
+        await trx
+          .insertInto("financial_relief_event")
+          .values({
+            id: crypto.randomUUID(),
+            request_id: r.id,
+            event_type: "declined",
+            from_status: r.status,
+            to_status: "declined",
+            note: "member archived",
+            actor_user_id: adminUserId,
+          })
+          .execute();
+      }
+    });
+  };
 }
 
 export function applyMembershipRelief(_db: Kysely<DB>) {

--- a/apps/api/src/features/financial-relief/service.ts
+++ b/apps/api/src/features/financial-relief/service.ts
@@ -1,0 +1,102 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+
+async function notImplemented(): Promise<never> {
+  const err = new Error("Not implemented") as Error & { statusCode: number };
+  err.statusCode = 501;
+  await Promise.resolve();
+  throw err;
+}
+
+/**
+ * Resolves the set of member ids the caller is allowed to submit a relief
+ * request for: their own member record (if any) plus any junior member they
+ * are linked to via member_parent_link.
+ */
+export function getEligibleMembers(db: Kysely<DB>) {
+  return async (callerUserEmail: string) => {
+    const self = await db
+      .selectFrom("member")
+      .where("email", "=", callerUserEmail)
+      .where("deleted_at", "is", null)
+      .select(["id", "name"])
+      .executeTakeFirst();
+
+    const items: Array<{
+      memberId: string;
+      name: string | null;
+      relationship: "self" | "junior";
+    }> = [];
+
+    if (self) {
+      items.push({
+        memberId: self.id,
+        name: self.name,
+        relationship: "self",
+      });
+
+      const juniors = await db
+        .selectFrom("member_parent_link")
+        .innerJoin("member", "member.id", "member_parent_link.member_id")
+        .where("member_parent_link.parent_member_id", "=", self.id)
+        .where("member.deleted_at", "is", null)
+        .select(["member.id", "member.name"])
+        .orderBy("member.name", "asc")
+        .execute();
+
+      for (const j of juniors) {
+        items.push({
+          memberId: j.id,
+          name: j.name,
+          relationship: "junior",
+        });
+      }
+    }
+
+    return { members: items };
+  };
+}
+
+export function submitReliefRequest(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function getMyReliefStatus(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function withdrawReliefRequest(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function listReliefRequestsForAdmin(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function getReliefRequestDetail(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function transitionReliefRequestStatus(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function declineReliefRequest(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function decideReliefRequest(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function closeReliefGrant(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function applyMembershipRelief(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}
+
+export function getReliefReport(_db: Kysely<DB>) {
+  return async () => await notImplemented();
+}

--- a/apps/api/src/features/financial-relief/service.ts
+++ b/apps/api/src/features/financial-relief/service.ts
@@ -11,6 +11,7 @@ import type { Kysely } from "kysely";
 import { createElement } from "react";
 import type Stripe from "stripe";
 import type {
+  ApplyMembershipRelief,
   CloseGrant,
   DecideReliefRequest,
   DeclineRequest,
@@ -1009,8 +1010,120 @@ export function closeReliefForArchivedMember(db: Kysely<DB>) {
   };
 }
 
-export function applyMembershipRelief(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+/**
+ * Manually-applied membership relief.
+ *
+ * Real membership purchases go through Stripe checkout and arrive as
+ * already-paid charge rows via the webhook, so there's no pre-pay
+ * moment for `applyReliefIfAny` to intercept. Instead, when a grant
+ * covers membership, the admin invokes this action to:
+ *   1. insert a relieved `charge` row of the appropriate amount, and
+ *   2. extend the member's membership.paid_until to the chosen date.
+ *
+ * Partial-relief case: the admin uses the existing `createCharge` flow
+ * to bill the member for their share, then this action for the waived
+ * portion.
+ */
+export function applyMembershipRelief(db: Kysely<DB>) {
+  return async (
+    adminUserId: string,
+    grantId: string,
+    data: ApplyMembershipRelief,
+  ) => {
+    const grant = await db
+      .selectFrom("financial_relief_grant")
+      .where("id", "=", grantId)
+      .select([
+        "id",
+        "request_id",
+        "member_id",
+        "covers_membership",
+        "closed_at",
+      ])
+      .executeTakeFirst();
+    if (!grant) httpError(404, "Grant not found");
+    if (grant.closed_at) httpError(400, "Grant is closed");
+    if (!grant.covers_membership) {
+      httpError(400, "This grant does not cover membership");
+    }
+
+    const chargeId = crypto.randomUUID();
+    const nowIso = new Date().toISOString();
+
+    await db.transaction().execute(async (trx) => {
+      // 1. Relieved membership charge — keeps amount_pence for reporting.
+      await trx
+        .insertInto("charge")
+        .values({
+          id: chargeId,
+          member_id: grant.member_id,
+          description: data.description,
+          amount_pence: data.amountPence,
+          charge_date: data.effectiveDate,
+          created_by: adminUserId,
+          type: "membership",
+          source: "financial_relief",
+          relieved_at: nowIso,
+          relieved_by: adminUserId,
+          relieved_reason: "financial relief",
+          relief_grant_id: grantId,
+        })
+        .execute();
+
+      // 2. Upsert membership.paid_until.
+      const existing = await trx
+        .selectFrom("membership")
+        .where("member_id", "=", grant.member_id)
+        .where((eb) =>
+          eb.or([eb("type", "=", data.membershipType), eb("type", "is", null)]),
+        )
+        .select(["id", "type", "paid_until"])
+        .executeTakeFirst();
+
+      if (existing) {
+        // Only extend, never shorten. (Admins occasionally call this
+        // twice in a session; second call shouldn't roll back paid_until.)
+        const nextPaidUntil =
+          new Date(data.membershipPaidUntil) > new Date(existing.paid_until)
+            ? data.membershipPaidUntil
+            : existing.paid_until;
+        await trx
+          .updateTable("membership")
+          .set({
+            paid_until: nextPaidUntil,
+            ...(existing.type ? {} : { type: data.membershipType }),
+          })
+          .where("id", "=", existing.id)
+          .execute();
+      } else {
+        await trx
+          .insertInto("membership")
+          .values({
+            id: crypto.randomUUID(),
+            member_id: grant.member_id,
+            type: data.membershipType,
+            paid_until: data.membershipPaidUntil,
+          })
+          .execute();
+      }
+
+      // 3. Audit event.
+      await trx
+        .insertInto("financial_relief_event")
+        .values({
+          id: crypto.randomUUID(),
+          request_id: grant.request_id,
+          event_type: "membership_relief_applied",
+          from_status: null,
+          to_status: null,
+          note: `${data.membershipType} until ${data.membershipPaidUntil} (£${(data.amountPence / 100).toFixed(2)})`,
+          actor_user_id: adminUserId,
+        })
+        .execute();
+    });
+
+    return { chargeId };
+  };
 }
 
 export function getReliefReport(_db: Kysely<DB>) {

--- a/apps/api/src/features/financial-relief/service.ts
+++ b/apps/api/src/features/financial-relief/service.ts
@@ -7,7 +7,7 @@ import {
 import type { RequestStatus } from "@percy-main/shared";
 import { render } from "@react-email/render";
 import type { FastifyBaseLogger } from "fastify";
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import { createElement } from "react";
 import type Stripe from "stripe";
 import type {
@@ -16,17 +16,11 @@ import type {
   DecideReliefRequest,
   DeclineRequest,
   ListReliefRequests,
+  ReliefReport,
   SubmitReliefRequest,
   TransitionStatus,
   WithdrawRequest,
 } from "./schemas.ts";
-
-async function notImplemented(): Promise<never> {
-  const err = new Error("Not implemented") as Error & { statusCode: number };
-  err.statusCode = 501;
-  await Promise.resolve();
-  throw err;
-}
 
 function httpError(statusCode: number, message: string): never {
   const err = new Error(message) as Error & { statusCode: number };
@@ -1126,8 +1120,132 @@ export function applyMembershipRelief(db: Kysely<DB>) {
   };
 }
 
-export function getReliefReport(_db: Kysely<DB>) {
-  return async () => await notImplemented();
+/**
+ * Aggregated relief totals for a date range. Sums the reporting value
+ * across relieved charges:
+ *   reporting_value = COALESCE(original_amount_pence, amount_pence)
+ * which equals the original full charge for partial relief and just
+ * amount_pence for full relief.
+ *
+ * Section breakdown is heuristic:
+ *   - match fees → group by the linked matchday's play_cricket_team
+ *     (junior team flag), women's/girls' inferred from team name
+ *   - membership → group by member.member_category
+ * Other rows roll up to "other".
+ *
+ * Public-facing report consumers (e.g. an annual write-up) should use
+ * the aggregate fields only — no member names or notes are returned.
+ */
+export function getReliefReport(db: Kysely<DB>) {
+  return async (params: ReliefReport) => {
+    const reportingValue = sql<string>`COALESCE(charge.original_amount_pence, charge.amount_pence)`;
+
+    const rows = await db
+      .selectFrom("charge")
+      .innerJoin("member", "member.id", "charge.member_id")
+      .leftJoin("matchday_player", "matchday_player.charge_id", "charge.id")
+      .leftJoin("matchday", "matchday.id", "matchday_player.matchday_id")
+      .leftJoin(
+        "play_cricket_team",
+        "play_cricket_team.id",
+        "matchday.play_cricket_team_id",
+      )
+      .where("charge.relieved_at", "is not", null)
+      .where("charge.relieved_at", ">=", params.dateFrom)
+      .where("charge.relieved_at", "<=", params.dateTo)
+      .select([
+        "charge.id as id",
+        "charge.member_id as memberId",
+        "charge.type as type",
+        sql<string>`${reportingValue}`.as("pence"),
+        "member.member_category as memberCategory",
+        "play_cricket_team.is_junior as teamIsJunior",
+        "play_cricket_team.name as teamName",
+      ])
+      .execute();
+
+    function classifySection(
+      row: (typeof rows)[number],
+    ): "juniors" | "womensGirls" | "senior" | "other" {
+      if (row.type === "match_fee") {
+        if (row.teamIsJunior) return "juniors";
+        if (
+          row.teamName &&
+          /\b(women|womens|ladies|girls)\b/i.test(row.teamName)
+        ) {
+          return "womensGirls";
+        }
+        return "senior";
+      }
+      if (
+        row.type === "membership" ||
+        row.type === "junior_membership" ||
+        row.type === "junior_registration"
+      ) {
+        const cat = row.memberCategory ?? "";
+        if (
+          row.type === "junior_membership" ||
+          row.type === "junior_registration" ||
+          cat.startsWith("junior")
+        ) {
+          return "juniors";
+        }
+        if (/women|girls/i.test(cat)) return "womensGirls";
+        return "senior";
+      }
+      return "other";
+    }
+
+    const buckets = {
+      juniors: { pence: 0, count: 0, members: new Set<string>() },
+      womensGirls: { pence: 0, count: 0, members: new Set<string>() },
+      senior: { pence: 0, count: 0, members: new Set<string>() },
+      other: { pence: 0, count: 0, members: new Set<string>() },
+    };
+
+    let totalForgivenPence = 0;
+    let membershipPence = 0;
+    let matchFeePence = 0;
+    const allMembers = new Set<string>();
+
+    for (const row of rows) {
+      const pence = Number(row.pence);
+      totalForgivenPence += pence;
+      if (row.type === "match_fee") matchFeePence += pence;
+      else if (
+        row.type === "membership" ||
+        row.type === "junior_membership" ||
+        row.type === "junior_registration"
+      ) {
+        membershipPence += pence;
+      }
+      const section = classifySection(row);
+      buckets[section].pence += pence;
+      buckets[section].count += 1;
+      buckets[section].members.add(row.memberId);
+      allMembers.add(row.memberId);
+    }
+
+    function freezeBucket(b: typeof buckets.juniors) {
+      return { pence: b.pence, count: b.count, members: b.members.size };
+    }
+
+    return {
+      totalForgivenPence,
+      byReliefType: {
+        membershipPence,
+        matchFeePence,
+      },
+      bySection: {
+        juniors: freezeBucket(buckets.juniors),
+        womensGirls: freezeBucket(buckets.womensGirls),
+        senior: freezeBucket(buckets.senior),
+        other: freezeBucket(buckets.other),
+      },
+      membersSupported: allMembers.size,
+      forgivenChargeCount: rows.length,
+    };
+  };
 }
 
 function toIsoString(v: unknown): string {

--- a/apps/api/src/features/matchday/schemas.ts
+++ b/apps/api/src/features/matchday/schemas.ts
@@ -192,6 +192,10 @@ const matchdayPlayerSchema = z.object({
   created_at: z.string(),
   member_category: z.string().nullable(),
   chargePaidAt: z.string().nullable(),
+  // Neutral, captain-facing status. Relief is reported as "waived"
+  // without naming the financial-relief mechanism — the application
+  // text and the grant note are never returned here.
+  chargeStatus: z.enum(["unpaid", "paid", "waived"]).nullable(),
   is_captain: z.boolean(),
   is_wicketkeeper: z.boolean(),
 });

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -222,6 +222,7 @@ export function getMatch(db: Kysely<DB>) {
           "matchday_player.is_wicketkeeper",
           "member.member_category",
           "charge.paid_at as chargePaidAt",
+          "charge.relieved_at as chargeRelievedAt",
         ])
         .orderBy("matchday_player.created_at", "asc")
         .execute(),
@@ -233,7 +234,28 @@ export function getMatch(db: Kysely<DB>) {
         .execute(),
     ]);
 
-    return { matchday: match, team: team ?? null, players, expenses };
+    // Derive a neutral status for the captain — never leak the
+    // relief audit columns themselves over this endpoint.
+    const projectedPlayers = players.map(
+      ({ chargeRelievedAt, chargePaidAt, ...rest }) => ({
+        ...rest,
+        chargePaidAt,
+        chargeStatus: !rest.charge_id
+          ? null
+          : chargePaidAt
+            ? ("paid" as const)
+            : chargeRelievedAt
+              ? ("waived" as const)
+              : ("unpaid" as const),
+      }),
+    );
+
+    return {
+      matchday: match,
+      team: team ?? null,
+      players: projectedPlayers,
+      expenses,
+    };
   };
 }
 

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -10,6 +10,7 @@ import {
 import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import type { S3Uploader } from "../../lib/s3-upload.ts";
+import { applyReliefIfAny } from "../financial-relief/apply-relief.ts";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 import type {
   AddPlayer,
@@ -755,11 +756,11 @@ export function confirmTeam(db: Kysely<DB>) {
         .selectAll()
         .execute();
 
+      const applyRelief = applyReliefIfAny(trx);
       for (const player of playingPlayers) {
         if (!player.member_id) continue;
 
         const category = player.member_category ?? "guest";
-        if (category === "bursary") continue;
 
         const rate = findFeeRate(
           feeRates,
@@ -790,6 +791,16 @@ export function confirmTeam(db: Kysely<DB>) {
           .set({ charge_id: chargeId })
           .where("id", "=", player.matchdayPlayerId)
           .execute();
+
+        // Auto-forgive if this member has an active relief grant
+        // covering match fees on this date. The charge keeps its
+        // amount_pence so reporting can still sum it.
+        await applyRelief({
+          chargeId,
+          memberId: player.member_id,
+          type: "match_fee",
+          chargeDate: matchday.match_date,
+        });
       }
     });
 
@@ -920,6 +931,8 @@ export function markFeePaid(db: Kysely<DB>) {
       })
       .where("id", "=", player.charge_id)
       .where("paid_at", "is", null)
+      // Captain shouldn't be marking a waived charge paid.
+      .where("relieved_at", "is", null)
       .execute();
 
     return { success: true };
@@ -955,15 +968,17 @@ export function cancelMatchday(db: Kysely<DB>) {
       );
     }
 
-    // Block if any non-deleted match-fee charge already exists. The
-    // user-facing rule is "close off without charging" — if charges
-    // already exist, treasurer needs to void/refund them through the
-    // normal flow first.
+    // Block if any non-deleted, non-relieved match-fee charge already
+    // exists. The user-facing rule is "close off without charging" — if
+    // unpaid charges already exist, treasurer needs to void/refund them
+    // through the normal flow first. Relieved charges carry no debt and
+    // are safe to leave in place when cancelling.
     const existingCharge = await db
       .selectFrom("matchday_player")
       .innerJoin("charge", "charge.id", "matchday_player.charge_id")
       .where("matchday_player.matchday_id", "=", matchdayId)
       .where("charge.deleted_at", "is", null)
+      .where("charge.relieved_at", "is", null)
       .select("charge.id")
       .executeTakeFirst();
 
@@ -1081,10 +1096,10 @@ export function finishMatch(
           .selectAll()
           .execute();
 
+        const applyRelief = applyReliefIfAny(db);
         for (const player of uncharged) {
           if (!player.member_id) continue;
           const category = player.member_category ?? "guest";
-          if (category === "bursary") continue;
 
           const rate = findFeeRate(
             feeRates,
@@ -1115,6 +1130,13 @@ export function finishMatch(
             .set({ charge_id: chargeId })
             .where("id", "=", player.matchdayPlayerId)
             .execute();
+
+          await applyRelief({
+            chargeId,
+            memberId: player.member_id,
+            type: "match_fee",
+            chargeDate: matchday.match_date,
+          });
         }
       }
 
@@ -1126,6 +1148,8 @@ export function finishMatch(
         .where("matchday_player.matchday_id", "=", matchdayId)
         .where("charge.paid_at", "is", null)
         .where("charge.deleted_at", "is", null)
+        // Don't nag members about charges the club has waived.
+        .where("charge.relieved_at", "is", null)
         .select([
           "member.name as member_name",
           "member.email as member_email",

--- a/apps/api/src/features/payments/webhook-service.ts
+++ b/apps/api/src/features/payments/webhook-service.ts
@@ -492,10 +492,15 @@ export function handlePaymentIntentSucceeded({
   ) {
     const paidAt = stripeDate(paymentIntent.created);
 
+    // A charge can be relieved *while* a payment is in flight. We must
+    // not flip `paid_at` on a now-relieved row — the Stripe payment will
+    // need to be refunded out-of-band by the treasurer. Filter both at
+    // select-time AND in the update predicate so a race can't slip past.
     const charges = await db
       .selectFrom("charge")
       .where("stripe_payment_intent_id", "=", paymentIntent.id)
       .where("paid_at", "is", null)
+      .where("relieved_at", "is", null)
       .select(["id", "member_id"])
       .execute();
 
@@ -513,6 +518,7 @@ export function handlePaymentIntentSucceeded({
         .set({ paid_at: paidAt.toISOString() })
         .where("id", "=", ch.id)
         .where("paid_at", "is", null)
+        .where("relieved_at", "is", null)
         .execute();
     }
 

--- a/apps/api/src/features/treasurer/service.ts
+++ b/apps/api/src/features/treasurer/service.ts
@@ -299,6 +299,8 @@ export function getOutstandingPayments(db: Kysely<DB>) {
         .where("charge.paid_at", "is", null)
         .where("charge.payment_confirmed_at", "is", null)
         .where("charge.deleted_at", "is", null)
+        // Relieved charges are not outstanding debt.
+        .where("charge.relieved_at", "is", null)
         .select([
           "charge.id",
           "charge.type",
@@ -317,6 +319,7 @@ export function getOutstandingPayments(db: Kysely<DB>) {
         .where("paid_at", "is", null)
         .where("payment_confirmed_at", "is", null)
         .where("deleted_at", "is", null)
+        .where("relieved_at", "is", null)
         .select(db.fn.countAll().as("total"))
         .executeTakeFirst(),
     ]);

--- a/apps/web/src/components/members/financial-relief-status.tsx
+++ b/apps/web/src/components/members/financial-relief-status.tsx
@@ -1,10 +1,5 @@
 import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { api, callApi } from "@/lib/api-client";
 import { REQUEST_STATUS_LABELS } from "@percy-main/shared";
 import { useQuery } from "@tanstack/react-query";
@@ -64,7 +59,10 @@ export function FinancialReliefStatus() {
               <p className="text-stone-700">
                 Support is in place
                 {r.activeGrant.coversMatchFees ? " for match donations" : ""}
-                {r.activeGrant.coversMembership ? " for membership" : ""}.
+                {r.activeGrant.coversMembership
+                  ? " for membership donations"
+                  : ""}
+                .
               </p>
             ) : null}
           </div>

--- a/apps/web/src/components/members/financial-relief-status.tsx
+++ b/apps/web/src/components/members/financial-relief-status.tsx
@@ -1,0 +1,75 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { api, callApi } from "@/lib/api-client";
+import { REQUEST_STATUS_LABELS } from "@percy-main/shared";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router";
+
+/**
+ * Members area: surface the caller's relief request(s) at the top of
+ * the Payments tab when any exist, or a discreet "ask for relief" link
+ * when none do. The form page itself lives at /members/financial-relief.
+ *
+ * Owning both states here keeps the dashboard tab dumb and stops a
+ * confusing "you already have an open request, but here's a button to
+ * make another one" appearing for members mid-review.
+ */
+export function FinancialReliefStatus() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["financial-relief", "me"],
+    queryFn: () => callApi(api.GET("/api/financial-relief/me")),
+  });
+
+  if (isLoading) return null;
+
+  const requests = data?.requests ?? [];
+
+  if (requests.length === 0) {
+    return (
+      <p className="text-xs text-stone-600">
+        Struggling with fees?{" "}
+        <Link
+          className="text-blue-900 underline"
+          to="/members/financial-relief"
+        >
+          Ask the club about financial relief.
+        </Link>
+      </p>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Your financial relief</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {requests.map((r) => (
+          <div key={r.id} className="flex flex-col gap-1 text-sm">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium">{r.memberName ?? "—"}</span>
+              <Badge variant="secondary">
+                {REQUEST_STATUS_LABELS[r.status]}
+              </Badge>
+            </div>
+            {r.memberFacingNote ? (
+              <p className="text-stone-700">{r.memberFacingNote}</p>
+            ) : null}
+            {r.activeGrant ? (
+              <p className="text-stone-700">
+                Support is in place
+                {r.activeGrant.coversMatchFees ? " for match donations" : ""}
+                {r.activeGrant.coversMembership ? " for membership" : ""}.
+              </p>
+            ) : null}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/require-verified-email.tsx
+++ b/apps/web/src/components/require-verified-email.tsx
@@ -1,20 +1,25 @@
-import { Navigate, Outlet } from "react-router";
+import { Navigate, Outlet, useLocation } from "react-router";
 import { useSession } from "../lib/auth-client.js";
 import { PageLoading } from "./page-loading.js";
 
 export function RequireVerifiedEmail() {
   const { data: session, isPending } = useSession();
+  const location = useLocation();
 
   if (isPending) {
     return <PageLoading />;
   }
 
+  // Preserve the originally-requested destination across the bounce so
+  // a deep link survives the registered → login → verified-email flow.
+  const returnTo = encodeURIComponent(location.pathname + location.search);
+
   if (!session) {
-    return <Navigate to="/auth/login" replace />;
+    return <Navigate to={`/auth/login?returnTo=${returnTo}`} replace />;
   }
 
   if (!session.user.emailVerified) {
-    return <Navigate to="/auth/registered" replace />;
+    return <Navigate to={`/auth/registered?returnTo=${returnTo}`} replace />;
   }
 
   return <Outlet />;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -6979,7 +6979,7 @@ export interface paths {
                 query?: {
                     page?: number;
                     pageSize?: number;
-                    status?: "all" | "unpaid" | "pending" | "paid" | "abandoned";
+                    status?: "all" | "unpaid" | "pending" | "paid" | "abandoned" | "relieved";
                     showDeleted?: boolean;
                     dateFrom?: string;
                     dateTo?: string;
@@ -7012,6 +7012,7 @@ export interface paths {
                                 source: string;
                                 deletedAt: string | null;
                                 deletedReason: string | null;
+                                relievedAt: string | null;
                                 memberName: string | null;
                                 memberEmail: string;
                                 memberCategory: string | null;
@@ -7021,7 +7022,7 @@ export interface paths {
                                     email: string;
                                 }[];
                                 /** @enum {string} */
-                                status: "paid" | "pending" | "unpaid" | "abandoned" | "deleted";
+                                status: "paid" | "pending" | "unpaid" | "abandoned" | "deleted" | "relieved";
                             }[];
                             total: number;
                             page: number;
@@ -8020,7 +8021,7 @@ export interface paths {
                                 charge_stripe_payment_intent_id: string | null;
                                 charge_created_at: string | null;
                                 /** @enum {string|null} */
-                                charge_status: "paid" | "pending" | "unpaid" | "abandoned" | "deleted" | null;
+                                charge_status: "paid" | "pending" | "unpaid" | "abandoned" | "deleted" | "relieved" | null;
                             }[];
                             expenses: {
                                 id: string;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -4117,6 +4117,8 @@ export interface paths {
                                 created_at: string;
                                 member_category: string | null;
                                 chargePaidAt: string | null;
+                                /** @enum {string|null} */
+                                chargeStatus: "unpaid" | "paid" | "waived" | null;
                                 is_captain: boolean;
                                 is_wicketkeeper: boolean;
                             }[];

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -11160,6 +11160,683 @@ export interface paths {
         };
         trace?: never;
     };
+    "/api/financial-relief/eligible-members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            members: {
+                                memberId: string;
+                                name: string | null;
+                                /** @enum {string} */
+                                relationship: "self" | "junior";
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/financial-relief/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            requests: {
+                                id: string;
+                                memberId: string;
+                                memberName: string | null;
+                                /** @enum {string} */
+                                status: "submitted" | "in_review" | "more_info_needed" | "approved" | "declined" | "withdrawn" | "expired";
+                                requestedMembershipFull: boolean;
+                                requestedMembershipPartial: boolean;
+                                requestedMatchFees: boolean;
+                                createdAt: string;
+                                memberFacingNote: string | null;
+                                activeGrant: {
+                                    /** @enum {string} */
+                                    decision: "approved_full" | "approved_partial" | "approved_temporary";
+                                    coversMembership: boolean;
+                                    coversMatchFees: boolean;
+                                    effectiveFrom: string;
+                                    effectiveToExclusive: string | null;
+                                } | null;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/financial-relief/requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        memberId: string;
+                        requestedMembershipFull: boolean;
+                        requestedMembershipPartial: boolean;
+                        requestedMatchFees: boolean;
+                        partialAmountPence?: number | null;
+                        /** @enum {string|null} */
+                        reasonCategory?: "cost_of_living" | "low_income" | "temporary_change" | "multiple_family" | "unemployment" | "caring" | "other_personal" | "prefer_not_to_say" | null;
+                        reasonText?: string | null;
+                        /** @enum {string|null} */
+                        duration?: "one_off" | "one_to_three_months" | "season" | "unsure" | "other" | null;
+                        durationOtherText?: string | null;
+                        /** @enum {string|null} */
+                        contributionAbility?: "yes_reduced" | "not_currently" | "unsure" | null;
+                        contributionAmountPence?: number | null;
+                        /** @default [] */
+                        volunteerOptions?: ("ground_work" | "scoring" | "umpiring" | "junior_sessions" | "womens_girls" | "bbq_kitchen" | "fundraising" | "social_media" | "admin" | "matchday_setup" | "transport" | "other" | "none")[];
+                        volunteerNotes?: string | null;
+                        /** @enum {string} */
+                        contactPreference: "none" | "email" | "phone" | "in_person";
+                        /** @enum {boolean} */
+                        privacyAcknowledged: true;
+                        /** @enum {boolean} */
+                        declarationConfirmed: true;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/financial-relief/requests/{requestId}/withdraw": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        reason?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/financial-relief/requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    page?: number;
+                    pageSize?: number;
+                    status?: ("submitted" | "in_review" | "more_info_needed" | "approved" | "declined" | "withdrawn" | "expired") | "all";
+                    search?: string;
+                    dateFrom?: string;
+                    dateTo?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                memberId: string;
+                                memberName: string | null;
+                                memberEmail: string;
+                                submittedByUserId: string;
+                                submittedByName: string | null;
+                                submittedByEmail: string;
+                                /** @enum {string} */
+                                status: "submitted" | "in_review" | "more_info_needed" | "approved" | "declined" | "withdrawn" | "expired";
+                                requestedMembershipFull: boolean;
+                                requestedMembershipPartial: boolean;
+                                requestedMatchFees: boolean;
+                                createdAt: string;
+                                updatedAt: string;
+                                decidedAt: string | null;
+                                decidedByName: string | null;
+                            }[];
+                            total: number;
+                            page: number;
+                            pageSize: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/financial-relief/requests/{requestId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            request: {
+                                id: string;
+                                memberId: string;
+                                memberName: string | null;
+                                memberEmail: string;
+                                submittedByUserId: string;
+                                submittedByName: string | null;
+                                submittedByEmail: string;
+                                /** @enum {string} */
+                                status: "submitted" | "in_review" | "more_info_needed" | "approved" | "declined" | "withdrawn" | "expired";
+                                requestedMembershipFull: boolean;
+                                requestedMembershipPartial: boolean;
+                                requestedMatchFees: boolean;
+                                partialAmountPence: number | null;
+                                reasonCategory: string | null;
+                                reasonText: string | null;
+                                duration: string | null;
+                                durationOtherText: string | null;
+                                contributionAbility: string | null;
+                                contributionAmountPence: number | null;
+                                volunteerOptions: string[];
+                                volunteerNotes: string | null;
+                                contactPreference: string;
+                                privacyAcknowledgedAt: string;
+                                declarationConfirmedAt: string;
+                                withdrawnAt: string | null;
+                                withdrawnReason: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                            };
+                            events: {
+                                id: string;
+                                eventType: string;
+                                fromStatus: string | null;
+                                toStatus: string | null;
+                                note: string | null;
+                                actorUserId: string;
+                                actorName: string | null;
+                                createdAt: string;
+                            }[];
+                            grant: {
+                                id: string;
+                                /** @enum {string} */
+                                decision: "approved_full" | "approved_partial" | "approved_temporary";
+                                coversMembership: boolean;
+                                coversMatchFees: boolean;
+                                membershipPartialPence: number | null;
+                                effectiveFrom: string;
+                                effectiveToExclusive: string | null;
+                                adminNotes: string | null;
+                                memberFacingNote: string | null;
+                                decidedBy: string;
+                                decidedByName: string | null;
+                                decidedAt: string;
+                                closedAt: string | null;
+                                closedBy: string | null;
+                                closedReason: string | null;
+                            } | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/financial-relief/requests/{requestId}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        toStatus: "in_review" | "more_info_needed";
+                        note?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/financial-relief/requests/{requestId}/decline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        memberFacingNote?: string | null;
+                        adminNote?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/financial-relief/requests/{requestId}/decide": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        decision: "approved_full" | "approved_partial" | "approved_temporary";
+                        coversMembership: boolean;
+                        coversMatchFees: boolean;
+                        membershipPartialPence?: number | null;
+                        effectiveFrom: string;
+                        effectiveToExclusive?: string | null;
+                        adminNotes?: string | null;
+                        memberFacingNote?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            grantId: string;
+                            forgivenChargeCount: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/financial-relief/grants/{grantId}/close": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    grantId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        reason: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/financial-relief/grants/{grantId}/apply-membership": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    grantId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        amountPence: number;
+                        effectiveDate: string;
+                        membershipPaidUntil: string;
+                        membershipType: string;
+                        description: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            chargeId: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/financial-relief/report": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    dateFrom: string;
+                    dateTo: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            totalForgivenPence: number;
+                            byReliefType: {
+                                membershipPence: number;
+                                matchFeePence: number;
+                            };
+                            bySection: {
+                                juniors: {
+                                    pence: number;
+                                    count: number;
+                                    members: number;
+                                };
+                                womensGirls: {
+                                    pence: number;
+                                    count: number;
+                                    members: number;
+                                };
+                                senior: {
+                                    pence: number;
+                                    count: number;
+                                    members: number;
+                                };
+                                other: {
+                                    pence: number;
+                                    count: number;
+                                    members: number;
+                                };
+                            };
+                            membersSupported: number;
+                            forgivenChargeCount: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/leads": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -19906,6 +19906,1400 @@
         }
       }
     },
+    "/api/financial-relief/eligible-members": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "members": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "memberId": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "relationship": {
+                            "type": "string",
+                            "enum": [
+                              "self",
+                              "junior"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "memberId",
+                          "name",
+                          "relationship"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "members"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial-relief/me": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "requests": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "memberId": {
+                            "type": "string"
+                          },
+                          "memberName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "submitted",
+                              "in_review",
+                              "more_info_needed",
+                              "approved",
+                              "declined",
+                              "withdrawn",
+                              "expired"
+                            ]
+                          },
+                          "requestedMembershipFull": {
+                            "type": "boolean"
+                          },
+                          "requestedMembershipPartial": {
+                            "type": "boolean"
+                          },
+                          "requestedMatchFees": {
+                            "type": "boolean"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "memberFacingNote": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "activeGrant": {
+                            "nullable": true,
+                            "type": "object",
+                            "properties": {
+                              "decision": {
+                                "type": "string",
+                                "enum": [
+                                  "approved_full",
+                                  "approved_partial",
+                                  "approved_temporary"
+                                ]
+                              },
+                              "coversMembership": {
+                                "type": "boolean"
+                              },
+                              "coversMatchFees": {
+                                "type": "boolean"
+                              },
+                              "effectiveFrom": {
+                                "type": "string"
+                              },
+                              "effectiveToExclusive": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "decision",
+                              "coversMembership",
+                              "coversMatchFees",
+                              "effectiveFrom",
+                              "effectiveToExclusive"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "memberId",
+                          "memberName",
+                          "status",
+                          "requestedMembershipFull",
+                          "requestedMembershipPartial",
+                          "requestedMatchFees",
+                          "createdAt",
+                          "memberFacingNote",
+                          "activeGrant"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "requests"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial-relief/requests": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "memberId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "requestedMembershipFull": {
+                    "type": "boolean"
+                  },
+                  "requestedMembershipPartial": {
+                    "type": "boolean"
+                  },
+                  "requestedMatchFees": {
+                    "type": "boolean"
+                  },
+                  "partialAmountPence": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "reasonCategory": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": [
+                      "cost_of_living",
+                      "low_income",
+                      "temporary_change",
+                      "multiple_family",
+                      "unemployment",
+                      "caring",
+                      "other_personal",
+                      "prefer_not_to_say"
+                    ]
+                  },
+                  "reasonText": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "duration": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": [
+                      "one_off",
+                      "one_to_three_months",
+                      "season",
+                      "unsure",
+                      "other"
+                    ]
+                  },
+                  "durationOtherText": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 500
+                  },
+                  "contributionAbility": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": [
+                      "yes_reduced",
+                      "not_currently",
+                      "unsure"
+                    ]
+                  },
+                  "contributionAmountPence": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "volunteerOptions": {
+                    "default": [],
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "ground_work",
+                        "scoring",
+                        "umpiring",
+                        "junior_sessions",
+                        "womens_girls",
+                        "bbq_kitchen",
+                        "fundraising",
+                        "social_media",
+                        "admin",
+                        "matchday_setup",
+                        "transport",
+                        "other",
+                        "none"
+                      ]
+                    }
+                  },
+                  "volunteerNotes": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "contactPreference": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "email",
+                      "phone",
+                      "in_person"
+                    ]
+                  },
+                  "privacyAcknowledged": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  },
+                  "declarationConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "memberId",
+                  "requestedMembershipFull",
+                  "requestedMembershipPartial",
+                  "requestedMatchFees",
+                  "contactPreference",
+                  "privacyAcknowledged",
+                  "declarationConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/financial-relief/requests/{requestId}/withdraw": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 500
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/financial-relief/requests": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": "all",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "submitted",
+                    "in_review",
+                    "more_info_needed",
+                    "approved",
+                    "declined",
+                    "withdrawn",
+                    "expired"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "all"
+                  ]
+                }
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateFrom",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateTo",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "memberId": {
+                            "type": "string"
+                          },
+                          "memberName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "memberEmail": {
+                            "type": "string"
+                          },
+                          "submittedByUserId": {
+                            "type": "string"
+                          },
+                          "submittedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "submittedByEmail": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "submitted",
+                              "in_review",
+                              "more_info_needed",
+                              "approved",
+                              "declined",
+                              "withdrawn",
+                              "expired"
+                            ]
+                          },
+                          "requestedMembershipFull": {
+                            "type": "boolean"
+                          },
+                          "requestedMembershipPartial": {
+                            "type": "boolean"
+                          },
+                          "requestedMatchFees": {
+                            "type": "boolean"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "decidedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "decidedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "memberId",
+                          "memberName",
+                          "memberEmail",
+                          "submittedByUserId",
+                          "submittedByName",
+                          "submittedByEmail",
+                          "status",
+                          "requestedMembershipFull",
+                          "requestedMembershipPartial",
+                          "requestedMatchFees",
+                          "createdAt",
+                          "updatedAt",
+                          "decidedAt",
+                          "decidedByName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "page": {
+                      "type": "number"
+                    },
+                    "pageSize": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "total",
+                    "page",
+                    "pageSize"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/financial-relief/requests/{requestId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "request": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "memberId": {
+                          "type": "string"
+                        },
+                        "memberName": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "memberEmail": {
+                          "type": "string"
+                        },
+                        "submittedByUserId": {
+                          "type": "string"
+                        },
+                        "submittedByName": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "submittedByEmail": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "submitted",
+                            "in_review",
+                            "more_info_needed",
+                            "approved",
+                            "declined",
+                            "withdrawn",
+                            "expired"
+                          ]
+                        },
+                        "requestedMembershipFull": {
+                          "type": "boolean"
+                        },
+                        "requestedMembershipPartial": {
+                          "type": "boolean"
+                        },
+                        "requestedMatchFees": {
+                          "type": "boolean"
+                        },
+                        "partialAmountPence": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "reasonCategory": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "reasonText": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "duration": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "durationOtherText": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "contributionAbility": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "contributionAmountPence": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "volunteerOptions": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "volunteerNotes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "contactPreference": {
+                          "type": "string"
+                        },
+                        "privacyAcknowledgedAt": {
+                          "type": "string"
+                        },
+                        "declarationConfirmedAt": {
+                          "type": "string"
+                        },
+                        "withdrawnAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "withdrawnReason": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "memberId",
+                        "memberName",
+                        "memberEmail",
+                        "submittedByUserId",
+                        "submittedByName",
+                        "submittedByEmail",
+                        "status",
+                        "requestedMembershipFull",
+                        "requestedMembershipPartial",
+                        "requestedMatchFees",
+                        "partialAmountPence",
+                        "reasonCategory",
+                        "reasonText",
+                        "duration",
+                        "durationOtherText",
+                        "contributionAbility",
+                        "contributionAmountPence",
+                        "volunteerOptions",
+                        "volunteerNotes",
+                        "contactPreference",
+                        "privacyAcknowledgedAt",
+                        "declarationConfirmedAt",
+                        "withdrawnAt",
+                        "withdrawnReason",
+                        "createdAt",
+                        "updatedAt"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "eventType": {
+                            "type": "string"
+                          },
+                          "fromStatus": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "toStatus": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "note": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "actorUserId": {
+                            "type": "string"
+                          },
+                          "actorName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "eventType",
+                          "fromStatus",
+                          "toStatus",
+                          "note",
+                          "actorUserId",
+                          "actorName",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "grant": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "decision": {
+                          "type": "string",
+                          "enum": [
+                            "approved_full",
+                            "approved_partial",
+                            "approved_temporary"
+                          ]
+                        },
+                        "coversMembership": {
+                          "type": "boolean"
+                        },
+                        "coversMatchFees": {
+                          "type": "boolean"
+                        },
+                        "membershipPartialPence": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "effectiveFrom": {
+                          "type": "string"
+                        },
+                        "effectiveToExclusive": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "adminNotes": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "memberFacingNote": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "decidedBy": {
+                          "type": "string"
+                        },
+                        "decidedByName": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "decidedAt": {
+                          "type": "string"
+                        },
+                        "closedAt": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "closedBy": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "closedReason": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "decision",
+                        "coversMembership",
+                        "coversMatchFees",
+                        "membershipPartialPence",
+                        "effectiveFrom",
+                        "effectiveToExclusive",
+                        "adminNotes",
+                        "memberFacingNote",
+                        "decidedBy",
+                        "decidedByName",
+                        "decidedAt",
+                        "closedAt",
+                        "closedBy",
+                        "closedReason"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "request",
+                    "events",
+                    "grant"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/financial-relief/requests/{requestId}/status": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "toStatus": {
+                    "type": "string",
+                    "enum": [
+                      "in_review",
+                      "more_info_needed"
+                    ]
+                  },
+                  "note": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                },
+                "required": [
+                  "toStatus"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/financial-relief/requests/{requestId}/decline": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "memberFacingNote": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "adminNote": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/financial-relief/requests/{requestId}/decide": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "decision": {
+                    "type": "string",
+                    "enum": [
+                      "approved_full",
+                      "approved_partial",
+                      "approved_temporary"
+                    ]
+                  },
+                  "coversMembership": {
+                    "type": "boolean"
+                  },
+                  "coversMatchFees": {
+                    "type": "boolean"
+                  },
+                  "membershipPartialPence": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "effectiveFrom": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "effectiveToExclusive": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "adminNotes": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 4000
+                  },
+                  "memberFacingNote": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                },
+                "required": [
+                  "decision",
+                  "coversMembership",
+                  "coversMatchFees",
+                  "effectiveFrom"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "grantId": {
+                      "type": "string"
+                    },
+                    "forgivenChargeCount": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "grantId",
+                    "forgivenChargeCount"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/financial-relief/grants/{grantId}/close": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "reason"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "grantId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/financial-relief/grants/{grantId}/apply-membership": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amountPence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "effectiveDate": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "membershipPaidUntil": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "membershipType": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "amountPence",
+                  "effectiveDate",
+                  "membershipPaidUntil",
+                  "membershipType",
+                  "description"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "grantId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "chargeId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "chargeId"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/financial-relief/report": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "query",
+            "name": "dateFrom",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "query",
+            "name": "dateTo",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "totalForgivenPence": {
+                      "type": "number"
+                    },
+                    "byReliefType": {
+                      "type": "object",
+                      "properties": {
+                        "membershipPence": {
+                          "type": "number"
+                        },
+                        "matchFeePence": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "membershipPence",
+                        "matchFeePence"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "bySection": {
+                      "type": "object",
+                      "properties": {
+                        "juniors": {
+                          "type": "object",
+                          "properties": {
+                            "pence": {
+                              "type": "number"
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "members": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "pence",
+                            "count",
+                            "members"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "womensGirls": {
+                          "type": "object",
+                          "properties": {
+                            "pence": {
+                              "type": "number"
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "members": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "pence",
+                            "count",
+                            "members"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "senior": {
+                          "type": "object",
+                          "properties": {
+                            "pence": {
+                              "type": "number"
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "members": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "pence",
+                            "count",
+                            "members"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "other": {
+                          "type": "object",
+                          "properties": {
+                            "pence": {
+                              "type": "number"
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "members": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "pence",
+                            "count",
+                            "members"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "juniors",
+                        "womensGirls",
+                        "senior",
+                        "other"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "membersSupported": {
+                      "type": "number"
+                    },
+                    "forgivenChargeCount": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "totalForgivenPence",
+                    "byReliefType",
+                    "bySection",
+                    "membersSupported",
+                    "forgivenChargeCount"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/leads": {
       "get": {
         "parameters": [

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -11910,7 +11910,8 @@
                 "unpaid",
                 "pending",
                 "paid",
-                "abandoned"
+                "abandoned",
+                "relieved"
               ]
             },
             "in": "query",
@@ -12008,6 +12009,10 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "relievedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "memberName": {
                             "nullable": true,
                             "type": "string"
@@ -12050,7 +12055,8 @@
                               "pending",
                               "unpaid",
                               "abandoned",
-                              "deleted"
+                              "deleted",
+                              "relieved"
                             ]
                           }
                         },
@@ -12068,6 +12074,7 @@
                           "source",
                           "deletedAt",
                           "deletedReason",
+                          "relievedAt",
                           "memberName",
                           "memberEmail",
                           "memberCategory",
@@ -13852,7 +13859,8 @@
                               "pending",
                               "unpaid",
                               "abandoned",
-                              "deleted"
+                              "deleted",
+                              "relieved"
                             ]
                           }
                         },

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -7219,6 +7219,15 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "chargeStatus": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "unpaid",
+                              "paid",
+                              "waived"
+                            ]
+                          },
                           "is_captain": {
                             "type": "boolean"
                           },
@@ -7236,6 +7245,7 @@
                           "created_at",
                           "member_category",
                           "chargePaidAt",
+                          "chargeStatus",
                           "is_captain",
                           "is_wicketkeeper"
                         ],

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -10,6 +10,7 @@ import { DocumentsTab } from "./documents-tab";
 import { DuplicatesTab } from "./duplicates-tab";
 import { ExpenseHistoryTab } from "./expense-history-tab";
 import { FantasyTab } from "./fantasy-tab";
+import { FinancialReliefTab } from "./financial-relief-tab";
 import { GameReportsTab } from "./game-reports-tab";
 import { IncidentsTab } from "./incidents-tab";
 import { JuniorsTab } from "./juniors-tab";
@@ -73,6 +74,11 @@ const SECTIONS = [
         render: () => <TreasurerTab />,
       },
       { value: "charges", label: "Charges", render: () => <ChargesTab /> },
+      {
+        value: "financial-relief",
+        label: "Financial Relief",
+        render: () => <FinancialReliefTab />,
+      },
       {
         value: "sponsorships",
         label: "Sponsorships",

--- a/apps/web/src/pages/admin/financial-relief-tab.reducer.test.ts
+++ b/apps/web/src/pages/admin/financial-relief-tab.reducer.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_FILTERS,
+  filtersFromSearchParams,
+  filtersToSearchParams,
+} from "./financial-relief-tab.reducer";
+
+describe("financial-relief filters", () => {
+  it("round-trips defaults to a minimal URL", () => {
+    const params = filtersToSearchParams(DEFAULT_FILTERS);
+    expect(params.get("section")).toBe("finance");
+    expect(params.get("sub")).toBe("financial-relief");
+    expect(params.get("status")).toBeNull();
+    expect(params.get("page")).toBeNull();
+    expect(params.get("search")).toBeNull();
+  });
+
+  it("encodes non-default filters", () => {
+    const params = filtersToSearchParams({
+      page: 3,
+      pageSize: 20,
+      status: "in_review",
+      search: "Smith",
+    });
+    expect(params.get("status")).toBe("in_review");
+    expect(params.get("page")).toBe("3");
+    expect(params.get("search")).toBe("Smith");
+  });
+
+  it("parses search params into a filters state, falling back to defaults", () => {
+    const params = new URLSearchParams("status=approved&page=2&search=Foo");
+    expect(filtersFromSearchParams(params)).toEqual({
+      page: 2,
+      pageSize: DEFAULT_FILTERS.pageSize,
+      status: "approved",
+      search: "Foo",
+    });
+  });
+
+  it("rejects unknown status values", () => {
+    const params = new URLSearchParams("status=nonsense");
+    expect(filtersFromSearchParams(params).status).toBe("all");
+  });
+
+  it("clamps invalid page values to 1", () => {
+    const params = new URLSearchParams("page=-3");
+    expect(filtersFromSearchParams(params).page).toBe(1);
+  });
+});

--- a/apps/web/src/pages/admin/financial-relief-tab.reducer.ts
+++ b/apps/web/src/pages/admin/financial-relief-tab.reducer.ts
@@ -1,0 +1,55 @@
+import { REQUEST_STATUSES, type RequestStatus } from "@percy-main/shared";
+
+export type StatusFilter = RequestStatus | "all";
+
+export const STATUS_FILTERS = ["all", ...REQUEST_STATUSES] as const;
+
+export interface FiltersState {
+  page: number;
+  pageSize: number;
+  status: StatusFilter;
+  search: string;
+}
+
+export const DEFAULT_FILTERS: FiltersState = {
+  page: 1,
+  pageSize: 20,
+  status: "all",
+  search: "",
+};
+
+function isStatusFilter(value: string | null): value is StatusFilter {
+  return !!value && STATUS_FILTERS.includes(value as StatusFilter);
+}
+
+export function filtersFromSearchParams(params: URLSearchParams): FiltersState {
+  const pageRaw = Number(params.get("page"));
+  const status = params.get("status");
+  return {
+    page: Number.isFinite(pageRaw) && pageRaw >= 1 ? pageRaw : 1,
+    pageSize: DEFAULT_FILTERS.pageSize,
+    status: isStatusFilter(status) ? status : "all",
+    search: params.get("search") ?? "",
+  };
+}
+
+/**
+ * Pure helper used by tests + the admin tab: builds the URLSearchParams
+ * patch (only including non-default values, so the URL stays clean) for
+ * the admin-panel section/sub-tab plus the relief-specific filter state.
+ */
+export function filtersToSearchParams(filters: FiltersState): URLSearchParams {
+  const params = new URLSearchParams();
+  // The admin-panel root keys must come along so direct linking lands
+  // on the right tab.
+  params.set("section", "finance");
+  params.set("sub", "financial-relief");
+  if (filters.status !== DEFAULT_FILTERS.status) {
+    params.set("status", filters.status);
+  }
+  if (filters.search) params.set("search", filters.search);
+  if (filters.page !== DEFAULT_FILTERS.page) {
+    params.set("page", String(filters.page));
+  }
+  return params;
+}

--- a/apps/web/src/pages/admin/financial-relief-tab.tsx
+++ b/apps/web/src/pages/admin/financial-relief-tab.tsx
@@ -100,7 +100,8 @@ export function FinancialReliefTab() {
   };
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-6">
+      <ReliefReportPanel />
       <div className="flex flex-wrap items-end gap-3">
         <div className="flex flex-col gap-1">
           <Label htmlFor="reliefStatus">Status</Label>
@@ -1132,5 +1133,148 @@ function ApplyMembershipReliefButton({
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+const SEASON_BUCKETS: Array<{
+  key: "juniors" | "womensGirls" | "senior" | "other";
+  label: string;
+}> = [
+  { key: "juniors", label: "Juniors" },
+  { key: "womensGirls", label: "Women's / Girls" },
+  { key: "senior", label: "Senior" },
+  { key: "other", label: "Other" },
+];
+
+function startOfYearIso() {
+  return `${new Date().getFullYear()}-01-01`;
+}
+
+function endOfYearIso() {
+  return `${new Date().getFullYear()}-12-31`;
+}
+
+const POUNDS_FORMATTER = new Intl.NumberFormat("en-GB", {
+  style: "currency",
+  currency: "GBP",
+});
+
+function formatPounds(pence: number): string {
+  return POUNDS_FORMATTER.format(pence / 100);
+}
+
+function ReliefReportPanel() {
+  const [report, update] = useReducer(
+    (
+      s: { dateFrom: string; dateTo: string; submitted: boolean },
+      patch: Partial<typeof s>,
+    ) => ({ ...s, ...patch }),
+    null,
+    () => ({
+      dateFrom: startOfYearIso(),
+      dateTo: endOfYearIso(),
+      submitted: false,
+    }),
+  );
+
+  const query = useQuery({
+    queryKey: ["admin-relief", "report", report.dateFrom, report.dateTo],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/financial-relief/report", {
+          params: {
+            query: { dateFrom: report.dateFrom, dateTo: report.dateTo },
+          },
+        }),
+      ),
+    enabled: report.submitted,
+  });
+
+  return (
+    <div className="rounded border border-stone-200 p-4">
+      <h2 className="text-base font-semibold">Relief summary</h2>
+      <p className="text-xs text-stone-600">
+        Aggregate totals of forgiven charges by section. No member details are
+        included, so these figures are safe to share publicly.
+      </p>
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="reportFrom">From</Label>
+          <Input
+            id="reportFrom"
+            type="date"
+            value={report.dateFrom}
+            onChange={(e) =>
+              update({ dateFrom: e.target.value, submitted: false })
+            }
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="reportTo">To</Label>
+          <Input
+            id="reportTo"
+            type="date"
+            value={report.dateTo}
+            onChange={(e) =>
+              update({ dateTo: e.target.value, submitted: false })
+            }
+          />
+        </div>
+        <Button onClick={() => update({ submitted: true })}>Summarise</Button>
+      </div>
+
+      {query.isLoading ? (
+        <p className="mt-3 text-sm text-stone-600">Loading…</p>
+      ) : query.data ? (
+        <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+          <SummaryCard
+            label="Total relief"
+            value={formatPounds(query.data.totalForgivenPence)}
+            sub={`${query.data.forgivenChargeCount} charges`}
+          />
+          <SummaryCard
+            label="Match donations"
+            value={formatPounds(query.data.byReliefType.matchFeePence)}
+          />
+          <SummaryCard
+            label="Membership"
+            value={formatPounds(query.data.byReliefType.membershipPence)}
+          />
+          <SummaryCard
+            label="Members supported"
+            value={String(query.data.membersSupported)}
+          />
+          {SEASON_BUCKETS.map(({ key, label }) => {
+            const b = query.data.bySection[key];
+            return (
+              <SummaryCard
+                key={key}
+                label={label}
+                value={formatPounds(b.pence)}
+                sub={`${b.count} charges · ${b.members} members`}
+              />
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="flex flex-col rounded border border-stone-200 px-3 py-2">
+      <span className="text-xs text-stone-600">{label}</span>
+      <span className="text-lg font-semibold">{value}</span>
+      {sub ? <span className="text-xs text-stone-500">{sub}</span> : null}
+    </div>
   );
 }

--- a/apps/web/src/pages/admin/financial-relief-tab.tsx
+++ b/apps/web/src/pages/admin/financial-relief-tab.tsx
@@ -1,0 +1,651 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { api, callApi } from "@/lib/api-client";
+import {
+  CONTACT_PREFERENCE_LABELS,
+  CONTRIBUTION_ABILITY_LABELS,
+  DURATION_LABELS,
+  REASON_CATEGORY_LABELS,
+  REQUEST_STATUS_LABELS,
+  VOLUNTEER_OPTION_LABELS,
+  type RequestStatus,
+} from "@percy-main/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useSearchParams } from "react-router";
+import {
+  DEFAULT_FILTERS,
+  STATUS_FILTERS,
+  filtersFromSearchParams,
+  filtersToSearchParams,
+  type StatusFilter,
+} from "./financial-relief-tab.reducer";
+
+export function FinancialReliefTab() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = useMemo(
+    () => filtersFromSearchParams(searchParams),
+    [searchParams],
+  );
+
+  const updateFilters = (
+    next: Partial<typeof DEFAULT_FILTERS>,
+    options: { resetPage?: boolean } = {},
+  ) => {
+    setSearchParams(
+      filtersToSearchParams({
+        ...filters,
+        ...next,
+        page: options.resetPage ? 1 : (next.page ?? filters.page),
+      }),
+      { replace: true },
+    );
+  };
+
+  const listQuery = useQuery({
+    queryKey: [
+      "admin-relief",
+      "list",
+      filters.page,
+      filters.pageSize,
+      filters.status,
+      filters.search,
+    ],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/financial-relief/requests", {
+          params: {
+            query: {
+              page: filters.page,
+              pageSize: filters.pageSize,
+              status: filters.status,
+              search: filters.search || undefined,
+            },
+          },
+        }),
+      ),
+  });
+
+  const selectedRequestId = searchParams.get("requestId") ?? null;
+  const openDetail = (id: string | null) => {
+    const params = filtersToSearchParams(filters);
+    if (id) params.set("requestId", id);
+    setSearchParams(params, { replace: true });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="reliefStatus">Status</Label>
+          <Select
+            value={filters.status}
+            onValueChange={(v) =>
+              updateFilters({ status: v as StatusFilter }, { resetPage: true })
+            }
+          >
+            <SelectTrigger id="reliefStatus" className="w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_FILTERS.map((s) => (
+                <SelectItem key={s} value={s}>
+                  {s === "all" ? "All" : REQUEST_STATUS_LABELS[s]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="reliefSearch">Search</Label>
+          <Input
+            id="reliefSearch"
+            placeholder="Member or submitter"
+            value={filters.search}
+            onChange={(e) =>
+              updateFilters({ search: e.target.value }, { resetPage: true })
+            }
+            className="w-[260px]"
+          />
+        </div>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Submitted</TableHead>
+            <TableHead>Member</TableHead>
+            <TableHead>Submitter</TableHead>
+            <TableHead>Requested</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Decided</TableHead>
+            <TableHead></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {listQuery.isLoading ? (
+            <TableRow>
+              <TableCell colSpan={7} className="text-center text-stone-600">
+                Loading…
+              </TableCell>
+            </TableRow>
+          ) : listQuery.data?.items.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={7} className="text-center text-stone-600">
+                No requests match these filters.
+              </TableCell>
+            </TableRow>
+          ) : (
+            listQuery.data?.items.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell className="text-sm">
+                  {new Date(row.createdAt).toLocaleDateString("en-GB")}
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-col">
+                    <span className="font-medium">{row.memberName ?? "—"}</span>
+                    <span className="text-xs text-stone-600">
+                      {row.memberEmail}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-col text-sm">
+                    <span>{row.submittedByName ?? "—"}</span>
+                    {row.submittedByEmail !== row.memberEmail ? (
+                      <span className="text-xs text-stone-600">
+                        {row.submittedByEmail}
+                      </span>
+                    ) : null}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1">
+                    {row.requestedMembershipFull ? (
+                      <Badge variant="secondary">Membership (full)</Badge>
+                    ) : null}
+                    {row.requestedMembershipPartial ? (
+                      <Badge variant="secondary">Membership (partial)</Badge>
+                    ) : null}
+                    {row.requestedMatchFees ? (
+                      <Badge variant="secondary">Match donations</Badge>
+                    ) : null}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <StatusPill status={row.status} />
+                </TableCell>
+                <TableCell className="text-sm">
+                  {row.decidedAt ? (
+                    <>
+                      {new Date(row.decidedAt).toLocaleDateString("en-GB")}
+                      {row.decidedByName ? (
+                        <div className="text-xs text-stone-600">
+                          {row.decidedByName}
+                        </div>
+                      ) : null}
+                    </>
+                  ) : (
+                    "—"
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => openDetail(row.id)}
+                  >
+                    Open
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      {listQuery.data && listQuery.data.total > filters.pageSize ? (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={filters.page <= 1}
+            onClick={() => updateFilters({ page: filters.page - 1 })}
+          >
+            Prev
+          </Button>
+          <span className="text-sm text-stone-600">
+            Page {filters.page} of{" "}
+            {Math.ceil(listQuery.data.total / filters.pageSize)}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={filters.page * filters.pageSize >= listQuery.data.total}
+            onClick={() => updateFilters({ page: filters.page + 1 })}
+          >
+            Next
+          </Button>
+        </div>
+      ) : null}
+
+      {selectedRequestId ? (
+        <RequestDetailDialog
+          requestId={selectedRequestId}
+          onClose={() => openDetail(null)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: RequestStatus }) {
+  const map: Record<
+    RequestStatus,
+    "secondary" | "warning" | "success" | "info"
+  > = {
+    submitted: "warning",
+    in_review: "info",
+    more_info_needed: "warning",
+    approved: "success",
+    declined: "secondary",
+    withdrawn: "secondary",
+    expired: "secondary",
+  };
+  return <Badge variant={map[status]}>{REQUEST_STATUS_LABELS[status]}</Badge>;
+}
+
+function RequestDetailDialog({
+  requestId,
+  onClose,
+}: {
+  requestId: string;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const detailQuery = useQuery({
+    queryKey: ["admin-relief", "detail", requestId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/financial-relief/requests/{requestId}", {
+          params: { path: { requestId } },
+        }),
+      ),
+  });
+
+  const transition = useMutation({
+    mutationFn: (body: {
+      toStatus: "in_review" | "more_info_needed";
+      note?: string | null;
+    }) =>
+      callApi(
+        api.POST("/api/admin/financial-relief/requests/{requestId}/status", {
+          params: { path: { requestId } },
+          body,
+        }),
+      ),
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["admin-relief", "detail", requestId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+      ]),
+  });
+
+  const [declineDialogOpen, setDeclineDialogOpen] = useState(false);
+  const isOpen = detailQuery.data
+    ? ["submitted", "in_review", "more_info_needed"].includes(
+        detailQuery.data.request.status,
+      )
+    : false;
+
+  return (
+    <Dialog open onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+        {detailQuery.isLoading ? (
+          <p className="text-sm text-stone-600">Loading…</p>
+        ) : !detailQuery.data ? (
+          <p className="text-sm text-stone-600">Request not found.</p>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                {detailQuery.data.request.memberName ?? "—"}
+              </DialogTitle>
+              <DialogDescription>
+                Submitted by {detailQuery.data.request.submittedByName ?? "—"} (
+                {detailQuery.data.request.submittedByEmail}) on{" "}
+                {new Date(
+                  detailQuery.data.request.createdAt,
+                ).toLocaleDateString("en-GB")}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="flex flex-col gap-4 text-sm">
+              <div>
+                <StatusPill status={detailQuery.data.request.status} />
+              </div>
+
+              <DetailSection title="Requested support">
+                <ul className="ml-4 list-disc">
+                  {detailQuery.data.request.requestedMembershipFull ? (
+                    <li>Full membership fee relief</li>
+                  ) : null}
+                  {detailQuery.data.request.requestedMembershipPartial ? (
+                    <li>
+                      Partial membership relief
+                      {detailQuery.data.request.partialAmountPence != null
+                        ? ` (manageable: £${(detailQuery.data.request.partialAmountPence / 100).toFixed(2)})`
+                        : ""}
+                    </li>
+                  ) : null}
+                  {detailQuery.data.request.requestedMatchFees ? (
+                    <li>Match donation relief</li>
+                  ) : null}
+                </ul>
+              </DetailSection>
+
+              <DetailSection title="Reason">
+                {detailQuery.data.request.reasonCategory ? (
+                  <p className="font-medium">
+                    {REASON_CATEGORY_LABELS[
+                      detailQuery.data.request
+                        .reasonCategory as keyof typeof REASON_CATEGORY_LABELS
+                    ] ?? detailQuery.data.request.reasonCategory}
+                  </p>
+                ) : null}
+                {detailQuery.data.request.reasonText ? (
+                  <p className="whitespace-pre-wrap text-stone-700">
+                    {detailQuery.data.request.reasonText}
+                  </p>
+                ) : (
+                  <p className="text-stone-500">No explanation provided.</p>
+                )}
+              </DetailSection>
+
+              <DetailSection title="Duration">
+                <p>
+                  {detailQuery.data.request.duration
+                    ? (DURATION_LABELS[
+                        detailQuery.data.request
+                          .duration as keyof typeof DURATION_LABELS
+                      ] ?? detailQuery.data.request.duration)
+                    : "—"}
+                </p>
+                {detailQuery.data.request.durationOtherText ? (
+                  <p className="text-stone-700">
+                    {detailQuery.data.request.durationOtherText}
+                  </p>
+                ) : null}
+              </DetailSection>
+
+              <DetailSection title="Contribution offered">
+                <p>
+                  {detailQuery.data.request.contributionAbility
+                    ? (CONTRIBUTION_ABILITY_LABELS[
+                        detailQuery.data.request
+                          .contributionAbility as keyof typeof CONTRIBUTION_ABILITY_LABELS
+                      ] ?? detailQuery.data.request.contributionAbility)
+                    : "—"}
+                </p>
+                {detailQuery.data.request.contributionAmountPence != null ? (
+                  <p>
+                    Amount: £
+                    {(
+                      detailQuery.data.request.contributionAmountPence / 100
+                    ).toFixed(2)}
+                  </p>
+                ) : null}
+              </DetailSection>
+
+              <DetailSection title="Non-financial contribution">
+                {detailQuery.data.request.volunteerOptions.length === 0 ? (
+                  <p className="text-stone-500">None selected.</p>
+                ) : (
+                  <ul className="ml-4 list-disc">
+                    {detailQuery.data.request.volunteerOptions.map((o) => (
+                      <li key={o}>
+                        {VOLUNTEER_OPTION_LABELS[
+                          o as keyof typeof VOLUNTEER_OPTION_LABELS
+                        ] ?? o}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {detailQuery.data.request.volunteerNotes ? (
+                  <p className="whitespace-pre-wrap text-stone-700">
+                    {detailQuery.data.request.volunteerNotes}
+                  </p>
+                ) : null}
+              </DetailSection>
+
+              <DetailSection title="Contact preference">
+                <p>
+                  {CONTACT_PREFERENCE_LABELS[
+                    detailQuery.data.request
+                      .contactPreference as keyof typeof CONTACT_PREFERENCE_LABELS
+                  ] ?? detailQuery.data.request.contactPreference}
+                </p>
+              </DetailSection>
+
+              {detailQuery.data.grant ? (
+                <DetailSection title="Active grant">
+                  <p>
+                    Covers{" "}
+                    {[
+                      detailQuery.data.grant.coversMembership
+                        ? "membership"
+                        : null,
+                      detailQuery.data.grant.coversMatchFees
+                        ? "match donations"
+                        : null,
+                    ]
+                      .filter(Boolean)
+                      .join(" + ") || "—"}
+                    , from{" "}
+                    {new Date(
+                      detailQuery.data.grant.effectiveFrom,
+                    ).toLocaleDateString("en-GB")}
+                    {detailQuery.data.grant.effectiveToExclusive
+                      ? ` until ${new Date(detailQuery.data.grant.effectiveToExclusive).toLocaleDateString("en-GB")}`
+                      : " (open-ended)"}
+                    .
+                  </p>
+                  {detailQuery.data.grant.memberFacingNote ? (
+                    <p className="text-stone-700">
+                      Note to member: {detailQuery.data.grant.memberFacingNote}
+                    </p>
+                  ) : null}
+                </DetailSection>
+              ) : null}
+
+              <DetailSection title="History">
+                <ul className="ml-4 list-disc">
+                  {detailQuery.data.events.map((e) => (
+                    <li key={e.id}>
+                      <span className="font-medium">{e.eventType}</span>{" "}
+                      &middot; {new Date(e.createdAt).toLocaleString("en-GB")}{" "}
+                      &middot; {e.actorName ?? "—"}
+                      {e.note ? ` — ${e.note}` : ""}
+                    </li>
+                  ))}
+                </ul>
+              </DetailSection>
+            </div>
+
+            <DialogFooter className="flex-wrap gap-2">
+              {isOpen ? (
+                <>
+                  {detailQuery.data.request.status !== "in_review" ? (
+                    <Button
+                      variant="outline"
+                      onClick={() =>
+                        transition.mutate({
+                          toStatus: "in_review",
+                          note: null,
+                        })
+                      }
+                      disabled={transition.isPending}
+                    >
+                      Move to in review
+                    </Button>
+                  ) : null}
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      transition.mutate({
+                        toStatus: "more_info_needed",
+                        note: null,
+                      })
+                    }
+                    disabled={transition.isPending}
+                  >
+                    Request more info
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={() => setDeclineDialogOpen(true)}
+                  >
+                    Decline
+                  </Button>
+                </>
+              ) : null}
+              <Button variant="ghost" onClick={onClose}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {declineDialogOpen ? (
+          <DeclineDialog
+            requestId={requestId}
+            onClose={() => setDeclineDialogOpen(false)}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeclineDialog({
+  requestId,
+  onClose,
+}: {
+  requestId: string;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [memberFacingNote, setMemberFacingNote] = useState("");
+  const [adminNote, setAdminNote] = useState("");
+
+  const decline = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/admin/financial-relief/requests/{requestId}/decline", {
+          params: { path: { requestId } },
+          body: {
+            memberFacingNote: memberFacingNote || null,
+            adminNote: adminNote || null,
+          },
+        }),
+      ),
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["admin-relief", "detail", requestId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+      ]).then(onClose),
+  });
+
+  return (
+    <Dialog open onOpenChange={(v) => !v && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Decline request</DialogTitle>
+          <DialogDescription>
+            The member-facing note is shown to the requester. The admin note
+            stays internal.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="memberFacingNote">
+              Member-facing note (optional)
+            </Label>
+            <Textarea
+              id="memberFacingNote"
+              rows={3}
+              value={memberFacingNote}
+              onChange={(e) => setMemberFacingNote(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="adminNote">Admin note (optional)</Label>
+            <Textarea
+              id="adminNote"
+              rows={3}
+              value={adminNote}
+              onChange={(e) => setAdminNote(e.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={decline.isPending}
+            onClick={() => decline.mutate()}
+          >
+            {decline.isPending ? "Declining…" : "Decline"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DetailSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <h3 className="text-sm font-semibold text-stone-800">{title}</h3>
+      <div className="flex flex-col gap-1">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin/financial-relief-tab.tsx
+++ b/apps/web/src/pages/admin/financial-relief-tab.tsx
@@ -37,7 +37,7 @@ import {
   type RequestStatus,
 } from "@percy-main/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useMemo, useReducer, useState } from "react";
 import { useSearchParams } from "react-router";
 import {
   DEFAULT_FILTERS,
@@ -542,10 +542,18 @@ function RequestDetailDialog({
                 </>
               ) : null}
               {detailQuery.data.grant && !detailQuery.data.grant.closedAt ? (
-                <CloseGrantButton
-                  grantId={detailQuery.data.grant.id}
-                  requestId={requestId}
-                />
+                <>
+                  {detailQuery.data.grant.coversMembership ? (
+                    <ApplyMembershipReliefButton
+                      grantId={detailQuery.data.grant.id}
+                      requestId={requestId}
+                    />
+                  ) : null}
+                  <CloseGrantButton
+                    grantId={detailQuery.data.grant.id}
+                    requestId={requestId}
+                  />
+                </>
               ) : null}
               <Button variant="ghost" onClick={onClose}>
                 Close
@@ -964,6 +972,161 @@ function CloseGrantButton({
               onClick={() => close.mutate()}
             >
               {close.isPending ? "Closing…" : "Close grant"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function ApplyMembershipReliefButton({
+  grantId,
+  requestId,
+}: {
+  grantId: string;
+  requestId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [form, update] = useReducer(
+    (
+      s: {
+        amountPounds: string;
+        effectiveDate: string;
+        membershipPaidUntil: string;
+        membershipType: string;
+        description: string;
+      },
+      patch: Partial<typeof s>,
+    ) => ({ ...s, ...patch }),
+    null,
+    () => ({
+      amountPounds: "",
+      effectiveDate: todayIso(),
+      membershipPaidUntil: "",
+      membershipType: "",
+      description: "",
+    }),
+  );
+  const {
+    amountPounds,
+    effectiveDate,
+    membershipPaidUntil,
+    membershipType,
+    description,
+  } = form;
+
+  const apply = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST(
+          "/api/admin/financial-relief/grants/{grantId}/apply-membership",
+          {
+            params: { path: { grantId } },
+            body: {
+              amountPence: Math.max(
+                0,
+                Math.round(Number(amountPounds || "0") * 100),
+              ),
+              effectiveDate,
+              membershipPaidUntil,
+              membershipType,
+              description,
+            },
+          },
+        ),
+      ),
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["admin-relief", "detail", requestId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+      ]).then(() => setOpen(false)),
+  });
+
+  const canSubmit =
+    !!membershipType &&
+    !!membershipPaidUntil &&
+    !!effectiveDate &&
+    !!description &&
+    Number(amountPounds) > 0 &&
+    !apply.isPending;
+
+  return (
+    <>
+      <Button variant="outline" onClick={() => setOpen(true)}>
+        Apply membership relief
+      </Button>
+      <Dialog open={open} onOpenChange={(v) => !v && setOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Apply membership relief</DialogTitle>
+            <DialogDescription>
+              Creates a relieved membership charge for reporting and extends
+              this member's paid_until.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="amountPounds">Amount (in £)</Label>
+              <Input
+                id="amountPounds"
+                type="number"
+                min="0"
+                step="1"
+                value={amountPounds}
+                onChange={(e) => update({ amountPounds: e.target.value })}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="applyEffective">Charge date</Label>
+                <Input
+                  id="applyEffective"
+                  type="date"
+                  value={effectiveDate}
+                  onChange={(e) => update({ effectiveDate: e.target.value })}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="paidUntil">Paid until</Label>
+                <Input
+                  id="paidUntil"
+                  type="date"
+                  value={membershipPaidUntil}
+                  onChange={(e) =>
+                    update({ membershipPaidUntil: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="membershipType">Membership type</Label>
+              <Input
+                id="membershipType"
+                placeholder="e.g. senior_player"
+                value={membershipType}
+                onChange={(e) => update({ membershipType: e.target.value })}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="applyDescription">Description</Label>
+              <Input
+                id="applyDescription"
+                placeholder="e.g. Senior membership (relief)"
+                value={description}
+                onChange={(e) => update({ description: e.target.value })}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button disabled={!canSubmit} onClick={() => apply.mutate()}>
+              {apply.isPending ? "Applying…" : "Apply"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/pages/admin/financial-relief-tab.tsx
+++ b/apps/web/src/pages/admin/financial-relief-tab.tsx
@@ -189,10 +189,14 @@ export function FinancialReliefTab() {
                 <TableCell>
                   <div className="flex flex-wrap gap-1">
                     {row.requestedMembershipFull ? (
-                      <Badge variant="secondary">Membership (full)</Badge>
+                      <Badge variant="secondary">
+                        Membership donation (full)
+                      </Badge>
                     ) : null}
                     {row.requestedMembershipPartial ? (
-                      <Badge variant="secondary">Membership (partial)</Badge>
+                      <Badge variant="secondary">
+                        Membership donation (partial)
+                      </Badge>
                     ) : null}
                     {row.requestedMatchFees ? (
                       <Badge variant="secondary">Match donations</Badge>
@@ -358,11 +362,11 @@ function RequestDetailDialog({
               <DetailSection title="Requested support">
                 <ul className="ml-4 list-disc">
                   {detailQuery.data.request.requestedMembershipFull ? (
-                    <li>Full membership fee relief</li>
+                    <li>Full membership donation relief</li>
                   ) : null}
                   {detailQuery.data.request.requestedMembershipPartial ? (
                     <li>
-                      Partial membership relief
+                      Partial membership donation relief
                       {detailQuery.data.request.partialAmountPence != null
                         ? ` (manageable: £${(detailQuery.data.request.partialAmountPence / 100).toFixed(2)})`
                         : ""}
@@ -463,7 +467,7 @@ function RequestDetailDialog({
                     Covers{" "}
                     {[
                       detailQuery.data.grant.coversMembership
-                        ? "membership"
+                        ? "membership donations"
                         : null,
                       detailQuery.data.grant.coversMatchFees
                         ? "match donations"
@@ -805,7 +809,7 @@ function DecideDialog({
                   }))
                 }
               />
-              <Label htmlFor="coversMembership">Membership</Label>
+              <Label htmlFor="coversMembership">Membership donations</Label>
             </div>
             <div className="flex items-center gap-2">
               <input
@@ -1237,7 +1241,7 @@ function ReliefReportPanel() {
             value={formatPounds(query.data.byReliefType.matchFeePence)}
           />
           <SummaryCard
-            label="Membership"
+            label="Membership donations"
             value={formatPounds(query.data.byReliefType.membershipPence)}
           />
           <SummaryCard

--- a/apps/web/src/pages/admin/financial-relief-tab.tsx
+++ b/apps/web/src/pages/admin/financial-relief-tab.tsx
@@ -320,6 +320,7 @@ function RequestDetailDialog({
   });
 
   const [declineDialogOpen, setDeclineDialogOpen] = useState(false);
+  const [decideDialogOpen, setDecideDialogOpen] = useState(false);
   const isOpen = detailQuery.data
     ? ["submitted", "in_review", "more_info_needed"].includes(
         detailQuery.data.request.status,
@@ -529,6 +530,9 @@ function RequestDetailDialog({
                   >
                     Request more info
                   </Button>
+                  <Button onClick={() => setDecideDialogOpen(true)}>
+                    Approve…
+                  </Button>
                   <Button
                     variant="destructive"
                     onClick={() => setDeclineDialogOpen(true)}
@@ -536,6 +540,12 @@ function RequestDetailDialog({
                     Decline
                   </Button>
                 </>
+              ) : null}
+              {detailQuery.data.grant && !detailQuery.data.grant.closedAt ? (
+                <CloseGrantButton
+                  grantId={detailQuery.data.grant.id}
+                  requestId={requestId}
+                />
               ) : null}
               <Button variant="ghost" onClick={onClose}>
                 Close
@@ -548,6 +558,12 @@ function RequestDetailDialog({
           <DeclineDialog
             requestId={requestId}
             onClose={() => setDeclineDialogOpen(false)}
+          />
+        ) : null}
+        {decideDialogOpen ? (
+          <DecideDialog
+            requestId={requestId}
+            onClose={() => setDecideDialogOpen(false)}
           />
         ) : null}
       </DialogContent>
@@ -647,5 +663,311 @@ function DetailSection({
       <h3 className="text-sm font-semibold text-stone-800">{title}</h3>
       <div className="flex flex-col gap-1">{children}</div>
     </div>
+  );
+}
+
+interface DecideFormState {
+  decision: "approved_full" | "approved_partial" | "approved_temporary";
+  coversMembership: boolean;
+  coversMatchFees: boolean;
+  membershipPartialPounds: string;
+  effectiveFrom: string;
+  effectiveToExclusive: string;
+  adminNotes: string;
+  memberFacingNote: string;
+}
+
+function todayIso(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function poundsToPenceOrNull(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.round(parsed * 100);
+}
+
+function DecideDialog({
+  requestId,
+  onClose,
+}: {
+  requestId: string;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [form, update] = useState<DecideFormState>({
+    decision: "approved_temporary",
+    coversMembership: false,
+    coversMatchFees: true,
+    membershipPartialPounds: "",
+    effectiveFrom: todayIso(),
+    effectiveToExclusive: "",
+    adminNotes: "",
+    memberFacingNote: "",
+  });
+
+  const decide = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/admin/financial-relief/requests/{requestId}/decide", {
+          params: { path: { requestId } },
+          body: {
+            decision: form.decision,
+            coversMembership: form.coversMembership,
+            coversMatchFees: form.coversMatchFees,
+            membershipPartialPence:
+              form.decision === "approved_partial" && form.coversMembership
+                ? poundsToPenceOrNull(form.membershipPartialPounds)
+                : null,
+            effectiveFrom: form.effectiveFrom,
+            effectiveToExclusive: form.effectiveToExclusive || null,
+            adminNotes: form.adminNotes || null,
+            memberFacingNote: form.memberFacingNote || null,
+          },
+        }),
+      ),
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["admin-relief", "detail", requestId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+      ]).then(onClose),
+  });
+
+  const canSubmit =
+    (form.coversMembership || form.coversMatchFees) &&
+    !!form.effectiveFrom &&
+    !decide.isPending;
+
+  return (
+    <Dialog open onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Approve request</DialogTitle>
+          <DialogDescription>
+            The grant takes effect from the chosen date. The member-facing note
+            is shown verbatim to the requester; admin notes stay internal.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="decision">Decision</Label>
+            <Select
+              value={form.decision}
+              onValueChange={(v) =>
+                update((s) => ({
+                  ...s,
+                  decision: v as DecideFormState["decision"],
+                }))
+              }
+            >
+              <SelectTrigger id="decision">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="approved_full">
+                  Approved (full relief)
+                </SelectItem>
+                <SelectItem value="approved_partial">
+                  Approved (partial relief)
+                </SelectItem>
+                <SelectItem value="approved_temporary">
+                  Approved (temporary relief)
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-medium">What does this cover?</span>
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="coversMembership"
+                checked={form.coversMembership}
+                onChange={(e) =>
+                  update((s) => ({
+                    ...s,
+                    coversMembership: e.target.checked,
+                  }))
+                }
+              />
+              <Label htmlFor="coversMembership">Membership</Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="coversMatchFees"
+                checked={form.coversMatchFees}
+                onChange={(e) =>
+                  update((s) => ({
+                    ...s,
+                    coversMatchFees: e.target.checked,
+                  }))
+                }
+              />
+              <Label htmlFor="coversMatchFees">Match donations</Label>
+            </div>
+          </div>
+          {form.decision === "approved_partial" && form.coversMembership ? (
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="membershipPartialPounds">
+                Member contributes (in £) towards membership
+              </Label>
+              <Input
+                id="membershipPartialPounds"
+                type="number"
+                min="0"
+                step="1"
+                value={form.membershipPartialPounds}
+                onChange={(e) =>
+                  update((s) => ({
+                    ...s,
+                    membershipPartialPounds: e.target.value,
+                  }))
+                }
+              />
+            </div>
+          ) : null}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="effectiveFrom">Effective from</Label>
+              <Input
+                id="effectiveFrom"
+                type="date"
+                value={form.effectiveFrom}
+                onChange={(e) =>
+                  update((s) => ({ ...s, effectiveFrom: e.target.value }))
+                }
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="effectiveToExclusive">
+                Until (exclusive, optional)
+              </Label>
+              <Input
+                id="effectiveToExclusive"
+                type="date"
+                value={form.effectiveToExclusive}
+                onChange={(e) =>
+                  update((s) => ({
+                    ...s,
+                    effectiveToExclusive: e.target.value,
+                  }))
+                }
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="memberFacingNote">
+              Member-facing note (shown to requester)
+            </Label>
+            <Textarea
+              id="memberFacingNote"
+              rows={3}
+              value={form.memberFacingNote}
+              onChange={(e) =>
+                update((s) => ({ ...s, memberFacingNote: e.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="decideAdminNotes">Admin notes (private)</Label>
+            <Textarea
+              id="decideAdminNotes"
+              rows={3}
+              value={form.adminNotes}
+              onChange={(e) =>
+                update((s) => ({ ...s, adminNotes: e.target.value }))
+              }
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit} onClick={() => decide.mutate()}>
+            {decide.isPending ? "Approving…" : "Approve"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CloseGrantButton({
+  grantId,
+  requestId,
+}: {
+  grantId: string;
+  requestId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [confirming, setConfirming] = useState(false);
+  const [reason, setReason] = useState("");
+
+  const close = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/admin/financial-relief/grants/{grantId}/close", {
+          params: { path: { grantId } },
+          body: { reason: reason || "closed by admin" },
+        }),
+      ),
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["admin-relief", "detail", requestId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+      ]).then(() => setConfirming(false)),
+  });
+
+  return (
+    <>
+      <Button variant="outline" onClick={() => setConfirming(true)}>
+        Close grant
+      </Button>
+      <Dialog
+        open={confirming}
+        onOpenChange={(v) => !v && setConfirming(false)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Close grant</DialogTitle>
+            <DialogDescription>
+              Previously-relieved charges stay relieved. Future charges stop
+              being auto-forgiven.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="closeReason">Reason</Label>
+            <Input
+              id="closeReason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="e.g. season ended"
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={close.isPending}
+              onClick={() => close.mutate()}
+            >
+              {close.isPending ? "Closing…" : "Close grant"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/apps/web/src/pages/admin/game-reports-tab.tsx
+++ b/apps/web/src/pages/admin/game-reports-tab.tsx
@@ -28,7 +28,13 @@ const EXPENSE_TYPE_LABELS: Record<string, string> = {
   miscellaneous: "Miscellaneous",
 };
 
-type ChargeStatus = "paid" | "pending" | "unpaid" | "abandoned" | "deleted";
+type ChargeStatus =
+  | "paid"
+  | "pending"
+  | "unpaid"
+  | "abandoned"
+  | "deleted"
+  | "relieved";
 
 function formatMatchDate(dateStr: string): string {
   const d = new Date(dateStr);
@@ -197,6 +203,12 @@ function ChargeStatusBadge({
       return <span className="text-xs text-stone-400">Abandoned</span>;
     case "deleted":
       return <span className="text-xs text-stone-400">Deleted</span>;
+    case "relieved":
+      return (
+        <span className="rounded bg-stone-100 px-1.5 py-0.5 text-xs font-medium text-stone-700">
+          Relieved
+        </span>
+      );
     default:
       return <span className="text-xs text-stone-400">-</span>;
   }

--- a/apps/web/src/pages/auth/login/email-password.tsx
+++ b/apps/web/src/pages/auth/login/email-password.tsx
@@ -1,6 +1,6 @@
 import { SimpleInput } from "@/components/form/simple-input.js";
 import { Button } from "@/components/ui/button.js";
-import { authClient } from "@/lib/auth-client.js";
+import { authClient, useSession } from "@/lib/auth-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState, type FC } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
@@ -38,6 +38,12 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo");
   const queryClient = useQueryClient();
+  // better-auth's session atom only refetches via a setTimeout(10) after
+  // sign-in, so a naive `navigate(returnTo)` arrives at the destination
+  // BEFORE the new session is in the atom — RequireAuth sees data=null
+  // and bounces straight back here. Awaiting refetch() forces the
+  // /get-session call to complete before we navigate.
+  const { refetch: refetchSession } = useSession();
 
   useEffect(() => {
     async function tryPasskeyAutofill() {
@@ -48,14 +54,15 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
       void authClient.signIn.passkey(
         { autoFill: true },
         {
-          onSuccess() {
+          async onSuccess() {
+            await refetchSession();
             void navigate(returnTo ?? "/members");
           },
         },
       );
     }
     void tryPasskeyAutofill();
-  }, [navigate, returnTo]);
+  }, [navigate, returnTo, refetchSession]);
 
   const signin = useMutation({
     mutationFn: async () => {
@@ -64,11 +71,12 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
         throw new Error(result.error.message ?? "Sign in failed");
       return result.data;
     },
-    onSuccess(data) {
+    async onSuccess(data) {
       if (data && "twoFactorRedirect" in data) {
         setPhase("2fa");
         return;
       }
+      await refetchSession();
       // Session changed — drop all cached queries so the new user sees fresh
       // data rather than the previous user's (or anonymous) cached responses.
       void queryClient.invalidateQueries();

--- a/apps/web/src/pages/auth/login/recovery.tsx
+++ b/apps/web/src/pages/auth/login/recovery.tsx
@@ -1,6 +1,6 @@
 import { SimpleInput } from "@/components/form/simple-input.js";
 import { Button } from "@/components/ui/button.js";
-import { authClient } from "@/lib/auth-client.js";
+import { authClient, useSession } from "@/lib/auth-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState, type FC } from "react";
 import { useNavigate, useSearchParams } from "react-router";
@@ -16,13 +16,15 @@ export const Recovery: FC<Props> = ({ setPhase }) => {
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo");
   const queryClient = useQueryClient();
+  const { refetch: refetchSession } = useSession();
 
   const verifyBackupCode = useMutation({
     mutationFn: () =>
       authClient.twoFactor.verifyBackupCode(
         { code: recoveryCode },
         {
-          onSuccess() {
+          async onSuccess() {
+            await refetchSession();
             void navigate(returnTo ?? "/members");
           },
         },

--- a/apps/web/src/pages/auth/login/recovery.tsx
+++ b/apps/web/src/pages/auth/login/recovery.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button.js";
 import { authClient } from "@/lib/auth-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState, type FC } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 import type { LoginPhase } from "../login.js";
 
 interface Props {
@@ -13,6 +13,8 @@ interface Props {
 export const Recovery: FC<Props> = ({ setPhase }) => {
   const [recoveryCode, setRecoveryCode] = useState("");
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get("returnTo");
   const queryClient = useQueryClient();
 
   const verifyBackupCode = useMutation({
@@ -21,7 +23,7 @@ export const Recovery: FC<Props> = ({ setPhase }) => {
         { code: recoveryCode },
         {
           onSuccess() {
-            void navigate("/members");
+            void navigate(returnTo ?? "/members");
           },
         },
       ),

--- a/apps/web/src/pages/auth/login/two-fa.tsx
+++ b/apps/web/src/pages/auth/login/two-fa.tsx
@@ -5,7 +5,7 @@ import {
   InputOTPSeparator,
   InputOTPSlot,
 } from "@/components/ui/input-otp.js";
-import { authClient } from "@/lib/auth-client.js";
+import { authClient, useSession } from "@/lib/auth-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState, type FC } from "react";
 import { useNavigate, useSearchParams } from "react-router";
@@ -21,13 +21,17 @@ export const TwoFA: FC<Props> = ({ setPhase }) => {
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo");
   const queryClient = useQueryClient();
+  const { refetch: refetchSession } = useSession();
 
   const signin = useMutation({
     mutationFn: () =>
       authClient.twoFactor.verifyTotp(
         { code: otp },
         {
-          onSuccess() {
+          async onSuccess() {
+            // See EmailPassword: refetch so the session atom is populated
+            // before the new route's RequireAuth reads it.
+            await refetchSession();
             void navigate(returnTo ?? "/members");
           },
         },

--- a/apps/web/src/pages/auth/login/two-fa.tsx
+++ b/apps/web/src/pages/auth/login/two-fa.tsx
@@ -8,7 +8,7 @@ import {
 import { authClient } from "@/lib/auth-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState, type FC } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 import type { LoginPhase } from "../login.js";
 
 interface Props {
@@ -18,6 +18,8 @@ interface Props {
 export const TwoFA: FC<Props> = ({ setPhase }) => {
   const [otp, setOtp] = useState("");
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get("returnTo");
   const queryClient = useQueryClient();
 
   const signin = useMutation({
@@ -26,7 +28,7 @@ export const TwoFA: FC<Props> = ({ setPhase }) => {
         { code: otp },
         {
           onSuccess() {
-            void navigate("/members");
+            void navigate(returnTo ?? "/members");
           },
         },
       ),

--- a/apps/web/src/pages/members/financial-relief.tsx
+++ b/apps/web/src/pages/members/financial-relief.tsx
@@ -239,7 +239,10 @@ export function Component() {
                     {r.activeGrant.coversMatchFees
                       ? " for match donations"
                       : ""}
-                    {r.activeGrant.coversMembership ? " for membership" : ""}.
+                    {r.activeGrant.coversMembership
+                      ? " for membership donations"
+                      : ""}
+                    .
                   </p>
                 ) : null}
               </div>
@@ -323,7 +326,7 @@ export function Component() {
                     ...(v ? { requestedMembershipPartial: false } : {}),
                   })
                 }
-                label="Full membership fee relief"
+                label="Full membership donation relief"
               />
               <CheckboxRow
                 id="reqMembershipPartial"
@@ -334,7 +337,7 @@ export function Component() {
                     ...(v ? { requestedMembershipFull: false } : {}),
                   })
                 }
-                label="Partial membership fee relief"
+                label="Partial membership donation relief"
               />
               {form.requestedMembershipPartial ? (
                 <div className="flex flex-col gap-1 pl-7">

--- a/apps/web/src/pages/members/financial-relief.tsx
+++ b/apps/web/src/pages/members/financial-relief.tsx
@@ -1,0 +1,652 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useDocumentMeta } from "@/hooks/use-document-meta.js";
+import { api, callApi } from "@/lib/api-client";
+import {
+  CONTACT_PREFERENCES,
+  CONTACT_PREFERENCE_LABELS,
+  CONTRIBUTION_ABILITIES,
+  CONTRIBUTION_ABILITY_LABELS,
+  DURATIONS,
+  DURATION_LABELS,
+  REASON_CATEGORIES,
+  REASON_CATEGORY_LABELS,
+  REQUEST_STATUS_LABELS,
+  VOLUNTEER_OPTIONS,
+  VOLUNTEER_OPTION_LABELS,
+  type ContactPreference,
+  type ContributionAbility,
+  type Duration,
+  type ReasonCategory,
+  type VolunteerOption,
+} from "@percy-main/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useReducer } from "react";
+import { Link } from "react-router";
+
+interface FormState {
+  memberId: string;
+  requestedMembershipFull: boolean;
+  requestedMembershipPartial: boolean;
+  requestedMatchFees: boolean;
+  partialAmountPounds: string;
+  reasonCategory: ReasonCategory | "";
+  reasonText: string;
+  duration: Duration | "";
+  durationOtherText: string;
+  contributionAbility: ContributionAbility | "";
+  contributionAmountPounds: string;
+  volunteerOptions: VolunteerOption[];
+  volunteerNotes: string;
+  contactPreference: ContactPreference;
+  privacyAcknowledged: boolean;
+  declarationConfirmed: boolean;
+}
+
+const initialState: FormState = {
+  memberId: "",
+  requestedMembershipFull: false,
+  requestedMembershipPartial: false,
+  requestedMatchFees: false,
+  partialAmountPounds: "",
+  reasonCategory: "",
+  reasonText: "",
+  duration: "",
+  durationOtherText: "",
+  contributionAbility: "",
+  contributionAmountPounds: "",
+  volunteerOptions: [],
+  volunteerNotes: "",
+  contactPreference: "none",
+  privacyAcknowledged: false,
+  declarationConfirmed: false,
+};
+
+function poundsToPence(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.round(parsed * 100);
+}
+
+// eslint-disable-next-line react-doctor/no-giant-component -- single multi-section relief application form; sections share validation state and a single submit
+export function Component() {
+  useDocumentMeta(
+    "Financial relief request",
+    "Ask the club for support with membership or match donation costs.",
+  );
+
+  const queryClient = useQueryClient();
+
+  const eligibleQuery = useQuery({
+    queryKey: ["financial-relief", "eligible-members"],
+    queryFn: () => callApi(api.GET("/api/financial-relief/eligible-members")),
+  });
+
+  const myStatusQuery = useQuery({
+    queryKey: ["financial-relief", "me"],
+    queryFn: () => callApi(api.GET("/api/financial-relief/me")),
+  });
+
+  const [form, update] = useReducer(
+    (s: FormState, p: Partial<FormState>) => ({ ...s, ...p }),
+    initialState,
+  );
+
+  const eligibleMembers = eligibleQuery.data?.members ?? [];
+
+  // Auto-select the only option if there's just one (the account holder).
+  const effectiveMemberId =
+    form.memberId ||
+    (eligibleMembers.length === 1 ? eligibleMembers[0].memberId : "");
+
+  const submit = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/financial-relief/requests", {
+          body: {
+            memberId: effectiveMemberId,
+            requestedMembershipFull: form.requestedMembershipFull,
+            requestedMembershipPartial: form.requestedMembershipPartial,
+            requestedMatchFees: form.requestedMatchFees,
+            partialAmountPence: form.requestedMembershipPartial
+              ? poundsToPence(form.partialAmountPounds)
+              : null,
+            reasonCategory: form.reasonCategory || null,
+            reasonText: form.reasonText || null,
+            duration: form.duration || null,
+            durationOtherText:
+              form.duration === "other" ? form.durationOtherText || null : null,
+            contributionAbility: form.contributionAbility || null,
+            contributionAmountPence:
+              form.contributionAbility === "yes_reduced"
+                ? poundsToPence(form.contributionAmountPounds)
+                : null,
+            volunteerOptions: form.volunteerOptions,
+            volunteerNotes: form.volunteerNotes || null,
+            contactPreference: form.contactPreference,
+            privacyAcknowledged: true as const,
+            declarationConfirmed: true as const,
+          },
+        }),
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["financial-relief"] });
+    },
+  });
+
+  const supportTypeChosen =
+    form.requestedMembershipFull ||
+    form.requestedMembershipPartial ||
+    form.requestedMatchFees;
+
+  const canSubmit =
+    !!effectiveMemberId &&
+    supportTypeChosen &&
+    form.privacyAcknowledged &&
+    form.declarationConfirmed &&
+    !submit.isPending;
+
+  const openRequest = useMemo(
+    () =>
+      myStatusQuery.data?.requests.find((r) =>
+        ["submitted", "in_review", "more_info_needed", "approved"].includes(
+          r.status,
+        ),
+      ) ?? null,
+    [myStatusQuery.data?.requests],
+  );
+
+  function toggleVolunteer(option: VolunteerOption, checked: boolean) {
+    update({
+      volunteerOptions: checked
+        ? [...form.volunteerOptions, option]
+        : form.volunteerOptions.filter((o) => o !== option),
+    });
+  }
+
+  if (submit.isSuccess) {
+    return (
+      <div className="container mx-auto max-w-2xl px-4 py-8">
+        <h1>Thank you</h1>
+        <p className="mt-4">
+          We&rsquo;ve received your request and a committee member will review
+          it shortly. We&rsquo;ll be in touch when there&rsquo;s news, using the
+          email address on your account.
+        </p>
+        <p className="mt-4">
+          You don&rsquo;t need to do anything else for now.
+        </p>
+        <p className="mt-6">
+          <Link className="text-blue-900 underline" to="/members">
+            Back to your members area
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <h1>Financial relief request</h1>
+
+      <p className="mt-4 text-sm text-stone-700">
+        Use this form if paying full club fees would make it hard for you or a
+        member of your family to take part at Percy Main. You don&rsquo;t need
+        to share detailed financial information. A short explanation is enough.
+      </p>
+
+      {myStatusQuery.data?.requests.length ? (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle className="text-base">Your current requests</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2">
+            {myStatusQuery.data.requests.map((r) => (
+              <div key={r.id} className="flex flex-col gap-1 text-sm">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium">{r.memberName ?? "—"}</span>
+                  <Badge variant="secondary">
+                    {REQUEST_STATUS_LABELS[r.status]}
+                  </Badge>
+                </div>
+                {r.memberFacingNote ? (
+                  <p className="text-stone-700">{r.memberFacingNote}</p>
+                ) : null}
+                {r.activeGrant ? (
+                  <p className="text-stone-700">
+                    Support is in place
+                    {r.activeGrant.coversMatchFees
+                      ? " for match donations"
+                      : ""}
+                    {r.activeGrant.coversMembership ? " for membership" : ""}.
+                  </p>
+                ) : null}
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {openRequest ? (
+        <Alert className="mt-6">
+          <AlertDescription>
+            You already have an open request. Please wait for the committee to
+            review it before sending another.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <form
+          className="mt-6 flex flex-col gap-6"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (canSubmit) submit.mutate();
+          }}
+        >
+          {/* 1. Member being supported */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Who is this request for?
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              {eligibleQuery.isLoading ? (
+                <p className="text-sm text-stone-600">
+                  Loading members&hellip;
+                </p>
+              ) : eligibleMembers.length === 0 ? (
+                <p className="text-sm text-stone-600">
+                  We can&rsquo;t find a club record matching your account.
+                  Please contact the club committee.
+                </p>
+              ) : eligibleMembers.length === 1 ? (
+                <p className="text-sm text-stone-700">
+                  {eligibleMembers[0].name}
+                </p>
+              ) : (
+                <Select
+                  value={form.memberId}
+                  onValueChange={(v) => update({ memberId: v })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Choose a member" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {eligibleMembers.map((m) => (
+                      <SelectItem key={m.memberId} value={m.memberId}>
+                        {m.name ?? m.memberId}
+                        {m.relationship === "junior" ? " (junior)" : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* 2. Type of support requested */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                What kind of support are you asking for?
+              </CardTitle>
+              <CardDescription>Tick all that apply.</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <CheckboxRow
+                id="reqMembershipFull"
+                checked={form.requestedMembershipFull}
+                onChange={(v) =>
+                  update({
+                    requestedMembershipFull: v,
+                    ...(v ? { requestedMembershipPartial: false } : {}),
+                  })
+                }
+                label="Full membership fee relief"
+              />
+              <CheckboxRow
+                id="reqMembershipPartial"
+                checked={form.requestedMembershipPartial}
+                onChange={(v) =>
+                  update({
+                    requestedMembershipPartial: v,
+                    ...(v ? { requestedMembershipFull: false } : {}),
+                  })
+                }
+                label="Partial membership fee relief"
+              />
+              {form.requestedMembershipPartial ? (
+                <div className="flex flex-col gap-1 pl-7">
+                  <Label htmlFor="partialAmount">
+                    What level of contribution would be manageable? (in £)
+                  </Label>
+                  <Input
+                    id="partialAmount"
+                    type="number"
+                    min="0"
+                    step="1"
+                    value={form.partialAmountPounds}
+                    onChange={(e) =>
+                      update({ partialAmountPounds: e.target.value })
+                    }
+                  />
+                </div>
+              ) : null}
+              <CheckboxRow
+                id="reqMatchFees"
+                checked={form.requestedMatchFees}
+                onChange={(v) => update({ requestedMatchFees: v })}
+                label="Match donation relief"
+              />
+            </CardContent>
+          </Card>
+
+          {/* 3. Reason */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Why would financial relief help?
+              </CardTitle>
+              <CardDescription>
+                A short explanation is enough. You don&rsquo;t need to provide
+                detailed financial information.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="reasonCategory">
+                  Which of these best describes your situation? (optional)
+                </Label>
+                <Select
+                  value={form.reasonCategory}
+                  onValueChange={(v) =>
+                    update({ reasonCategory: v as ReasonCategory })
+                  }
+                >
+                  <SelectTrigger id="reasonCategory">
+                    <SelectValue placeholder="Choose one (optional)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {REASON_CATEGORIES.map((c) => (
+                      <SelectItem key={c} value={c}>
+                        {REASON_CATEGORY_LABELS[c]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="reasonText">In your own words (optional)</Label>
+                <Textarea
+                  id="reasonText"
+                  rows={4}
+                  maxLength={2000}
+                  value={form.reasonText}
+                  onChange={(e) => update({ reasonText: e.target.value })}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 4. Duration */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                How long do you expect to need support for?
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <Select
+                value={form.duration}
+                onValueChange={(v) => update({ duration: v as Duration })}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose one" />
+                </SelectTrigger>
+                <SelectContent>
+                  {DURATIONS.map((d) => (
+                    <SelectItem key={d} value={d}>
+                      {DURATION_LABELS[d]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {form.duration === "other" ? (
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="durationOther">Please describe</Label>
+                  <Input
+                    id="durationOther"
+                    value={form.durationOtherText}
+                    onChange={(e) =>
+                      update({ durationOtherText: e.target.value })
+                    }
+                  />
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+
+          {/* 5. Contribution */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Are you able to contribute something towards club costs at this
+                time?
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <Select
+                value={form.contributionAbility}
+                onValueChange={(v) =>
+                  update({ contributionAbility: v as ContributionAbility })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose one" />
+                </SelectTrigger>
+                <SelectContent>
+                  {CONTRIBUTION_ABILITIES.map((c) => (
+                    <SelectItem key={c} value={c}>
+                      {CONTRIBUTION_ABILITY_LABELS[c]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {form.contributionAbility === "yes_reduced" ? (
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="contributionAmount">
+                    What amount would be manageable? (in £)
+                  </Label>
+                  <Input
+                    id="contributionAmount"
+                    type="number"
+                    min="0"
+                    step="1"
+                    value={form.contributionAmountPounds}
+                    onChange={(e) =>
+                      update({ contributionAmountPounds: e.target.value })
+                    }
+                  />
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+
+          {/* 6. Volunteering */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Could you help the club in non-financial ways?
+              </CardTitle>
+              <CardDescription>
+                This could include ground work, scoring, umpiring, helping at
+                junior sessions, fundraising, matchday setup, admin, or other
+                volunteering. We understand this isn&rsquo;t possible for
+                everyone.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                {VOLUNTEER_OPTIONS.map((option) => (
+                  <CheckboxRow
+                    key={option}
+                    id={`volunteer_${option}`}
+                    checked={form.volunteerOptions.includes(option)}
+                    onChange={(v) => toggleVolunteer(option, v)}
+                    label={VOLUNTEER_OPTION_LABELS[option]}
+                  />
+                ))}
+              </div>
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="volunteerNotes">
+                  Roughly what you could help with and how often (optional)
+                </Label>
+                <Textarea
+                  id="volunteerNotes"
+                  rows={3}
+                  maxLength={2000}
+                  value={form.volunteerNotes}
+                  onChange={(e) => update({ volunteerNotes: e.target.value })}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 7. Contact preference */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Would you prefer to chat before a decision is made?
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Select
+                value={form.contactPreference}
+                onValueChange={(v) =>
+                  update({ contactPreference: v as ContactPreference })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CONTACT_PREFERENCES.map((c) => (
+                    <SelectItem key={c} value={c}>
+                      {CONTACT_PREFERENCE_LABELS[c]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </CardContent>
+          </Card>
+
+          {/* 8. Declarations */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Before you submit</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3 text-sm text-stone-700">
+              <p>
+                Percy Main Community Sports Club will use the information in
+                this form to assess your request, administer any approved
+                financial relief, and record the value of fees or charges
+                waived. If support is approved, future eligible charges may be
+                recorded internally as waived. This allows the club to report
+                the total value of support provided without publicly identifying
+                individuals.
+              </p>
+              <p>
+                Information about financial relief requests is only visible to
+                the relevant club committee members. Where match donation relief
+                is approved, the relevant team captain may also be able to see
+                that match donations have been waived, so they can administer
+                team payments correctly.
+              </p>
+              <p>
+                We will not publish individual names or details when reporting
+                on financial relief provided by the club.
+              </p>
+              <CheckboxRow
+                id="privacyAck"
+                checked={form.privacyAcknowledged}
+                onChange={(v) => update({ privacyAcknowledged: v })}
+                label="I&rsquo;ve read and understood the above."
+              />
+              <CheckboxRow
+                id="declarationConfirmed"
+                checked={form.declarationConfirmed}
+                onChange={(v) => update({ declarationConfirmed: v })}
+                label="I confirm that the information provided is accurate to the best of my knowledge and that I will tell the club if my circumstances change."
+              />
+            </CardContent>
+          </Card>
+
+          {submit.error ? (
+            <Alert variant="destructive">
+              <AlertDescription>
+                {submit.error instanceof Error
+                  ? submit.error.message
+                  : "Something went wrong. Please try again or contact the club."}
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={!canSubmit}>
+              {submit.isPending ? "Submitting…" : "Submit request"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function CheckboxRow({
+  id,
+  checked,
+  onChange,
+  label,
+}: {
+  id: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <Checkbox
+        id={id}
+        className="mt-1"
+        checked={checked}
+        onCheckedChange={(v) => onChange(v === true)}
+      />
+      <Label
+        htmlFor={id}
+        className="leading-snug"
+        dangerouslySetInnerHTML={{ __html: label }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/members/financial-relief.tsx
+++ b/apps/web/src/pages/members/financial-relief.tsx
@@ -40,7 +40,7 @@ import {
   type VolunteerOption,
 } from "@percy-main/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useReducer } from "react";
+import { useMemo, useReducer, type ReactNode } from "react";
 import { Link } from "react-router";
 
 interface FormState {
@@ -594,7 +594,7 @@ export function Component() {
                 id="privacyAck"
                 checked={form.privacyAcknowledged}
                 onChange={(v) => update({ privacyAcknowledged: v })}
-                label="I&rsquo;ve read and understood the above."
+                label="I’ve read and understood the above."
               />
               <CheckboxRow
                 id="declarationConfirmed"
@@ -635,7 +635,7 @@ function CheckboxRow({
   id: string;
   checked: boolean;
   onChange: (v: boolean) => void;
-  label: string;
+  label: ReactNode;
 }) {
   return (
     <div className="flex items-start gap-2">
@@ -645,11 +645,9 @@ function CheckboxRow({
         checked={checked}
         onCheckedChange={(v) => onChange(v === true)}
       />
-      <Label
-        htmlFor={id}
-        className="leading-snug"
-        dangerouslySetInnerHTML={{ __html: label }}
-      />
+      <Label htmlFor={id} className="leading-snug">
+        {label}
+      </Label>
     </div>
   );
 }

--- a/apps/web/src/pages/members/members-dashboard.tsx
+++ b/apps/web/src/pages/members/members-dashboard.tsx
@@ -1,6 +1,7 @@
 import { ChangePassword } from "@/components/members/change-password";
 import { Charges } from "@/components/members/charges";
 import { Documents } from "@/components/members/documents";
+import { FinancialReliefStatus } from "@/components/members/financial-relief-status";
 import {
   MemberDetails,
   useMemberDetails,
@@ -141,17 +142,9 @@ export function Component() {
           </TabsContent>
           <TabsContent value="payments">
             <div className="flex flex-col gap-8">
+              <FinancialReliefStatus />
               <Charges />
               <Subscriptions />
-              <p className="text-xs text-stone-600">
-                Struggling with fees?{" "}
-                <Link
-                  className="text-blue-900 underline"
-                  to="/members/financial-relief"
-                >
-                  Ask the club about financial relief.
-                </Link>
-              </p>
             </div>
           </TabsContent>
           <TabsContent value="documents">

--- a/apps/web/src/pages/members/members-dashboard.tsx
+++ b/apps/web/src/pages/members/members-dashboard.tsx
@@ -143,6 +143,15 @@ export function Component() {
             <div className="flex flex-col gap-8">
               <Charges />
               <Subscriptions />
+              <p className="text-xs text-stone-600">
+                Struggling with fees?{" "}
+                <Link
+                  className="text-blue-900 underline"
+                  to="/members/financial-relief"
+                >
+                  Ask the club about financial relief.
+                </Link>
+              </p>
             </div>
           </TabsContent>
           <TabsContent value="documents">

--- a/apps/web/src/pages/membership/membership-join.tsx
+++ b/apps/web/src/pages/membership/membership-join.tsx
@@ -30,10 +30,6 @@ function JoinWizardInner() {
           <CardTitle>Join Percy Main Community Sports Club</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground mb-6 text-sm">
-            Fill in your details so we can keep in touch and keep you safe at
-            the club. You can skip this for now and complete it later.
-          </p>
           {hasDetails ? (
             <div className="rounded border border-green-300 bg-green-50 p-3 text-sm text-green-800">
               Your details are already on file. You can proceed to payment.

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -1028,7 +1028,7 @@ function MatchdayView({
                           data.matchday.status === "finished") &&
                           player.status === "playing" &&
                           player.charge_id &&
-                          !player.chargePaidAt && (
+                          player.chargeStatus === "unpaid" && (
                             <>
                               {payingPlayerId === player.id ? (
                                 <div className="flex items-center gap-1">
@@ -1077,11 +1077,15 @@ function MatchdayView({
                         {data.matchday.status !== "pending" &&
                           player.status === "playing" &&
                           payingPlayerId !== player.id &&
-                          (player.chargePaidAt ? (
+                          (player.chargeStatus === "paid" ? (
                             <span className="rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-800">
                               Donation paid
                             </span>
-                          ) : player.charge_id ? (
+                          ) : player.chargeStatus === "waived" ? (
+                            <span className="rounded bg-stone-100 px-1.5 py-0.5 text-xs font-medium text-stone-700">
+                              Donation waived
+                            </span>
+                          ) : player.chargeStatus === "unpaid" ? (
                             <span className="rounded bg-yellow-100 px-1.5 py-0.5 text-xs font-medium text-yellow-800">
                               Donation pending
                             </span>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -181,6 +181,10 @@ export const router = createBrowserRouter([
                 path: "members/documents/:documentId",
                 lazy: () => import("./pages/members/document-viewer.js"),
               },
+              {
+                path: "members/financial-relief",
+                lazy: () => import("./pages/members/financial-relief.js"),
+              },
               // Membership flows
               {
                 path: "membership/join",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import eslint from "@eslint/js";
+import reactPlugin from "eslint-plugin-react";
 import hooksPlugin from "eslint-plugin-react-hooks";
 import reactDoctor from "react-doctor/eslint-plugin";
 import tseslint from "typescript-eslint";
@@ -92,6 +93,9 @@ export default tseslint.config(
   },
   {
     files: ["apps/web/src/**/*.{ts,tsx}"],
+    plugins: {
+      react: reactPlugin,
+    },
     rules: {
       // Vite SPA — there is no SSR. `new Date()` reachable from JSX cannot
       // mismatch between server and client because the server doesn't render.
@@ -100,6 +104,10 @@ export default tseslint.config(
       // Vite SPA — no server actions / progressive enhancement story. Forms
       // rely on `e.preventDefault()` + a mutation; that's the correct pattern.
       "react-doctor/no-prevent-default": "off",
+      // dangerouslySetInnerHTML is the XSS landmine — block it at the lint
+      // gate instead of only surfacing it as a warn-level CLI finding in the
+      // react-doctor PR comment.
+      "react/no-danger": "error",
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@eslint/js": "^10",
     "eslint": "^10",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "openapi-typescript": "^7.13.0",
     "prettier": "^3.8.3",

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -139,9 +139,14 @@ export interface Charge {
   description: string;
   id: string;
   member_id: string;
+  original_amount_pence: number | null;
   paid_at: string | null;
   payment_confirmed_at: string | null;
   payment_method: string | null;
+  relief_grant_id: string | null;
+  relieved_at: string | null;
+  relieved_by: string | null;
+  relieved_reason: string | null;
   source: Generated<string>;
   stripe_payment_intent_id: string | null;
   type: Generated<string>;
@@ -289,6 +294,62 @@ export interface FantasyTeamScore {
   id: Generated<number>;
   season: string;
   total_points: Generated<number>;
+}
+
+export interface FinancialReliefEvent {
+  actor_user_id: string;
+  created_at: Generated<Timestamp>;
+  event_type: string;
+  from_status: string | null;
+  id: string;
+  note: string | null;
+  request_id: string;
+  to_status: string | null;
+}
+
+export interface FinancialReliefGrant {
+  admin_notes: string | null;
+  closed_at: Timestamp | null;
+  closed_by: string | null;
+  closed_reason: string | null;
+  covers_match_fees: boolean;
+  covers_membership: boolean;
+  decided_at: Generated<Timestamp>;
+  decided_by: string;
+  decision: string;
+  effective_from: Timestamp;
+  effective_to_exclusive: Timestamp | null;
+  id: string;
+  member_facing_note: string | null;
+  member_id: string;
+  membership_partial_pence: number | null;
+  request_id: string;
+}
+
+export interface FinancialReliefRequest {
+  contact_preference: string;
+  contribution_ability: string | null;
+  contribution_amount_pence: number | null;
+  created_at: Generated<Timestamp>;
+  declaration_confirmed_at: Timestamp;
+  duration: string | null;
+  duration_other_text: string | null;
+  id: string;
+  member_id: string;
+  partial_amount_pence: number | null;
+  privacy_acknowledged_at: Timestamp;
+  reason_category: string | null;
+  reason_text: string | null;
+  requested_match_fees: boolean;
+  requested_membership_full: boolean;
+  requested_membership_partial: boolean;
+  status: Generated<string>;
+  submitted_by_user_id: string;
+  updated_at: Generated<Timestamp>;
+  volunteer_notes: string | null;
+  volunteer_options: Generated<Json>;
+  withdrawn_at: Timestamp | null;
+  withdrawn_reason: string | null;
 }
 
 export interface GameScore {
@@ -889,6 +950,9 @@ export interface DB {
   fantasy_team: FantasyTeam;
   fantasy_team_player: FantasyTeamPlayer;
   fantasy_team_score: FantasyTeamScore;
+  financial_relief_event: FinancialReliefEvent;
+  financial_relief_grant: FinancialReliefGrant;
+  financial_relief_request: FinancialReliefRequest;
   game_score: GameScore;
   game_sponsorship: GameSponsorship;
   junior_team: JuniorTeam;

--- a/packages/db/src/migrations/2026-05-12T06:31:12.274Z.ts
+++ b/packages/db/src/migrations/2026-05-12T06:31:12.274Z.ts
@@ -1,0 +1,224 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Financial relief workflow.
+ *
+ * Three new tables plus relief columns on `charge`:
+ *
+ *  - financial_relief_request  — the member-submitted application form.
+ *    A partial unique index limits to one open request per member.
+ *
+ *  - financial_relief_grant    — created when an admin approves a request.
+ *    Declines are NEVER persisted as grants (they live on the request +
+ *    an event). A partial unique index limits to one active grant per
+ *    member.
+ *
+ *  - financial_relief_event    — append-only audit trail of status
+ *    transitions, decisions, notes, and the membership-relief action.
+ *
+ * Relief columns on `charge` mirror the deleted_at/by/reason audit
+ * triplet pattern used elsewhere in the schema. `original_amount_pence`
+ * is set ONLY on the partial-relief path so reporting can sum
+ * `COALESCE(original_amount_pence, amount_pence)` to recover the full
+ * pre-relief value without sibling rows.
+ *
+ * The check constraint `charge_relief_consistent` enforces that the
+ * three relief audit fields move together.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // --- financial_relief_request ---------------------------------------
+  await db.schema
+    .createTable("financial_relief_request")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("submitted_by_user_id", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("member_id", "text", (col) =>
+      col.notNull().references("member.id"),
+    )
+    .addColumn("status", "text", (col) => col.notNull().defaultTo("submitted"))
+    .addColumn("requested_membership_full", "boolean", (col) => col.notNull())
+    .addColumn("requested_membership_partial", "boolean", (col) =>
+      col.notNull(),
+    )
+    .addColumn("requested_match_fees", "boolean", (col) => col.notNull())
+    .addColumn("partial_amount_pence", "integer")
+    .addColumn("reason_category", "text")
+    .addColumn("reason_text", "text")
+    .addColumn("duration", "text")
+    .addColumn("duration_other_text", "text")
+    .addColumn("contribution_ability", "text")
+    .addColumn("contribution_amount_pence", "integer")
+    .addColumn("volunteer_options", "jsonb", (col) =>
+      col.notNull().defaultTo(sql`'[]'::jsonb`),
+    )
+    .addColumn("volunteer_notes", "text")
+    .addColumn("contact_preference", "text", (col) => col.notNull())
+    .addColumn("privacy_acknowledged_at", "timestamptz", (col) => col.notNull())
+    .addColumn("declaration_confirmed_at", "timestamptz", (col) =>
+      col.notNull(),
+    )
+    .addColumn("withdrawn_at", "timestamptz")
+    .addColumn("withdrawn_reason", "text")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addCheckConstraint(
+      "financial_relief_request_status_check",
+      sql`status IN ('submitted','in_review','more_info_needed','approved','declined','withdrawn','expired')`,
+    )
+    .addCheckConstraint(
+      "financial_relief_request_contact_pref_check",
+      sql`contact_preference IN ('none','email','phone','in_person')`,
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("financial_relief_request_member_id_idx")
+    .on("financial_relief_request")
+    .column("member_id")
+    .execute();
+
+  // One open request per member. Partial unique index — DB-level
+  // guarantee against the race the service tries to avoid with locks.
+  await sql`
+    CREATE UNIQUE INDEX financial_relief_request_one_open_uidx
+      ON financial_relief_request (member_id)
+      WHERE status IN ('submitted','in_review','more_info_needed')
+  `.execute(db);
+
+  // --- financial_relief_grant -----------------------------------------
+  await db.schema
+    .createTable("financial_relief_grant")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("request_id", "text", (col) =>
+      col.notNull().references("financial_relief_request.id"),
+    )
+    .addColumn("member_id", "text", (col) =>
+      col.notNull().references("member.id"),
+    )
+    .addColumn("decision", "text", (col) => col.notNull())
+    .addColumn("covers_membership", "boolean", (col) => col.notNull())
+    .addColumn("covers_match_fees", "boolean", (col) => col.notNull())
+    .addColumn("membership_partial_pence", "integer")
+    .addColumn("effective_from", "date", (col) => col.notNull())
+    .addColumn("effective_to_exclusive", "date")
+    .addColumn("admin_notes", "text")
+    .addColumn("member_facing_note", "text")
+    .addColumn("decided_by", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("decided_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("closed_at", "timestamptz")
+    .addColumn("closed_by", "text", (col) => col.references("user.id"))
+    .addColumn("closed_reason", "text")
+    .addCheckConstraint(
+      "financial_relief_grant_decision_check",
+      sql`decision IN ('approved_full','approved_partial','approved_temporary')`,
+    )
+    .addCheckConstraint(
+      "financial_relief_grant_closed_consistent_check",
+      sql`(closed_at IS NULL AND closed_by IS NULL) OR (closed_at IS NOT NULL AND closed_by IS NOT NULL)`,
+    )
+    .execute();
+
+  // One active grant per member.
+  await sql`
+    CREATE UNIQUE INDEX financial_relief_grant_one_active_uidx
+      ON financial_relief_grant (member_id)
+      WHERE closed_at IS NULL
+  `.execute(db);
+
+  // --- financial_relief_event -----------------------------------------
+  await db.schema
+    .createTable("financial_relief_event")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("request_id", "text", (col) =>
+      col.notNull().references("financial_relief_request.id"),
+    )
+    .addColumn("event_type", "text", (col) => col.notNull())
+    .addColumn("from_status", "text")
+    .addColumn("to_status", "text")
+    .addColumn("note", "text")
+    .addColumn("actor_user_id", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addCheckConstraint(
+      "financial_relief_event_type_check",
+      sql`event_type IN ('status_changed','note_added','more_info_requested','grant_created','grant_closed','declined','withdrawn','membership_relief_applied')`,
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("financial_relief_event_request_id_idx")
+    .on("financial_relief_event")
+    .columns(["request_id", "created_at"])
+    .execute();
+
+  // --- relief columns on charge ---------------------------------------
+  // Stored as text to match the existing deleted_at column convention
+  // on this table.
+  await db.schema
+    .alterTable("charge")
+    .addColumn("relieved_at", "text")
+    .execute();
+  await db.schema
+    .alterTable("charge")
+    .addColumn("relieved_by", "text", (col) => col.references("user.id"))
+    .execute();
+  await db.schema
+    .alterTable("charge")
+    .addColumn("relieved_reason", "text")
+    .execute();
+  await db.schema
+    .alterTable("charge")
+    .addColumn("relief_grant_id", "text", (col) =>
+      col.references("financial_relief_grant.id"),
+    )
+    .execute();
+  await db.schema
+    .alterTable("charge")
+    .addColumn("original_amount_pence", "integer")
+    .execute();
+
+  await sql`
+    ALTER TABLE charge ADD CONSTRAINT charge_relief_consistent CHECK (
+      (relieved_at IS NULL AND relieved_by IS NULL AND relieved_reason IS NULL AND original_amount_pence IS NULL)
+      OR
+      (relieved_at IS NOT NULL AND relieved_by IS NOT NULL AND relieved_reason IS NOT NULL)
+    )
+  `.execute(db);
+
+  await sql`
+    CREATE INDEX charge_relieved_at_idx
+      ON charge (relieved_at)
+      WHERE relieved_at IS NOT NULL
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE charge DROP CONSTRAINT IF EXISTS charge_relief_consistent`.execute(
+    db,
+  );
+  await sql`DROP INDEX IF EXISTS charge_relieved_at_idx`.execute(db);
+  await db.schema
+    .alterTable("charge")
+    .dropColumn("original_amount_pence")
+    .execute();
+  await db.schema.alterTable("charge").dropColumn("relief_grant_id").execute();
+  await db.schema.alterTable("charge").dropColumn("relieved_reason").execute();
+  await db.schema.alterTable("charge").dropColumn("relieved_by").execute();
+  await db.schema.alterTable("charge").dropColumn("relieved_at").execute();
+
+  await db.schema.dropTable("financial_relief_event").execute();
+  await db.schema.dropTable("financial_relief_grant").execute();
+  await db.schema.dropTable("financial_relief_request").execute();
+}

--- a/packages/db/src/migrations/2026-05-12T08:00:09.935Z.ts
+++ b/packages/db/src/migrations/2026-05-12T08:00:09.935Z.ts
@@ -1,0 +1,34 @@
+import { sql, type Kysely } from "kysely";
+
+/**
+ * Backfill `member` rows for users that registered before the
+ * signup→member auto-link hook existed.
+ *
+ * The hook (apps/api/src/features/auth/auth.ts databaseHooks.user.create.after)
+ * inserts a paired `member` row at user-create time. Anyone who
+ * registered prior to that change has a `user` but no `member`, so
+ * downstream lookups (financial relief eligible-members,
+ * matchday/charge attribution, etc.) come up empty for those legacy
+ * accounts. This migration creates a 1:1 catch-up row for each.
+ *
+ * Idempotent via the LEFT JOIN exclusion: re-running this would be a
+ * no-op because all eligible users now have a member.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    INSERT INTO member (id, email, name)
+    SELECT
+      gen_random_uuid()::text,
+      u.email,
+      u.name
+    FROM "user" u
+    LEFT JOIN member m ON m.email = u.email
+    WHERE m.id IS NULL
+      AND u.email IS NOT NULL
+  `.execute(db);
+}
+
+export async function down(_db: Kysely<unknown>): Promise<void> {
+  // No safe rollback: we can't distinguish backfilled rows from rows
+  // an admin created manually. Treat this as a one-way data fix.
+}

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -4,6 +4,7 @@ export { AvailabilityRequest } from "./templates/AvailabilityRequest.tsx";
 export { ChaosWeekAnnouncement } from "./templates/ChaosWeekAnnouncement.tsx";
 export { ChargeNotification } from "./templates/ChargeNotification.tsx";
 export { FantasyReminder } from "./templates/FantasyReminder.tsx";
+export { FinancialReliefDecision } from "./templates/FinancialReliefDecision.tsx";
 export { FinancialReliefReceived } from "./templates/FinancialReliefReceived.tsx";
 export { IncidentReportConfirmation } from "./templates/IncidentReportConfirmation.tsx";
 export { MembershipUpdated } from "./templates/MembershipUpdated.tsx";

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -4,6 +4,7 @@ export { AvailabilityRequest } from "./templates/AvailabilityRequest.tsx";
 export { ChaosWeekAnnouncement } from "./templates/ChaosWeekAnnouncement.tsx";
 export { ChargeNotification } from "./templates/ChargeNotification.tsx";
 export { FantasyReminder } from "./templates/FantasyReminder.tsx";
+export { FinancialReliefReceived } from "./templates/FinancialReliefReceived.tsx";
 export { IncidentReportConfirmation } from "./templates/IncidentReportConfirmation.tsx";
 export { MembershipUpdated } from "./templates/MembershipUpdated.tsx";
 export { PaymentReminder } from "./templates/PaymentReminder.tsx";

--- a/packages/email/src/templates/FinancialReliefDecision.tsx
+++ b/packages/email/src/templates/FinancialReliefDecision.tsx
@@ -1,0 +1,85 @@
+// organize-imports-ignore — React must stay: tsx/esbuild uses classic JSX transform for workspace deps
+import React, { type FC } from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Text,
+} from "@react-email/components";
+import { email } from "../email.ts";
+import * as styles from "../styles.ts";
+
+interface Props {
+  imageBaseUrl: string;
+  recipientName: string;
+  outcome: "approved" | "declined";
+  memberFacingNote: string | null;
+}
+
+const Component: FC<Props> = ({
+  imageBaseUrl,
+  recipientName,
+  outcome,
+  memberFacingNote,
+}) => (
+  <Html>
+    <Head />
+    <Preview>An update on your request to Percy Main CC</Preview>
+    <Body style={styles.main}>
+      <Container style={styles.container}>
+        <Img
+          src={`${imageBaseUrl}/club_logo.png`}
+          width="100"
+          height="100"
+          alt="Percy Main Club Logo"
+          style={styles.logo}
+        />
+        <Text style={styles.paragraph}>Hi {recipientName},</Text>
+        {outcome === "approved" ? (
+          <Text style={styles.paragraph}>
+            We&rsquo;ve reviewed your request and the committee is glad to offer
+            support. The relevant fees will be taken care of by the club from
+            our end &mdash; you don&rsquo;t need to do anything.
+          </Text>
+        ) : (
+          <Text style={styles.paragraph}>
+            Thank you for getting in touch. After review, the committee
+            isn&rsquo;t able to support this request right now.
+          </Text>
+        )}
+        {memberFacingNote ? (
+          <Text style={styles.paragraph}>{memberFacingNote}</Text>
+        ) : null}
+        <Text style={styles.paragraph}>
+          If your circumstances change, please get in touch &mdash; you can
+          always reply to this email or contact the club directly.
+        </Text>
+        <Text style={styles.paragraph}>
+          Best,
+          <br />
+          Percy Main CC
+        </Text>
+        <Hr style={styles.hr} />
+        <Text style={styles.footer}>
+          Percy Main Cricket Club, St. Johns Terrace, North Shields, NE29 6HS
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export const FinancialReliefDecision = email<Props>(
+  "An update on your request to Percy Main CC",
+  {
+    preview: {
+      imageBaseUrl: "http://localhost:5173/images",
+      recipientName: "Jane Smith",
+      outcome: "approved",
+      memberFacingNote: "Match donations for the 2026 season are waived.",
+    },
+  },
+)(Component);

--- a/packages/email/src/templates/FinancialReliefReceived.tsx
+++ b/packages/email/src/templates/FinancialReliefReceived.tsx
@@ -1,0 +1,68 @@
+// organize-imports-ignore — React must stay: tsx/esbuild uses classic JSX transform for workspace deps
+import React, { type FC } from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Text,
+} from "@react-email/components";
+import { email } from "../email.ts";
+import * as styles from "../styles.ts";
+
+interface Props {
+  imageBaseUrl: string;
+  recipientName: string;
+}
+
+const Component: FC<Props> = ({ imageBaseUrl, recipientName }) => (
+  <Html>
+    <Head />
+    <Preview>We&rsquo;ve received your request to Percy Main CC</Preview>
+    <Body style={styles.main}>
+      <Container style={styles.container}>
+        <Img
+          src={`${imageBaseUrl}/club_logo.png`}
+          width="100"
+          height="100"
+          alt="Percy Main Club Logo"
+          style={styles.logo}
+        />
+        <Text style={styles.paragraph}>Hi {recipientName},</Text>
+        <Text style={styles.paragraph}>
+          Thank you for getting in touch. We&rsquo;ve received your request and
+          a committee member will review it shortly. We&rsquo;ll be in touch
+          when there&rsquo;s news.
+        </Text>
+        <Text style={styles.paragraph}>
+          If anything changes in the meantime, just reply to this email or
+          contact the club.
+        </Text>
+        <Text style={styles.paragraph}>
+          Best,
+          <br />
+          Percy Main CC
+        </Text>
+        <Hr style={styles.hr} />
+        <Text style={styles.footer}>
+          Percy Main Cricket Club, St. Johns Terrace, North Shields, NE29 6HS
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+// Email subject is intentionally vague — "financial relief" never appears
+// in the subject line so an inbox preview never outs the member.
+export const FinancialReliefReceived = email<Props>(
+  "Your request to Percy Main CC",
+  {
+    preview: {
+      imageBaseUrl: "http://localhost:5173/images",
+      recipientName: "Jane Smith",
+    },
+  },
+)(Component);

--- a/packages/shared/src/financial-relief.ts
+++ b/packages/shared/src/financial-relief.ts
@@ -1,0 +1,168 @@
+import { z } from "zod";
+
+export const REASON_CATEGORIES = [
+  "cost_of_living",
+  "low_income",
+  "temporary_change",
+  "multiple_family",
+  "unemployment",
+  "caring",
+  "other_personal",
+  "prefer_not_to_say",
+] as const;
+
+export const REASON_CATEGORY_LABELS: Record<
+  (typeof REASON_CATEGORIES)[number],
+  string
+> = {
+  cost_of_living: "Cost of living pressures",
+  low_income: "Low household income",
+  temporary_change: "Temporary change in circumstances",
+  multiple_family: "Multiple family members taking part",
+  unemployment: "Unemployment or reduced hours",
+  caring: "Caring responsibilities",
+  other_personal: "Other personal circumstances",
+  prefer_not_to_say: "Prefer not to say",
+};
+
+export const reasonCategorySchema = z.enum(REASON_CATEGORIES);
+export type ReasonCategory = z.infer<typeof reasonCategorySchema>;
+
+export const DURATIONS = [
+  "one_off",
+  "one_to_three_months",
+  "season",
+  "unsure",
+  "other",
+] as const;
+
+export const DURATION_LABELS: Record<(typeof DURATIONS)[number], string> = {
+  one_off: "One-off support",
+  one_to_three_months: "1–3 months",
+  season: "This season",
+  unsure: "Unsure",
+  other: "Other",
+};
+
+export const durationSchema = z.enum(DURATIONS);
+export type Duration = z.infer<typeof durationSchema>;
+
+export const CONTRIBUTION_ABILITIES = [
+  "yes_reduced",
+  "not_currently",
+  "unsure",
+] as const;
+
+export const CONTRIBUTION_ABILITY_LABELS: Record<
+  (typeof CONTRIBUTION_ABILITIES)[number],
+  string
+> = {
+  yes_reduced: "Yes — I/we can pay a reduced amount",
+  not_currently: "Not currently",
+  unsure: "Unsure / would like to discuss",
+};
+
+export const contributionAbilitySchema = z.enum(CONTRIBUTION_ABILITIES);
+export type ContributionAbility = z.infer<typeof contributionAbilitySchema>;
+
+export const VOLUNTEER_OPTIONS = [
+  "ground_work",
+  "scoring",
+  "umpiring",
+  "junior_sessions",
+  "womens_girls",
+  "bbq_kitchen",
+  "fundraising",
+  "social_media",
+  "admin",
+  "matchday_setup",
+  "transport",
+  "other",
+  "none",
+] as const;
+
+export const VOLUNTEER_OPTION_LABELS: Record<
+  (typeof VOLUNTEER_OPTIONS)[number],
+  string
+> = {
+  ground_work: "Ground work / maintenance days",
+  scoring: "Scoring",
+  umpiring: "Umpiring",
+  junior_sessions: "Coaching or helping at junior sessions",
+  womens_girls: "Helping with women's/girls' sessions",
+  bbq_kitchen: "Barbecue / kitchen / refreshments",
+  fundraising: "Fundraising events",
+  social_media: "Social media / photography / match reports",
+  admin: "Admin support",
+  matchday_setup: "Matchday setup or tidy-up",
+  transport: "Transport support",
+  other: "Other",
+  none: "I/we cannot commit to volunteering at the moment",
+};
+
+export const volunteerOptionSchema = z.enum(VOLUNTEER_OPTIONS);
+export type VolunteerOption = z.infer<typeof volunteerOptionSchema>;
+
+export const CONTACT_PREFERENCES = [
+  "none",
+  "email",
+  "phone",
+  "in_person",
+] as const;
+
+export const CONTACT_PREFERENCE_LABELS: Record<
+  (typeof CONTACT_PREFERENCES)[number],
+  string
+> = {
+  none: "No, please decide based on this form",
+  email: "Yes, by email",
+  phone: "Yes, by phone",
+  in_person: "Yes, in person",
+};
+
+export const contactPreferenceSchema = z.enum(CONTACT_PREFERENCES);
+export type ContactPreference = z.infer<typeof contactPreferenceSchema>;
+
+export const REQUEST_STATUSES = [
+  "submitted",
+  "in_review",
+  "more_info_needed",
+  "approved",
+  "declined",
+  "withdrawn",
+  "expired",
+] as const;
+
+export const REQUEST_STATUS_LABELS: Record<
+  (typeof REQUEST_STATUSES)[number],
+  string
+> = {
+  submitted: "Submitted",
+  in_review: "In review",
+  more_info_needed: "More information needed",
+  approved: "Approved",
+  declined: "Declined",
+  withdrawn: "Withdrawn",
+  expired: "Expired",
+};
+
+export const requestStatusSchema = z.enum(REQUEST_STATUSES);
+export type RequestStatus = z.infer<typeof requestStatusSchema>;
+
+export const GRANT_DECISIONS = [
+  "approved_full",
+  "approved_partial",
+  "approved_temporary",
+] as const;
+
+export const GRANT_DECISION_LABELS: Record<
+  (typeof GRANT_DECISIONS)[number],
+  string
+> = {
+  approved_full: "Approved — full relief",
+  approved_partial: "Approved — partial relief",
+  approved_temporary: "Approved — temporary relief",
+};
+
+export const grantDecisionSchema = z.enum(GRANT_DECISIONS);
+export type GrantDecision = z.infer<typeof grantDecisionSchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -35,6 +35,37 @@ export { chartSpecSchema, type ChartSpec } from "./scout-chart.ts";
 export { videoSpecSchema, type VideoSpec } from "./scout-video.ts";
 
 export {
+  CONTACT_PREFERENCES,
+  CONTACT_PREFERENCE_LABELS,
+  CONTRIBUTION_ABILITIES,
+  CONTRIBUTION_ABILITY_LABELS,
+  DURATIONS,
+  DURATION_LABELS,
+  GRANT_DECISIONS,
+  GRANT_DECISION_LABELS,
+  REASON_CATEGORIES,
+  REASON_CATEGORY_LABELS,
+  REQUEST_STATUSES,
+  REQUEST_STATUS_LABELS,
+  VOLUNTEER_OPTIONS,
+  VOLUNTEER_OPTION_LABELS,
+  contactPreferenceSchema,
+  contributionAbilitySchema,
+  durationSchema,
+  grantDecisionSchema,
+  reasonCategorySchema,
+  requestStatusSchema,
+  volunteerOptionSchema,
+  type ContactPreference,
+  type ContributionAbility,
+  type Duration,
+  type GrantDecision,
+  type ReasonCategory,
+  type RequestStatus,
+  type VolunteerOption,
+} from "./financial-relief.ts";
+
+export {
   scoutLeagueTableSchema,
   scoutReportContentSchema,
   scoutReportDisplayTitle,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       eslint:
         specifier: ^10
         version: 10.3.0(jiti@2.7.0)
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@10.3.0(jiti@2.7.0))
@@ -264,7 +267,7 @@ importers:
         version: 3.0.176(react@19.2.4)(zod@4.3.6)
       '@better-auth/passkey':
         specifier: ^1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.5))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.5))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4692,6 +4695,34 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlast@1.2.5:
+    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.tosorted@1.1.4:
+    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -4713,6 +4744,10 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
@@ -4725,6 +4760,10 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
@@ -4907,6 +4946,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
@@ -4960,6 +5002,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -5114,6 +5160,9 @@ packages:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
@@ -5220,6 +5269,18 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
   date-fns-tz@3.2.0:
     resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
     peerDependencies:
@@ -5268,6 +5329,14 @@ packages:
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -5319,6 +5388,10 @@ packages:
   dockerode@4.0.12:
     resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
     engines: {node: '>= 8.0'}
+
+  doctrine@2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -5396,12 +5469,20 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-iterator-helpers@1.3.2:
+    resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
   es-module-lexer@2.1.0:
@@ -5413,6 +5494,14 @@ packages:
 
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
   es-toolkit@1.45.1:
@@ -5454,6 +5543,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
+  eslint-plugin-react@7.37.5:
+    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -5677,6 +5772,10 @@ packages:
   fontkit@2.0.4:
     resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -5716,6 +5815,13 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
   gaxios@6.7.1:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
     engines: {node: '>=14'}
@@ -5731,6 +5837,10 @@ packages:
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -5760,6 +5870,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
@@ -5784,6 +5898,10 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
 
   google-ads-api@23.0.0:
     resolution: {integrity: sha512-SwgqKKdgJF4oVhJ/P3Wees5kh382pQescZuq/BxwTZq7el4lYFfiwTqOcs8aM0kYmdDG0o74Y7BrWaUTDxFrTA==}
@@ -5822,9 +5940,20 @@ packages:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
 
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -5836,6 +5965,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-estree@3.1.3:
@@ -5939,6 +6072,10 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
@@ -5953,11 +6090,43 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
@@ -5966,9 +6135,17 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -5985,6 +6162,18 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -5993,9 +6182,33 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
 
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -6008,8 +6221,23 @@ packages:
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -6025,6 +6253,10 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  iterator.prototype@1.1.5:
+    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
+    engines: {node: '>= 0.4'}
 
   jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
@@ -6110,6 +6342,10 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -6541,6 +6777,9 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
@@ -6650,6 +6889,10 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-exports-info@1.6.0:
+    resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
+    engines: {node: '>= 0.4'}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -6686,6 +6929,26 @@ packages:
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.entries@1.1.9:
+    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
   obug@2.1.1:
@@ -6737,6 +7000,10 @@ packages:
   ora@9.4.0:
     resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
     engines: {node: '>=20'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
 
   oxc-parser@0.128.0:
     resolution: {integrity: sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw==}
@@ -6812,6 +7079,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
@@ -6892,6 +7162,10 @@ packages:
 
   png-js@2.0.0:
     resolution: {integrity: sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -7246,6 +7520,14 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
 
@@ -7291,6 +7573,11 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@2.0.0-next.6:
+    resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -7339,11 +7626,23 @@ packages:
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
+    engines: {node: '>=0.4'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
 
   safe-regex2@5.1.0:
     resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
@@ -7390,6 +7689,18 @@ packages:
 
   set-cookie-parser@3.0.1:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -7502,6 +7813,10 @@ packages:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   stream-chain@2.2.5:
     resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
 
@@ -7535,6 +7850,25 @@ packages:
 
   string.prototype.codepointat@0.2.1:
     resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
+  string.prototype.matchall@4.0.12:
+    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.repeat@1.0.0:
+    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -7604,6 +7938,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   svg-arc-to-cubic-bezier@3.2.0:
     resolution: {integrity: sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==}
@@ -7756,6 +8094,22 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
+
   typescript-eslint@8.59.2:
     resolution: {integrity: sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -7771,6 +8125,10 @@ packages:
   unbash@3.0.0:
     resolution: {integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==}
     engines: {node: '>=14'}
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -7994,6 +8352,22 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -9433,18 +9807,6 @@ snapshots:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       mongodb: 7.1.0
-
-  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.5))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@simplewebauthn/browser': 13.3.0
-      '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.5)
-      better-call: 1.3.2(zod@4.3.6)
-      nanostores: 1.1.1
-      zod: 4.3.6
 
   '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(mongodb@7.1.0)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.5))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
     dependencies:
@@ -13283,6 +13645,63 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array-includes@3.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
+  array.prototype.findlast@1.2.5:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.tosorted@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
   asap@2.0.6: {}
 
   asn1@0.2.6:
@@ -13305,6 +13724,8 @@ snapshots:
 
   astring@1.9.0: {}
 
+  async-function@1.0.0: {}
+
   async-lock@1.4.1: {}
 
   async@3.2.6: {}
@@ -13312,6 +13733,10 @@ snapshots:
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   avvio@9.2.0:
     dependencies:
@@ -13445,6 +13870,11 @@ snapshots:
 
   bowser@2.14.1: {}
 
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
@@ -13502,6 +13932,13 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
 
   call-bound@1.0.4:
     dependencies:
@@ -13629,6 +14066,8 @@ snapshots:
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
+  concat-map@0.0.1: {}
+
   content-disposition@1.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -13718,6 +14157,24 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
   date-fns-tz@3.2.0(date-fns@4.1.0):
     dependencies:
       date-fns: 4.1.0
@@ -13751,6 +14208,18 @@ snapshots:
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   defu@6.1.4: {}
 
@@ -13803,6 +14272,10 @@ snapshots:
       uuid: 10.0.0
     transitivePeerDependencies:
       - supports-color
+
+  doctrine@2.1.0:
+    dependencies:
+      esutils: 2.0.3
 
   dom-serializer@2.0.0:
     dependencies:
@@ -13893,9 +14366,85 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.20
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-iterator-helpers@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-set-tostringtag: 2.1.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      iterator.prototype: 1.1.5
+      math-intrinsics: 1.1.0
 
   es-module-lexer@2.1.0: {}
 
@@ -13909,6 +14458,16 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   es-toolkit@1.45.1: {}
 
@@ -13999,6 +14558,28 @@ snapshots:
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-react@7.37.5(eslint@10.3.0(jiti@2.7.0)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.3.2
+      eslint: 10.3.0(jiti@2.7.0)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.6
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
 
   eslint-scope@9.1.2:
     dependencies:
@@ -14276,6 +14857,10 @@ snapshots:
       unicode-properties: 1.4.1
       unicode-trie: 2.0.0
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -14314,6 +14899,17 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.2
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
   gaxios@6.7.1:
     dependencies:
       extend: 3.0.2
@@ -14350,6 +14946,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  generator-function@2.0.1: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -14377,6 +14975,12 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -14412,6 +15016,11 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
 
   google-ads-api@23.0.0:
     dependencies:
@@ -14490,7 +15099,17 @@ snapshots:
       - encoding
       - supports-color
 
+  has-bigints@1.1.0: {}
+
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -14499,6 +15118,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -14641,6 +15264,12 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
   internmap@2.0.3: {}
 
   ipaddr.js@2.3.0: {}
@@ -14652,16 +15281,68 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
   is-arrayish@0.2.1: {}
 
   is-arrayish@0.3.4:
     optional: true
 
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
 
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
@@ -14673,11 +15354,48 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
   is-stream@2.0.1: {}
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
 
   is-unicode-supported@0.1.0: {}
 
@@ -14685,7 +15403,20 @@ snapshots:
 
   is-url@1.2.4: {}
 
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
   isarray@1.0.0: {}
+
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -14701,6 +15432,15 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  iterator.prototype@1.1.5:
+    dependencies:
+      define-data-property: 1.1.4
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      has-symbols: 1.1.0
+      set-function-name: 2.0.2
 
   jackspeak@2.3.6:
     dependencies:
@@ -14773,6 +15513,13 @@ snapshots:
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
+
+  jsx-ast-utils@3.3.5:
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.flat: 1.3.3
+      object.assign: 4.1.7
+      object.values: 1.2.1
 
   jwa@2.0.1:
     dependencies:
@@ -15457,6 +16204,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.1.0
@@ -15558,6 +16309,13 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-exports-info@1.6.0:
+    dependencies:
+      array.prototype.flatmap: 1.3.3
+      es-errors: 1.3.0
+      object.entries: 1.1.9
+      semver: 6.3.1
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -15585,6 +16343,38 @@ snapshots:
   object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  object.entries@1.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+
+  object.values@1.2.1:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
 
   obug@2.1.1: {}
 
@@ -15656,6 +16446,12 @@ snapshots:
       log-symbols: 7.0.1
       stdin-discarder: 0.3.2
       string-width: 8.2.1
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
 
   oxc-parser@0.128.0:
     dependencies:
@@ -15788,6 +16584,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
@@ -15884,6 +16682,8 @@ snapshots:
   png-js@2.0.0:
     dependencies:
       fflate: 0.8.2
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
 
@@ -16251,6 +17051,26 @@ snapshots:
 
   reflect-metadata@0.2.2: {}
 
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
   rehype-recma@1.0.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -16334,6 +17154,15 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@2.0.0-next.6:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      node-exports-info: 1.6.0
+      object-keys: 1.1.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   restore-cursor@3.1.0:
     dependencies:
@@ -16420,9 +17249,28 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
 
   safe-regex2@5.1.0:
     dependencies:
@@ -16461,6 +17309,28 @@ snapshots:
   set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.0.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
 
   setprototypeof@1.2.0: {}
 
@@ -16640,6 +17510,11 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
   stream-chain@2.2.5: {}
 
   stream-events@1.0.5:
@@ -16681,6 +17556,50 @@ snapshots:
       strip-ansi: 7.2.0
 
   string.prototype.codepointat@0.2.1: {}
+
+  string.prototype.matchall@4.0.12:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      regexp.prototype.flags: 1.5.4
+      set-function-name: 2.0.2
+      side-channel: 1.1.0
+
+  string.prototype.repeat@1.0.0:
+    dependencies:
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
 
   string_decoder@1.1.1:
     dependencies:
@@ -16766,6 +17685,8 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-arc-to-cubic-bezier@3.2.0: {}
 
@@ -16944,6 +17865,39 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
   typescript-eslint@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.3.0(jiti@2.7.0))(typescript@5.9.3)
@@ -16958,6 +17912,13 @@ snapshots:
   typescript@5.9.3: {}
 
   unbash@3.0.0: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
 
   undici-types@5.26.5: {}
 
@@ -17213,6 +18174,47 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.20
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

Adds the full financial relief workflow end-to-end: member-facing application form, admin review + decide + decline + close-grant + apply-membership-relief, payment-lifecycle integration so relieved charges aren't chased / bundled / counted as debt, captain-facing "waived" status, and an aggregate reporting endpoint + admin summary panel.

Builds on the brief in [`FINANCIAL_RELIEF_PLAN.md`](./FINANCIAL_RELIEF_PLAN.md) (included in the diff so the review trail and ADR rationale are part of the PR). 8 phases, 8 commits, in build-order.

Plus 8 follow-up commits picked up while wiring real auth + testing the flow:

- `requireRole` → `requirePermission` migration to land on the post-#302 auth model (relief gates on `finance:manage`)
- Real returnTo bug: better-auth's session atom only refetches via a `setTimeout(10)` post sign-in, so synchronous `navigate(returnTo)` arrived at the destination before the new session was in the atom and `RequireAuth` bounced back to `/auth/login`. Fixed with `await refetchSession()` in email-password / passkey-autofill / 2FA / recovery. Plus three places that hardcoded `/members` (2FA, recovery, require-verified-email).
- New users now get a paired `member` row at sign-up via a better-auth `databaseHooks.user.create.after`; a one-shot migration backfills legacy users who registered before this hook landed.
- `requireAuth` preHandler added to the four member-facing relief routes — they relied on `getAuthSession` to populate `request.authSession`, but that's only set by `requireAuth` running as a preHandler, so every call 401'd without it.
- Payments tab UX: when a member already has a relief request, the discreet "ask for relief" link is replaced with a card showing status + admin's member-facing note (the note had no member-visible home before).
- Copy: "membership fee" → "membership donation" mirroring the existing "match fee" → "match donation" rename.
- Tiny: trim the redundant preamble paragraph above the membership-join form.

## Test plan

- [ ] DB migrations apply on a fresh dev box (`pnpm --filter @percy-main/db run db:up`)
- [ ] `pnpm --filter api test` (unit) — 451+ green
- [ ] `pnpm --filter api test:integration` (real Postgres via testcontainers) — 22 new tests in `financial-relief/integration.test.ts`, plus the rest still pass
- [ ] `pnpm --filter web test` — reducer tests green
- [ ] **Member smoke**: sign up fresh → `/members/financial-relief` form loads with caller pre-selected; submit; "Your financial relief" card now shows on the Payments tab with status pill
- [ ] **Returns-to smoke**: log out, deep-link to `/scout`, log back in — should land on `/scout`, not on `/auth/login?returnTo=%2Fscout`
- [ ] **Admin smoke**: as a `finance_admin` (or legacy `admin`), open Finance → Financial Relief, decide a request as `approved_temporary` covering match donations, verify any of the member's unpaid match-fee charges flip to relieved
- [ ] **Captain smoke**: as an `official` viewing a matchday with a relieved member, donation status shows "Donation waived" (no Mark-Paid button)
- [ ] **Reporting**: with a few relieved charges in place, the Relief summary card on the admin tab returns sensible totals broken down by section

🤖 Generated with [Claude Code](https://claude.com/claude-code)