### PR TITLE
news: State of the Club Survey 2026 announcement

### DIFF
--- a/apps/web/content/news/2026/state-of-the-club-survey-2026.mdx
+++ b/apps/web/content/news/2026/state-of-the-club-survey-2026.mdx
@@ -1,0 +1,51 @@
+---
+title: State of the Club Survey 2026
+date: 2026-05-15
+author: alex-young
+slug: state-of-the-club-survey-2026
+tags:
+  - Committee
+  - Charity
+---
+
+We're asking everyone who is part of the Percy Main Community Sports Club family — players, parents and guardians, volunteers, sponsors and supporters — to take ten minutes to fill in our first **State of the Club** survey.
+
+[**Complete the anonymous member survey →**](https://tally.so/r/D4xK0q)
+
+## Why we're doing this
+
+The club has grown a lot in the last couple of years: more juniors, women's softball, football, boxing, new committee, new facilities work. Before we plan the next twelve months we want to hear honestly from the people who actually turn up — what's working, what isn't, and what you think we should prioritise next.
+
+## Who should complete it
+
+Anyone connected to the club. You don't have to play. If you're a parent, a sponsor, an occasional volunteer, or you just come down to watch — your view matters and the survey has a path for you.
+
+## How we'll use your responses
+
+We will use the answers to:
+
+- improve how the club is run day-to-day
+- make new members feel more welcome
+- understand how people find and join the club
+- improve our communication
+- identify barriers to participation, including financial ones
+- support funding and grant applications
+- keep the club safe, welcoming and community-focused
+
+We'll report the headline themes back to members later in the summer.
+
+## It's anonymous
+
+The survey is anonymous unless you choose to leave your name and contact details at the end (which is entirely optional — for example if you'd like us to follow up on an idea or a volunteering offer). Individual responses will not be shared or published. We may quote anonymous comments or share statistics in summaries to members, funders or the wider community.
+
+## Please don't use it for safeguarding concerns
+
+**The survey is not a route for reporting safeguarding or welfare concerns.** If you have a current concern, please contact the club's safeguarding/welfare officer directly or use the official reporting route — those are dealt with confidentially and properly, and a survey is not the right place for them.
+
+## When it closes
+
+The survey is open now and closes on **Friday 12 June 2026**. It should take around 8–10 minutes.
+
+[**Complete the anonymous member survey →**](https://tally.so/r/D4xK0q)
+
+Thank you for taking the time to help shape the club.


### PR DESCRIPTION
## Summary
- Adds news article authored by Alex Young announcing the anonymous State of the Club 2026 member survey
- Links to a published Tally form (`tally.so/r/D4xK0q`, in the PMCC workspace) built via the Tally MCP from the spec in #341
- Survey closes Friday **12 June 2026**

Closes #341.

The article covers everything the ticket asked for: why we're doing the survey, who should complete it, how responses will be used, that it is anonymous, when it closes, the safeguarding-not-here notice, and a CTA link to the external survey.

The Tally form mirrors the question structure from the issue (9 sections + optional follow-up), with:
- linear scales labelled appropriately (1 = Strongly disagree etc.)
- 6.1 (overall experience) set to a 1–10 scale
- 9.2 (focus for next 12 months) capped at 3 selections
- free-text questions optional
- optional follow-up section fully optional
- auto-close set for 2026-06-12 23:59

## Test plan
- [x] `pnpm --filter web build` compiles the new MDX
- [x] `pnpm prettier --write` leaves the file unchanged
- [x] Visit `/news/state-of-the-club-survey-2026` in preview and confirm article renders with author, date, CTA links
- [x] Open `https://tally.so/r/D4xK0q` and walk through the form end-to-end