### PR TITLE
fix(auth): stop passkey autofill re-firing on session refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: millionco/react-doctor@main
+      # Pinned to a SHA: their @main shipped a `--pr-comment` flag on
+      # 2026-05-16 that the `react-doctor@latest` npm tag doesn't
+      # recognise yet, breaking CI. Bump deliberately once that gap
+      # closes.
+      - uses: millionco/react-doctor@529015d1d89441c4708f49413ecd540db7c04255
         with:
           diff: main
           directory: apps/web

--- a/apps/web/src/pages/auth/login/email-password.tsx
+++ b/apps/web/src/pages/auth/login/email-password.tsx
@@ -93,15 +93,17 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
   };
 
   useEffect(() => {
+    let cancelled = false;
     async function tryPasskeyAutofill() {
       const available =
         await PublicKeyCredential?.isConditionalMediationAvailable?.();
-      if (!available) return;
+      if (!available || cancelled) return;
 
       void authClient.signIn.passkey(
         { autoFill: true },
         {
           async onSuccess() {
+            if (cancelled) return;
             await refetchSession();
             navigateBack("/members");
           },
@@ -109,9 +111,19 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
       );
     }
     void tryPasskeyAutofill();
-    // navigateBack closes over returnTo; deps cover it via `returnTo`.
+    return () => {
+      cancelled = true;
+    };
+    // Run once on mount. Re-running this effect kicks off a fresh
+    // WebAuthn conditional-mediation ceremony, aborts the previous one
+    // client-side ("Cancelling existing WebAuthn API call for new one"),
+    // and leaves the server's stored challenge out of sync with whatever
+    // the user eventually completes, producing CHALLENGE_NOT_FOUND on
+    // verify. better-auth's useSession returns a new `refetch` reference
+    // on every session-atom update, so listing it in deps would re-trigger
+    // the ceremony every time the session refreshes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [navigate, returnTo, refetchSession]);
+  }, []);
 
   const signin = useMutation({
     mutationFn: async () => {

--- a/apps/web/src/pages/auth/login/email-password.tsx
+++ b/apps/web/src/pages/auth/login/email-password.tsx
@@ -105,6 +105,7 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
           async onSuccess() {
             if (cancelled) return;
             await refetchSession();
+            if (cancelled) return;
             navigateBack("/members");
           },
         },


### PR DESCRIPTION
## Summary

- `tryPasskeyAutofill` useEffect in `apps/web/src/pages/auth/login/email-password.tsx` had `refetchSession` in its dep array.
- better-auth's `useSession` returns a fresh `refetch` reference on every session-atom update, so the effect re-ran whenever the session refreshed.
- Each re-run kicked off a new WebAuthn conditional-mediation ceremony, aborted the previous one client-side, and the server's stored challenge ended up out of sync with whatever the user eventually completed - `CHALLENGE_NOT_FOUND` on verify.
- Got noticeably worse after b415d8b started reading `data` / `isPending` from `useSession` to support the already-signed-in bounce (every session refresh now re-renders this component).

Fix: run the autofill effect once on mount with a `cancelled` flag for cleanup, so an in-flight ceremony completing after unmount becomes a no-op.

## Repro (before)

1. Land on /auth/login while a passkey is registered.
2. Open Chrome DevTools console. You see `[Better Auth] Error verifying passkey AbortError: Authentication ceremony was sent an abort signal` and `AbortError: Cancelling existing WebAuthn API call for new one`.
3. Pick the passkey from the username autocomplete. Server returns `{"message":"Challenge not found","code":"CHALLENGE_NOT_FOUND"}`.

## Test plan

- [ ] Load /auth/login on a browser with a registered passkey - no abort errors in console.
- [ ] Pick passkey from autocomplete - completes and lands on /members.
- [ ] Open /auth/login while already signed in - bounces straight to /members (the b415d8b behaviour still works).
- [ ] Email/password login still works.

## Notes

Related to the prod memory bump on main (bb44ff7) - OOM kills were making the symptom much worse but weren't the root cause. This fix is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)