### PR TITLE
chore(deps): force ws>=8.20.1 via pnpm override (GHSA-58qx-3vcg-4xpx)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   fast-xml-parser@<5.7.0: '>=5.7.0'
   postcss@<8.5.10: '>=8.5.10'
+  ws@<8.20.1: '>=8.20.1'
   yaml@<2.8.3: '>=2.8.3'
 
 importers:
@@ -7982,18 +7983,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
@@ -12825,7 +12814,7 @@ snapshots:
       cors: 2.8.6
       debug: 4.4.3(supports-color@10.2.2)
       engine.io-parser: 5.2.3
-      ws: 8.18.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -15733,7 +15722,7 @@ snapshots:
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
-      ws: 8.18.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16669,8 +16658,6 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
-
-  ws@8.18.3: {}
 
   ws@8.20.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,4 +19,5 @@ allowBuilds:
 overrides:
   fast-xml-parser@<5.7.0: ">=5.7.0"
   postcss@<8.5.10: ">=8.5.10"
+  ws@<8.20.1: ">=8.20.1"
   yaml@<2.8.3: ">=2.8.3"


### PR DESCRIPTION
## Summary

- Adds a pnpm override forcing `ws` to `>=8.20.1` across all transitive deps.
- Closes Dependabot alert [#100](https://github.com/percy-main/website-v2/security/dependabot/100) (GHSA-58qx-3vcg-4xpx, uninitialized memory disclosure via `WebSocket.close` reason).

## Why an override

The direct `ws` dep was already bumped to `8.20.1` in #373, but `react-email@6.1.5` still pulls in `socket.io@4.8.3` -> `engine.io@6.6.7` / `socket.io-adapter@2.5.6`, both of which pin `ws@8.18.3`. The override is the only way to evict the vulnerable copy until upstream socket.io bumps.

Practical risk on this codebase is low - react-email is a dev-time tool and its socket.io server is only used for the email preview live-reload - but Dependabot doesn't model that, and the override has no runtime cost.

## Test plan

- [x] `pnpm install` - lockfile now contains only `ws@8.20.1`; `ws@8.18.3` entry removed; `engine.io` / `socket.io-adapter` snapshots rewritten to depend on `8.20.1`.
- [x] `pnpm run typecheck` - clean.
- [x] `pnpm run lint` - clean.
- [x] `pnpm format` - no diff.