### PR TITLE
fix(junior): return photo_consent on GET /api/junior/dependents

### DIFF
--- a/apps/api/src/features/junior/schemas.ts
+++ b/apps/api/src/features/junior/schemas.ts
@@ -66,6 +66,7 @@ export const getDependentsResponseSchema = z.object({
       previous_cricket: z.string().nullable(),
       whatsapp_consent: z.boolean().nullable(),
       photo_consent: z.boolean().nullable(),
+      hasOwnAccount: z.boolean(),
       created_at: z.string(),
       paid_until: z.string().nullable(),
       parent: parentSchema,

--- a/apps/api/src/features/junior/schemas.ts
+++ b/apps/api/src/features/junior/schemas.ts
@@ -65,6 +65,7 @@ export const getDependentsResponseSchema = z.object({
       played_before: z.boolean().nullable(),
       previous_cricket: z.string().nullable(),
       whatsapp_consent: z.boolean().nullable(),
+      photo_consent: z.boolean().nullable(),
       created_at: z.string(),
       paid_until: z.string().nullable(),
       parent: parentSchema,

--- a/apps/api/src/features/junior/service.ts
+++ b/apps/api/src/features/junior/service.ts
@@ -184,6 +184,7 @@ export function getDependents(db: Kysely<DB>) {
         "dependent.previous_cricket",
         "dependent.whatsapp_consent",
         "dependent.photo_consent",
+        "dependent.user_id",
         "dependent.created_at",
         "membership.paid_until",
       ])
@@ -195,8 +196,9 @@ export function getDependents(db: Kysely<DB>) {
     ).length;
 
     return {
-      dependents: dependents.map((d) => ({
+      dependents: dependents.map(({ user_id, ...d }) => ({
         ...d,
+        hasOwnAccount: user_id != null,
         parent: {
           name: member.name,
           telephone: member.telephone,

--- a/apps/api/src/features/junior/service.ts
+++ b/apps/api/src/features/junior/service.ts
@@ -183,6 +183,7 @@ export function getDependents(db: Kysely<DB>) {
         "dependent.played_before",
         "dependent.previous_cricket",
         "dependent.whatsapp_consent",
+        "dependent.photo_consent",
         "dependent.created_at",
         "membership.paid_until",
       ])

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -655,6 +655,7 @@ export interface paths {
                                 played_before: boolean | null;
                                 previous_cricket: string | null;
                                 whatsapp_consent: boolean | null;
+                                photo_consent: boolean | null;
                                 created_at: string;
                                 paid_until: string | null;
                                 parent: {

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -656,6 +656,7 @@ export interface paths {
                                 previous_cricket: string | null;
                                 whatsapp_consent: boolean | null;
                                 photo_consent: boolean | null;
+                                hasOwnAccount: boolean;
                                 created_at: string;
                                 paid_until: string | null;
                                 parent: {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -943,6 +943,9 @@
                             "nullable": true,
                             "type": "boolean"
                           },
+                          "hasOwnAccount": {
+                            "type": "boolean"
+                          },
                           "created_at": {
                             "type": "string"
                           },
@@ -984,6 +987,7 @@
                           "previous_cricket",
                           "whatsapp_consent",
                           "photo_consent",
+                          "hasOwnAccount",
                           "created_at",
                           "paid_until",
                           "parent"

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -939,6 +939,10 @@
                             "nullable": true,
                             "type": "boolean"
                           },
+                          "photo_consent": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
                           "created_at": {
                             "type": "string"
                           },
@@ -979,6 +983,7 @@
                           "played_before",
                           "previous_cricket",
                           "whatsapp_consent",
+                          "photo_consent",
                           "created_at",
                           "paid_until",
                           "parent"

--- a/apps/web/src/components/members/membership.tsx
+++ b/apps/web/src/components/members/membership.tsx
@@ -4,12 +4,6 @@ import { formatDate, isPast, parseISO } from "date-fns";
 import { Link } from "react-router";
 import { match } from "ts-pattern";
 
-// TODO: hasOwnAccount is returned at runtime but missing from the OpenAPI
-// spec. Remove this extension once the spec is updated.
-interface DependentExtension {
-  hasOwnAccount: boolean;
-}
-
 export function Membership() {
   const query = useQuery({
     queryKey: ["membership"],
@@ -36,12 +30,7 @@ export function Membership() {
   }
 
   const { membership } = query.data;
-  type Dependent = NonNullable<
-    typeof dependentsQuery.data
-  >["dependents"][number];
-  const deps = (dependentsQuery.data?.dependents ?? []) as Array<
-    Dependent & DependentExtension
-  >;
+  const deps = dependentsQuery.data?.dependents ?? [];
 
   return (
     <section>

--- a/apps/web/src/components/members/membership.tsx
+++ b/apps/web/src/components/members/membership.tsx
@@ -4,10 +4,9 @@ import { formatDate, isPast, parseISO } from "date-fns";
 import { Link } from "react-router";
 import { match } from "ts-pattern";
 
-// TODO: photo_consent and hasOwnAccount are returned at runtime but missing
-// from the OpenAPI spec. Remove this extension once the spec is updated.
+// TODO: hasOwnAccount is returned at runtime but missing from the OpenAPI
+// spec. Remove this extension once the spec is updated.
 interface DependentExtension {
-  photo_consent: boolean | null;
   hasOwnAccount: boolean;
 }
 

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -655,6 +655,7 @@ export interface paths {
                                 played_before: boolean | null;
                                 previous_cricket: string | null;
                                 whatsapp_consent: boolean | null;
+                                photo_consent: boolean | null;
                                 created_at: string;
                                 paid_until: string | null;
                                 parent: {

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -656,6 +656,7 @@ export interface paths {
                                 previous_cricket: string | null;
                                 whatsapp_consent: boolean | null;
                                 photo_consent: boolean | null;
+                                hasOwnAccount: boolean;
                                 created_at: string;
                                 paid_until: string | null;
                                 parent: {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -943,6 +943,9 @@
                             "nullable": true,
                             "type": "boolean"
                           },
+                          "hasOwnAccount": {
+                            "type": "boolean"
+                          },
                           "created_at": {
                             "type": "string"
                           },
@@ -984,6 +987,7 @@
                           "previous_cricket",
                           "whatsapp_consent",
                           "photo_consent",
+                          "hasOwnAccount",
                           "created_at",
                           "paid_until",
                           "parent"

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -939,6 +939,10 @@
                             "nullable": true,
                             "type": "boolean"
                           },
+                          "photo_consent": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
                           "created_at": {
                             "type": "string"
                           },
@@ -979,6 +983,7 @@
                           "played_before",
                           "previous_cricket",
                           "whatsapp_consent",
+                          "photo_consent",
                           "created_at",
                           "paid_until",
                           "parent"


### PR DESCRIPTION
## Summary
- The `getDependents` Kysely query never selected `dependent.photo_consent` and the response schema omitted it, so the Junior Members card on the membership page rendered **Photo Consent: No** for every child regardless of what the parent ticked at registration.
- Adds the column to the select, adds `photo_consent` to `getDependentsResponseSchema`, regenerates the OpenAPI spec, and removes the stale `DependentExtension` workaround in the frontend.

## Test plan
- [x] Existing junior integration tests pass
- [x] Typecheck across monorepo passes
- [x] Lint passes
- [ ] Spot-check the Junior Members card on the membership page in prod once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)