### PR TITLE
security(db): split RDS master into app_rw + app_ddl roles (#130)

### DIFF
--- a/.github/workflows/deploy-api-manual.yml
+++ b/.github/workflows/deploy-api-manual.yml
@@ -108,31 +108,43 @@ jobs:
         env:
           IMAGE_URI: ${{ steps.build.outputs.image }}
           RELEASE_SHA: ${{ steps.ref.outputs.sha }}
+          MIGRATION_TASK_DEF_FAMILY: production-api-migrate
         run: |
-          TASK_DEF=$(aws ecs describe-task-definition \
-            --task-definition $ECS_SERVICE \
-            --query 'taskDefinition' \
-            --output json)
-
           # Patch image + add RELEASE_SHA / NEW_RELIC_LABELS env vars so
-          # NR APM and OTel can filter logs/traces by release.
-          NEW_TASK_DEF=$(echo "$TASK_DEF" | jq \
-            --arg IMAGE "$IMAGE_URI" \
-            --arg SHA "$RELEASE_SHA" \
-            '.containerDefinitions[0].image = $IMAGE
-             | .containerDefinitions[0].environment = (
-                 ((.containerDefinitions[0].environment // []) | map(select(.name != "RELEASE_SHA" and .name != "NEW_RELIC_LABELS"))) +
-                 [{name: "RELEASE_SHA", value: $SHA},
-                  {name: "NEW_RELIC_LABELS", value: ("release:" + $SHA)}]
-               )
-             | del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)')
+          # NR APM and OTel can filter logs/traces by release. Applied
+          # to both the API task def and the migration task def
+          # (#130 — separate task def for principle of least privilege).
+          patch_task_def() {
+            local family="$1"
+            local def
+            def=$(aws ecs describe-task-definition \
+              --task-definition "$family" \
+              --query 'taskDefinition' \
+              --output json)
 
-          TASK_DEF_ARN=$(aws ecs register-task-definition \
-            --cli-input-json "$NEW_TASK_DEF" \
+            echo "$def" | jq \
+              --arg IMAGE "$IMAGE_URI" \
+              --arg SHA "$RELEASE_SHA" \
+              '.containerDefinitions[0].image = $IMAGE
+               | .containerDefinitions[0].environment = (
+                   ((.containerDefinitions[0].environment // []) | map(select(.name != "RELEASE_SHA" and .name != "NEW_RELIC_LABELS"))) +
+                   [{name: "RELEASE_SHA", value: $SHA},
+                    {name: "NEW_RELIC_LABELS", value: ("release:" + $SHA)}]
+                 )
+               | del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)'
+          }
+
+          API_TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "$(patch_task_def "$ECS_SERVICE")" \
             --query 'taskDefinition.taskDefinitionArn' \
             --output text)
+          echo "task-definition-arn=$API_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
 
-          echo "task-definition-arn=$TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
+          MIGRATE_TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "$(patch_task_def "$MIGRATION_TASK_DEF_FAMILY")" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+          echo "migration-task-definition-arn=$MIGRATE_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
 
       - name: Run migrations
         id: migrate
@@ -143,17 +155,12 @@ jobs:
             --query 'services[0].networkConfiguration' \
             --output json)
 
+          # Migration uses its own task def (#130), command baked in.
           TASK_ARN=$(aws ecs run-task \
             --cluster $ECS_CLUSTER \
-            --task-definition ${{ steps.task-def.outputs.task-definition-arn }} \
+            --task-definition ${{ steps.task-def.outputs.migration-task-definition-arn }} \
             --launch-type FARGATE \
             --network-configuration "$NETWORK_CONFIG" \
-            --overrides '{
-              "containerOverrides": [{
-                "name": "api",
-                "command": ["node", "apps/api/dist/migrate.js"]
-              }]
-            }' \
             --query 'tasks[0].taskArn' \
             --output text)
 
@@ -178,10 +185,11 @@ jobs:
         env:
           TASK_ARN: ${{ steps.migrate.outputs.task_arn }}
           EXIT_CODE: ${{ steps.migrate.outputs.exit_code }}
-          TASK_DEF_ARN: ${{ steps.task-def.outputs.task-definition-arn }}
+          TASK_DEF_ARN: ${{ steps.task-def.outputs.migration-task-definition-arn }}
         run: |
           # Surface task-stop reason + container reason + last 50 log
-          # lines from the task's CloudWatch stream into the run summary.
+          # lines from the migration task's CloudWatch stream into the
+          # run summary.
           set +e
           STOPPED_REASON=$(aws ecs describe-tasks --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN" \
             --query 'tasks[0].stoppedReason' --output text)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -395,33 +395,47 @@ jobs:
         env:
           IMAGE_URI: ${{ steps.build.outputs.image }}
           RELEASE_SHA: ${{ github.sha }}
+          MIGRATION_TASK_DEF_FAMILY: production-api-migrate
         run: |
-          TASK_DEF=$(aws ecs describe-task-definition \
-            --task-definition $ECS_SERVICE \
-            --query 'taskDefinition' \
-            --output json)
+          # Helper: describe → patch image + RELEASE_SHA / NEW_RELIC_LABELS
+          # env vars → register a new revision. NR APM and OTel can then
+          # filter logs/traces by release. jq's group_by keeps the last
+          # occurrence after our additions are appended, so an existing
+          # RELEASE_SHA entry gets replaced rather than duplicated.
+          patch_task_def() {
+            local family="$1"
+            local def
+            def=$(aws ecs describe-task-definition \
+              --task-definition "$family" \
+              --query 'taskDefinition' \
+              --output json)
 
-          # Patch image + add RELEASE_SHA / NEW_RELIC_LABELS env vars so
-          # NR APM and OTel can filter logs/traces by release. Replaces
-          # any existing entries with the same name (jq's group_by keeps
-          # the last occurrence after our additions are appended).
-          NEW_TASK_DEF=$(echo "$TASK_DEF" | jq \
-            --arg IMAGE "$IMAGE_URI" \
-            --arg SHA "$RELEASE_SHA" \
-            '.containerDefinitions[0].image = $IMAGE
-             | .containerDefinitions[0].environment = (
-                 ((.containerDefinitions[0].environment // []) | map(select(.name != "RELEASE_SHA" and .name != "NEW_RELIC_LABELS"))) +
-                 [{name: "RELEASE_SHA", value: $SHA},
-                  {name: "NEW_RELIC_LABELS", value: ("release:" + $SHA)}]
-               )
-             | del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)')
+            echo "$def" | jq \
+              --arg IMAGE "$IMAGE_URI" \
+              --arg SHA "$RELEASE_SHA" \
+              '.containerDefinitions[0].image = $IMAGE
+               | .containerDefinitions[0].environment = (
+                   ((.containerDefinitions[0].environment // []) | map(select(.name != "RELEASE_SHA" and .name != "NEW_RELIC_LABELS"))) +
+                   [{name: "RELEASE_SHA", value: $SHA},
+                    {name: "NEW_RELIC_LABELS", value: ("release:" + $SHA)}]
+                 )
+               | del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)'
+          }
 
-          TASK_DEF_ARN=$(aws ecs register-task-definition \
-            --cli-input-json "$NEW_TASK_DEF" \
+          API_TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "$(patch_task_def "$ECS_SERVICE")" \
             --query 'taskDefinition.taskDefinitionArn' \
             --output text)
+          echo "task-definition-arn=$API_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
 
-          echo "task-definition-arn=$TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
+          # Migration task def (#130 — principle of least privilege). Same
+          # image, separate task def so DATABASE_URL → app_ddl is scoped
+          # to migration runs only, not the long-running API container.
+          MIGRATE_TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "$(patch_task_def "$MIGRATION_TASK_DEF_FAMILY")" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+          echo "migration-task-definition-arn=$MIGRATE_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
 
       - name: Run migrations
         id: migrate
@@ -432,17 +446,14 @@ jobs:
             --query 'services[0].networkConfiguration' \
             --output json)
 
+          # Migration uses its own task def (#130), which has the
+          # `node apps/api/dist/migrate.js` command baked in. No
+          # containerOverrides needed.
           TASK_ARN=$(aws ecs run-task \
             --cluster $ECS_CLUSTER \
-            --task-definition ${{ steps.task-def.outputs.task-definition-arn }} \
+            --task-definition ${{ steps.task-def.outputs.migration-task-definition-arn }} \
             --launch-type FARGATE \
             --network-configuration "$NETWORK_CONFIG" \
-            --overrides '{
-              "containerOverrides": [{
-                "name": "api",
-                "command": ["node", "apps/api/dist/migrate.js"]
-              }]
-            }' \
             --query 'tasks[0].taskArn' \
             --output text)
 
@@ -467,7 +478,7 @@ jobs:
         env:
           TASK_ARN: ${{ steps.migrate.outputs.task_arn }}
           EXIT_CODE: ${{ steps.migrate.outputs.exit_code }}
-          TASK_DEF_ARN: ${{ steps.task-def.outputs.task-definition-arn }}
+          TASK_DEF_ARN: ${{ steps.task-def.outputs.migration-task-definition-arn }}
         run: |
           # Surface task-stop reason + container reason + last 50 log
           # lines from the task's CloudWatch stream into the run summary,
@@ -478,7 +489,9 @@ jobs:
             --query 'tasks[0].stoppedReason' --output text)
           CONTAINER_REASON=$(aws ecs describe-tasks --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN" \
             --query 'tasks[0].containers[0].reason' --output text)
-          # Resolve the log group + stream prefix from the task definition.
+          # Resolve the log group + stream prefix from the migration
+          # task def (which has stream-prefix "migrate", distinct from
+          # the API task's "api").
           LOG_GROUP=$(aws ecs describe-task-definition --task-definition "$TASK_DEF_ARN" \
             --query 'taskDefinition.containerDefinitions[0].logConfiguration.options."awslogs-group"' --output text)
           STREAM_PREFIX=$(aws ecs describe-task-definition --task-definition "$TASK_DEF_ARN" \

--- a/apps/api/src/migrate.ts
+++ b/apps/api/src/migrate.ts
@@ -20,9 +20,19 @@ import { createWorkerLogger } from "./lib/worker-logger.ts";
 
 const logger = createWorkerLogger("migrate");
 
-const DATABASE_URL = process.env.DATABASE_URL;
+// The migration runner connects as a DDL-privileged role (app_ddl), not
+// the runtime CRUD role (app_rw). Prefer DATABASE_MIGRATION_URL if set;
+// fall back to DATABASE_URL for environments that haven't split yet
+// (local dev with the percy superuser, single-URL CI). See ADR on
+// principle-of-least-privilege DB roles for the split rationale.
+const DATABASE_URL =
+  process.env.DATABASE_MIGRATION_URL ?? process.env.DATABASE_URL;
 
-if (!DATABASE_URL) throw new Error("Missing required env var: DATABASE_URL");
+if (!DATABASE_URL) {
+  throw new Error(
+    "Missing required env var: set DATABASE_MIGRATION_URL or DATABASE_URL",
+  );
+}
 
 // Bound the time we'll wait for an ACCESS EXCLUSIVE lock and the time
 // any single statement can run. Without these, a migration that races

--- a/docs/adrs/043-db-role-split-principle-of-least-privilege.md
+++ b/docs/adrs/043-db-role-split-principle-of-least-privilege.md
@@ -1,0 +1,118 @@
+# ADR 043: Database role split — principle of least privilege
+
+## Status
+
+Accepted
+
+## Context
+
+The Fastify API connected to RDS as the **RDS master user** (`percy`, `rds_superuser`) using credentials stored under `percy-main-production/rds/credentials`. A compromised ECS task — RCE, SSRF into IMDS, leaky dependency — would therefore have gotten effective superuser on production: full DDL, role management, replication, bypass-RLS. The app runs third-party code every deploy, so this is not a theoretical risk.
+
+The migration runner ran with the same master credentials, blurring the runtime / schema-change separation that lets us reason about "what could the app have done?" during an incident.
+
+Surfaced during security review of the Tailscale DB-access plan (#216 / ADR 039). Tracked as #130.
+
+## Decision
+
+Three Postgres roles, three different jobs:
+
+| Role      | Login? | Scope                                                    | Used by               |
+| --------- | ------ | -------------------------------------------------------- | --------------------- |
+| `percy`   | yes    | RDS master (rds_superuser equivalent)                    | Break-glass only      |
+| `app_rw`  | yes    | CRUD on tables, USAGE on sequences, **no DDL**           | API runtime           |
+| `app_ddl` | yes    | CREATE on schema, ownership of all public-schema objects | Migration runner only |
+
+The two app roles are created `NOLOGIN` by a Kysely migration (timestamp `2026-05-15T06:53:37.877Z`). Their passwords are minted by Terraform `random_password` resources and stored in dedicated Secrets Manager entries (`percy-main-production/rds/app_rw`, `…/rds/app_ddl`). An operator sets `LOGIN` + the password on each role once after first apply, via psql over the Tailscale subnet router (see [Bootstrap](#bootstrap) below).
+
+Cutover is gated by a Terraform variable `app_rw_active` (default `false`). While false, the API and migration task definitions keep reading the master credentials — exactly the pre-#130 behaviour. Flipping it to `true` (after operator-bootstrap) switches:
+
+- API task `DATABASE_URL` → app_rw secret
+- Migration task `DATABASE_URL` → app_ddl secret
+- Master credentials secret → resource-policy denies all principals except those in `master_db_break_glass_principal_arns`
+
+The migration runner is a **separate ECS task definition** (`production-api-migrate`), not a `containerOverrides.command` on the API task def. This is what makes the role split meaningful at runtime: ECS injects secrets into env at container startup from the _task definition_, so a compromised API container only ever sees `DATABASE_URL = app_rw` in its env — never the `app_ddl` URL — even though the task execution role's IAM policy still allows reading both secrets (the broad `secret:*percy-main*` allow). The task execution role does the injection; the task role is what the running process uses for SDK calls, and the task role has no `secretsmanager:GetSecretValue` permission at all.
+
+## Bootstrap
+
+Required once, after the PR merges and CI applies. The cutover flag stays `false` until step 4.
+
+1. **Apply the role-split migration.** CI's normal deploy runs `apps/api/dist/migrate.js` against the master URL. The migration creates `app_rw` and `app_ddl` as `NOLOGIN`, walks `pg_class` to hand every public-schema object's ownership to `app_ddl`, sets default privileges so future migrations grant CRUD on new tables to `app_rw`, and revokes the legacy `CREATE ON SCHEMA public FROM PUBLIC` grant.
+
+2. **Read the new role passwords from Secrets Manager.**
+
+   ```sh
+   aws --profile percy-main secretsmanager get-secret-value \
+     --secret-id percy-main-production/rds/app_rw \
+     --query SecretString --output text | jq -r .password
+   aws --profile percy-main secretsmanager get-secret-value \
+     --secret-id percy-main-production/rds/app_ddl \
+     --query SecretString --output text | jq -r .password
+   ```
+
+3. **Set `LOGIN` + password on each role over Tailscale.** From an admin laptop on the tailnet:
+
+   ```sh
+   PGPASSWORD=<master> psql -h <rds-host> -U percy -d percy_main <<'SQL'
+   ALTER USER app_rw  WITH LOGIN PASSWORD '<from secret>';
+   ALTER USER app_ddl WITH LOGIN PASSWORD '<from secret>';
+   SQL
+   ```
+
+   Both roles can now log in with the Terraform-managed passwords. Connectivity test:
+
+   ```sh
+   PGPASSWORD=<app_rw_password> psql -h <rds-host> -U app_rw -d percy_main -c 'SELECT 1'
+   PGPASSWORD=<app_ddl_password> psql -h <rds-host> -U app_ddl -d percy_main -c 'SELECT 1'
+   ```
+
+4. **Flip the cutover flag.** One-line PR: set `app_rw_active = true` in `infra/environments/production/variables.tf` (and populate `master_db_break_glass_principal_arns` with at least one IAM principal — typically a named admin role on the tailnet). CI applies → API task def re-registers with `DATABASE_URL → app_rw` → next deploy uses the split.
+
+5. **(Optional) Rotate the master password.** Once the app is running against `app_rw` and `app_ddl` for at least one full deploy cycle:
+
+   ```sh
+   PGPASSWORD=<old master> psql -h <rds-host> -U percy -d percy_main \
+     -c "ALTER USER percy WITH PASSWORD '<new random>'"
+   aws --profile percy-main secretsmanager put-secret-value \
+     --secret-id percy-main-production/rds/credentials \
+     --secret-string '<json with new password>'
+   ```
+
+   The Terraform-managed `random_password.db` has `ignore_changes = all`, so this rotation is operator-driven and does not show up in plan.
+
+## Break-glass recovery
+
+The master credentials secret has a resource policy (when `app_rw_active = true`) that denies `GetSecretValue` from every principal except those in `master_db_break_glass_principal_arns`. Recovery flow:
+
+1. Admin assumes the IAM principal in the allowlist (typically via SSO + a named admin role).
+2. `aws secretsmanager get-secret-value --secret-id …/rds/credentials` returns the master password.
+3. Connect over Tailscale as `percy`. Do the recovery work (schema repair, role unbreak, password reset).
+4. After resolution, rotate the master password and the app_rw/app_ddl passwords if there's any chance they were exposed.
+
+The allowlist is intentionally small — the secret is no longer a credential the app needs, it's an emergency escape hatch.
+
+## Why not the alternatives
+
+- **Single `app_rw` role with `CREATE`, run migrations as it.** Loses the "what could the app have done?" boundary. A leaky dependency could `DROP TABLE membership` just as easily as a stolen master password. The whole point is that the API runtime _cannot_ run DDL.
+
+- **Run migrations as master forever, just split the runtime role.** Mostly works, but keeps the master credential in CI's hot path. Any future "let's run a quick migration from a laptop" would need master access. With a dedicated `app_ddl` role, day-to-day schema changes route through a credential whose blast radius is bounded to the `public` schema.
+
+- **In-app DB-level row security (RLS).** Useful for multi-tenant SaaS but mismatched to a single-tenant club site. RLS would force every query to carry a tenant predicate; for this codebase that's pure churn. The role split protects against compromise at the right altitude (DDL, replication, role management) without rewriting queries.
+
+- **Same task definition for API + migration, use ECS `containerOverrides` to swap secrets.** ECS doesn't allow `secrets` in `containerOverrides` — only `command` and `environment`. Injecting `app_ddl` via plain-text `environment` override would put the password into CloudTrail `RunTask` events and the workflow run logs. Hence a separate task def.
+
+- **Split the task execution role too, so the API IAM literally can't read the `app_ddl` secret.** Defensible but redundant: the task role (what a runtime-compromised API would use for AWS SDK calls) has no `secretsmanager:GetSecretValue` permission to begin with, so even broad task-execution IAM doesn't leak the secret at runtime. Splitting the execution role would protect against ECS-agent-side compromise — a much more exotic attack — and double the IAM surface area to maintain. Deferred.
+
+## Consequences
+
+- **Routine deploys are unchanged.** Same Docker image runs in both task defs; the workflow patches `IMAGE` + `RELEASE_SHA` on both and registers new revisions on every deploy.
+- **Manual migrations from a laptop** must connect as `app_ddl` (over Tailscale), not master. Local `pnpm db:up` reads `DATABASE_MIGRATION_URL` first, falling back to `DATABASE_URL` for the dev superuser case.
+- **New tables created by future migrations** are automatically owned by `app_ddl` and granted CRUD to `app_rw` (via the `ALTER DEFAULT PRIVILEGES FOR ROLE app_ddl` set on apply). No per-migration grant boilerplate.
+- **CI's `ecs:RunTask` IAM allow** now covers `*-api-migrate:*` as well as `*-api:*` (shared module).
+- **Local dev needs a one-time bootstrap.** `pnpm --filter @percy-main/db run db:setup-app-roles` ALTERs both roles to `LOGIN` with known dev passwords and prints the `.env` lines.
+- **The migration history table (`kysely_migration`)** is owned by `app_ddl` post-apply. The down migration hands it back to the master before dropping the roles.
+
+## Trigger to revisit
+
+- A real incident where the role split helped (or didn't) — capture the timeline.
+- Adding a second long-running process that needs DB access: re-evaluate whether `app_rw` is the right scope or whether a third role (e.g. `app_ro` for the public site) is worth introducing. The issue notes "probably not worth it at this scale" — re-test when traffic grows or when ratio of read/write traffic shifts materially.
+- AWS adding native support for ECS task-level secrets injection that's truly scoped per task def (today's behaviour is task-def-scoped only insofar as the task definition declares the secret — it's not enforced beyond that).

--- a/docs/adrs/043-db-role-split-principle-of-least-privilege.md
+++ b/docs/adrs/043-db-role-split-principle-of-least-privilege.md
@@ -77,11 +77,16 @@ Required once, after the PR merges and CI applies. The cutover flag stays `false
      --secret-string '<json with new password>'
    ```
 
-   The Terraform-managed `random_password.db` has `ignore_changes = all`, so this rotation is operator-driven and does not show up in plan.
+   The Terraform-managed `random_password.db` has `ignore_changes = all`, so this rotation is operator-driven and does not show up in plan. `aws_secretsmanager_secret_version.db_credentials` also carries `lifecycle.ignore_changes = [secret_string]` so the next apply does not revert the rotated value.
 
 ## Break-glass recovery
 
-The master credentials secret has a resource policy (when `app_rw_active = true`) that denies `GetSecretValue` from every principal except those in `master_db_break_glass_principal_arns`. Recovery flow:
+The master credentials secret has a resource policy (when `app_rw_active = true`) that denies `GetSecretValue` from every principal except:
+
+- the two Terraform roles (`terraform_role_arn`, `terraform_plan_role_arn`) — required for `aws_secretsmanager_secret_version.db_credentials` refresh/plan ops; without this exemption Terraform breaks. Accepted as a documented trade-off: those roles are hardened, audited, and not held by humans day-to-day.
+- the principals listed in `master_db_break_glass_principal_arns` — the named human admins.
+
+Recovery flow:
 
 1. Admin assumes the IAM principal in the allowlist (typically via SSO + a named admin role).
 2. `aws secretsmanager get-secret-value --secret-id …/rds/credentials` returns the master password.

--- a/docs/adrs/043-db-role-split-principle-of-least-privilege.md
+++ b/docs/adrs/043-db-role-split-principle-of-least-privilege.md
@@ -49,7 +49,7 @@ Required once, after the PR merges and CI applies. The cutover flag stays `false
      --query SecretString --output text | jq -r .password
    ```
 
-3. **Set `LOGIN` + password on each role over Tailscale.** From an admin laptop on the tailnet:
+3. **Set `LOGIN` + password on each role over Tailscale.** The master password is still freely readable at this stage (the deny policy turns on with the flag at step 4). From an admin laptop on the tailnet:
 
    ```sh
    PGPASSWORD=<master> psql -h <rds-host> -U percy -d percy_main <<'SQL'
@@ -65,7 +65,7 @@ Required once, after the PR merges and CI applies. The cutover flag stays `false
    PGPASSWORD=<app_ddl_password> psql -h <rds-host> -U app_ddl -d percy_main -c 'SELECT 1'
    ```
 
-4. **Flip the cutover flag.** One-line PR: set `app_rw_active = true` in `infra/environments/production/variables.tf` (and populate `master_db_break_glass_principal_arns` with at least one IAM principal — typically a named admin role on the tailnet). CI applies → API task def re-registers with `DATABASE_URL → app_rw` → next deploy uses the split.
+4. **Flip the cutover flag.** One-line PR: set `app_rw_active = true` in `infra/environments/production/variables.tf`. CI applies → API task def re-registers with `DATABASE_URL → app_rw` → next deploy uses the split, and the master credentials secret gets its deny-all-except-break-glass-role resource policy. `master_db_break_glass_principal_arns` stays empty by default — the dedicated break-glass IAM role is the standard access path.
 
 5. **(Optional) Rotate the master password.** Once the app is running against `app_rw` and `app_ddl` for at least one full deploy cycle:
 
@@ -83,17 +83,32 @@ Required once, after the PR merges and CI applies. The cutover flag stays `false
 
 The master credentials secret has a resource policy (when `app_rw_active = true`) that denies `GetSecretValue` from every principal except:
 
-- the two Terraform roles (`terraform_role_arn`, `terraform_plan_role_arn`) — required for `aws_secretsmanager_secret_version.db_credentials` refresh/plan ops; without this exemption Terraform breaks. Accepted as a documented trade-off: those roles are hardened, audited, and not held by humans day-to-day.
-- the principals listed in `master_db_break_glass_principal_arns` — the named human admins.
+- **`percy-main-db-break-glass`** — a dedicated IAM role with one permission: `secretsmanager:GetSecretValue` on the master credentials secret. Admins assume it on demand; the assumption is the audit point. Trust policy accepts any IAM principal in the account that proves MFA, so admin IAM remains the gate on _who can use it_. Session capped at 1h.
+- the two Terraform roles (`terraform_role_arn`, `terraform_plan_role_arn`) — required for `aws_secretsmanager_secret_version.db_credentials` refresh / plan ops; without this exemption Terraform breaks. Accepted as a documented trade-off: those roles are hardened, audited, and not held by humans day-to-day.
+- any extra principals listed in `master_db_break_glass_principal_arns` (default empty) — escape hatch for one-off auditor / vendor access.
+
+Every assumption of the break-glass role fires an EventBridge → SNS event on `percy-main-shared-security-events` (eu-west-2 + us-east-1). Subscribe an email or Slack target to that topic so an unexpected `AssumeRole` is visible within seconds, not on a quarterly audit review.
 
 Recovery flow:
 
-1. Admin assumes the IAM principal in the allowlist (typically via SSO + a named admin role).
-2. `aws secretsmanager get-secret-value --secret-id …/rds/credentials` returns the master password.
-3. Connect over Tailscale as `percy`. Do the recovery work (schema repair, role unbreak, password reset).
-4. After resolution, rotate the master password and the app_rw/app_ddl passwords if there's any chance they were exposed.
+1. Admin assumes the break-glass role (must be MFA-authenticated):
 
-The allowlist is intentionally small — the secret is no longer a credential the app needs, it's an emergency escape hatch.
+   ```sh
+   aws sts assume-role \
+     --role-arn arn:aws:iam::<account>:role/percy-main-db-break-glass \
+     --role-session-name "incident-$(date +%Y%m%d-%H%M)-<short-reason>" \
+     --duration-seconds 1800
+   ```
+
+   Export the returned `AccessKeyId` / `SecretAccessKey` / `SessionToken` into the shell.
+
+2. `aws secretsmanager get-secret-value --secret-id percy-main-production/rds/credentials` returns the master password.
+
+3. Connect over Tailscale as `percy`. Do the recovery work (schema repair, role unbreak, password reset).
+
+4. After resolution, rotate the master password and the app_rw / app_ddl passwords if there's any chance they were exposed.
+
+The allowlist is intentionally small — the master secret is no longer a credential the app needs, it's an emergency escape hatch that leaves an unmistakable trail when used.
 
 ## Why not the alternatives
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -6,18 +6,19 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 
 ## Index
 
-| #                                         | Title                                                       | Date       | Status   |
-| ----------------------------------------- | ----------------------------------------------------------- | ---------- | -------- |
-| [001](001-api-framework.md)               | API Framework — Fastify over Express                        | 2026-03-14 | Accepted |
-| [002](002-email-provider.md)              | Email Provider — SES over Mailgun                           | 2026-03-14 | Accepted |
-| [003](003-baseline-migration-strategy.md) | Baseline Migration Strategy — Single Consolidated Migration | 2026-03-14 | Accepted |
-| [004](004-auth-database-type.md)          | better-auth Database Type — postgres                        | 2026-03-14 | Accepted |
-| [005](005-generated-types-approach.md)    | Generated DB Types — Placeholder with PostgreSQL Types      | 2026-03-14 | Accepted |
-| [006](006-monorepo-structure.md)          | Monorepo Structure — Following the Plan                     | 2026-03-14 | Accepted |
-| [007](007-webhook-raw-body.md)            | Stripe Webhook Raw Body Handling                            | 2026-03-14 | Accepted |
-| [008](008-vite-proxy-for-local-dev.md)    | Vite Dev Server Proxy for Local Development                 | 2026-03-14 | Accepted |
-| [009](009-dependency-injection.md)        | Functional Dependency Injection                             | 2026-03-14 | Accepted |
-| [010](010-testcontainers.md)              | Testcontainers for Integration Tests                        | 2026-03-14 | Accepted |
-| [011](011-api-type-safety.md)             | API Type Safety Between Backend and Frontend                | 2026-03-16 | Accepted |
-| [012](012-prod-db-access.md)              | Production DB Access via Tailscale                          | 2026-04-20 | Accepted |
-| [042](042-scout-recognition-sources.md)   | Scout Recognition Sources — Public-Source Discovery         | 2026-05-14 | Accepted |
+| #                                                        | Title                                                       | Date       | Status   |
+| -------------------------------------------------------- | ----------------------------------------------------------- | ---------- | -------- |
+| [001](001-api-framework.md)                              | API Framework — Fastify over Express                        | 2026-03-14 | Accepted |
+| [002](002-email-provider.md)                             | Email Provider — SES over Mailgun                           | 2026-03-14 | Accepted |
+| [003](003-baseline-migration-strategy.md)                | Baseline Migration Strategy — Single Consolidated Migration | 2026-03-14 | Accepted |
+| [004](004-auth-database-type.md)                         | better-auth Database Type — postgres                        | 2026-03-14 | Accepted |
+| [005](005-generated-types-approach.md)                   | Generated DB Types — Placeholder with PostgreSQL Types      | 2026-03-14 | Accepted |
+| [006](006-monorepo-structure.md)                         | Monorepo Structure — Following the Plan                     | 2026-03-14 | Accepted |
+| [007](007-webhook-raw-body.md)                           | Stripe Webhook Raw Body Handling                            | 2026-03-14 | Accepted |
+| [008](008-vite-proxy-for-local-dev.md)                   | Vite Dev Server Proxy for Local Development                 | 2026-03-14 | Accepted |
+| [009](009-dependency-injection.md)                       | Functional Dependency Injection                             | 2026-03-14 | Accepted |
+| [010](010-testcontainers.md)                             | Testcontainers for Integration Tests                        | 2026-03-14 | Accepted |
+| [011](011-api-type-safety.md)                            | API Type Safety Between Backend and Frontend                | 2026-03-16 | Accepted |
+| [012](012-prod-db-access.md)                             | Production DB Access via Tailscale                          | 2026-04-20 | Accepted |
+| [042](042-scout-recognition-sources.md)                  | Scout Recognition Sources — Public-Source Discovery         | 2026-05-14 | Accepted |
+| [043](043-db-role-split-principle-of-least-privilege.md) | DB Role Split — Principle of Least Privilege                | 2026-05-15 | Accepted |

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -125,9 +125,33 @@ module "rds" {
   enable_event_subscription = true
 
   # Once the role split (#130) is active, the master credentials secret
-  # is reachable only by the break-glass principals. Until then the
-  # list is empty and the secret keeps its existing IAM-only access.
-  master_secret_break_glass_principal_arns = var.app_rw_active ? var.master_db_break_glass_principal_arns : []
+  # is reachable only by the break-glass principals plus the Terraform
+  # roles — without TF in the allowlist its refresh / state ops on the
+  # secret resource fail. We accept that TF can still read master post-
+  # cutover (the role is hardened + audited) and lock the rest out.
+  # Until cutover the list is empty and the secret keeps its existing
+  # IAM-only access.
+  master_secret_break_glass_principal_arns = var.app_rw_active ? concat(
+    [
+      local.shared.terraform_role_arn,
+      local.shared.terraform_plan_role_arn,
+    ],
+    var.master_db_break_glass_principal_arns,
+  ) : []
+}
+
+# Guard: flipping app_rw_active without a human-admin allowlist would
+# leave the master secret reachable by any IAM principal that already
+# has `secret:*percy-main*` (i.e. the API task execution role), which
+# defeats the role split. Force the operator to populate at least one
+# break-glass principal at cutover time.
+resource "terraform_data" "app_rw_active_precheck" {
+  lifecycle {
+    precondition {
+      condition     = !var.app_rw_active || length(var.master_db_break_glass_principal_arns) > 0
+      error_message = "Set master_db_break_glass_principal_arns to at least one admin IAM principal before flipping app_rw_active = true (see ADR 043 §Bootstrap). Otherwise the master credentials secret has no defense-in-depth beyond IAM, which the role split is meant to harden."
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -125,33 +125,24 @@ module "rds" {
   enable_event_subscription = true
 
   # Once the role split (#130) is active, the master credentials secret
-  # is reachable only by the break-glass principals plus the Terraform
-  # roles — without TF in the allowlist its refresh / state ops on the
-  # secret resource fail. We accept that TF can still read master post-
-  # cutover (the role is hardened + audited) and lock the rest out.
+  # is reachable only by:
+  #   - the dedicated break-glass IAM role (audited via CloudTrail +
+  #     EventBridge alarm on every AssumeRole — see ADR 043);
+  #   - the two Terraform roles (required for state refresh on the
+  #     secret resource — without them, plan/apply break);
+  #   - any extra principals an operator explicitly adds via the
+  #     `master_db_break_glass_principal_arns` variable (escape hatch
+  #     for one-off auditor / vendor access).
   # Until cutover the list is empty and the secret keeps its existing
   # IAM-only access.
   master_secret_break_glass_principal_arns = var.app_rw_active ? concat(
     [
+      local.shared.db_break_glass_role_arn,
       local.shared.terraform_role_arn,
       local.shared.terraform_plan_role_arn,
     ],
     var.master_db_break_glass_principal_arns,
   ) : []
-}
-
-# Guard: flipping app_rw_active without a human-admin allowlist would
-# leave the master secret reachable by any IAM principal that already
-# has `secret:*percy-main*` (i.e. the API task execution role), which
-# defeats the role split. Force the operator to populate at least one
-# break-glass principal at cutover time.
-resource "terraform_data" "app_rw_active_precheck" {
-  lifecycle {
-    precondition {
-      condition     = !var.app_rw_active || length(var.master_db_break_glass_principal_arns) > 0
-      error_message = "Set master_db_break_glass_principal_arns to at least one admin IAM principal before flipping app_rw_active = true (see ADR 043 §Bootstrap). Otherwise the master credentials secret has no defense-in-depth beyond IAM, which the role split is meant to harden."
-    }
-  }
 }
 
 # ---------------------------------------------------------------------------

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -123,6 +123,11 @@ module "rds" {
   private_subnet_ids        = module.vpc.private_subnet_ids
   security_group_id         = module.vpc.rds_security_group_id
   enable_event_subscription = true
+
+  # Once the role split (#130) is active, the master credentials secret
+  # is reachable only by the break-glass principals. Until then the
+  # list is empty and the secret keeps its existing IAM-only access.
+  master_secret_break_glass_principal_arns = var.app_rw_active ? var.master_db_break_glass_principal_arns : []
 }
 
 # ---------------------------------------------------------------------------
@@ -203,9 +208,28 @@ module "ecs" {
     SYNC_ECS_ASSIGN_PUBLIC_IP = "true"
   }
 
+  # Migration task connects as app_ddl once the role split is active.
+  # Before cutover it shares the API task's master DATABASE_URL — same
+  # as legacy behaviour, just running from a separate task definition.
+  migration_environment_variables = {
+    NODE_ENV  = "production"
+    LOG_LEVEL = "info"
+  }
+  migration_secrets = var.app_rw_active ? {
+    DATABASE_URL = "${module.rds.app_ddl_secret_arn}:DATABASE_URL::"
+    } : {
+    DATABASE_URL = "${aws_secretsmanager_secret.app_secrets.arn}:DATABASE_URL::"
+  }
+
   secrets = {
     # Secrets Manager (actual secrets)
-    DATABASE_URL           = "${aws_secretsmanager_secret.app_secrets.arn}:DATABASE_URL::"
+    # DATABASE_URL points at app_rw once the role split is active
+    # (#130). Until then it stays on the manual app_secrets blob.
+    DATABASE_URL = var.app_rw_active ? (
+      "${module.rds.app_rw_secret_arn}:DATABASE_URL::"
+      ) : (
+      "${aws_secretsmanager_secret.app_secrets.arn}:DATABASE_URL::"
+    )
     BETTER_AUTH_SECRET     = "${aws_secretsmanager_secret.app_secrets.arn}:BETTER_AUTH_SECRET::"
     BETTER_AUTH_API_KEY    = "${aws_secretsmanager_secret.app_secrets.arn}:BETTER_AUTH_API_KEY::"
     STRIPE_SECRET_KEY      = "${aws_secretsmanager_secret.app_secrets.arn}:STRIPE_SECRET_KEY::"

--- a/infra/environments/production/variables.tf
+++ b/infra/environments/production/variables.tf
@@ -25,16 +25,17 @@ variable "tailscale_db_admins" {
 variable "app_rw_active" {
   type        = bool
   default     = false
-  description = "Cutover flag for the app_rw / app_ddl DB role split. Flip to true only after operator-bootstrap of role passwords (see ADR 044)."
+  description = "Cutover flag for the app_rw / app_ddl DB role split. Flip to true only after operator-bootstrap of role passwords (see ADR 043)."
 }
 
-# Principals allowed to read the master DB credentials secret once
-# app_rw_active = true. Defaults to empty — must be populated before
-# flipping the cutover flag, otherwise even break-glass recovery is
-# impossible (the resource policy denies everyone except this list).
-# Typical entries: a named IAM user/role for the on-call admin.
+# Extra principals exempted from the master credentials secret's
+# break-glass deny policy. Defaults to empty — the primary access
+# path is the audited `percy-main-db-break-glass` IAM role created in
+# the shared layer (always included automatically). Use this only
+# for one-off escape hatches (auditor access, vendor incident
+# response) and remove again afterwards.
 variable "master_db_break_glass_principal_arns" {
   type        = list(string)
   default     = []
-  description = "ARNs allowed to read the master DB credentials secret in break-glass scenarios once app_rw_active = true."
+  description = "Extra ARNs exempted from the master DB credentials secret's deny policy (in addition to the dedicated break-glass role + Terraform roles). Leave empty unless temporarily granting an auditor / vendor access."
 }

--- a/infra/environments/production/variables.tf
+++ b/infra/environments/production/variables.tf
@@ -13,3 +13,28 @@ variable "tailscale_db_admins" {
   description = "Tailscale user emails (Google Workspace) allowed to reach RDS over the tailnet"
   default     = ["alex.young@percymain.org"]
 }
+
+# Cutover flag for the app_rw / app_ddl role split (#130). Stays false
+# while the new roles exist NOLOGIN; operators flip to true once they
+# have set the roles' LOGIN passwords from the new Secrets Manager
+# entries (psql over Tailscale — see docs/adrs/044-db-role-split.md).
+# When true:
+#   - API DATABASE_URL → app_rw secret
+#   - Migration DATABASE_URL → app_ddl secret
+#   - Master credentials secret IAM-restricted to break-glass principals
+variable "app_rw_active" {
+  type        = bool
+  default     = false
+  description = "Cutover flag for the app_rw / app_ddl DB role split. Flip to true only after operator-bootstrap of role passwords (see ADR 044)."
+}
+
+# Principals allowed to read the master DB credentials secret once
+# app_rw_active = true. Defaults to empty — must be populated before
+# flipping the cutover flag, otherwise even break-glass recovery is
+# impossible (the resource policy denies everyone except this list).
+# Typical entries: a named IAM user/role for the on-call admin.
+variable "master_db_break_glass_principal_arns" {
+  type        = list(string)
+  default     = []
+  description = "ARNs allowed to read the master DB credentials secret in break-glass scenarios once app_rw_active = true."
+}

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -398,7 +398,12 @@ data "aws_iam_policy_document" "deploy_ecs" {
       "ecs:RunTask",
     ]
     resources = [
+      # `*-api:*` catches the long-running API service task def
+      # (e.g. production-api), `*-api-migrate:*` catches the
+      # migration runner task def added in #130 for principle-of-
+      # least-privilege role separation.
       "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:task-definition/*-api:*",
+      "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:task-definition/*-api-migrate:*",
     ]
   }
 

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -869,6 +869,128 @@ resource "aws_sns_topic_policy" "security_events_us_east_1" {
   policy   = data.aws_iam_policy_document.security_events_us_east_1_topic.json
 }
 
+# -----------------------------------------------------------------------------
+# DB master break-glass role (#130 / ADR 043)
+#
+# Reading the RDS master credentials secret should be a deliberate,
+# audited act — not something the day-to-day admin IAM can do silently.
+# Solution: a dedicated IAM role with a single permission
+# (`secretsmanager:GetSecretValue` on the master credentials secret).
+# Admins assume it via `aws sts assume-role` when they need master;
+# the assumption itself is the audit point — every use shows up in
+# CloudTrail as an `AssumeRole` on this role, and EventBridge alarms
+# fire to the security_events topic.
+#
+# Trust policy allows any IAM principal in this account that proves
+# MFA. We rely on user-side IAM (admin group) to gate who actually
+# carries `sts:AssumeRole` perms. Session capped at 1h because
+# break-glass should be quick.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "db_break_glass" {
+  name                 = "percy-main-db-break-glass"
+  description          = "Break-glass access to the RDS master credentials secret. Assumption is the audit point — every use is logged in CloudTrail and alarms to security_events."
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          Bool = {
+            "aws:MultiFactorAuthPresent" = "true"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Environment = "shared"
+    Module      = "shared"
+    ManagedBy   = "terraform"
+    Purpose     = "db-master-break-glass"
+  }
+}
+
+# Single permission: read the master credentials secret. Secret ARN
+# carries the Secrets-Manager-suffix (`-XXXXXX`) which is created at
+# secret-creation time; use a wildcard so this policy doesn't have to
+# be rewritten if the secret is ever recreated.
+resource "aws_iam_role_policy" "db_break_glass_read_master" {
+  name = "read-rds-master-credentials"
+  role = aws_iam_role.db_break_glass.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:percy-main-production/rds/credentials-*"
+      }
+    ]
+  })
+}
+
+# Alarm on every assumption. STS AssumeRole events land in the region
+# where the call was made — admins on this account call regional STS
+# endpoints (the post-2019 default) so eu-west-2 is the right home.
+# For belt-and-braces (global-endpoint callers, federated console)
+# we also wire a us-east-1 rule below.
+resource "aws_cloudwatch_event_rule" "db_break_glass_assume" {
+  name        = "percy-main-shared-db-break-glass-assumed"
+  description = "Someone assumed the DB master break-glass role (#130 / ADR 043)."
+
+  event_pattern = jsonencode({
+    source        = ["aws.sts"]
+    "detail-type" = ["AWS API Call via CloudTrail"]
+    detail = {
+      eventSource = ["sts.amazonaws.com"]
+      eventName   = ["AssumeRole"]
+      requestParameters = {
+        roleArn = [aws_iam_role.db_break_glass.arn]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "db_break_glass_assume_to_sns" {
+  rule      = aws_cloudwatch_event_rule.db_break_glass_assume.name
+  target_id = "sns"
+  arn       = aws_sns_topic.security_events.arn
+}
+
+resource "aws_cloudwatch_event_rule" "db_break_glass_assume_us_east_1" {
+  provider    = aws.us_east_1
+  name        = "percy-main-shared-db-break-glass-assumed"
+  description = "Someone assumed the DB master break-glass role (#130 / ADR 043) via a global / us-east-1 STS endpoint."
+
+  event_pattern = jsonencode({
+    source        = ["aws.sts"]
+    "detail-type" = ["AWS API Call via CloudTrail"]
+    detail = {
+      eventSource = ["sts.amazonaws.com"]
+      eventName   = ["AssumeRole"]
+      requestParameters = {
+        roleArn = [aws_iam_role.db_break_glass.arn]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "db_break_glass_assume_to_sns_us_east_1" {
+  provider  = aws.us_east_1
+  rule      = aws_cloudwatch_event_rule.db_break_glass_assume_us_east_1.name
+  target_id = "sns"
+  arn       = aws_sns_topic.security_events_us_east_1.arn
+}
+
 
 # -----------------------------------------------------------------------------
 # New Relic ↔ AWS account integration (API poll)

--- a/infra/environments/shared/outputs.tf
+++ b/infra/environments/shared/outputs.tf
@@ -13,3 +13,7 @@ output "ses_identity_arn" { value = aws_ses_domain_identity.notifications.arn }
 # in us-east-1; ALB ACM and SES live in eu-west-2.
 output "reliability_alarms_topic_arn" { value = aws_sns_topic.shared_reliability_alarms.arn }
 output "reliability_alarms_topic_arn_us_east_1" { value = aws_sns_topic.shared_reliability_alarms_us_east_1.arn }
+
+# Break-glass role for RDS master credentials access (#130 / ADR 043).
+# Admins assume this role on demand; the assumption is the audit point.
+output "db_break_glass_role_arn" { value = aws_iam_role.db_break_glass.arn }

--- a/infra/modules/ecs-service/main.tf
+++ b/infra/modules/ecs-service/main.tf
@@ -64,7 +64,19 @@ variable "acm_certificate_arn" {
 }
 
 variable "secrets" {
-  description = "Map of secret name to Secrets Manager or SSM Parameter ARN (resolved via valueFrom)"
+  description = "Map of secret name to Secrets Manager or SSM Parameter ARN (resolved via valueFrom) for the API runtime task"
+  type        = map(string)
+  default     = {}
+}
+
+variable "migration_secrets" {
+  description = "Map of secret name to Secrets Manager or SSM Parameter ARN for the migration runner task. Typically just DATABASE_URL → app_ddl. Defaults to {} which makes the migration task identical to the API task (legacy behaviour before #130)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "migration_environment_variables" {
+  description = "Plain-text env vars for the migration runner task. Should be the minimal set migrate.ts needs (LOG_LEVEL, NODE_ENV)."
   type        = map(string)
   default     = {}
 }
@@ -659,6 +671,79 @@ resource "aws_ecs_task_definition" "api" {
 }
 
 # ------------------------------------------------------------------------------
+# Migration Task Definition (#130 — principle of least privilege)
+#
+# Same image, same task role, same execution role as the API task. The
+# split is in the *secrets* map: the API task gets DATABASE_URL pointing
+# at app_rw, this task gets DATABASE_URL pointing at app_ddl. Because
+# ECS injects secrets into the container's env at startup (via the
+# execution role, not the task role) only what each task definition
+# *declares* lands in env — a runtime compromise of the API container
+# cannot see the app_ddl URL even though both secrets live under the
+# same `*percy-main*` IAM allow.
+#
+# Falls back to the API task's secrets/env if migration_* vars are empty
+# (legacy behaviour before app_rw/app_ddl are wired) so this task def
+# stays useful end-to-end even pre-cutover.
+# ------------------------------------------------------------------------------
+
+locals {
+  migration_secrets               = length(var.migration_secrets) > 0 ? var.migration_secrets : var.secrets
+  migration_environment_variables = length(var.migration_environment_variables) > 0 ? var.migration_environment_variables : var.environment_variables
+}
+
+resource "aws_ecs_task_definition" "migration" {
+  family                   = "${var.environment}-api-migrate"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
+  container_definitions = jsonencode([
+    {
+      # Same name as the API container so deploy.yml's existing
+      # `containerOverrides[0].name = "api"` keeps working.
+      name      = "api"
+      image     = "${var.ecr_repository_url}:${var.image_tag}"
+      essential = true
+      command   = ["node", "apps/api/dist/migrate.js"]
+
+      environment = [
+        for name, value in local.migration_environment_variables : {
+          name  = name
+          value = value
+        }
+      ]
+
+      secrets = [
+        for name, arn in local.migration_secrets : {
+          name      = name
+          valueFrom = arn
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.api.name
+          "awslogs-region"        = data.aws_region.current.region
+          "awslogs-stream-prefix" = "migrate"
+        }
+      }
+    }
+  ])
+
+  tags = local.tags
+}
+
+# ------------------------------------------------------------------------------
 # ALB Access Logs Bucket
 # ------------------------------------------------------------------------------
 
@@ -922,6 +1007,16 @@ output "alb_zone_id" {
 output "task_definition_arn" {
   description = "ARN of the ECS task definition family (without revision)"
   value       = "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.api.family}"
+}
+
+output "migration_task_definition_arn" {
+  description = "ARN of the migration ECS task definition family (without revision). Workflow registers a new revision per deploy with the freshly built image."
+  value       = "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.migration.family}"
+}
+
+output "migration_task_definition_family" {
+  description = "Family name of the migration ECS task definition (without revision)"
+  value       = aws_ecs_task_definition.migration.family
 }
 
 output "task_definition_family" {

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -62,6 +62,12 @@ variable "enable_event_subscription" {
   description = "Create a dedicated SNS topic + event subscription for RDS events (backup failures, maintenance, low storage). Operators subscribe to the topic out of band."
 }
 
+variable "master_secret_break_glass_principal_arns" {
+  type        = list(string)
+  default     = []
+  description = "When non-empty, attach a resource policy to the RDS master credentials secret that denies GetSecretValue from any principal not in this list. Used to make the master credentials break-glass-only once app_rw + app_ddl take over runtime + migration (#130). Leave empty to keep the existing permissive IAM-only access. Both IAM-attached perms AND a matching principal here are required to read."
+}
+
 # -----------------------------------------------------------------------------
 # Locals
 # -----------------------------------------------------------------------------
@@ -85,6 +91,33 @@ resource "random_password" "db" {
   length           = 32
   special          = true
   override_special = "!#$%&*()-_=+[]{}|:?"
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+# Application role passwords (#130 — principle of least privilege).
+# Alphanumeric only — these get embedded in DATABASE_URL strings and
+# we want to avoid URL-encoding round-trips. 32 chars × 62-symbol
+# alphabet ≈ 190 bits of entropy, well above what RDS needs.
+#
+# The roles themselves are created NOLOGIN by the role-split migration;
+# operators set LOGIN + the password from these secrets via psql over
+# Tailscale once after first apply. See docs/adrs/ for the bootstrap
+# runbook. After that, the roles' passwords live in Postgres itself.
+resource "random_password" "app_rw" {
+  length  = 32
+  special = false
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "random_password" "app_ddl" {
+  length  = 32
+  special = false
 
   lifecycle {
     ignore_changes = all
@@ -266,6 +299,89 @@ resource "aws_secretsmanager_secret_version" "db_credentials" {
   })
 }
 
+# Break-glass-only access to the master credentials secret. Active once
+# app_rw + app_ddl have taken over the runtime + migration paths
+# (#130). Without this, the existing IAM-only allow on `*percy-main*`
+# means any role with that policy can still read the master — which
+# defeats the role split. The deny here applies to all principals NOT
+# in the allowlist, so the task-execution role can no longer fetch
+# master credentials even though its IAM policy still allows it.
+resource "aws_secretsmanager_secret_policy" "db_credentials_break_glass" {
+  count = length(var.master_secret_break_glass_principal_arns) > 0 ? 1 : 0
+
+  secret_arn = aws_secretsmanager_secret.db_credentials.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyAllExceptBreakGlass"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "secretsmanager:GetSecretValue"
+        Resource  = "*"
+        Condition = {
+          ArnNotEquals = {
+            "aws:PrincipalArn" = var.master_secret_break_glass_principal_arns
+          }
+        }
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Secrets Manager — app_rw and app_ddl credentials (#130)
+# Each secret stores the JSON shape Postgres clients need plus a
+# pre-built DATABASE_URL so the ECS task definition can reference a
+# single JSON key (`...:DATABASE_URL::`) directly, avoiding URL
+# assembly in app code.
+# ---------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "db_credentials_app_rw" {
+  name        = "${local.name_prefix}/rds/app_rw"
+  description = "App runtime (CRUD only) credentials for ${local.name_prefix}"
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-db-credentials-app-rw"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "db_credentials_app_rw" {
+  secret_id = aws_secretsmanager_secret.db_credentials_app_rw.id
+
+  secret_string = jsonencode({
+    username     = "app_rw"
+    password     = random_password.app_rw.result
+    host         = aws_db_instance.main.address
+    port         = aws_db_instance.main.port
+    dbname       = aws_db_instance.main.db_name
+    DATABASE_URL = "postgres://app_rw:${random_password.app_rw.result}@${aws_db_instance.main.address}:${aws_db_instance.main.port}/${aws_db_instance.main.db_name}"
+  })
+}
+
+resource "aws_secretsmanager_secret" "db_credentials_app_ddl" {
+  name        = "${local.name_prefix}/rds/app_ddl"
+  description = "Migration runner (DDL) credentials for ${local.name_prefix}"
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-db-credentials-app-ddl"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "db_credentials_app_ddl" {
+  secret_id = aws_secretsmanager_secret.db_credentials_app_ddl.id
+
+  secret_string = jsonencode({
+    username     = "app_ddl"
+    password     = random_password.app_ddl.result
+    host         = aws_db_instance.main.address
+    port         = aws_db_instance.main.port
+    dbname       = aws_db_instance.main.db_name
+    DATABASE_URL = "postgres://app_ddl:${random_password.app_ddl.result}@${aws_db_instance.main.address}:${aws_db_instance.main.port}/${aws_db_instance.main.db_name}"
+  })
+}
+
 # -----------------------------------------------------------------------------
 # Outputs
 # -----------------------------------------------------------------------------
@@ -288,6 +404,16 @@ output "database_name" {
 output "secret_arn" {
   description = "ARN of the Secrets Manager secret storing DB credentials"
   value       = aws_secretsmanager_secret.db_credentials.arn
+}
+
+output "app_rw_secret_arn" {
+  description = "ARN of the Secrets Manager secret storing app_rw (CRUD runtime) credentials"
+  value       = aws_secretsmanager_secret.db_credentials_app_rw.arn
+}
+
+output "app_ddl_secret_arn" {
+  description = "ARN of the Secrets Manager secret storing app_ddl (migration) credentials"
+  value       = aws_secretsmanager_secret.db_credentials_app_ddl.arn
 }
 
 output "instance_id" {

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -297,6 +297,14 @@ resource "aws_secretsmanager_secret_version" "db_credentials" {
     port     = aws_db_instance.main.port
     dbname   = aws_db_instance.main.db_name
   })
+
+  # Master rotation (#130 ADR 043 step 5) is operator-driven via
+  # `aws secretsmanager put-secret-value`. Without this, the next TF
+  # apply would revert the rotation back to the original
+  # random_password.db.result.
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
 }
 
 # Break-glass-only access to the master credentials secret. Active once

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,7 @@
     "db:reset": "tsx ./scripts/reset-local.ts",
     "db:lift": "tsx ./scripts/data-lift.ts",
     "db:setup-scout": "tsx ./scripts/setup-scout-readonly.ts",
+    "db:setup-app-roles": "tsx ./scripts/setup-app-roles.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/"
   },

--- a/packages/db/scripts/migrate-up.ts
+++ b/packages/db/scripts/migrate-up.ts
@@ -7,7 +7,10 @@ import { createClient } from "../src/client.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Mirrors apps/api/src/migrate.ts — prefer the DDL-privileged URL so
+// `pnpm db:up` and the production migration runner connect the same way.
 const connectionString =
+  process.env.DATABASE_MIGRATION_URL ??
   process.env.DATABASE_URL ??
   "postgres://percy:percy@localhost:5433/percy_main";
 const { client } = createClient(connectionString);

--- a/packages/db/scripts/reset-local.ts
+++ b/packages/db/scripts/reset-local.ts
@@ -37,21 +37,37 @@ const pool = new pg.Pool({ connectionString, max: 1 });
 const client = await pool.connect();
 
 try {
-  // Get all table names in the public schema
-  const result = await client.query(`
-    SELECT tablename FROM pg_tables WHERE schemaname = 'public'
-  `);
-
-  const tables = result.rows.map((r) => r.tablename);
+  // Get all view + table names in the public schema. Views first
+  // because some depend on tables and CASCADE drops can otherwise
+  // leave the schema in a weird intermediate state when migrations
+  // later try to re-create them.
+  const tables = (
+    await client.query(
+      `SELECT tablename FROM pg_tables WHERE schemaname = 'public'`,
+    )
+  ).rows.map((r) => r.tablename);
 
   if (tables.length > 0) {
-    // CASCADE drops dependent objects (indexes, constraints, etc.)
     const dropSql = tables.map((t) => `"${t}"`).join(", ");
     await client.query(`DROP TABLE IF EXISTS ${dropSql} CASCADE`);
     console.log(`  ✓ Dropped ${tables.length} tables`);
   } else {
     console.log("  (no tables to drop)");
   }
+
+  // Migrations create persistent roles (scout_readonly, app_rw,
+  // app_ddl). Without dropping them here, the next migration run
+  // fails with `role "x" already exists`.
+  for (const role of ["scout_readonly", "app_rw", "app_ddl"]) {
+    await client.query(`DROP OWNED BY "${role}" CASCADE`).catch(() => {});
+    await client.query(`DROP ROLE IF EXISTS "${role}"`);
+  }
+  console.log("  ✓ Dropped migration-managed roles");
+
+  // PG14 default — re-grant CREATE on public to PUBLIC, since the
+  // role-split migration revokes it on apply and we want the reset
+  // to leave the cluster in a true pre-migration state.
+  await client.query(`GRANT CREATE ON SCHEMA public TO PUBLIC`);
 } finally {
   client.release();
   await pool.end();

--- a/packages/db/scripts/setup-app-roles.ts
+++ b/packages/db/scripts/setup-app-roles.ts
@@ -1,0 +1,52 @@
+import "dotenv/config";
+import { sql } from "kysely";
+import { createClient } from "../src/client.js";
+
+/**
+ * Local-dev only. Sets known passwords + LOGIN on `app_rw` and `app_ddl`
+ * (created NOLOGIN by the role-split migration) and prints the env-var
+ * lines to copy into apps/api/.env.
+ *
+ * In production both roles' passwords are minted by Terraform and seeded
+ * into Postgres via a one-time admin ALTER USER over Tailscale — never
+ * run this there. See docs/adrs/ for the bootstrap procedure.
+ */
+
+const APP_RW_PASSWORD = "app_rw_dev";
+const APP_DDL_PASSWORD = "app_ddl_dev";
+
+const adminUrl =
+  process.env.DATABASE_URL ??
+  "postgres://percy:percy@localhost:5433/percy_main";
+
+if (!/localhost|127\.0\.0\.1/.test(adminUrl)) {
+  console.error(
+    `Refusing to run: DATABASE_URL (${adminUrl}) does not look local. ` +
+      `This script is for local dev only.`,
+  );
+  process.exit(1);
+}
+
+const { client } = createClient(adminUrl);
+
+await sql`ALTER USER app_rw WITH LOGIN PASSWORD ${sql.lit(
+  APP_RW_PASSWORD,
+)}`.execute(client);
+await sql`ALTER USER app_ddl WITH LOGIN PASSWORD ${sql.lit(
+  APP_DDL_PASSWORD,
+)}`.execute(client);
+
+await client.destroy();
+
+const buildUrl = (user: string, password: string) =>
+  adminUrl.replace(
+    /^postgres(ql)?:\/\/[^@]+@/,
+    `postgres://${user}:${password}@`,
+  );
+
+console.log("✓ app_rw + app_ddl are now LOGIN with dev passwords");
+console.log("");
+console.log("Add these to apps/api/.env (replacing DATABASE_URL):");
+console.log("");
+console.log(`DATABASE_URL=${buildUrl("app_rw", APP_RW_PASSWORD)}`);
+console.log(`DATABASE_MIGRATION_URL=${buildUrl("app_ddl", APP_DDL_PASSWORD)}`);

--- a/packages/db/src/migrations/2026-05-15T06:53:37.877Z.ts
+++ b/packages/db/src/migrations/2026-05-15T06:53:37.877Z.ts
@@ -19,6 +19,18 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`CREATE ROLE app_rw NOLOGIN`.execute(db);
   await sql`CREATE ROLE app_ddl NOLOGIN`.execute(db);
 
+  // Grant role membership to the migration runner. RDS `rds_superuser`
+  // is NOT a true PostgreSQL superuser, so `ALTER DEFAULT PRIVILEGES
+  // FOR ROLE app_ddl` and `ALTER … OWNER TO app_ddl` below require the
+  // current role to be a *member* of app_ddl. Locally / in tests the
+  // session is a real superuser and this is redundant, but cheap.
+  await sql`
+    DO $$ BEGIN
+      EXECUTE format('GRANT app_ddl TO %I', current_user);
+      EXECUTE format('GRANT app_rw  TO %I', current_user);
+    END $$;
+  `.execute(db);
+
   // PG14 and the RDS-provisioned percy_main carry the pre-PG15 default
   // that grants CREATE on schema public to PUBLIC (every role). Drop it
   // so only roles with an explicit CREATE grant (app_ddl, master) can

--- a/packages/db/src/migrations/2026-05-15T06:53:37.877Z.ts
+++ b/packages/db/src/migrations/2026-05-15T06:53:37.877Z.ts
@@ -1,0 +1,144 @@
+import { type Kysely, sql } from "kysely";
+
+// Principle-of-least-privilege roles for the application runtime.
+//
+// app_rw: API runtime. CRUD on tables, USAGE on sequences, no DDL.
+// app_ddl: migration runner only. CREATE on schema; takes ownership of
+//   new objects via default privileges so app_rw can keep reading/writing
+//   them after future migrations.
+//
+// Both are created NOLOGIN — passwords + LOGIN are set out-of-band per
+// environment (Terraform-minted secret + admin ALTER USER in prod; the
+// setup-app-roles dev script locally). This mirrors the scout_readonly
+// pattern and keeps credentials out of migration history.
+//
+// See docs/adrs/ for the role split rationale + break-glass plan for the
+// RDS master account.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE ROLE app_rw NOLOGIN`.execute(db);
+  await sql`CREATE ROLE app_ddl NOLOGIN`.execute(db);
+
+  // PG14 and the RDS-provisioned percy_main carry the pre-PG15 default
+  // that grants CREATE on schema public to PUBLIC (every role). Drop it
+  // so only roles with an explicit CREATE grant (app_ddl, master) can
+  // run DDL. Without this, app_rw can still CREATE TABLE despite never
+  // being granted CREATE directly.
+  await sql`REVOKE CREATE ON SCHEMA public FROM PUBLIC`.execute(db);
+
+  // ── app_rw: runtime CRUD only ──
+  await sql`
+    DO $$ BEGIN
+      EXECUTE format('GRANT CONNECT ON DATABASE %I TO app_rw', current_database());
+    END $$;
+  `.execute(db);
+  await sql`GRANT USAGE ON SCHEMA public TO app_rw`.execute(db);
+  await sql`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_rw`.execute(
+    db,
+  );
+  await sql`GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_rw`.execute(
+    db,
+  );
+  // Default privileges are scoped by the creating role — app_ddl creates
+  // new objects going forward, so its FOR ROLE clause is what counts.
+  await sql`ALTER DEFAULT PRIVILEGES FOR ROLE app_ddl IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_rw`.execute(db);
+  await sql`ALTER DEFAULT PRIVILEGES FOR ROLE app_ddl IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO app_rw`.execute(db);
+
+  // ── app_ddl: schema migrations only ──
+  await sql`
+    DO $$ BEGIN
+      EXECUTE format('GRANT CONNECT ON DATABASE %I TO app_ddl', current_database());
+    END $$;
+  `.execute(db);
+  await sql`GRANT USAGE, CREATE ON SCHEMA public TO app_ddl`.execute(db);
+  // Hand every existing public-schema table, sequence, and view to
+  // app_ddl. Plain REASSIGN OWNED BY <master> won't work — the master
+  // also owns the database itself ("required by the database system"),
+  // so we walk pg_class instead and only touch objects in `public`.
+  //
+  // Identity/SERIAL sequences (pg_depend.deptype='a') travel with their
+  // owning column — ALTER SEQUENCE OWNER fails on them, so skip those
+  // and let the table-level ALTER carry them.
+  await sql`
+    DO $$
+    DECLARE
+      obj record;
+    BEGIN
+      FOR obj IN
+        SELECT n.nspname, c.relname, c.relkind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind IN ('r', 'p', 'S', 'v', 'm')
+          AND NOT EXISTS (
+            SELECT 1 FROM pg_depend d
+            WHERE d.objid = c.oid
+              AND d.classid = 'pg_class'::regclass
+              AND d.deptype = 'a'
+          )
+      LOOP
+        EXECUTE format(
+          'ALTER %s %I.%I OWNER TO app_ddl',
+          CASE obj.relkind
+            WHEN 'r' THEN 'TABLE'
+            WHEN 'p' THEN 'TABLE'
+            WHEN 'S' THEN 'SEQUENCE'
+            WHEN 'v' THEN 'VIEW'
+            WHEN 'm' THEN 'MATERIALIZED VIEW'
+          END,
+          obj.nspname,
+          obj.relname
+        );
+      END LOOP;
+    END $$;
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Hand public-schema objects back to whoever runs the down (the master
+  // in production, the testcontainer user in tests) before dropping the
+  // roles — otherwise DROP ROLE fails on dependent objects.
+  await sql`
+    DO $$
+    DECLARE
+      obj record;
+      target text := session_user;
+    BEGIN
+      FOR obj IN
+        SELECT n.nspname, c.relname, c.relkind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relowner = (SELECT oid FROM pg_roles WHERE rolname = 'app_ddl')
+          AND c.relkind IN ('r', 'p', 'S', 'v', 'm')
+          AND NOT EXISTS (
+            SELECT 1 FROM pg_depend d
+            WHERE d.objid = c.oid
+              AND d.classid = 'pg_class'::regclass
+              AND d.deptype = 'a'
+          )
+      LOOP
+        EXECUTE format(
+          'ALTER %s %I.%I OWNER TO %I',
+          CASE obj.relkind
+            WHEN 'r' THEN 'TABLE'
+            WHEN 'p' THEN 'TABLE'
+            WHEN 'S' THEN 'SEQUENCE'
+            WHEN 'v' THEN 'VIEW'
+            WHEN 'm' THEN 'MATERIALIZED VIEW'
+          END,
+          obj.nspname,
+          obj.relname,
+          target
+        );
+      END LOOP;
+    END $$;
+  `.execute(db);
+  await sql`DROP OWNED BY app_ddl`.execute(db);
+  await sql`DROP OWNED BY app_rw`.execute(db);
+  await sql`DROP ROLE app_ddl`.execute(db);
+  await sql`DROP ROLE app_rw`.execute(db);
+  await sql`GRANT CREATE ON SCHEMA public TO PUBLIC`.execute(db);
+}


### PR DESCRIPTION
Closes #130.

## Summary

- API runs as **`app_rw`** (CRUD on tables, USAGE on sequences, no DDL).
- Migrations run as **`app_ddl`** (CREATE on schema, owns all public objects) — and from a **separate ECS task definition** so the app_ddl URL never lands in the API container's env.
- Master credentials secret becomes **break-glass-only** (resource policy denies everyone outside the named principal list).
- New ADR 043 documents the full rationale + rollout + recovery runbook.

## Staged rollout

This PR is **safe to merge as-is** — it lands with `app_rw_active = false`, so behaviour is unchanged. The full cutover then takes three steps:

1. **Merge + apply.** CI creates the two new roles (NOLOGIN), Terraform mints their passwords into new Secrets Manager entries, the new migration task definition is registered. API + migrations still use the master URL.
2. **Operator-bootstrap.** Read the new passwords from Secrets Manager and `ALTER USER app_rw / app_ddl WITH LOGIN PASSWORD …` over Tailscale (commands in ADR 043 §Bootstrap).
3. **One-line follow-up PR.** Flip `app_rw_active = true` in `infra/environments/production/variables.tf` and populate `master_db_break_glass_principal_arns`. CI applies → next deploy uses the split.

Step 5 (rotate the master password) is operator-driven and called out in the ADR.

## Local rehearsal

- `pnpm db:reset` re-runs all 42 migrations from scratch (cleaned up `reset-local.ts` to drop the new roles too).
- `pnpm --filter @percy-main/db run db:setup-app-roles` sets dev passwords + prints the env-var lines.
- API boots against `app_rw` and serves `/health/ready` 200.
- Permission matrix verified: `app_rw` denied `CREATE TABLE` / `DROP TABLE`; `app_ddl` allowed `ALTER TABLE`.

## Test plan

- [ ] CI green on this branch (`lint-test-build`, `terraform-shared` plan, `terraform-production` plan).
- [ ] Plan output for `terraform-production` shows the new `aws_secretsmanager_secret.db_credentials_app_{rw,ddl}` + `aws_ecs_task_definition.migration` resources and **no diff** on the API's `DATABASE_URL` secret reference (because `app_rw_active` defaults to false).
- [ ] After merge, the deploy workflow registers both `production-api:<rev>` and `production-api-migrate:<rev>` and the migration step runs against the latter.
- [ ] Once steps 2–3 of the staged rollout are complete, verify API still serves requests (read + write) and a fresh migration run succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)