### PR TITLE
lint: ban TODO comments via no-warning-comments

### DIFF
--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -216,7 +216,7 @@ export function sendChargeNotification(db: Kysely<DB>) {
       return { sent: false, reason: "No outstanding charges" };
     }
 
-    // TODO: Send email notification via email service
+    // Email send not wired up - see #367
     return { sent: true, chargeCount: unpaidCharges.length };
   };
 }
@@ -1500,8 +1500,7 @@ export function chasePayment(db: Kysely<DB>) {
       throw error;
     }
 
-    // TODO: Send PaymentReminder email via email service
-    // For now, return success — email integration will be wired when packages/email is complete
+    // Email send not wired up - see #367
     return { success: true };
   };
 }

--- a/apps/api/src/features/payments/webhook-service.ts
+++ b/apps/api/src/features/payments/webhook-service.ts
@@ -76,7 +76,6 @@ export function handleCheckoutCompleted({
     // --- Game sponsorship ---
     const sponsorMeta = gameSponsoredSchema.safeParse(fullSession.metadata);
     if (fullSession.payment_status === "paid" && sponsorMeta.success) {
-      // TODO: Slack notification (skip for now)
       const email = fullSession.customer_details?.email;
       if (email && fullSession.amount_total) {
         const result = await charge({
@@ -566,8 +565,6 @@ export function handlePaymentIntentSucceeded({
         .executeTakeFirst();
 
       if (sponsorship) {
-        // TODO: Slack notification (skip for now)
-
         await send({
           to: sponsorship.sponsor_email,
           subject: SponsorshipConfirmation.subject,
@@ -582,7 +579,6 @@ export function handlePaymentIntentSucceeded({
         });
       }
     } else {
-      // TODO: Slack notification (skip for now)
       log.info(
         { gameId: meta.gameId },
         "Game sponsored (no sponsorship record)",
@@ -642,8 +638,6 @@ export function handlePaymentIntentSucceeded({
       .executeTakeFirst();
 
     if (sponsorship) {
-      // TODO: Slack notification (skip for now)
-
       await send({
         to: sponsorship.sponsor_email,
         subject: PlayerSponsorshipConfirmation.subject,

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -609,8 +609,6 @@ async function syncMatches(
  *
  * Follows the curried factory pattern: `runSync(db, api)` returns an async
  * function that accepts sync config and performs the sync.
- *
- * TODO: Wire up as EventBridge scheduled task or admin HTTP trigger
  */
 export function runSync(
   db: Kysely<DB>,

--- a/apps/web/src/components/marketing/lead-form.tsx
+++ b/apps/web/src/components/marketing/lead-form.tsx
@@ -63,7 +63,7 @@ function emptyToUndefined(value: string): string | undefined {
   return trimmed.length === 0 ? undefined : trimmed;
 }
 
-// eslint-disable-next-line react-doctor/no-giant-component -- single conversion form whose adult/junior variants share submit logic, validation, attribution capture and analytics; splitting would just thread props between halves of one cohesive form. TODO: revisit if a third variant is added.
+// eslint-disable-next-line react-doctor/no-giant-component -- single conversion form whose adult/junior variants share submit logic, validation, attribution capture and analytics; splitting would just thread props between halves of one cohesive form.
 export const LeadForm: FC<LeadFormProps> = ({
   campaignId,
   segment,

--- a/apps/web/src/pages/admin/charges-tab.tsx
+++ b/apps/web/src/pages/admin/charges-tab.tsx
@@ -68,7 +68,7 @@ const statusBadgeMap: Record<
   relieved: { variant: "secondary", label: "Relieved" },
 };
 
-// eslint-disable-next-line react-doctor/no-giant-component -- admin charges tab: filter bar + paginated table + row actions (refund, void, edit) all share the filters reducer + table query; splitting would mean lifting the reducer and queryClient through props for marginal benefit. TODO: extract row-level mutations into a hook if more action verbs are added.
+// eslint-disable-next-line react-doctor/no-giant-component -- admin charges tab: filter bar + paginated table + row actions (refund, void, edit) all share the filters reducer + table query; splitting would mean lifting the reducer and queryClient through props for marginal benefit.
 export function ChargesTab() {
   const queryClient = useQueryClient();
   const [filters, dispatch] = useReducer(

--- a/apps/web/src/pages/admin/expense-history-tab.tsx
+++ b/apps/web/src/pages/admin/expense-history-tab.tsx
@@ -69,7 +69,7 @@ const STATUS_CONFIG: Record<
 
 // --- Component ---
 
-// eslint-disable-next-line react-doctor/no-giant-component -- expense history admin tab: filter bar + summary chart + grouped paginated table + row dialogs all share the filters reducer and a single export-CSV path. TODO: pull rows + dialogs into siblings once they need to be reused elsewhere.
+// eslint-disable-next-line react-doctor/no-giant-component -- expense history admin tab: filter bar + summary chart + grouped paginated table + row dialogs all share the filters reducer and a single export-CSV path.
 export function ExpenseHistoryTab() {
   const [defaults] = useState(() => getFinancialYearDefaults(new Date()));
   const [filters, dispatch] = useReducer(

--- a/apps/web/src/pages/admin/incidents-tab.tsx
+++ b/apps/web/src/pages/admin/incidents-tab.tsx
@@ -339,7 +339,7 @@ function IncidentDetailBody({
   );
 }
 
-// eslint-disable-next-line react-doctor/no-giant-component -- incident review form: 12 fields all submit together as a PATCH with one validation/mutation lifecycle; splitting fragments a single H&S record's edit semantics. TODO: extract the safeguarding sub-section once it grows attachments.
+// eslint-disable-next-line react-doctor/no-giant-component -- incident review form: 12 fields all submit together as a PATCH with one validation/mutation lifecycle; splitting fragments a single H&S record's edit semantics.
 function IncidentEditForm({
   id,
   initial,

--- a/apps/web/src/pages/admin/leads-tab.tsx
+++ b/apps/web/src/pages/admin/leads-tab.tsx
@@ -39,7 +39,7 @@ const SOURCE_OPTIONS = [
   { value: "contact_form", label: "Contact form" },
 ];
 
-// eslint-disable-next-line react-doctor/no-giant-component -- admin leads tab: filter bar + table + per-row status mutations and detail dialog share the filters reducer and a single query. TODO: extract LeadRow when row actions grow beyond status changes.
+// eslint-disable-next-line react-doctor/no-giant-component -- admin leads tab: filter bar + table + per-row status mutations and detail dialog share the filters reducer and a single query.
 export function LeadsTab() {
   const [filters, dispatch] = useReducer(
     leadsFilterReducer,

--- a/apps/web/src/pages/membership/membership-junior.tsx
+++ b/apps/web/src/pages/membership/membership-junior.tsx
@@ -207,7 +207,7 @@ function SocialMembershipUpsell() {
   );
 }
 
-// eslint-disable-next-line react-doctor/no-giant-component -- multi-step junior registration wizard: parent-account / dependents / consent / payment all share the wizard reducer + 4 mutations + Stripe integration. TODO: extract step bodies (StepParent, StepDependents, StepConsent, StepPayment) as siblings — sized job, deferred to its own PR.
+// eslint-disable-next-line react-doctor/no-giant-component -- multi-step junior registration wizard: parent-account / dependents / consent / payment all share the wizard reducer + 4 mutations + Stripe integration.
 function JuniorRegistrationInner() {
   const [wizard, dispatch] = useReducer(juniorWizardReducer, undefined, () =>
     initialJuniorWizardState(),

--- a/apps/web/src/pages/official/official.tsx
+++ b/apps/web/src/pages/official/official.tsx
@@ -559,7 +559,7 @@ function TeamMatchesView({
   );
 }
 
-// eslint-disable-next-line react-doctor/no-giant-component -- captain/official matchday view: player roster + add/remove + payment confirmation + result selector + expense management + team-news image; all sections share the matchday query and 6+ mutations. Sub-sections (RoleSelectors, DownloadTeamNewsButton, ExpensesSection) are already siblings. TODO: extract the result-entry bar once additional result-types are added.
+// eslint-disable-next-line react-doctor/no-giant-component -- captain/official matchday view: player roster + add/remove + payment confirmation + result selector + expense management + team-news image; all sections share the matchday query and 6+ mutations. Sub-sections (RoleSelectors, DownloadTeamNewsButton, ExpensesSection) are already siblings.
 function MatchdayView({
   matchdayId,
   isHome,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,6 +55,10 @@ export default tseslint.config(
         { allowNumber: true },
       ],
       "react-hooks/exhaustive-deps": "error",
+      "no-warning-comments": [
+        "error",
+        { terms: ["todo"], location: "anywhere" },
+      ],
     },
   },
   // apps/web runs the React Compiler — recommended-latest's compiler-aware


### PR DESCRIPTION
## Summary
- Adds `no-warning-comments` (term: `todo`, location: `anywhere`) to the root ESLint config.
- Clears every TODO comment surfaced by the new rule. Verdict per file:
  - **Aspirational, deleted:** 4× `TODO: Slack notification (skip for now)` in `webhook-service.ts`, and the stale `TODO: Wire up as EventBridge scheduled task` in `play-cricket/sync.ts` (sync is already EventBridge-scheduled in staging + production).
  - **Real bug, tracked:** Both admin chase TODOs (`sendChargeNotification`, `chasePayment`) replaced with a `// see #367` reference. The endpoints currently return `{ sent: true }` without sending an email - #367 tracks wiring the actual `ChargeNotification` / `PaymentReminder` templates the way matchday already does.
  - **Refactor wishes, deleted:** Stripped the trailing `TODO: extract X when Y` clauses from seven `react-doctor/no-giant-component` eslint-disable explanations. The preceding `-- ...` justification stands on its own.

## Dependency on #365
The last remaining TODO (`apps/web/src/components/members/membership.tsx:7`) is fixed by #365 (which deletes the `DependentExtension` workaround). This PR depends on #365 landing first; once #365 merges, rebase this onto main and CI goes green.

## Test plan
- [x] Lint passes for everything other than the membership.tsx line addressed by #365
- [x] Typecheck across monorepo
- [x] API unit + junior integration tests pass
- [ ] Rebase onto main once #365 lands, confirm CI green, flip out of draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)