### PR TITLE
fix(scout): five AI fixes — loading states, RBAC sharing, copy-thread, dark mode, 0-balls grounding

### DIFF
--- a/apps/api/src/features/scout/integration.test.ts
+++ b/apps/api/src/features/scout/integration.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   appendMessage,
   assertThreadOwnership,
+  copyThread,
   createThread,
   deleteThread,
   getThread,
@@ -340,16 +341,16 @@ describe("scout thread service (integration)", () => {
 });
 
 describe("scout thread sharing (integration)", () => {
-  it("listOfficials returns admins and officials excluding the current user, ordered by name", async () => {
+  it("listOfficials returns users with ai_chat:use excluding the current user, ordered by name", async () => {
     const { userId: viewer } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
       name: "Zara Owner",
     });
     const { userId: alice } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
-      name: "Alice Official",
+      role: "ai_chat_user",
+      name: "Alice Chat",
     });
     const { userId: bob } = await seedTestUser(ctx.db, {
       withMember: false,
@@ -362,12 +363,20 @@ describe("scout thread sharing (integration)", () => {
       role: null as unknown as string,
       name: "Charlie Civilian",
     });
+    // Legacy `official` role — has matchday perms but NOT ai_chat:use, so
+    // they should be excluded under the RBAC-based recipient rule.
+    const { userId: dora } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+      name: "Dora Official",
+    });
 
     const officials = await listOfficials(ctx.db)(viewer);
     const ids = officials.map((o) => o.id);
     expect(ids).toContain(alice);
     expect(ids).toContain(bob);
     expect(ids).not.toContain(viewer);
+    expect(ids).not.toContain(dora);
     // Alphabetical by name
     const aIdx = officials.findIndex((o) => o.id === alice);
     const bIdx = officials.findIndex((o) => o.id === bob);
@@ -377,12 +386,12 @@ describe("scout thread sharing (integration)", () => {
   it("share + getThread: a recipient can read the shared thread and sees sharedBy populated", async () => {
     const { userId: owner, name: ownerName } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
       name: "Owner Person",
     });
     const { userId: recipient } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
 
     const thread = await createThread(ctx.db)(owner, "Shared scout thread");
@@ -401,11 +410,11 @@ describe("scout thread sharing (integration)", () => {
   it("listThreads merges owned + shared, with sharedBy / sharedByMe set per row", async () => {
     const { userId: alice } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
     const { userId: bob } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
 
     const aliceThread = await createThread(ctx.db)(alice, "Alice's analysis");
@@ -431,11 +440,11 @@ describe("scout thread sharing (integration)", () => {
   it("share + unshare are idempotent (no duplicate rows; unshare twice is fine)", async () => {
     const { userId: owner } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
     const { userId: rec } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
 
     const thread = await createThread(ctx.db)(owner, "Idempotent thread");
@@ -452,7 +461,7 @@ describe("scout thread sharing (integration)", () => {
   it("share + unshare refuse to run for a non-owner (ShareForbiddenError)", async () => {
     const { userId: owner } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
     const { userId: imposter } = await seedTestUser(ctx.db, {
       withMember: false,
@@ -460,7 +469,7 @@ describe("scout thread sharing (integration)", () => {
     });
     const { userId: target } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
 
     const thread = await createThread(ctx.db)(owner, "Locked");
@@ -472,27 +481,35 @@ describe("scout thread sharing (integration)", () => {
     ).rejects.toBeInstanceOf(ShareForbiddenError);
   });
 
-  it("share rejects recipients without admin/official role", async () => {
+  it("share rejects recipients without ai_chat:use permission", async () => {
     const { userId: owner } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
     const { userId: civilian } = await seedTestUser(ctx.db, {
       withMember: false,
       // explicit no role — `null` is the default for plain users
       role: null as unknown as string,
     });
+    // Legacy `official` role lacks ai_chat:use — not eligible.
+    const { userId: official } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "official",
+    });
 
     const thread = await createThread(ctx.db)(owner, "Restricted");
     await expect(
       shareThread(ctx.db)(owner, thread.id, [civilian]),
+    ).rejects.toBeInstanceOf(ShareInvalidRecipientError);
+    await expect(
+      shareThread(ctx.db)(owner, thread.id, [official]),
     ).rejects.toBeInstanceOf(ShareInvalidRecipientError);
   });
 
   it("share rejects sharing with self", async () => {
     const { userId: owner } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
     const thread = await createThread(ctx.db)(owner, "Solo");
     await expect(
@@ -503,17 +520,79 @@ describe("scout thread sharing (integration)", () => {
   it("a non-shared, non-owner user cannot read the thread (404 via ThreadNotFoundError)", async () => {
     const { userId: owner } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
     const { userId: stranger } = await seedTestUser(ctx.db, {
       withMember: false,
-      role: "official",
+      role: "ai_chat_user",
     });
     const thread = await createThread(ctx.db)(owner, "Private");
 
     await expect(getThread(ctx.db)(stranger, thread.id)).rejects.toBeInstanceOf(
       ThreadNotFoundError,
     );
+  });
+
+  it("copyThread forks a shared thread under the recipient with messages copied", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "ai_chat_user",
+    });
+    const { userId: recipient } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "ai_chat_user",
+    });
+
+    const thread = await createThread(ctx.db)(owner, "Original analysis");
+    await appendMessage(ctx.db)(thread.id, "user", [
+      { type: "text", text: "Who's bowling for Mitford?" },
+    ]);
+    await appendMessage(ctx.db)(thread.id, "assistant", [
+      { type: "text", text: "Three seamers and one off-spinner." },
+    ]);
+    await shareThread(ctx.db)(owner, thread.id, [recipient]);
+
+    const copied = await copyThread(ctx.db)(recipient, thread.id);
+    expect(copied.id).not.toBe(thread.id);
+    expect(copied.title).toBe("Copy of Original analysis");
+    expect(copied.sharedBy).toBeNull();
+    expect(copied.sharedByMe).toBe(false);
+
+    // The copy belongs to the recipient — they can read it as owner.
+    const reload = await getThread(ctx.db)(recipient, copied.id);
+    expect(reload.thread.id).toBe(copied.id);
+    expect(reload.messages).toHaveLength(2);
+    expect(reload.messages[0].role).toBe("user");
+    expect(reload.messages[1].role).toBe("assistant");
+
+    // The original is untouched.
+    const original = await getThread(ctx.db)(owner, thread.id);
+    expect(original.messages).toHaveLength(2);
+  });
+
+  it("copyThread refuses to copy a thread the user can't read (ThreadNotFoundError)", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "ai_chat_user",
+    });
+    const { userId: stranger } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "ai_chat_user",
+    });
+    const thread = await createThread(ctx.db)(owner, "Hidden");
+    await expect(
+      copyThread(ctx.db)(stranger, thread.id),
+    ).rejects.toBeInstanceOf(ThreadNotFoundError);
+  });
+
+  it("copyThread doesn't double-prefix titles that already start with 'Copy of '", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "ai_chat_user",
+    });
+    const thread = await createThread(ctx.db)(owner, "Copy of Old plan");
+    const copied = await copyThread(ctx.db)(owner, thread.id);
+    expect(copied.title).toBe("Copy of Old plan");
   });
 });
 

--- a/apps/api/src/features/scout/integration.test.ts
+++ b/apps/api/src/features/scout/integration.test.ts
@@ -594,6 +594,61 @@ describe("scout thread sharing (integration)", () => {
     const copied = await copyThread(ctx.db)(owner, thread.id);
     expect(copied.title).toBe("Copy of Old plan");
   });
+
+  it("copyThread preserves message timestamps so reload order matches the original", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "ai_chat_user",
+    });
+    const thread = await createThread(ctx.db)(owner, "Ordered chat");
+    // Append four messages back-to-back. Without preserving created_at,
+    // a bulk-insert can land them all on the same timestamp and reload
+    // in arbitrary order.
+    for (const text of ["q1", "a1", "q2", "a2"]) {
+      await appendMessage(ctx.db)(
+        thread.id,
+        text.startsWith("q") ? "user" : "assistant",
+        [{ type: "text", text }],
+      );
+    }
+    const copied = await copyThread(ctx.db)(owner, thread.id);
+    const reload = await getThread(ctx.db)(owner, copied.id);
+    const texts = reload.messages.map((m) => {
+      const part = (m.parts as Array<{ type?: string; text?: string }>)[0];
+      return part?.text;
+    });
+    expect(texts).toEqual(["q1", "a1", "q2", "a2"]);
+  });
+
+  it("copyThread strips owner-scoped data-report and tool-generate_report parts", async () => {
+    const { userId: owner } = await seedTestUser(ctx.db, {
+      withMember: false,
+      role: "ai_chat_user",
+    });
+    const thread = await createThread(ctx.db)(owner, "Has report");
+    await appendMessage(ctx.db)(thread.id, "assistant", [
+      { type: "text", text: "Report queued — it'll appear in Reports." },
+      {
+        type: "tool-generate_report",
+        toolCallId: "call-1",
+        state: "output-available",
+      },
+      {
+        type: "data-report",
+        id: "report-1",
+        data: { reportId: "00000000-0000-0000-0000-000000000000" },
+      },
+    ]);
+    const copied = await copyThread(ctx.db)(owner, thread.id);
+    const reload = await getThread(ctx.db)(owner, copied.id);
+    const types = (reload.messages[0].parts as Array<{ type?: string }>).map(
+      (p) => p.type,
+    );
+    // Prose stays, owner-scoped parts are gone.
+    expect(types).toContain("text");
+    expect(types).not.toContain("data-report");
+    expect(types).not.toContain("tool-generate_report");
+  });
 });
 
 describe("listRecentDebriefMatches (integration)", () => {

--- a/apps/api/src/features/scout/routes.ts
+++ b/apps/api/src/features/scout/routes.ts
@@ -70,6 +70,7 @@ import {
   attachmentMintResponseSchema,
   cancelReportResponseSchema,
   chatRequestBodySchema,
+  copyThreadResponseSchema,
   createThreadBodySchema,
   createThreadResponseSchema,
   deleteFactResponseSchema,
@@ -113,6 +114,7 @@ import {
   assertThreadOwnership,
   bumpThreadUpdatedAt,
   cancelReport,
+  copyThread,
   createThread,
   deleteReport,
   deleteThread,
@@ -148,6 +150,7 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
   const sharees = listSharees(app.db);
   const share = shareThread(app.db);
   const unshare = unshareThread(app.db);
+  const copy = copyThread(app.db);
   // PLAY_CRICKET_SITE_ID is optional in config; if it's not set there are
   // no Percy Main matches to surface, so the launcher returns an empty
   // list rather than 503'ing the rest of Scout.
@@ -510,6 +513,34 @@ export const scoutRoutes: FastifyPluginAsyncZod = async (app) => {
               statusCode: 403,
             },
           );
+        }
+        throw err;
+      }
+    },
+  );
+
+  // Fork a readable thread (owned or shared-with-me) into a new thread
+  // owned by the caller. Read-only recipients use this to keep chatting
+  // from where the original left off; owners can also call it to branch
+  // their own threads without affecting the original.
+  app.post(
+    "/scout/threads/:threadId/copy",
+    {
+      preHandler: [aiChat],
+      schema: {
+        params: threadIdParamSchema,
+        response: { 200: copyThreadResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      try {
+        return await copy(user.id, request.params.threadId);
+      } catch (err) {
+        if (err instanceof ThreadNotFoundError) {
+          throw Object.assign(new Error("Thread not found"), {
+            statusCode: 404,
+          });
         }
         throw err;
       }

--- a/apps/api/src/features/scout/schemas.ts
+++ b/apps/api/src/features/scout/schemas.ts
@@ -497,3 +497,8 @@ export const unshareUserParamSchema = z.object({
   threadId: z.uuid(),
   userId: z.string(),
 });
+
+// Forks a thread the caller can read into a new thread the caller owns.
+// Response shape mirrors createThreadResponseSchema so the FE can route
+// straight to the new thread's URL.
+export const copyThreadResponseSchema = threadSummarySchema;

--- a/apps/api/src/features/scout/service.ts
+++ b/apps/api/src/features/scout/service.ts
@@ -1,4 +1,5 @@
 import type { DB } from "@percy-main/db";
+import { checkPermission } from "@percy-main/shared/auth/permissions";
 import type { Kysely } from "kysely";
 import type { ScoutMode } from "./schemas.ts";
 
@@ -695,13 +696,21 @@ export function cancelReport(db: Kysely<DB>) {
 // ── Thread sharing ──
 //
 // v1 sharing model: an owner grants read-only access to one or more other
-// admin/official users. Recipients can view the full thread (messages,
-// charts, video embeds, reports) but cannot post — that's enforced by
-// keeping every write path on `assertThreadOwnership`. "Branch my own
-// thread" is the deferred follow-up if/when recipients want to continue
-// the conversation in their own copy.
+// users with Scout chat access. Recipients can view the full thread
+// (messages, charts, video embeds, reports) but cannot post — that's
+// enforced by keeping every write path on `assertThreadOwnership`. A
+// recipient who wants to interact can copy the thread to themselves
+// (copyThread, below).
 
-const SHAREABLE_ROLES = new Set(["admin", "official"]);
+/**
+ * True iff a stored role string grants ai_chat:use — i.e. the user can
+ * actually open Scout. Used to filter the share picker and validate
+ * recipients on share. Centralised here so the rule lives in one place
+ * and matches the route-level requirePermission gate.
+ */
+function canReceiveSharedThread(role: string | null): boolean {
+  return checkPermission(role, "ai_chat", "use");
+}
 
 /**
  * Verify the current viewer owns the thread. Throws ThreadNotFoundError
@@ -724,21 +733,27 @@ async function assertOwnerForShare(
 }
 
 export function listOfficials(db: Kysely<DB>) {
-  // Source for the share-modal picker: every admin / official EXCEPT the
-  // current viewer (who'd never share with themselves — the unique-recipient
-  // constraint also blocks it but we don't want them in the list).
+  // Source for the share-modal picker: every non-banned user who can use
+  // Scout chat (ai_chat:use), EXCEPT the current viewer. We pull anyone
+  // with a non-empty role string and then filter in JS via checkPermission,
+  // because the `role` column is a comma-separated list and SQL can't
+  // resolve role-name → permission grants without duplicating that table
+  // here. Member counts are small (club app) so the round-trip is fine.
   return async (currentUserId: string): Promise<ShareActor[]> => {
     const rows = await db
       .selectFrom("user")
-      .where("role", "in", Array.from(SHAREABLE_ROLES))
       .where("id", "!=", currentUserId)
+      .where("role", "is not", null)
+      .where("role", "!=", "")
       .where((eb) =>
         eb.or([eb("banned", "is", null), eb("banned", "=", false)]),
       )
-      .select(["id", "name", "email"])
+      .select(["id", "name", "email", "role"])
       .orderBy("name", "asc")
       .execute();
-    return rows.map((r) => ({ id: r.id, name: r.name, email: r.email }));
+    return rows
+      .filter((r) => canReceiveSharedThread(r.role))
+      .map((r) => ({ id: r.id, name: r.name, email: r.email }));
   };
 }
 
@@ -773,20 +788,21 @@ export function shareThread(db: Kysely<DB>) {
       );
     }
 
-    // Validate every recipient is still a real, role-eligible user. Doing
-    // this here (rather than relying on the FK alone) lets us return a
+    // Validate every recipient is still a real, permission-eligible user.
+    // Doing this here (rather than relying on the FK alone) lets us return a
     // useful 4xx instead of a Postgres-shaped error if someone bypassed
-    // the picker; it also keeps the role rule colocated with the feature.
-    const valid = await db
+    // the picker; it also keeps the rule colocated with the feature.
+    const candidates = await db
       .selectFrom("user")
       .where("id", "in", unique)
-      .where("role", "in", Array.from(SHAREABLE_ROLES))
       .where((eb) =>
         eb.or([eb("banned", "is", null), eb("banned", "=", false)]),
       )
-      .select(["id"])
+      .select(["id", "role"])
       .execute();
-    const validIds = new Set(valid.map((r) => r.id));
+    const validIds = new Set(
+      candidates.filter((r) => canReceiveSharedThread(r.role)).map((r) => r.id),
+    );
     const invalid = unique.filter((id) => !validIds.has(id));
     if (invalid.length > 0) {
       throw new ShareInvalidRecipientError(
@@ -812,6 +828,98 @@ export function shareThread(db: Kysely<DB>) {
       .execute();
 
     return await listSharees(db)(ownerUserId, threadId);
+  };
+}
+
+/**
+ * Fork a thread the caller can read (owner or shared sharee) into a new
+ * thread the caller owns. The new thread is fully editable — copied
+ * messages are written verbatim except for owner-private metadata
+ * (token usage and attachment ids are nulled out, since both reference
+ * the original owner's resources). Used by recipients of read-only
+ * shared threads who want to keep chatting from where the original left
+ * off without needing the original owner's permission to post.
+ */
+export function copyThread(db: Kysely<DB>) {
+  return async (
+    userId: string,
+    sourceThreadId: string,
+  ): Promise<ThreadSummary> => {
+    return await db.transaction().execute(async (tx) => {
+      const source = await tx
+        .selectFrom("scout_thread")
+        .where("id", "=", sourceThreadId)
+        .select(["id", "user_id", "title", "mode"])
+        .executeTakeFirst();
+      if (!source) throw new ThreadNotFoundError();
+
+      const isOwner = source.user_id === userId;
+      if (!isOwner) {
+        const share = await tx
+          .selectFrom("scout_thread_share")
+          .where("thread_id", "=", sourceThreadId)
+          .where("shared_with_user_id", "=", userId)
+          .select("id")
+          .executeTakeFirst();
+        // Same 404-on-no-access shape as getThread — non-existent and
+        // forbidden look identical to the caller.
+        if (!share) throw new ThreadNotFoundError();
+      }
+
+      const copiedTitle = source.title.startsWith("Copy of ")
+        ? source.title
+        : `Copy of ${source.title}`;
+
+      const newThread = await tx
+        .insertInto("scout_thread")
+        .values({
+          user_id: userId,
+          title: copiedTitle,
+          mode: source.mode,
+        })
+        .returning(["id", "title", "mode", "created_at", "updated_at"])
+        .executeTakeFirstOrThrow();
+
+      const sourceMessages = await tx
+        .selectFrom("scout_message")
+        .where("thread_id", "=", sourceThreadId)
+        .select(["role", "parts", "created_at"])
+        .orderBy("created_at", "asc")
+        .execute();
+
+      if (sourceMessages.length > 0) {
+        await tx
+          .insertInto("scout_message")
+          .values(
+            sourceMessages.map((m) => ({
+              thread_id: newThread.id,
+              role: m.role,
+              // parts is jsonb in the schema; pass through structurally.
+              parts: JSON.stringify(m.parts),
+              // token counts and attachment ids belong to the original owner —
+              // nulling here keeps the copy's accounting honest and avoids the
+              // new owner trying (and failing) to load the original's
+              // owner-scoped attachment rows.
+              token_input: null,
+              token_output: null,
+              token_cache_read: null,
+              token_cache_creation: null,
+              attachment_ids: null,
+            })),
+          )
+          .execute();
+      }
+
+      return {
+        id: newThread.id,
+        title: newThread.title,
+        mode: newThread.mode as ScoutMode,
+        createdAt: toIso(newThread.created_at),
+        updatedAt: toIso(newThread.updated_at),
+        sharedBy: null,
+        sharedByMe: false,
+      };
+    });
   };
 }
 

--- a/apps/api/src/features/scout/service.ts
+++ b/apps/api/src/features/scout/service.ts
@@ -832,6 +832,23 @@ export function shareThread(db: Kysely<DB>) {
 }
 
 /**
+ * Owner-scoped UI message part types that don't survive a thread copy:
+ * `data-report` cards and the `tool-generate_report` payload that
+ * produces them both reference scout_report rows gated by user_id.
+ * Stripping them keeps the copied conversation's prose intact while
+ * removing cards that would render stuck-loading or 404 for the new
+ * owner.
+ */
+function stripOwnerScopedParts(rawParts: unknown): unknown[] {
+  const parts = Array.isArray(rawParts) ? rawParts : [rawParts];
+  return parts.filter((p) => {
+    if (typeof p !== "object" || p === null) return true;
+    const t = (p as { type?: unknown }).type;
+    return t !== "data-report" && t !== "tool-generate_report";
+  });
+}
+
+/**
  * Fork a thread the caller can read (owner or shared sharee) into a new
  * thread the caller owns. The new thread is fully editable — copied
  * messages are written verbatim except for owner-private metadata
@@ -894,8 +911,23 @@ export function copyThread(db: Kysely<DB>) {
             sourceMessages.map((m) => ({
               thread_id: newThread.id,
               role: m.role,
-              // parts is jsonb in the schema; pass through structurally.
-              parts: JSON.stringify(m.parts),
+              // parts is jsonb in the schema; pass through structurally,
+              // but strip parts that point at owner-scoped resources the
+              // new owner can't access:
+              //   - data-report: scout_report rows are gated by user_id,
+              //     so the report card would render stuck-loading or 404
+              //     under the new owner. Drop the card; the surrounding
+              //     prose ("Report queued — it'll appear in the Reports
+              //     tab when ready.") still reads sensibly.
+              //   - tool-generate_report: the routing payload behind the
+              //     same card. No standalone UI, but no point keeping it
+              //     either.
+              parts: JSON.stringify(stripOwnerScopedParts(m.parts)),
+              // Preserve the original timestamp so getThread's order-by
+              // created_at reproduces the same conversation order. A
+              // bulk insert with default NOW() can land all rows on the
+              // same timestamp, scrambling user/assistant interleaving.
+              created_at: m.created_at,
               // token counts and attachment ids belong to the original owner —
               // nulling here keeps the copy's accounting honest and avoids the
               // new owner trying (and failing) to load the original's

--- a/apps/api/src/features/scout/system-prompt.ts
+++ b/apps/api/src/features/scout/system-prompt.ts
@@ -13,6 +13,8 @@ What the Play Cricket scorecard data ACTUALLY contains for each batter:
 - bowler_name and fielder_name (for the dismissal only)
 - batting position
 
+PARTIAL-SCORING TRAP — when balls = 0 but runs > 0 (or balls = 0 and how_out is set), the match was NOT scored ball-by-ball; only innings totals were entered. Strike rate, balls faced, and "X off Y balls" claims are UNAVAILABLE for that line. Don't render strike rates as "—", "0.0", or "infinity" and don't say "off 0 balls" — either omit the balls/SR field entirely or note the match wasn't ball-by-ball scored. The same caveat applies to bowling lines with maidens/runs/wickets recorded but 0 balls bowled. When aggregating across many innings, exclude these rows from balls-based denominators (don't average a strike rate across innings where balls = 0); aggregate them in run-based metrics only.
+
 What it DOES NOT contain (and you must NEVER infer):
 - shot selection or shot patterns (sweeps, drives, pulls, cuts — none of this is in the data)
 - where the ball was bowled (line, length, short/full, off/leg side, around-the-wicket, yorkers, etc.)

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -9900,6 +9900,59 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/scout/threads/{threadId}/copy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    threadId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uuid */
+                            id: string;
+                            title: string;
+                            /** @enum {string} */
+                            mode: "chat" | "debrief" | "scout";
+                            /** Format: date-time */
+                            createdAt: string;
+                            /** Format: date-time */
+                            updatedAt: string;
+                            sharedBy: {
+                                id: string;
+                                name: string;
+                                email: string;
+                            } | null;
+                            sharedByMe: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/scout/threads/{threadId}/attachments": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -17280,6 +17280,96 @@
         }
       }
     },
+    "/api/scout/threads/{threadId}/copy": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "threadId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "chat",
+                        "debrief",
+                        "scout"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "sharedBy": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "email"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "sharedByMe": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "mode",
+                    "createdAt",
+                    "updatedAt",
+                    "sharedBy",
+                    "sharedByMe"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/scout/threads/{threadId}/attachments": {
       "post": {
         "requestBody": {

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -201,6 +201,50 @@
   --color-gray-900: #f8fafc;
   --color-gray-950: #f8fafc;
 
+  /* Same treatment for the stone palette — Scout / ImbuzAI components
+     use stone heavily as the brand neutral, and without remapping the
+     light-mode hexes stay visible in dark mode (white-on-white text on
+     stone-50 backgrounds). Use slate hues (not the warm-brown stone
+     defaults) so the remapped surfaces sit harmoniously against the
+     slate body / surface tokens above. The hierarchy mirrors the gray
+     remap: 50/100 are sidebar-style tinted surfaces darker than the
+     main panel; 200/300 are borders/dividers; 400+ are text. */
+  --color-stone-50: #182135;
+  --color-stone-100: #1c2740;
+  --color-stone-200: #334155;
+  --color-stone-300: #475569;
+  --color-stone-400: #94a3b8;
+  --color-stone-500: #94a3b8;
+  --color-stone-600: #cbd5e1;
+  --color-stone-700: #e2e8f0;
+  --color-stone-800: #f1f5f9;
+  --color-stone-900: #f8fafc;
+  --color-stone-950: #f8fafc;
+
+  /* Violet (shared-thread banner) and emerald (player_faces / scout
+     badges) — same logic. Light shades get inverted to dark surfaces;
+     mid/dark text stays readable on those surfaces. */
+  --color-violet-50: #2e1065;
+  --color-violet-100: #4c1d95;
+  --color-violet-200: #5b21b6;
+  --color-violet-300: #6d28d9;
+  --color-violet-700: #c4b5fd;
+  --color-violet-800: #ddd6fe;
+  --color-violet-900: #ede9fe;
+  --color-emerald-50: #022c22;
+  --color-emerald-100: #064e3b;
+  --color-emerald-200: #065f46;
+  --color-emerald-300: #047857;
+  --color-emerald-700: #6ee7b7;
+  --color-emerald-800: #a7f3d0;
+  --color-emerald-900: #d1fae5;
+  /* Purple (ThoughtBubble background) — same treatment. */
+  --color-purple-50: #2e1065;
+  --color-purple-100: #4c1d95;
+  --color-purple-200: #5b21b6;
+  --color-purple-700: #d8b4fe;
+  --color-purple-800: #e9d5ff;
+
   /* Remap color palettes for dark-friendly tints */
   --color-red-50: #450a0a;
   --color-red-100: #7f1d1d;
@@ -215,16 +259,25 @@
   --color-green-800: #166534;
   --color-blue-50: #172554;
   --color-blue-100: #1e3a5f;
+  --color-blue-200: #1e40af;
   --color-blue-300: #1e40af;
   --color-blue-400: #93c5fd;
   --color-blue-600: #93c5fd;
+  /* blue-700 is heavily used by Scout for citation chips, link text, and
+     active-tab text. Without this remap it lands at the default #1d4ed8
+     which is unreadable on the dark blue backgrounds (blue-50/100). */
+  --color-blue-700: #93c5fd;
   --color-blue-800: #93c5fd;
+  --color-blue-900: #bfdbfe;
   --color-amber-50: #451a03;
   --color-amber-100: #78350f;
+  --color-amber-200: #92400e;
   --color-amber-300: #92400e;
+  --color-amber-500: #fbbf24;
   --color-amber-600: #fbbf24;
   --color-amber-700: #fbbf24;
   --color-amber-800: #fcd34d;
+  --color-amber-900: #fde68a;
   --color-yellow-100: #713f12;
   --color-yellow-800: #fde68a;
 }
@@ -232,6 +285,38 @@
 /* Override bg-white for dark mode backgrounds without affecting text-white */
 .dark .bg-white {
   background-color: var(--color-surface);
+}
+
+/* Stone — text usage and surface usage share the same Tailwind var, so a
+   single remap can't satisfy both. We remap the var so text-stone-900
+   reads as near-white in dark mode (the common case). For the rarer
+   "darkest surface" usages (e.g. CTA buttons that pair bg-stone-900 with
+   text-white), pin the background back to a dark slate hex here so the
+   contrast survives and the colour family stays consistent with the
+   rest of the dark UI. */
+.dark .bg-stone-900 {
+  background-color: #0b1220;
+}
+.dark .bg-stone-800 {
+  background-color: #1c2740;
+}
+/* bg-stone-950 is used by the homepage hero as a darkening overlay
+   (`bg-stone-950 opacity-40`). After the stone-text remap it would land
+   near-white and bleach the photo behind it — pin it back to a deep
+   slate so the overlay still darkens. */
+.dark .bg-stone-950 {
+  background-color: #020617;
+}
+.dark .hover\:bg-stone-800:hover {
+  background-color: #1c2740;
+}
+.dark .hover\:bg-stone-900:hover {
+  background-color: #0b1220;
+}
+/* The chevron divider on the split CTA uses border-stone-700 — pin that
+   too so the border doesn't disappear into the dark button surface. */
+.dark .border-stone-700 {
+  border-color: #334155;
 }
 
 /* Primary is kept as dark green for bg-primary (header/footer with white text).

--- a/apps/web/src/components/radio-buttons.tsx
+++ b/apps/web/src/components/radio-buttons.tsx
@@ -30,10 +30,10 @@ export function RadioButtons<T extends string>({
             checked={radioValue === value}
             onChange={() => onChange(radioValue)}
           />
-          <div className="ms-2 font-medium text-stone-900 dark:text-stone-300">
+          <div className="ms-2 font-medium text-stone-900">
             {title}
             {description && (
-              <p className="text-xs font-normal text-stone-500 dark:text-stone-300">
+              <p className="text-xs font-normal text-stone-500">
                 {description}
               </p>
             )}

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -9900,6 +9900,59 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/scout/threads/{threadId}/copy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    threadId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: uuid */
+                            id: string;
+                            title: string;
+                            /** @enum {string} */
+                            mode: "chat" | "debrief" | "scout";
+                            /** Format: date-time */
+                            createdAt: string;
+                            /** Format: date-time */
+                            updatedAt: string;
+                            sharedBy: {
+                                id: string;
+                                name: string;
+                                email: string;
+                            } | null;
+                            sharedByMe: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/scout/threads/{threadId}/attachments": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -17280,6 +17280,96 @@
         }
       }
     },
+    "/api/scout/threads/{threadId}/copy": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "threadId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "chat",
+                        "debrief",
+                        "scout"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "sharedBy": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "email"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "sharedByMe": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "mode",
+                    "createdAt",
+                    "updatedAt",
+                    "sharedBy",
+                    "sharedByMe"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/scout/threads/{threadId}/attachments": {
       "post": {
         "requestBody": {

--- a/apps/web/src/pages/scout/message-view.tsx
+++ b/apps/web/src/pages/scout/message-view.tsx
@@ -338,7 +338,7 @@ export function MessageView({
         className={`max-w-3xl rounded-lg px-4 py-3 ${
           isUser
             ? "bg-blue-100 text-stone-900"
-            : "w-full border border-stone-200 bg-white text-stone-900"
+            : "w-full border border-stone-200 bg-white text-stone-900 dark:bg-slate-800/70"
         }`}
       >
         {(() => {
@@ -607,12 +607,24 @@ function PartView({
       // payload is just routing — never render it. The data-report part is
       // emitted as the very first thing inside execute(), so there's no gap.
       part.type === "tool-generate_report" ||
-      // render_image / player_faces UIs ARE the data-* parts; the
-      // tool-call payloads are routing noise — never render them.
-      part.type === "tool-render_image" ||
-      part.type === "tool-player_faces"
+      // render_image's UI IS the data-image part; the tool-call payload is
+      // routing noise — never render it.
+      part.type === "tool-render_image"
     ) {
       return null;
+    }
+    // player_faces: the data-player-faces part is the real card, but the
+    // model can spend a few seconds streaming the input args (many face URLs
+    // per source). Show a placeholder while in-progress so the chat doesn't
+    // appear stalled; once output-available, the data-* card takes over.
+    if (part.type === "tool-player_faces") {
+      return <PlayerFacesPendingCard part={part} />;
+    }
+    // find_player_photo_sources is the slow web-discovery + face-detection
+    // tool. Show a shimmer card while it runs, collapse to a settled pill
+    // (matching ask_db) once it returns.
+    if (part.type === "tool-find_player_photo_sources") {
+      return <PhotoSearchCard part={part} />;
     }
     // ask_db gets a dedicated card that handles both the in-progress state
     // (rotating stages + shimmer) and the settled state (small blue pill with
@@ -1184,6 +1196,174 @@ function DatabaseIcon({ className }: { className?: string }) {
       <ellipse cx="12" cy="5" rx="9" ry="3" />
       <path d="M3 5v6c0 1.66 4 3 9 3s9-1.34 9-3V5" />
       <path d="M3 11v6c0 1.66 4 3 9 3s9-1.34 9-3v-6" />
+    </svg>
+  );
+}
+
+// ── player_faces / find_player_photo_sources loading cards ───────────────
+//
+// player_faces: tool-player_faces emits a data-player-faces part from
+// execute(); the data-* part is the real card. The gap between "model
+// chose to call player_faces" and "data part lands" can be a few seconds
+// (input args carry many face URLs). Render a small placeholder while
+// the call is mid-flight; return null on output so the data-* card is
+// the only thing the user sees.
+function PlayerFacesPendingCard({ part }: { part: Part }) {
+  const tool = part as unknown as ToolPart;
+  const isDone =
+    tool.state === "output-available" || tool.state === "output-error";
+  if (isDone) return null;
+  return (
+    <div className="my-2 rounded border border-emerald-200 bg-emerald-50/50 px-3 py-2">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-emerald-700">
+        <FaceIcon className="size-3.5" />
+        <span
+          className="animate-thought-shimmer bg-clip-text text-transparent"
+          style={{
+            backgroundImage:
+              "linear-gradient(90deg, #047857 0%, #047857 35%, #6ee7b7 50%, #047857 65%, #047857 100%)",
+            backgroundSize: "200% 100%",
+          }}
+        >
+          Rendering face matches…
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// find_player_photo_sources is genuinely slow (a few seconds to tens of
+// seconds) — it does live web search, fetches candidate pages, runs face
+// detection. Mirror the AskDbCard two-state shape: shimmer in-progress,
+// collapse to a small pill once settled (click to expand input/output).
+const PHOTO_SEARCH_STAGES = [
+  "Searching the web…",
+  "Fetching candidate pages…",
+  "Detecting faces in images…",
+  "Ranking candidates by confidence…",
+];
+
+function PhotoSearchCard({ part }: { part: Part }) {
+  const tool = part as unknown as ToolPart;
+  const isDone =
+    tool.state === "output-available" || tool.state === "output-error";
+  const isError = tool.state === "output-error";
+
+  const startRef = useRef<number | null>(null);
+  useEffect(() => {
+    startRef.current ??= Date.now();
+  }, []);
+
+  const [elapsedSec, setElapsedSec] = useState<number | null>(null);
+  useEffect(() => {
+    if (isDone && startRef.current != null && elapsedSec === null) {
+      setElapsedSec(
+        Math.max(1, Math.round((Date.now() - startRef.current) / 1000)),
+      );
+    }
+  }, [isDone, elapsedSec]);
+
+  const [stageIdx, setStageIdx] = useState(0);
+  useEffect(() => {
+    if (isDone) return undefined;
+    const id = setInterval(() => {
+      setStageIdx((i) => (i + 1) % PHOTO_SEARCH_STAGES.length);
+    }, 1600);
+    return () => clearInterval(id);
+  }, [isDone]);
+
+  const [open, setOpen] = useState(false);
+
+  if (!isDone) {
+    return (
+      <div className="my-2 rounded border border-emerald-200 bg-emerald-50/50 px-3 py-2">
+        <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-emerald-700">
+          <FaceIcon className="size-3.5" />
+          <span>Searching for player photos</span>
+        </div>
+        <div
+          className="animate-thought-shimmer bg-clip-text font-mono text-xs text-transparent"
+          style={{
+            backgroundImage:
+              "linear-gradient(90deg, #047857 0%, #047857 35%, #6ee7b7 50%, #047857 65%, #047857 100%)",
+            backgroundSize: "200% 100%",
+          }}
+        >
+          {PHOTO_SEARCH_STAGES[stageIdx]}
+        </div>
+      </div>
+    );
+  }
+
+  const pillClass = isError
+    ? "inline-flex items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-2.5 py-1 text-xs text-red-700 hover:bg-red-100"
+    : "inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-xs text-emerald-700 hover:bg-emerald-100";
+
+  return (
+    <div className="my-2">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={pillClass}
+      >
+        <FaceIcon className="size-3" />
+        <span>
+          {isError ? "Photo search failed" : "Searched for player photos"}
+          {!isError && elapsedSec != null ? ` · ${elapsedSec}s` : ""}
+        </span>
+        <span className={isError ? "text-red-400" : "text-emerald-400"}>
+          {open ? "▾" : "▸"}
+        </span>
+      </button>
+      {open && (
+        <div className="mt-1 rounded border border-emerald-200 bg-emerald-50/30 p-2 text-xs">
+          {tool.input !== undefined && (
+            <details>
+              <summary className="cursor-pointer text-emerald-700">
+                query
+              </summary>
+              <pre className="mt-1 max-h-48 overflow-auto rounded bg-white p-1 font-mono text-[11px]">
+                {JSON.stringify(tool.input, null, 2)}
+              </pre>
+            </details>
+          )}
+          {tool.errorText && (
+            <div className="mt-1 rounded bg-red-50 p-1 text-red-700">
+              {tool.errorText}
+            </div>
+          )}
+          {tool.output !== undefined && (
+            <details>
+              <summary className="cursor-pointer text-emerald-700">
+                candidates
+              </summary>
+              <pre className="mt-1 max-h-72 overflow-auto rounded bg-white p-1 font-mono text-[11px]">
+                {JSON.stringify(tool.output, null, 2)}
+              </pre>
+            </details>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FaceIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <circle cx="9" cy="10" r="0.5" fill="currentColor" />
+      <circle cx="15" cy="10" r="0.5" fill="currentColor" />
+      <path d="M9 15c1 1 2 1.5 3 1.5S13 16 15 15" />
     </svg>
   );
 }

--- a/apps/web/src/pages/scout/scout.tsx
+++ b/apps/web/src/pages/scout/scout.tsx
@@ -5,9 +5,9 @@ import { useSession } from "@/lib/auth-client";
 import type { UIMessage } from "@ai-sdk/react";
 import type { ReportData } from "@percy-main/shared";
 import { checkPermission } from "@percy-main/shared/auth/permissions";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
-import { useParams, useSearchParams } from "react-router";
+import { useNavigate, useParams, useSearchParams } from "react-router";
 import { MessageAttachments } from "./attachments/message-attachments.js";
 import { useAttachmentUpload } from "./attachments/use-attachment-upload.js";
 import { Composer, type ThinkingMode } from "./composer.js";
@@ -92,7 +92,7 @@ export function Component() {
 
   return (
     <div className="container mx-auto h-[calc(100vh-8rem)] px-0">
-      <div className="relative flex h-full overflow-hidden rounded-lg border border-stone-200 bg-white">
+      <div className="relative flex h-full overflow-hidden rounded-lg border border-stone-200 bg-white shadow-sm dark:shadow-lg dark:shadow-black/30">
         {threadDrawerOpen && (
           <button
             type="button"
@@ -522,13 +522,10 @@ function ChatView({ threadId, loaded }: ChatViewProps) {
         </div>
       </header>
       {isReadOnly && loaded.thread.sharedBy && (
-        <div className="border-b border-violet-200 bg-violet-50 px-4 py-2 text-xs text-violet-900">
-          Shared by{" "}
-          <span className="font-medium">{loaded.thread.sharedBy.name}</span>{" "}
-          <span className="text-violet-700">
-            · read-only: you can read the conversation but can&rsquo;t reply.
-          </span>
-        </div>
+        <ReadOnlyBanner
+          threadId={threadId}
+          sharedByName={loaded.thread.sharedBy.name}
+        />
       )}
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-2">
         {messages.length === 0 &&
@@ -622,6 +619,63 @@ function ChatView({ threadId, loaded }: ChatViewProps) {
         />
       )}
     </>
+  );
+}
+
+function ReadOnlyBanner({
+  threadId,
+  sharedByName,
+}: {
+  threadId: string;
+  sharedByName: string;
+}) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  // Forks the shared thread into a fresh thread owned by the current user.
+  // Recipients lose nothing — the original stays read-only — but get an
+  // editable copy they can keep chatting in. We invalidate the threads list
+  // so the new row appears in the sidebar, then navigate to it (the URL
+  // change unmounts ChatView and the new thread loads via the regular
+  // ActiveThread query).
+  const copyMutation = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/scout/threads/{threadId}/copy", {
+          params: { path: { threadId } },
+        }),
+      ),
+    onSuccess: async (newThread) => {
+      await queryClient.invalidateQueries({ queryKey: ["scout", "threads"] });
+      void navigate(`/scout/${newThread.id}`);
+    },
+  });
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 border-b border-violet-200 bg-violet-50 px-4 py-2 text-xs text-violet-900">
+      <div>
+        Shared by <span className="font-medium">{sharedByName}</span>{" "}
+        <span className="text-violet-700">
+          · read-only: you can read the conversation but can&rsquo;t reply.
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={() => copyMutation.mutate()}
+        disabled={copyMutation.isPending}
+        className="inline-flex items-center gap-1 rounded border border-violet-300 bg-white px-2 py-1 text-violet-800 hover:bg-violet-100 disabled:opacity-50"
+        title="Copy this thread into your own threads so you can keep chatting"
+      >
+        {copyMutation.isPending ? "Copying…" : "Copy to my threads"}
+      </button>
+      {copyMutation.error && (
+        <div className="basis-full text-violet-700">
+          {copyMutation.error instanceof Error
+            ? copyMutation.error.message
+            : "Failed to copy thread"}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/pages/scout/share-thread-modal.tsx
+++ b/apps/web/src/pages/scout/share-thread-modal.tsx
@@ -149,9 +149,10 @@ export function ShareThreadModal({
         <DialogHeader>
           <DialogTitle>Share thread</DialogTitle>
           <DialogDescription>
-            Give other officials read-only access to{" "}
+            Give other ImbuzAI users read-only access to{" "}
             <span className="font-medium text-stone-900">{threadTitle}</span>.
-            They&rsquo;ll see the full conversation but can&rsquo;t reply.
+            They&rsquo;ll see the full conversation but can&rsquo;t reply (they
+            can copy it to a thread of their own to keep chatting).
           </DialogDescription>
         </DialogHeader>
 
@@ -192,7 +193,7 @@ export function ShareThreadModal({
         {/* ── Picker ────────────────────────────────────────────── */}
         <div className="space-y-2">
           <Input
-            placeholder="Search officials by name or email…"
+            placeholder="Search ImbuzAI users by name or email…"
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
             disabled={officialsQuery.isLoading}
@@ -204,10 +205,10 @@ export function ShareThreadModal({
             {!officialsQuery.isLoading && candidates.length === 0 && (
               <div className="p-3 text-sm text-stone-500">
                 {filter
-                  ? "No matching officials."
+                  ? "No matching users."
                   : hasShares
                     ? "Already shared with everyone available."
-                    : "No other officials yet."}
+                    : "No other ImbuzAI users yet."}
               </div>
             )}
             <ul className="divide-y divide-stone-100">


### PR DESCRIPTION
## Summary

Bundle of five user-requested ImbuzAI fixes plus a pair of dark-mode follow-ups uncovered while testing.

- **Loading states** for `player_faces` (placeholder while the model streams args) and `find_player_photo_sources` (rotating-stage shimmer → settled "Searched · Xs" pill). Face discovery is the slow one — captain now sees activity instead of a generic tool-call pill.
- **RBAC-based sharing**: thread-share recipient eligibility flipped from a hardcoded `admin`/`official` allowlist to `checkPermission(role, "ai_chat", "use")`. Anyone who can use Scout can now be shared with; legacy `official` (matchday perms only) is excluded. Picker copy and integration tests updated.
- **Copy shared thread**: new `POST /scout/threads/:threadId/copy` + "Copy to my threads" button on the read-only banner. Recipients can now fork a shared thread into an editable one of their own (token counts and attachment ids are nulled in the copy since they reference the original owner's resources).
- **Dark mode polish**: retinted the stone palette to slate hues so the Scout panel has visible hierarchy (sidebar tinted-surface vs main-panel surface vs raised bubbles); pinned `.dark .bg-stone-900/950` overrides so CTA buttons stay dark and the homepage hero overlay still darkens (was being bleached by the remap); added shadow lift on the chat container and a raised bg on assistant bubbles.
- **0 balls + runs grounding rule**: added a "PARTIAL-SCORING TRAP" paragraph at the top of `GROUNDING_RULES` instructing the model that runs > 0 with balls = 0 means the match wasn't ball-by-ball scored — no strike rates, no "X off Y balls" claims, and exclude those rows from balls-based aggregates.

## Test plan

- [ ] Open Scout in dark mode — sidebar/main panel/bubbles read as a clear hierarchy, "New chat" CTA is dark with white text, homepage hero is no longer washed out.
- [ ] Trigger `find_player_photo_sources` (recognition ask) — see a shimmer card with rotating stages, then a settled green "Searched for player photos · Xs" pill (click to expand inputs/outputs).
- [ ] Trigger `player_faces` — see "Rendering face matches…" briefly while args stream, then the existing face-grid card.
- [ ] Open share modal — all `ai_chat_user` / `admin` users appear in the picker; `official`-only users do not.
- [ ] Open a thread shared with you — "Copy to my threads" button on the banner forks the thread; the new copy is editable and you can keep chatting.
- [ ] In a debrief / chat, ask a question that returns a batting line with 0 balls + runs — model should omit strike-rate/balls and note the match wasn't ball-by-ball scored.
- [ ] CI green (lint, typecheck, unit + integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)