### PR TITLE
fix(rbac): gate admin sub-tabs and admin-panel link by actual permission

### DIFF
--- a/apps/web/src/components/require-elevated.tsx
+++ b/apps/web/src/components/require-elevated.tsx
@@ -1,11 +1,13 @@
-import { hasAnyElevatedRole } from "@percy-main/shared/auth/permissions";
+import { hasAdminPanelAccess } from "@percy-main/shared/auth/permissions";
 import { Navigate, Outlet } from "react-router";
 import { useSession } from "../lib/auth-client.js";
 import { PageLoading } from "./page-loading.js";
 
 /**
- * Gates a route to any user with a non-default role. Used at the admin-portal
- * root; individual tabs/routes inside then check their own RequirePermission.
+ * Gates the /admin route to users who have at least one admin-panel sub-tab
+ * unlocked. AI-only roles (ai_chat_user, ai_facts_viewer, etc.) are
+ * intentionally redirected because the admin panel would be empty for them —
+ * Scout has its own dedicated page.
  */
 export function RequireElevated() {
   const { data: session, isPending } = useSession();
@@ -14,6 +16,6 @@ export function RequireElevated() {
   if (!session) return <Navigate to="/auth/login" replace />;
 
   const role = (session.user as { role?: string | null }).role ?? null;
-  if (!hasAnyElevatedRole(role)) return <Navigate to="/" replace />;
+  if (!hasAdminPanelAccess(role)) return <Navigate to="/" replace />;
   return <Outlet />;
 }

--- a/apps/web/src/hooks/use-has-permission.ts
+++ b/apps/web/src/hooks/use-has-permission.ts
@@ -1,5 +1,6 @@
 import {
   checkPermission,
+  hasAdminPanelAccess,
   hasAnyElevatedRole,
   type Action,
   type Resource,
@@ -24,12 +25,27 @@ export function useHasPermission<R extends Resource>(
 }
 
 /**
- * True iff the current user has any non-default role. Used to gate the
- * "Admin Panel" links scattered across the members/matchday/etc. pages.
+ * True iff the current user has any non-default role. Kept for places that
+ * genuinely just need "is this an elevated user" — but for "show the Admin
+ * Panel link" use {@link useHasAdminPanelAccess}, since AI-only roles count
+ * as elevated but don't see anything in /admin.
  */
 export function useHasAnyElevatedRole(): boolean {
   const { data: session } = useSession();
   if (!session) return false;
   const role = (session.user as { role?: string | null }).role ?? null;
   return hasAnyElevatedRole(role);
+}
+
+/**
+ * True iff the current user has at least one admin-panel sub-tab unlocked.
+ * Used to gate the "Admin Panel" links and the /admin route — replaces
+ * useHasAnyElevatedRole at those callsites so AI-only roles (which are
+ * "elevated" but have zero admin-panel surface) don't see a dead link.
+ */
+export function useHasAdminPanelAccess(): boolean {
+  const { data: session } = useSession();
+  if (!session) return false;
+  const role = (session.user as { role?: string | null }).role ?? null;
+  return hasAdminPanelAccess(role);
 }

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -22,31 +22,51 @@ import { RecordLinkingTab } from "./record-linking-tab";
 import { SponsorshipsTab } from "./sponsorships-tab";
 import { TreasurerTab } from "./treasurer-tab";
 
+interface SubTabDef {
+  value: string;
+  label: string;
+  /**
+   * Whether the current user's role has the BE permission this sub-tab's API
+   * requires. Mirrors the backend requirePermission gates so we never show a
+   * tab whose data won't load. Sub-tabs without an explicit gate return true.
+   */
+  visible: (role: string | null) => boolean;
+  render: () => React.ReactNode;
+}
+
 interface SectionDef {
   value: string;
   label: string;
-  subTabs: Array<{
-    value: string;
-    label: string;
-    render: () => React.ReactNode;
-  }>;
+  subTabs: readonly SubTabDef[];
 }
 
-const SECTIONS = [
+const SECTIONS: readonly SectionDef[] = [
   {
     value: "people",
     label: "People",
     subTabs: [
-      { value: "members", label: "Members", render: () => <MembersTab /> },
-      { value: "juniors", label: "Juniors", render: () => <JuniorsTab /> },
+      {
+        value: "members",
+        label: "Members",
+        visible: (role) => checkPermission(role, "users", "view"),
+        render: () => <MembersTab />,
+      },
+      {
+        value: "juniors",
+        label: "Juniors",
+        visible: (role) => checkPermission(role, "juniors", "view"),
+        render: () => <JuniorsTab />,
+      },
       {
         value: "duplicates",
         label: "Duplicates",
+        visible: (role) => checkPermission(role, "users", "manage"),
         render: () => <DuplicatesTab />,
       },
       {
         value: "record-linking",
         label: "Record Linking",
+        visible: (role) => checkPermission(role, "users", "manage"),
         render: () => <RecordLinkingTab />,
       },
     ],
@@ -55,11 +75,22 @@ const SECTIONS = [
     value: "outreach",
     label: "Outreach",
     subTabs: [
-      { value: "leads", label: "Leads", render: () => <LeadsTab /> },
-      { value: "contacts", label: "Contacts", render: () => <ContactsTab /> },
+      {
+        value: "leads",
+        label: "Leads",
+        visible: (role) => checkPermission(role, "marketing", "view"),
+        render: () => <LeadsTab />,
+      },
+      {
+        value: "contacts",
+        label: "Contacts",
+        visible: (role) => checkPermission(role, "marketing", "view"),
+        render: () => <ContactsTab />,
+      },
       {
         value: "marketing-outbox",
         label: "Marketing Outbox",
+        visible: (role) => checkPermission(role, "marketing", "view"),
         render: () => <MarketingOutboxTab />,
       },
     ],
@@ -71,23 +102,38 @@ const SECTIONS = [
       {
         value: "overview",
         label: "Overview",
+        visible: (role) => checkPermission(role, "finance", "manage"),
         render: () => <TreasurerTab />,
       },
-      { value: "charges", label: "Charges", render: () => <ChargesTab /> },
+      {
+        value: "charges",
+        label: "Charges",
+        visible: (role) => checkPermission(role, "finance", "view"),
+        render: () => <ChargesTab />,
+      },
       {
         value: "financial-relief",
         label: "Financial Relief",
+        visible: (role) => checkPermission(role, "finance", "manage"),
         render: () => <FinancialReliefTab />,
       },
       {
         value: "sponsorships",
         label: "Sponsorships",
+        visible: (role) => checkPermission(role, "finance", "manage"),
         render: () => <SponsorshipsTab />,
       },
       {
         value: "expenses",
         label: "Expenses",
+        visible: (role) => checkPermission(role, "finance", "manage"),
         render: () => <ExpenseHistoryTab />,
+      },
+      {
+        value: "match-fees",
+        label: "Match Donations",
+        visible: (role) => checkPermission(role, "finance", "view"),
+        render: () => <MatchFeesTab />,
       },
     ],
   },
@@ -98,14 +144,15 @@ const SECTIONS = [
       {
         value: "game-reports",
         label: "Game Reports",
+        visible: (role) => checkPermission(role, "matchday", "view"),
         render: () => <GameReportsTab />,
       },
       {
-        value: "match-fees",
-        label: "Match Donations",
-        render: () => <MatchFeesTab />,
+        value: "fantasy",
+        label: "Fantasy",
+        visible: (role) => checkPermission(role, "fantasy", "manage"),
+        render: () => <FantasyTab />,
       },
-      { value: "fantasy", label: "Fantasy", render: () => <FantasyTab /> },
     ],
   },
   {
@@ -115,11 +162,13 @@ const SECTIONS = [
       {
         value: "incidents",
         label: "Incidents",
+        visible: (role) => checkPermission(role, "incidents", "view"),
         render: () => <IncidentsTab />,
       },
       {
         value: "documents",
         label: "Documents",
+        visible: (role) => checkPermission(role, "documents", "manage"),
         render: () => <DocumentsTab />,
       },
     ],
@@ -131,51 +180,36 @@ const SECTIONS = [
       {
         value: "users",
         label: "User Roles",
+        visible: (role) => checkPermission(role, "users", "manage_roles"),
         render: () => <AccessTab />,
       },
     ],
   },
-] as const satisfies readonly SectionDef[];
+];
 
-type Section = (typeof SECTIONS)[number];
-type SectionValue = Section["value"];
+type SectionValue = (typeof SECTIONS)[number]["value"];
 
 const DEFAULT_SECTION: SectionValue = "people";
 
-function findSection(value: string | null): Section | undefined {
+function findSection(value: string | null): SectionDef | undefined {
   return SECTIONS.find((s) => s.value === value);
 }
 
-function getSection(value: string | null): Section {
+function getSection(value: string | null): SectionDef {
   return findSection(value) ?? SECTIONS[0];
 }
 
 /**
- * Whether a section's tabs are reachable for the current user. Each tab's
- * backing API still 403s independently, but this filter hides sections the
- * user can't usefully open so the admin panel doesn't show dead links.
+ * Filter a section's sub-tabs to those the user can actually open. Each
+ * sub-tab declares its own permission gate above, mirroring the backend's
+ * requirePermission. A section is visible iff at least one of its sub-tabs
+ * is.
  */
-function isSectionVisible(value: SectionValue, role: string | null): boolean {
-  switch (value) {
-    case "people":
-      return checkPermission(role, "users", "view");
-    case "outreach":
-      return checkPermission(role, "marketing", "view");
-    case "finance":
-      return checkPermission(role, "finance", "view");
-    case "cricket":
-      return (
-        checkPermission(role, "matchday", "view") ||
-        checkPermission(role, "fantasy", "manage")
-      );
-    case "compliance":
-      return (
-        checkPermission(role, "incidents", "view") ||
-        checkPermission(role, "documents", "manage")
-      );
-    case "access":
-      return checkPermission(role, "users", "manage_roles");
-  }
+function visibleSubTabs(
+  section: SectionDef,
+  role: string | null,
+): readonly SubTabDef[] {
+  return section.subTabs.filter((t) => t.visible(role));
 }
 
 export function Component() {
@@ -185,32 +219,43 @@ export function Component() {
 
   const role =
     (session?.user as { role?: string | null } | undefined)?.role ?? null;
-  const visibleSections = SECTIONS.filter((s) =>
-    isSectionVisible(s.value, role),
-  );
+  const sectionsWithVisibleSubTabs = SECTIONS.reduce<
+    Array<{ section: SectionDef; subTabs: readonly SubTabDef[] }>
+  >((acc, s) => {
+    const subTabs = visibleSubTabs(s, role);
+    if (subTabs.length > 0) acc.push({ section: s, subTabs });
+    return acc;
+  }, []);
 
   const sectionParam = searchParams.get("section");
-  const requested = getSection(sectionParam);
-  const section = visibleSections.includes(requested)
-    ? requested
-    : (visibleSections[0] ?? SECTIONS[0]);
+  const requestedSection = getSection(sectionParam);
+  const current =
+    sectionsWithVisibleSubTabs.find(
+      (s) => s.section.value === requestedSection.value,
+    ) ?? sectionsWithVisibleSubTabs[0];
 
   const subParam = searchParams.get("sub");
-  const subTab =
-    section.subTabs.find((s) => s.value === subParam) ?? section.subTabs[0];
+  const subTab = current
+    ? (current.subTabs.find((s) => s.value === subParam) ?? current.subTabs[0])
+    : undefined;
 
   const onSectionChange = (value: string) => {
-    const next = findSection(value);
+    const next = sectionsWithVisibleSubTabs.find(
+      (s) => s.section.value === value,
+    );
     if (!next) return;
     const params = new URLSearchParams();
-    if (next.value !== DEFAULT_SECTION) params.set("section", next.value);
+    if (next.section.value !== DEFAULT_SECTION)
+      params.set("section", next.section.value);
     setSearchParams(params, { replace: true });
   };
 
   const onSubChange = (value: string) => {
+    if (!current) return;
     const params = new URLSearchParams();
-    if (section.value !== DEFAULT_SECTION) params.set("section", section.value);
-    if (value !== section.subTabs[0].value) params.set("sub", value);
+    if (current.section.value !== DEFAULT_SECTION)
+      params.set("section", current.section.value);
+    if (value !== current.subTabs[0].value) params.set("sub", value);
     setSearchParams(params, { replace: true });
   };
 
@@ -230,44 +275,50 @@ export function Component() {
             </Link>
           </div>
         </div>
-        <Tabs
-          value={section.value}
-          onValueChange={onSectionChange}
-          className="w-full"
-        >
-          <TabsList>
-            {visibleSections.map((s) => (
-              <TabsTrigger key={s.value} value={s.value}>
-                {s.label}
-              </TabsTrigger>
-            ))}
-          </TabsList>
+        {current && subTab ? (
+          <Tabs
+            value={current.section.value}
+            onValueChange={onSectionChange}
+            className="w-full"
+          >
+            <TabsList>
+              {sectionsWithVisibleSubTabs.map((s) => (
+                <TabsTrigger key={s.section.value} value={s.section.value}>
+                  {s.section.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
 
-          {visibleSections.map((s) => (
-            <TabsContent key={s.value} value={s.value}>
-              {s.value === section.value && (
-                <Tabs
-                  value={subTab.value}
-                  onValueChange={onSubChange}
-                  className="w-full"
-                >
-                  <TabsList className="mt-4">
+            {sectionsWithVisibleSubTabs.map((s) => (
+              <TabsContent key={s.section.value} value={s.section.value}>
+                {s.section.value === current.section.value && (
+                  <Tabs
+                    value={subTab.value}
+                    onValueChange={onSubChange}
+                    className="w-full"
+                  >
+                    <TabsList className="mt-4">
+                      {s.subTabs.map((sub) => (
+                        <TabsTrigger key={sub.value} value={sub.value}>
+                          {sub.label}
+                        </TabsTrigger>
+                      ))}
+                    </TabsList>
                     {s.subTabs.map((sub) => (
-                      <TabsTrigger key={sub.value} value={sub.value}>
-                        {sub.label}
-                      </TabsTrigger>
+                      <TabsContent key={sub.value} value={sub.value}>
+                        {sub.value === subTab.value && sub.render()}
+                      </TabsContent>
                     ))}
-                  </TabsList>
-                  {s.subTabs.map((sub) => (
-                    <TabsContent key={sub.value} value={sub.value}>
-                      {sub.value === subTab.value && sub.render()}
-                    </TabsContent>
-                  ))}
-                </Tabs>
-              )}
-            </TabsContent>
-          ))}
-        </Tabs>
+                  </Tabs>
+                )}
+              </TabsContent>
+            ))}
+          </Tabs>
+        ) : (
+          <p className="text-stone-700">
+            You don&apos;t have access to any admin sections.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/pages/junior-manager/junior-manager.tsx
+++ b/apps/web/src/pages/junior-manager/junior-manager.tsx
@@ -15,7 +15,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
-import { useHasAnyElevatedRole } from "@/hooks/use-has-permission.js";
+import { useHasAdminPanelAccess } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
 import { useSession } from "@/lib/auth-client";
@@ -53,7 +53,7 @@ function usePlayers(teamId: string, enabled: boolean) {
 export function Component() {
   useDocumentMeta("Junior Teams");
   const { data: session } = useSession();
-  const hasAdminAccess = useHasAnyElevatedRole();
+  const hasAdminAccess = useHasAdminPanelAccess();
 
   if (!session) return null;
 

--- a/apps/web/src/pages/matchday/matchday-hub.tsx
+++ b/apps/web/src/pages/matchday/matchday-hub.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import {
-  useHasAnyElevatedRole,
+  useHasAdminPanelAccess,
   useHasPermission,
 } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client";
@@ -19,7 +19,7 @@ import { Link } from "react-router";
 export function Component() {
   useDocumentMeta("Matchday");
   const { data: session } = useSession();
-  const hasAdminAccess = useHasAnyElevatedRole();
+  const hasAdminAccess = useHasAdminPanelAccess();
   const isOfficial = useHasPermission("matchday", "view").allowed;
 
   if (!session) return null;

--- a/apps/web/src/pages/members/members-dashboard.tsx
+++ b/apps/web/src/pages/members/members-dashboard.tsx
@@ -22,7 +22,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import {
-  useHasAnyElevatedRole,
+  useHasAdminPanelAccess,
   useHasPermission,
 } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client";
@@ -57,7 +57,7 @@ export function Component() {
     });
   };
 
-  const hasAdminAccess = useHasAnyElevatedRole();
+  const hasAdminAccess = useHasAdminPanelAccess();
   const hasJuniorAccess = useHasPermission("juniors", "view").allowed;
 
   if (!session) return null;

--- a/apps/web/src/pages/official/availability.tsx
+++ b/apps/web/src/pages/official/availability.tsx
@@ -17,7 +17,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
-import { useHasAnyElevatedRole } from "@/hooks/use-has-permission.js";
+import { useHasAdminPanelAccess } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen.js";
 import { useSession } from "@/lib/auth-client";
@@ -78,7 +78,7 @@ export function Component() {
 // ── Request List ──
 
 function RequestListView() {
-  const hasAdminAccess = useHasAnyElevatedRole();
+  const hasAdminAccess = useHasAdminPanelAccess();
   const query = useQuery({
     queryKey: ["availability", "requests"],
     queryFn: () => callApi(api.GET("/api/availability/requests")),

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -9,7 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
-import { useHasAnyElevatedRole } from "@/hooks/use-has-permission.js";
+import { useHasAdminPanelAccess } from "@/hooks/use-has-permission.js";
 import { API_BASE, api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen.js";
 import { useSession } from "@/lib/auth-client";
@@ -227,7 +227,7 @@ function RoleSelectors({
 export function Component() {
   useDocumentMeta("Match Official");
   const { data: session } = useSession();
-  const hasAdminAccess = useHasAnyElevatedRole();
+  const hasAdminAccess = useHasAdminPanelAccess();
 
   if (!session) return null;
 

--- a/apps/web/src/pages/scout/scout.tsx
+++ b/apps/web/src/pages/scout/scout.tsx
@@ -1,8 +1,10 @@
 import { ImbuzaiMascot } from "@/components/imbuzai-mascot.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
+import { useSession } from "@/lib/auth-client";
 import type { UIMessage } from "@ai-sdk/react";
 import type { ReportData } from "@percy-main/shared";
+import { checkPermission } from "@percy-main/shared/auth/permissions";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
@@ -32,9 +34,16 @@ export function Component() {
   useDocumentMeta("ImbuzAI");
   const { threadId } = useParams<{ threadId?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
+  const { data: session } = useSession();
+  const role =
+    (session?.user as { role?: string | null } | undefined)?.role ?? null;
+  const tabPerms = scoutTabVisibility(role);
   // URL-state per the project's URL-state convention. The non-chat tabs
   // are global (not per-thread) so they survive switching between threads.
-  const view: ScoutView = viewFromParam(searchParams.get("view"));
+  const requestedView: ScoutView = viewFromParam(searchParams.get("view"));
+  const view: ScoutView = tabPerms[requestedView]
+    ? requestedView
+    : (firstVisibleScoutTab(tabPerms) ?? "chat");
 
   const setView = (next: ScoutView) => {
     setSearchParams(
@@ -76,6 +85,11 @@ export function Component() {
     return () => window.removeEventListener("keydown", onKey);
   }, [threadDrawerOpen]);
 
+  // Show the thread sidebar only when the user can actually list threads —
+  // GET /scout/threads is gated by ai_chat:use, so a facts- or knowledge-only
+  // user would just see an error panel in the sidebar.
+  const showThreadSidebar = tabPerms.chat;
+
   return (
     <div className="container mx-auto h-[calc(100vh-8rem)] px-0">
       <div className="relative flex h-full overflow-hidden rounded-lg border border-stone-200 bg-white">
@@ -87,15 +101,20 @@ export function Component() {
             onClick={() => setThreadDrawerOpen(false)}
           />
         )}
-        <ThreadList
-          mobileOpen={threadDrawerOpen}
-          onMobileClose={() => setThreadDrawerOpen(false)}
-        />
+        {showThreadSidebar && (
+          <ThreadList
+            mobileOpen={threadDrawerOpen}
+            onMobileClose={() => setThreadDrawerOpen(false)}
+            role={role}
+          />
+        )}
         <main className="flex min-w-0 flex-1 flex-col">
           <ScoutTabs
             view={view}
             setView={setView}
             onOpenThreadDrawer={() => setThreadDrawerOpen(true)}
+            tabPerms={tabPerms}
+            showThreadsToggle={showThreadSidebar}
           />
           {view === "reports" ? (
             <ReportsView />
@@ -103,10 +122,12 @@ export function Component() {
             <FactsAdminView />
           ) : view === "knowledge" ? (
             <KnowledgeAdminView />
+          ) : !tabPerms.chat ? (
+            <NoAccessState />
           ) : threadId ? (
             <ActiveThread threadId={threadId} />
           ) : (
-            <EmptyState />
+            <EmptyState role={role} />
           )}
         </main>
       </div>
@@ -114,49 +135,93 @@ export function Component() {
   );
 }
 
+interface ScoutTabPerms {
+  chat: boolean;
+  reports: boolean;
+  facts: boolean;
+  knowledge: boolean;
+}
+
+function scoutTabVisibility(role: string | null): ScoutTabPerms {
+  return {
+    chat: checkPermission(role, "ai_chat", "use"),
+    reports: checkPermission(role, "ai_scout", "use"),
+    facts: checkPermission(role, "ai_facts", "view"),
+    knowledge: checkPermission(role, "ai_knowledge", "view"),
+  };
+}
+
+function firstVisibleScoutTab(perms: ScoutTabPerms): ScoutView | undefined {
+  const order: ScoutView[] = ["chat", "reports", "facts", "knowledge"];
+  return order.find((v) => perms[v]);
+}
+
 function ScoutTabs({
   view,
   setView,
   onOpenThreadDrawer,
+  tabPerms,
+  showThreadsToggle,
 }: {
   view: ScoutView;
   setView: (next: ScoutView) => void;
   onOpenThreadDrawer: () => void;
+  tabPerms: ScoutTabPerms;
+  showThreadsToggle: boolean;
 }) {
   // h-12 matches the sidebar's NewThreadSplitButton container so the bottom
   // border on the tabs nav lines up exactly with the bottom border under
   // "New chat".
   return (
     <nav className="flex h-12 shrink-0 items-stretch border-b border-stone-200 bg-stone-50">
-      <button
-        type="button"
-        onClick={onOpenThreadDrawer}
-        aria-label="Open threads"
-        className="inline-flex items-center px-3 text-stone-600 hover:text-stone-900 lg:hidden"
-      >
-        <ThreadsIcon className="size-5" />
-      </button>
-      <TabButton
-        active={view === "chat"}
-        onClick={() => setView("chat")}
-        label="Chat"
-      />
-      <TabButton
-        active={view === "reports"}
-        onClick={() => setView("reports")}
-        label="Reports"
-      />
-      <TabButton
-        active={view === "facts"}
-        onClick={() => setView("facts")}
-        label="Facts"
-      />
-      <TabButton
-        active={view === "knowledge"}
-        onClick={() => setView("knowledge")}
-        label="Knowledge"
-      />
+      {showThreadsToggle && (
+        <button
+          type="button"
+          onClick={onOpenThreadDrawer}
+          aria-label="Open threads"
+          className="inline-flex items-center px-3 text-stone-600 hover:text-stone-900 lg:hidden"
+        >
+          <ThreadsIcon className="size-5" />
+        </button>
+      )}
+      {tabPerms.chat && (
+        <TabButton
+          active={view === "chat"}
+          onClick={() => setView("chat")}
+          label="Chat"
+        />
+      )}
+      {tabPerms.reports && (
+        <TabButton
+          active={view === "reports"}
+          onClick={() => setView("reports")}
+          label="Reports"
+        />
+      )}
+      {tabPerms.facts && (
+        <TabButton
+          active={view === "facts"}
+          onClick={() => setView("facts")}
+          label="Facts"
+        />
+      )}
+      {tabPerms.knowledge && (
+        <TabButton
+          active={view === "knowledge"}
+          onClick={() => setView("knowledge")}
+          label="Knowledge"
+        />
+      )}
     </nav>
+  );
+}
+
+function NoAccessState() {
+  return (
+    <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-stone-500">
+      You don&rsquo;t have access to ImbuzAI chat. Ask a superadmin if you
+      should.
+    </div>
   );
 }
 
@@ -184,7 +249,7 @@ function TabButton({
   );
 }
 
-function EmptyState() {
+function EmptyState({ role }: { role: string | null }) {
   return (
     <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-stone-500">
       <div className="flex flex-col items-center gap-4">
@@ -206,7 +271,7 @@ function EmptyState() {
           </div>
         </div>
         <div className="flex w-64">
-          <NewThreadButton />
+          <NewThreadButton role={role} />
         </div>
       </div>
     </div>

--- a/apps/web/src/pages/scout/thread-list.tsx
+++ b/apps/web/src/pages/scout/thread-list.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { api, callApi } from "@/lib/api-client";
+import { checkPermission } from "@percy-main/shared/auth/permissions";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
@@ -30,25 +31,37 @@ interface ThreadSummary {
   sharedByMe: boolean;
 }
 
-const MODE_OPTIONS: ReadonlyArray<{
+interface ModeOption {
   value: ScoutMode;
   label: string;
   description: string;
-}> = [
+  /**
+   * Predicate over the user's role string. Mirrors the BE permission the
+   * mode ultimately needs — debrief and chat threads create via
+   * `ai_chat:use`, scout threads kick off report generation which is
+   * `ai_scout:use`.
+   */
+  visible: (role: string | null) => boolean;
+}
+
+const MODE_OPTIONS: readonly ModeOption[] = [
   {
     value: "chat",
     label: "Chat",
     description: "Free-form scouting research and Q&A",
+    visible: (role) => checkPermission(role, "ai_chat", "use"),
   },
   {
     value: "debrief",
     label: "Debrief",
     description: "Walk through a recent match — grow the fact corpus",
+    visible: (role) => checkPermission(role, "ai_chat", "use"),
   },
   {
     value: "scout",
     label: "Scout",
     description: "Pick an upcoming fixture, build toward a report PDF",
+    visible: (role) => checkPermission(role, "ai_scout", "use"),
   },
 ];
 
@@ -66,9 +79,17 @@ interface ThreadListProps {
   // are ignored — the sidebar sits in normal flex flow.
   mobileOpen: boolean;
   onMobileClose: () => void;
+  // User's role string, threaded through so the new-thread split-button can
+  // hide modes the user can't actually create (scout mode needs ai_scout:use,
+  // chat/debrief need ai_chat:use).
+  role: string | null;
 }
 
-export function ThreadList({ mobileOpen, onMobileClose }: ThreadListProps) {
+export function ThreadList({
+  mobileOpen,
+  onMobileClose,
+  role,
+}: ThreadListProps) {
   const params = useParams<{ threadId?: string }>();
   const activeThreadId = params.threadId;
   const navigate = useNavigate();
@@ -114,7 +135,7 @@ export function ThreadList({ mobileOpen, onMobileClose }: ThreadListProps) {
           the sidebar/main split, regardless of the natural size of the
           contents on either side. */}
       <div className="flex h-12 shrink-0 items-center gap-2 border-b border-stone-200 px-3">
-        <NewThreadButton onCreated={onMobileClose} />
+        <NewThreadButton role={role} onCreated={onMobileClose} />
         <button
           type="button"
           onClick={onMobileClose}
@@ -273,13 +294,29 @@ function ModeBadge({ mode }: { mode: ScoutMode }) {
 // hero without lifting state to a common parent. onCreated is the optional
 // post-success hook — the sidebar uses it to dismiss the mobile drawer
 // once a thread has been created.
-export function NewThreadButton({ onCreated }: { onCreated?: () => void }) {
+export function NewThreadButton({
+  role,
+  onCreated,
+}: {
+  // Caller-supplied because NewThreadButton is reused in the empty-state hero
+  // — keeping the prop explicit avoids tying the component to a useSession
+  // hook call that the hero's parent may not need.
+  role: string | null;
+  onCreated?: () => void;
+}) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  // Filter the dropdown to modes the user can actually use. If the user
+  // somehow lacks every mode permission, render nothing — the empty button
+  // would be a dead-end.
+  const visibleModes = MODE_OPTIONS.filter((m) => m.visible(role));
   // Active mode for the split-button. Local state — survives clicks within
   // the page but not reload; the dropdown is a transient affordance, not a
-  // navigable URL state.
-  const [activeMode, setActiveMode] = useState<ScoutMode>("chat");
+  // navigable URL state. Initialised to the first visible mode so the
+  // create action always corresponds to something the user can do.
+  const [activeMode, setActiveMode] = useState<ScoutMode>(
+    visibleModes[0]?.value ?? "chat",
+  );
 
   const createMutation = useMutation({
     mutationFn: (mode: ScoutMode) =>
@@ -297,12 +334,15 @@ export function NewThreadButton({ onCreated }: { onCreated?: () => void }) {
     },
   });
 
+  if (visibleModes.length === 0) return null;
+
   return (
     <NewThreadSplitButton
       activeMode={activeMode}
       onModeChange={setActiveMode}
       onCreate={() => createMutation.mutate(activeMode)}
       pending={createMutation.isPending}
+      visibleModes={visibleModes}
     />
   );
 }
@@ -318,14 +358,16 @@ function NewThreadSplitButton({
   onModeChange,
   onCreate,
   pending,
+  visibleModes,
 }: {
   activeMode: ScoutMode;
   onModeChange: (mode: ScoutMode) => void;
   onCreate: () => void;
   pending: boolean;
+  visibleModes: readonly ModeOption[];
 }) {
   const activeLabel =
-    MODE_OPTIONS.find((o) => o.value === activeMode)?.label ?? "Chat";
+    visibleModes.find((o) => o.value === activeMode)?.label ?? "Chat";
 
   return (
     <div className="flex flex-1">
@@ -351,7 +393,7 @@ function NewThreadSplitButton({
             value={activeMode}
             onValueChange={(v) => onModeChange(v as ScoutMode)}
           >
-            {MODE_OPTIONS.map((opt) => (
+            {visibleModes.map((opt) => (
               <DropdownMenuRadioItem
                 key={opt.value}
                 value={opt.value}

--- a/packages/shared/src/auth/permissions.ts
+++ b/packages/shared/src/auth/permissions.ts
@@ -189,6 +189,33 @@ export function hasAnyElevatedRole(
 }
 
 /**
+ * True iff the user has at least one permission that surfaces an admin-panel
+ * sub-tab. Used to gate the "Admin Panel" links scattered around the
+ * members/matchday/junior-manager/official areas, plus the /admin route
+ * wrapper. AI-only roles (ai_chat_user, ai_scout_user, ai_facts_viewer,
+ * ai_knowledge_viewer) intentionally do NOT qualify — they have access to
+ * the Scout area instead. Keep this in sync with the per-sub-tab visibility
+ * predicates in `apps/web/src/pages/admin/admin-panel.tsx`.
+ */
+export function hasAdminPanelAccess(
+  rawRole: string | null | undefined,
+): boolean {
+  return (
+    checkPermission(rawRole, "users", "view") ||
+    checkPermission(rawRole, "users", "manage") ||
+    checkPermission(rawRole, "users", "manage_roles") ||
+    checkPermission(rawRole, "juniors", "view") ||
+    checkPermission(rawRole, "marketing", "view") ||
+    checkPermission(rawRole, "finance", "view") ||
+    checkPermission(rawRole, "finance", "manage") ||
+    checkPermission(rawRole, "matchday", "view") ||
+    checkPermission(rawRole, "fantasy", "manage") ||
+    checkPermission(rawRole, "incidents", "view") ||
+    checkPermission(rawRole, "documents", "manage")
+  );
+}
+
+/**
  * Parse a stored role string (comma-separated) into an array of role names.
  * Drops `user` because it's an implicit baseline, not a meaningful role:
  * letting it round-trip into UI state and back through saves bloats the


### PR DESCRIPTION
## Summary

- Admin panel now filters per-sub-tab, not just per-section. Each sub-tab declares its own `visible(role)` predicate mirroring the backend `requirePermission` gate. Fixes incidents_admin seeing Compliance → Documents (the original report), and juniors_admin not seeing People → Juniors. Moved Match Donations from Cricket to Finance to match its `finance:view` backing perm.
- Scout (ImbuzAI) tabs (Chat / Reports / Facts / Knowledge) and the new-thread dropdown (Chat / Debrief / Scout) filter the same way against `ai_chat:use` / `ai_scout:use` / `ai_facts:view` / `ai_knowledge:view`. The thread sidebar hides when the user lacks `ai_chat:use` (it would otherwise just render an error).
- Adds `hasAdminPanelAccess` helper + `useHasAdminPanelAccess` hook. The "Admin Panel" link gates in members-dashboard / matchday-hub / junior-manager / official / availability, plus the `/admin` `RequireElevated` route guard, all switch to it so AI-only roles (which were "elevated" but had zero admin-panel surface) no longer see a dead link or land on an empty `/admin`.

## Trade-offs / follow-ups

These are flagged but **not** addressed in this PR:

- `finance_viewer` is effectively crippled — backend requires `finance:manage` for Treasurer / Sponsorships / Financial Relief / Expenses (all read-only dashboards). A viewer only sees Charges + Match Donations. Worth loosening those reads to `finance:view` separately.
- `POST /scout/threads` accepts `mode: "scout"` with only `ai_chat:use`, but the resulting report generation requires `ai_scout:use`. FE dropdown now gates Scout mode by `ai_scout:use`, but the BE should match.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (522 pass)
- [ ] As `incidents_admin`: Compliance section visible, Documents sub-tab hidden
- [ ] As `documents_admin`: Compliance section visible, only Documents sub-tab
- [ ] As `juniors_admin`: People section visible, only Juniors sub-tab
- [ ] As `finance_viewer`: Finance section shows Charges + Match Donations only
- [ ] As `ai_chat_user`: Members area shows no Admin Panel link; `/admin` redirects to `/`; Scout shows Chat tab only
- [ ] As `ai_facts_viewer`: Scout shows Facts tab only, no thread sidebar
- [ ] As `superadmin`: every section + sub-tab still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)