### PR TITLE
ci: bump GitHub Actions to Node 24-capable versions

### DIFF
--- a/.github/actions/notify-deploy-failure/action.yml
+++ b/.github/actions/notify-deploy-failure/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Open issue + post Slack
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       env:
         JOB_NAME: ${{ inputs.job }}
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -13,7 +13,7 @@ runs:
       with:
         version: 11.1.2
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: pnpm

--- a/.github/workflows/_lint-test-build.yml
+++ b/.github/workflows/_lint-test-build.yml
@@ -37,7 +37,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
@@ -48,11 +48,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-lint-${{ github.sha }}
@@ -65,11 +65,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-typecheck-${{ github.sha }}
@@ -82,11 +82,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-test-${{ github.sha }}
@@ -130,7 +130,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
@@ -156,11 +156,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-build-${{ github.sha }}
@@ -198,7 +198,7 @@ jobs:
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          junit_files: "junit-xml/**/*.xml"
+          files: "junit-xml/**/*.xml"
           check_name: "Vitest results"
           comment_mode: changes in failures
           action_fail: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     # `safe-ddl-ack: <reason>` token in any commit message.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - run: bash .github/scripts/check-unsafe-ddl.sh "origin/${{ github.base_ref }}"
@@ -50,7 +50,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: millionco/react-doctor@main
@@ -69,7 +69,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build API image (local, no push)
         id: build
@@ -104,7 +104,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high

--- a/.github/workflows/deploy-api-manual.yml
+++ b/.github/workflows/deploy-api-manual.yml
@@ -41,7 +41,7 @@ jobs:
       ECS_CLUSTER: percy-main-production-cluster
       ECS_SERVICE: production-api
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/deploy-terraform-manual.yml
+++ b/.github/workflows/deploy-terraform-manual.yml
@@ -54,7 +54,7 @@ jobs:
     # against an arbitrary ref still requires reviewer approval.
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -181,7 +181,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/deploy-web-manual.yml
+++ b/.github/workflows/deploy-web-manual.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -55,7 +55,7 @@ jobs:
         with:
           version: 11.1.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
       matchday: ${{ steps.filter.outputs.matchday }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -83,7 +83,7 @@ jobs:
       NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
       TF_VAR_newrelic_account_id: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -215,7 +215,7 @@ jobs:
     env:
       TF_VERSION: "1.7"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -331,7 +331,7 @@ jobs:
       ECS_CLUSTER: percy-main-production-cluster
       ECS_SERVICE: production-api
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -673,13 +673,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
         with:
           version: 11.1.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -839,7 +839,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Verify required GitHub repo variables are set
         # First-run protection. The matchday bucket + distribution are
@@ -868,7 +868,7 @@ jobs:
         with:
           version: 11.1.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/rotate-secrets-reminder.yml
+++ b/.github/workflows/rotate-secrets-reminder.yml
@@ -17,7 +17,7 @@ jobs:
   open-reminder:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Open or update reminder issue
         env:

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         environment: [shared, production]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -92,7 +92,7 @@ jobs:
 
       - name: Open drift issue
         if: steps.plan.outputs.exitcode == '2'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           ENV: ${{ matrix.environment }}
         with:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         environment: [shared, production]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -88,7 +88,7 @@ jobs:
 
       - name: Post plan to PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary
- Bumps every flagged GitHub Action to a release that runs on Node 24, clearing the Node 20 deprecation warnings annotating every CI run.
- `checkout@v4 → v6`, `setup-node@v4 → v6`, `cache@v4 → v5`, `github-script@v7 → v9`.
- Renames the deprecated `junit_files` input to `files` for `EnricoMi/publish-unit-test-result-action@v2`.

## Test plan
- [ ] CI runs green on this branch
- [ ] No "Node.js 20 actions are deprecated" annotations remain
- [ ] No "junit_files has been deprecated" annotation on publish-test-results

🤖 Generated with [Claude Code](https://claude.com/claude-code)