### PR TITLE
chore(deps): bump pnpm to 11.1.2 and pin via action-setup

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -9,7 +9,9 @@ description: >
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
+      with:
+        version: 11.1.2
 
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/deploy-web-manual.yml
+++ b/.github/workflows/deploy-web-manual.yml
@@ -51,7 +51,9 @@ jobs:
           echo "sha=${DEPLOYED_SHA}" >> "$GITHUB_OUTPUT"
           echo "Deployed SHA: ${DEPLOYED_SHA}"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.1.2
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -685,7 +685,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.1.2
 
       - uses: actions/setup-node@v4
         with:
@@ -872,7 +874,9 @@ jobs:
             exit 1
           fi
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.1.2
 
       - uses: actions/setup-node@v4
         with:

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Install and build
 FROM node:22-alpine AS builder
-RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.1.2 --activate
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
@@ -19,7 +19,7 @@ RUN pnpm --filter '!@percy-main/web' --filter '!email-viewer' run build
 
 # Stage 2: Production
 FROM node:22-alpine AS runner
-RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.1.2 --activate
 
 # Install fonts for Sharp SVG rendering (OG images) and AWS RDS CA bundle
 RUN apk add --no-cache fontconfig font-noto ca-certificates wget && \

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "percy-main",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.0.0",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "dev": "bash scripts/dev.sh",
     "dev:api": "pnpm --filter api dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,15 @@ packages:
   - "apps/*"
   - "packages/*"
   - "infra"
+# Postinstall script policy. pnpm 11 requires an explicit decision per
+# package whose install script would otherwise run. Mirrors prior pnpm 10
+# behaviour where these were all ignored without issue: sharp ships
+# prebuilt platform bindings via its `@img/sharp-*` optional deps,
+# esbuild via `@esbuild/*`, and cpu-features / ssh2 / protobufjs are
+# transitive dev-time only.
+allowBuilds:
+  cpu-features: false
+  esbuild: false
+  protobufjs: false
+  sharp: false
+  ssh2: false


### PR DESCRIPTION
## Summary

Supersedes #262 (dependabot's naive bump of `pnpm/action-setup` v4→v6). That bump alone risked CI silently running pnpm 11 (via action-setup v6's bundled pnpm) against a lockfile generated under pnpm 10 — see pnpm/action-setup#225 / #227.

This PR does the version bump *and* the pinning together:

- **pnpm 10.0.0 → 11.1.2** in `packageManager` and both `corepack prepare` lines in `apps/api/Dockerfile`
- **`pnpm/action-setup@v6` with explicit `version: 11.1.2`** in all four invocations:
  - `.github/actions/setup-deps/action.yml`
  - `.github/workflows/deploy.yml` (×2)
  - `.github/workflows/deploy-web-manual.yml`
- **`allowBuilds:` block in `pnpm-workspace.yaml`** — pnpm 11 requires an explicit per-package decision for install scripts that would otherwise run. Set to `false` for all 8 to mirror prior pnpm 10 behaviour (sharp + esbuild use their `@img/sharp-*` / `@esbuild/*` prebuilt platform deps; the rest are dev-time transitive).

Lockfile is unchanged (`lockfileVersion: '9.0'` is shared between pnpm 10 and 11).

## Test plan

- [x] `pnpm install --frozen-lockfile` clean under pnpm 11.1.2 (no `ERR_PNPM_IGNORED_BUILDS`)
- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [ ] CI green on this branch
- [ ] API Docker build still produces a working image (sharp OG generation specifically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)