### PR TITLE
fix(ci): serialize terraform plans across PRs to avoid lock contention

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,6 +28,14 @@ env:
 jobs:
   plan:
     runs-on: ubuntu-latest
+    # Backend-wide serialization. The workflow-level concurrency above
+    # handles cancel-on-new-commit within a single PR; this job-level
+    # group queues plans across PRs against the same backend so they
+    # don't race on the DynamoDB state lock. Per-environment so shared
+    # and production can plan in parallel.
+    concurrency:
+      group: terraform-plan-${{ matrix.environment }}
+      cancel-in-progress: false
     strategy:
       matrix:
         environment: [shared, production]


### PR DESCRIPTION
## Summary
- Add a job-level concurrency group keyed on environment to the PR plan workflow so concurrent PRs queue against the same backend instead of racing the DynamoDB state lock.
- The workflow-level group stays per-ref (still cancels in-flight plans when a new commit lands on the same PR); the new job-level group handles cross-PR serialization.
- Per-environment so shared and production can still plan in parallel.

## Why
Triaging 7 Dependabot PRs surfaced repeated ` plan (shared)` failures with \`Error acquiring the state lock\` / \`ConditionalCheckFailedException\`. The existing \`tf-unlock\` step correctly recovered the state for the next run, but the failing job was already lost - because the root cause wasn't a stale lock, it was concurrent plan jobs from different PRs colliding on the single backend lock.

## Test plan
- [ ] CI plan job runs on this PR and succeeds for both shared and production
- [ ] Open a second PR touching \`infra/**\` while this one's plan is in flight - the second PR's plan should pend until the first finishes, not fail with a lock error