### PR TITLE
fix(scout): pin RunTask to API service's current revision

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -153,12 +153,12 @@ const configSchema = z.object({
     .default(900),
   // The KB ingestion worker reuses the API task definition + cluster /
   // subnets / security group from SYNC_ECS_*, just like the report
-  // worker — only the container command + per-task env override differ.
+  // worker - only the container command + per-task env override differ.
   // The plan called for a dedicated SCOUT_KB_WORKER_TASK_DEFINITION,
-  // but since the report worker already shares SYNC_ECS_TASK_DEFINITION
-  // with the sync task and that has held up fine, we follow the same
-  // pattern here. If KB ingest ever needs different CPU / memory we'll
-  // split task definitions then.
+  // but since the report worker already shares the API service config
+  // and that has held up fine, we follow the same pattern here. If KB
+  // ingest ever needs different CPU / memory we'll split task
+  // definitions then.
 
   // Observability (New Relic via OpenTelemetry)
   NEW_RELIC_LICENSE_KEY: z.string().optional(),
@@ -249,7 +249,12 @@ const configSchema = z.object({
   // Sync task launch (admin "Sync now" button → ECS RunTask)
   AWS_REGION: z.string().default("eu-west-2"),
   SYNC_ECS_CLUSTER: z.string().optional(),
-  SYNC_ECS_TASK_DEFINITION: z.string().optional(),
+  // Service name used to resolve the running task-def revision via
+  // DescribeServices. RunTask receives that specific revision instead
+  // of the family name, so workers always run the same image the API
+  // is running (and dodge stray Terraform-registered revisions that
+  // point at the no-longer-published `:latest` tag).
+  SYNC_ECS_SERVICE: z.string().optional(),
   SYNC_ECS_SUBNETS: z.string().optional(), // comma-separated
   SYNC_ECS_SECURITY_GROUP: z.string().optional(),
   SYNC_ECS_ASSIGN_PUBLIC_IP: z

--- a/apps/api/src/features/play-cricket/trigger-sync.ts
+++ b/apps/api/src/features/play-cricket/trigger-sync.ts
@@ -1,5 +1,6 @@
 import { ECSClient, RunTaskCommand } from "@aws-sdk/client-ecs";
 import type { Config } from "../../config.ts";
+import { resolveActiveTaskDefinition } from "../../lib/ecs-task-definition.ts";
 
 export interface TriggerSyncResult {
   taskArn: string;
@@ -22,11 +23,11 @@ export class SyncLaunchError extends Error {
 export function triggerSync(config: Config) {
   return async (): Promise<TriggerSyncResult> => {
     const cluster = config.SYNC_ECS_CLUSTER;
-    const taskDefinition = config.SYNC_ECS_TASK_DEFINITION;
+    const service = config.SYNC_ECS_SERVICE;
     const subnetsRaw = config.SYNC_ECS_SUBNETS;
     const securityGroup = config.SYNC_ECS_SECURITY_GROUP;
 
-    if (!cluster || !taskDefinition || !subnetsRaw || !securityGroup) {
+    if (!cluster || !service || !subnetsRaw || !securityGroup) {
       throw new SyncNotConfiguredError();
     }
 
@@ -36,6 +37,12 @@ export function triggerSync(config: Config) {
       .filter(Boolean);
 
     const ecs = new ECSClient({ region: config.AWS_REGION });
+
+    const taskDefinition = await resolveActiveTaskDefinition(
+      ecs,
+      cluster,
+      service,
+    );
 
     // RunTask returns once ECS accepts task placement (typically <1s); the sync
     // itself runs entirely inside the spawned Fargate task. Hard-cap at 10s so

--- a/apps/api/src/features/scout/knowledge/launch.ts
+++ b/apps/api/src/features/scout/knowledge/launch.ts
@@ -1,6 +1,7 @@
 import { ECSClient, RunTaskCommand } from "@aws-sdk/client-ecs";
 import { context, propagation } from "@opentelemetry/api";
 import type { Config } from "../../../config.ts";
+import { resolveActiveTaskDefinition } from "../../../lib/ecs-task-definition.ts";
 import { runIngest, type RunIngestDeps } from "./run-ingest.ts";
 
 /**
@@ -48,12 +49,11 @@ export async function launchScoutKbIngest({
   documentId,
 }: LaunchScoutKbOpts): Promise<void> {
   const cluster = config.SYNC_ECS_CLUSTER;
-  const taskDefinition = config.SYNC_ECS_TASK_DEFINITION;
+  const service = config.SYNC_ECS_SERVICE;
   const subnetsRaw = config.SYNC_ECS_SUBNETS;
   const securityGroup = config.SYNC_ECS_SECURITY_GROUP;
 
-  const ecsConfigured =
-    cluster && taskDefinition && subnetsRaw && securityGroup;
+  const ecsConfigured = cluster && service && subnetsRaw && securityGroup;
 
   if (!ecsConfigured) {
     // Dev fallback. Fire-and-forget — runIngest persists row state
@@ -74,6 +74,12 @@ export async function launchScoutKbIngest({
     .filter(Boolean);
 
   const ecs = new ECSClient({ region: config.AWS_REGION });
+
+  const taskDefinition = await resolveActiveTaskDefinition(
+    ecs,
+    cluster,
+    service,
+  );
 
   const result = await ecs.send(
     new RunTaskCommand({

--- a/apps/api/src/features/scout/report/launch.ts
+++ b/apps/api/src/features/scout/report/launch.ts
@@ -1,6 +1,7 @@
 import { ECSClient, RunTaskCommand } from "@aws-sdk/client-ecs";
 import { context, propagation } from "@opentelemetry/api";
 import type { Config } from "../../../config.ts";
+import { resolveActiveTaskDefinition } from "../../../lib/ecs-task-definition.ts";
 import { runReport, type RunReportDeps } from "./run-report.ts";
 
 /**
@@ -67,12 +68,11 @@ export async function launchScoutReport({
   reportId,
 }: LaunchScoutReportOpts): Promise<void> {
   const cluster = config.SYNC_ECS_CLUSTER;
-  const taskDefinition = config.SYNC_ECS_TASK_DEFINITION;
+  const service = config.SYNC_ECS_SERVICE;
   const subnetsRaw = config.SYNC_ECS_SUBNETS;
   const securityGroup = config.SYNC_ECS_SECURITY_GROUP;
 
-  const ecsConfigured =
-    cluster && taskDefinition && subnetsRaw && securityGroup;
+  const ecsConfigured = cluster && service && subnetsRaw && securityGroup;
 
   if (!ecsConfigured) {
     // Dev fallback. Fire-and-forget — the row is the source of truth, so the
@@ -94,6 +94,12 @@ export async function launchScoutReport({
     .filter(Boolean);
 
   const ecs = new ECSClient({ region: config.AWS_REGION });
+
+  const taskDefinition = await resolveActiveTaskDefinition(
+    ecs,
+    cluster,
+    service,
+  );
 
   // RunTask returns once ECS accepts task placement (typically <1s). The
   // worker itself runs entirely inside the Fargate task. Hard-cap at 10s so

--- a/apps/api/src/lib/ecs-task-definition.ts
+++ b/apps/api/src/lib/ecs-task-definition.ts
@@ -1,0 +1,39 @@
+import { DescribeServicesCommand, type ECSClient } from "@aws-sdk/client-ecs";
+
+export class TaskDefinitionResolveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TaskDefinitionResolveError";
+  }
+}
+
+/**
+ * Returns the task-definition ARN the live ECS service is currently
+ * running. Worker launchers (Scout report, KB ingest, play-cricket
+ * sync) call this and pass the result to RunTask so the spawned task
+ * always matches the API revision.
+ *
+ * Why: passing a bare family name to RunTask resolves to the latest
+ * ACTIVE revision. Terraform re-registers a revision with `:latest`
+ * on every apply (the image is hardcoded in the module), and `:latest`
+ * is no longer published to ECR. The API service has
+ * `ignore_changes = [task_definition]` so it ignores the broken
+ * revision; this helper extends the same shield to workers.
+ */
+export async function resolveActiveTaskDefinition(
+  ecs: ECSClient,
+  cluster: string,
+  service: string,
+): Promise<string> {
+  const result = await ecs.send(
+    new DescribeServicesCommand({ cluster, services: [service] }),
+    { abortSignal: AbortSignal.timeout(5_000) },
+  );
+  const arn = result.services?.[0]?.taskDefinition;
+  if (!arn) {
+    throw new TaskDefinitionResolveError(
+      `Could not resolve task-definition for service ${service} in cluster ${cluster}`,
+    );
+  }
+  return arn;
+}

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -219,10 +219,10 @@ module "ecs" {
     PHOENIX_PROJECT_NAME       = "percy-main-scout-production"
     AWS_REGION                 = "eu-west-2"
     # Cannot reference module.ecs.* outputs that depend on the task definition
-    # here - that would cycle through the env-vars input. The cluster and family
-    # names are deterministic from the environment, so inline them.
+    # here - that would cycle through the env-vars input. The cluster and
+    # service names are deterministic from the environment, so inline them.
     SYNC_ECS_CLUSTER          = "percy-main-production-cluster"
-    SYNC_ECS_TASK_DEFINITION  = "production-api"
+    SYNC_ECS_SERVICE          = "production-api"
     SYNC_ECS_SUBNETS          = join(",", module.vpc.public_subnet_ids)
     SYNC_ECS_SECURITY_GROUP   = module.vpc.ecs_security_group_id
     SYNC_ECS_ASSIGN_PUBLIC_IP = "true"

--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -142,10 +142,10 @@ module "ecs" {
     PHOENIX_PROJECT_NAME       = "percy-main-scout-staging"
     AWS_REGION                 = "eu-west-2"
     # Cannot reference module.ecs.* outputs that depend on the task definition
-    # here — that would cycle through the env-vars input. The cluster and family
-    # names are deterministic from the environment, so inline them.
+    # here - that would cycle through the env-vars input. The cluster and
+    # service names are deterministic from the environment, so inline them.
     SYNC_ECS_CLUSTER          = "percy-main-staging-cluster"
-    SYNC_ECS_TASK_DEFINITION  = "staging-api"
+    SYNC_ECS_SERVICE          = "staging-api"
     SYNC_ECS_SUBNETS          = join(",", module.vpc.public_subnet_ids)
     SYNC_ECS_SECURITY_GROUP   = module.vpc.ecs_security_group_id
     SYNC_ECS_ASSIGN_PUBLIC_IP = "true"

--- a/infra/modules/ecs-service/main.tf
+++ b/infra/modules/ecs-service/main.tf
@@ -388,6 +388,16 @@ resource "aws_iam_role_policy" "task_run_sync" {
         Resource = "arn:aws:ecs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.api.family}:*"
       },
       {
+        # Workers pin RunTask to the API service's currently-running
+        # revision so they ride the same image the live API is on,
+        # bypassing stray task-def revisions Terraform leaves behind
+        # pointing at `:latest`. Requires DescribeServices on the API
+        # service.
+        Effect   = "Allow"
+        Action   = "ecs:DescribeServices"
+        Resource = aws_ecs_service.api.id
+      },
+      {
         Effect = "Allow"
         Action = "iam:PassRole"
         Resource = [


### PR DESCRIPTION
## Summary

- Scout report launches in production failed with `CannotPullContainerError: ...percy-main-api:latest: not found` because workers used the bare task-def family name with RunTask, which resolves to the latest ACTIVE revision - and Terraform re-registers a revision pointing at `:latest` (no longer published to ECR) on every apply.
- Today's recurrence: config-only push to main triggered `terraform-production` but skipped `deploy-api` (no API file changes), leaving revision 146 (`:latest`) as the latest active. The API service kept running revision 145 (the real SHA) because it has `ignore_changes = [task_definition]`, but workers resolved to 146 and broke.
- This PR pins RunTask to the API service's currently-running revision via `DescribeServices`. Workers now ride the exact same image the API is running.

## Changes

- `apps/api/src/lib/ecs-task-definition.ts` - new helper `resolveActiveTaskDefinition(ecs, cluster, service)` returns the live service's `taskDefinition` ARN.
- `apps/api/src/features/scout/report/launch.ts`, `apps/api/src/features/scout/knowledge/launch.ts`, `apps/api/src/features/play-cricket/trigger-sync.ts` - use the helper; pass the resolved ARN to `RunTaskCommand` instead of a bare family name.
- `apps/api/src/config.ts` - add `SYNC_ECS_SERVICE`, drop unused `SYNC_ECS_TASK_DEFINITION`.
- `infra/modules/ecs-service/main.tf` - grant `ecs:DescribeServices` on the API service to the task role.
- `infra/environments/{production,staging}/main.tf` - swap env var.

## Out of scope

EventBridge Scheduler still passes `task_definition_arn = ...:family` to the 3am play-cricket cron (`infra/modules/scheduling/main.tf`). Same exposure - separate fix needed there because the scheduler config is static and can't call DescribeServices. Worth a follow-up issue.

The deeper structural fix (Option A from the chat) is to stop Terraform registering revisions at all after the initial create (lifecycle ignore_changes on `container_definitions`). Worth an ADR; deliberately deferred so this PR stays scoped to the immediate breakage.

## Test plan

- [ ] Merge and watch the deploy run register a fresh revision with the real SHA
- [ ] Confirm the deployed service has updated to the new revision
- [ ] Launch a Scout report in production and verify the Fargate task starts (no `CannotPullContainerError`)
- [ ] Spot-check that play-cricket "Sync now" still works
- [ ] Re-run a KB ingest from the admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)