### PR TITLE
chore(deps): upgrade stripe SDK 17 → 22 (closes #371)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -65,7 +65,7 @@
     "react-dom": "^19.2.6",
     "react-email": "^6.1.5",
     "sharp": "^0.34.5",
-    "stripe": "^17.5.0",
+    "stripe": "^22.1.1",
     "ts-pattern": "^5.6.0",
     "zod": "^4.4.3"
   },

--- a/apps/api/src/features/members/service.ts
+++ b/apps/api/src/features/members/service.ts
@@ -74,13 +74,18 @@ export function getMySubscriptions(stripe: Stripe) {
         typeof item?.price?.product === "string" ? item.price.product : "";
       const product = products.get(productId) ?? { id: "", name: "" };
 
+      // In API 2025-03-31.basil onwards, `current_period_end` moved off
+      // the Subscription onto each item. For single-item subscriptions
+      // (our only flavour) the item period == the subscription period.
+      const periodEnd = item?.current_period_end ?? sub.created;
+
       return {
         id: sub.id,
         name: item?.price?.nickname ?? null,
         product,
         created: new Date(sub.created * 1000).toISOString(),
         status: sub.status,
-        paidUntil: new Date(sub.current_period_end * 1000).toISOString(),
+        paidUntil: new Date(periodEnd * 1000).toISOString(),
       };
     });
   };

--- a/apps/api/src/features/payments/integration.test.ts
+++ b/apps/api/src/features/payments/integration.test.ts
@@ -338,6 +338,7 @@ describe("handleInvoicePayment", () => {
 
     const paymentIntentId = `pi_${randomUUID()}`;
     const subscriptionId = `sub_${randomUUID()}`;
+    const invoiceId = `in_${randomUUID()}`;
 
     const mockStripe = {
       customers: {
@@ -355,6 +356,26 @@ describe("handleInvoicePayment", () => {
             membership: "senior_player",
             source: "direct",
           },
+          items: {
+            data: [
+              {
+                price: {
+                  type: "recurring",
+                  recurring: { interval: "month", interval_count: 1 },
+                },
+              },
+            ],
+          },
+        }),
+      },
+      invoicePayments: {
+        list: vi.fn().mockResolvedValue({
+          data: [
+            {
+              is_default: true,
+              payment: { payment_intent: paymentIntentId },
+            },
+          ],
         }),
       },
     } as any;
@@ -369,21 +390,14 @@ describe("handleInvoicePayment", () => {
 
     await handler(
       {
+        id: invoiceId,
         customer: `cus_123`,
-        subscription: subscriptionId,
-        billing_reason: "subscription_create",
-        payment_intent: paymentIntentId,
-        amount_paid: 5000,
-        lines: {
-          data: [
-            {
-              price: {
-                type: "recurring",
-                recurring: { interval: "month", interval_count: 1 },
-              },
-            },
-          ],
+        parent: {
+          type: "subscription_details",
+          subscription_details: { subscription: subscriptionId },
         },
+        billing_reason: "subscription_create",
+        amount_paid: 5000,
       } as any,
       EVENT_CREATED,
     );
@@ -412,6 +426,7 @@ describe("handleInvoicePayment", () => {
     });
 
     const subscriptionId = `sub_${randomUUID()}`;
+    const invoiceId = `in_${randomUUID()}`;
 
     const mockStripe = {
       customers: {
@@ -428,7 +443,20 @@ describe("handleInvoicePayment", () => {
             type: "membership",
             membership: "senior_player",
           },
+          items: {
+            data: [
+              {
+                price: {
+                  type: "recurring",
+                  recurring: { interval: "month", interval_count: 1 },
+                },
+              },
+            ],
+          },
         }),
+      },
+      invoicePayments: {
+        list: vi.fn().mockResolvedValue({ data: [] }),
       },
     } as any;
 
@@ -442,21 +470,14 @@ describe("handleInvoicePayment", () => {
 
     await handler(
       {
+        id: invoiceId,
         customer: `cus_123`,
-        subscription: subscriptionId,
-        billing_reason: "subscription_create",
-        payment_intent: `pi_${randomUUID()}`,
-        amount_paid: 5000,
-        lines: {
-          data: [
-            {
-              price: {
-                type: "recurring",
-                recurring: { interval: "month", interval_count: 1 },
-              },
-            },
-          ],
+        parent: {
+          type: "subscription_details",
+          subscription_details: { subscription: subscriptionId },
         },
+        billing_reason: "subscription_create",
+        amount_paid: 5000,
       } as any,
       EVENT_CREATED,
     );
@@ -476,6 +497,7 @@ describe("handleInvoicePayment", () => {
 
     const paymentIntentId = `pi_${randomUUID()}`;
     const subscriptionId = `sub_${randomUUID()}`;
+    const invoiceId = `in_${randomUUID()}`;
 
     const mockStripe = {
       customers: {
@@ -489,6 +511,26 @@ describe("handleInvoicePayment", () => {
         retrieve: vi.fn().mockResolvedValue({
           id: subscriptionId,
           metadata: { type: "membership", membership: "social" },
+          items: {
+            data: [
+              {
+                price: {
+                  type: "recurring",
+                  recurring: { interval: "month", interval_count: 1 },
+                },
+              },
+            ],
+          },
+        }),
+      },
+      invoicePayments: {
+        list: vi.fn().mockResolvedValue({
+          data: [
+            {
+              is_default: true,
+              payment: { payment_intent: paymentIntentId },
+            },
+          ],
         }),
       },
     } as any;
@@ -503,21 +545,14 @@ describe("handleInvoicePayment", () => {
 
     await handler(
       {
+        id: invoiceId,
         customer: `cus_123`,
-        subscription: subscriptionId,
-        billing_reason: "subscription_cycle",
-        payment_intent: paymentIntentId,
-        amount_paid: 3000,
-        lines: {
-          data: [
-            {
-              price: {
-                type: "recurring",
-                recurring: { interval: "month", interval_count: 1 },
-              },
-            },
-          ],
+        parent: {
+          type: "subscription_details",
+          subscription_details: { subscription: subscriptionId },
         },
+        billing_reason: "subscription_cycle",
+        amount_paid: 3000,
       } as any,
       EVENT_CREATED,
     );
@@ -530,6 +565,88 @@ describe("handleInvoicePayment", () => {
       .executeTakeFirst();
     expect(charge).toBeDefined();
     expect(charge?.description).toContain("Membership renewal");
+  });
+
+  it("reads legacy (pre-Basil) invoice.subscription + payment_intent shape", async () => {
+    // Webhook endpoints configured for api_version <= 2025-03-30 deliver
+    // invoices with `subscription` and `payment_intent` at the top level,
+    // not under `parent.subscription_details`. We must handle both until
+    // every endpoint is rotated to Basil+.
+    const { email, memberId } = await seedTestUser(ctx.db, {
+      email: `invoice-legacy-${randomUUID()}@test.com`,
+    });
+
+    const paymentIntentId = `pi_${randomUUID()}`;
+    const subscriptionId = `sub_${randomUUID()}`;
+    const invoiceId = `in_${randomUUID()}`;
+
+    const mockStripe = {
+      customers: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: `cus_${randomUUID()}`,
+          email,
+          deleted: false,
+        }),
+      },
+      subscriptions: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: subscriptionId,
+          metadata: {
+            type: "membership",
+            membership: "senior_player",
+            source: "direct",
+          },
+          items: {
+            data: [
+              {
+                price: {
+                  type: "recurring",
+                  recurring: { interval: "month", interval_count: 1 },
+                },
+              },
+            ],
+          },
+        }),
+      },
+      // Legacy shape: invoicePayments.list should never be called because
+      // payment_intent is read directly off the invoice.
+      invoicePayments: {
+        list: vi.fn(),
+      },
+    } as any;
+
+    const handler = handleInvoicePayment({
+      db: ctx.db,
+      stripe: mockStripe,
+      log: mockLog,
+      baseUrl: "http://localhost:5173",
+      send: vi.fn(),
+    });
+
+    await handler(
+      {
+        id: invoiceId,
+        customer: `cus_123`,
+        // Pre-Basil top-level fields:
+        subscription: subscriptionId,
+        payment_intent: paymentIntentId,
+        // parent is omitted entirely on legacy payloads
+        billing_reason: "subscription_create",
+        amount_paid: 5000,
+      } as any,
+      EVENT_CREATED,
+    );
+
+    expect(mockStripe.invoicePayments.list).not.toHaveBeenCalled();
+
+    const charge = await ctx.db
+      .selectFrom("charge")
+      .where("member_id", "=", memberId ?? "")
+      .where("stripe_payment_intent_id", "=", paymentIntentId)
+      .selectAll()
+      .executeTakeFirst();
+    expect(charge).toBeDefined();
+    expect(charge?.description).toContain("Membership payment");
   });
 
   it("throws on missing customer", async () => {
@@ -591,6 +708,7 @@ describe("handleInvoicePayment", () => {
 
     const paymentIntentId = `pi_${randomUUID()}`;
     const subscriptionId = `sub_${randomUUID()}`;
+    const invoiceId = `in_${randomUUID()}`;
 
     const mockStripe = {
       customers: {
@@ -604,6 +722,26 @@ describe("handleInvoicePayment", () => {
         retrieve: vi.fn().mockResolvedValue({
           id: subscriptionId,
           metadata: {},
+          items: {
+            data: [
+              {
+                price: {
+                  type: "recurring",
+                  recurring: { interval: "month", interval_count: 1 },
+                },
+              },
+            ],
+          },
+        }),
+      },
+      invoicePayments: {
+        list: vi.fn().mockResolvedValue({
+          data: [
+            {
+              is_default: true,
+              payment: { payment_intent: paymentIntentId },
+            },
+          ],
         }),
       },
     } as any;
@@ -618,21 +756,14 @@ describe("handleInvoicePayment", () => {
 
     await handler(
       {
+        id: invoiceId,
         customer: `cus_123`,
-        subscription: subscriptionId,
-        billing_reason: "subscription_cycle",
-        payment_intent: paymentIntentId,
-        amount_paid: 3000,
-        lines: {
-          data: [
-            {
-              price: {
-                type: "recurring",
-                recurring: { interval: "month", interval_count: 1 },
-              },
-            },
-          ],
+        parent: {
+          type: "subscription_details",
+          subscription_details: { subscription: subscriptionId },
         },
+        billing_reason: "subscription_cycle",
+        amount_paid: 3000,
       } as any,
       EVENT_CREATED,
     );

--- a/apps/api/src/features/payments/service.ts
+++ b/apps/api/src/features/payments/service.ts
@@ -150,10 +150,19 @@ export function createSubscription(db: Kysely<DB>, stripe: Stripe) {
         payment_settings: {
           save_default_payment_method: "on_subscription",
         },
-        expand: ["latest_invoice.payment_intent"],
+        expand: ["latest_invoice.confirmation_secret"],
+        // The webhook handler parses this with `membershipSchema`, which
+        // requires `type: "membership"` to discriminate from sponsorship
+        // metadata. The `source: "direct"` flag tells handleInvoicePayment
+        // that this subscription came from /api/subscribe (not Checkout),
+        // so its initial subscription_create invoice should be processed
+        // here rather than skipped (Checkout's first invoice is handled
+        // by checkout.session.completed).
         metadata: {
+          type: "membership",
           membership: data.membership,
           email: data.email,
+          source: "direct",
         },
       };
 
@@ -174,12 +183,20 @@ export function createSubscription(db: Kysely<DB>, stripe: Stripe) {
 
     const subscription = await stripe.subscriptions.create(subscriptionParams);
 
-    const invoice = subscription.latest_invoice as {
-      payment_intent: { client_secret: string };
-    };
+    // In API 2025-03-31.basil onwards, the PaymentIntent's client_secret is
+    // surfaced via Invoice.confirmation_secret rather than the (now-removed)
+    // Invoice.payment_intent expansion.
+    const invoice =
+      subscription.latest_invoice as import("stripe").Stripe.Invoice;
+    const clientSecret = invoice.confirmation_secret?.client_secret;
+    if (!clientSecret) {
+      throw new Error(
+        `Subscription ${subscription.id} has no confirmation_secret on its latest invoice`,
+      );
+    }
 
     return {
-      clientSecret: invoice.payment_intent.client_secret,
+      clientSecret,
       subscriptionId: subscription.id,
     };
   };

--- a/apps/api/src/features/payments/stripe-utils.ts
+++ b/apps/api/src/features/payments/stripe-utils.ts
@@ -19,9 +19,15 @@ const addDurations = (a: Duration, b: Duration): Duration => {
  * - One-time prices are treated as 12 months.
  * - Recurring prices use the interval and interval_count.
  * - Unknown items contribute zero duration.
+ *
+ * Accepts checkout-session `LineItem`s or `SubscriptionItem`s — both expose
+ * a `.price` with the `type`/`recurring` we need. `InvoiceLineItem` is not
+ * supported: in API 2025-03-31.basil onwards its `price` field moved to
+ * `pricing.price_details.price` and is not expanded on webhook payloads,
+ * so callers should resolve the subscription and pass its items instead.
  */
 export const invoiceLinesToDuration = (
-  lineItems: Stripe.InvoiceLineItem[] | Stripe.LineItem[],
+  lineItems: Stripe.LineItem[] | Stripe.SubscriptionItem[],
 ): Duration =>
   lineItems
     .map((li): Duration => {

--- a/apps/api/src/features/payments/webhook-service.test.ts
+++ b/apps/api/src/features/payments/webhook-service.test.ts
@@ -43,7 +43,7 @@ describe("stripe-utils", () => {
     it("returns 12 months (1 year) for one-time price", () => {
       const lineItems = [
         { price: { type: "one_time" as const } },
-      ] as unknown as Stripe.InvoiceLineItem[];
+      ] as unknown as Stripe.LineItem[];
       const result = invoiceLinesToDuration(lineItems);
       // 12 months normalises to 1 year via date-fns intervalToDuration
       expect(result.years).toBe(1);
@@ -57,7 +57,7 @@ describe("stripe-utils", () => {
             recurring: { interval: "month", interval_count: 1 },
           },
         },
-      ] as unknown as Stripe.InvoiceLineItem[];
+      ] as unknown as Stripe.LineItem[];
       const result = invoiceLinesToDuration(lineItems);
       expect(result.months).toBe(1);
     });
@@ -65,7 +65,7 @@ describe("stripe-utils", () => {
     it("returns zero duration for unknown price type", () => {
       const lineItems = [
         { price: { type: "unknown" } },
-      ] as unknown as Stripe.InvoiceLineItem[];
+      ] as unknown as Stripe.LineItem[];
       const result = invoiceLinesToDuration(lineItems);
       expect(result.years ?? 0).toBe(0);
       expect(result.months ?? 0).toBe(0);
@@ -80,7 +80,7 @@ describe("stripe-utils", () => {
             recurring: { interval: "month", interval_count: 3 },
           },
         }, // 3 months
-      ] as unknown as Stripe.InvoiceLineItem[];
+      ] as unknown as Stripe.LineItem[];
       const result = invoiceLinesToDuration(lineItems);
       // 12 + 3 = 15 months = 1 year 3 months
       expect(result.years).toBe(1);
@@ -94,9 +94,7 @@ describe("stripe-utils", () => {
     });
 
     it("handles null price gracefully", () => {
-      const lineItems = [
-        { price: null },
-      ] as unknown as Stripe.InvoiceLineItem[];
+      const lineItems = [{ price: null }] as unknown as Stripe.LineItem[];
       const result = invoiceLinesToDuration(lineItems);
       expect(result.years ?? 0).toBe(0);
       expect(result.months ?? 0).toBe(0);

--- a/apps/api/src/features/payments/webhook-service.ts
+++ b/apps/api/src/features/payments/webhook-service.ts
@@ -190,10 +190,10 @@ export function handleCheckoutCompleted({
  * types still needs to read the legacy field that those types no longer
  * declare. The `LegacyInvoiceShape` cast is the bridge.
  */
-type LegacyInvoiceShape = {
+interface LegacyInvoiceShape {
   subscription?: string | Stripe.Subscription | null;
   payment_intent?: string | Stripe.PaymentIntent | null;
-};
+}
 
 function invoiceSubscriptionId(invoice: Stripe.Invoice): string | undefined {
   const basilRef = invoice.parent?.subscription_details?.subscription;

--- a/apps/api/src/features/payments/webhook-service.ts
+++ b/apps/api/src/features/payments/webhook-service.ts
@@ -277,11 +277,19 @@ async function resolveSubscriptionMembershipMetadata(
  * Reads both shapes for the same reason as `invoiceSubscriptionId`:
  *  - Pre-Basil endpoints: `invoice.payment_intent` is the PI directly
  *  - Basil+ endpoints: PI lives in the (paginated) InvoicePayments list
+ *
+ * The `stripe.invoicePayments.list` call is NOT wrapped in a try/catch:
+ * transient Stripe API failures must surface so the webhook 500s and
+ * Stripe retries. Otherwise we'd record a charge with no PI link, and
+ * `createPaymentCharge` dedups by PI — a retried webhook would then
+ * double-charge the member.
+ *
+ * Returns `undefined` only when the call succeeded and no PI is
+ * attached (e.g. invoice paid by BACS / out-of-band).
  */
 async function invoicePaymentIntentId(
   stripe: Stripe,
   invoice: Stripe.Invoice,
-  log: FastifyBaseLogger,
 ): Promise<string | undefined> {
   const legacyPi = (invoice as Stripe.Invoice & LegacyInvoiceShape)
     .payment_intent;
@@ -289,23 +297,15 @@ async function invoicePaymentIntentId(
     return typeof legacyPi === "string" ? legacyPi : legacyPi.id;
   }
 
-  try {
-    const payments = await stripe.invoicePayments.list({
-      invoice: invoice.id,
-      limit: 10,
-    });
-    const defaultPayment =
-      payments.data.find((p) => p.is_default) ?? payments.data[0];
-    const pi = defaultPayment?.payment.payment_intent;
-    if (!pi) return undefined;
-    return typeof pi === "string" ? pi : pi.id;
-  } catch (err) {
-    log.warn(
-      { err, invoiceId: invoice.id },
-      "invoice_payment_intent_lookup_failed",
-    );
-    return undefined;
-  }
+  const payments = await stripe.invoicePayments.list({
+    invoice: invoice.id,
+    limit: 10,
+  });
+  const defaultPayment =
+    payments.data.find((p) => p.is_default) ?? payments.data[0];
+  const pi = defaultPayment?.payment.payment_intent;
+  if (!pi) return undefined;
+  return typeof pi === "string" ? pi : pi.id;
 }
 
 export function handleInvoicePayment({
@@ -370,7 +370,7 @@ export function handleInvoicePayment({
       ? `Membership renewal - ${meta.membership}`
       : `Membership payment - ${meta.membership}`;
 
-    const paymentIntentId = await invoicePaymentIntentId(stripe, invoice, log);
+    const paymentIntentId = await invoicePaymentIntentId(stripe, invoice);
 
     const chargeResult = await charge({
       memberEmail: email,

--- a/apps/api/src/features/payments/webhook-service.ts
+++ b/apps/api/src/features/payments/webhook-service.ts
@@ -178,21 +178,51 @@ export function handleCheckoutCompleted({
  * Skips initial invoices for checkout-created subscriptions (those are
  * handled by checkout.session.completed).
  */
+/**
+ * Pull the subscription ID off an invoice.
+ *
+ * Reads both shapes because the wire format depends on the webhook
+ * endpoint's configured API version, NOT the SDK version:
+ *  - Pre-Basil endpoints (api_version <= 2025-03-30): `invoice.subscription`
+ *  - Basil+ endpoints (2025-03-31 onwards): `invoice.parent.subscription_details.subscription`
+ *
+ * Until every endpoint is rotated to Basil+, code that runs against v22
+ * types still needs to read the legacy field that those types no longer
+ * declare. The `LegacyInvoiceShape` cast is the bridge.
+ */
+type LegacyInvoiceShape = {
+  subscription?: string | Stripe.Subscription | null;
+  payment_intent?: string | Stripe.PaymentIntent | null;
+};
+
+function invoiceSubscriptionId(invoice: Stripe.Invoice): string | undefined {
+  const basilRef = invoice.parent?.subscription_details?.subscription;
+  if (basilRef) {
+    return typeof basilRef === "string" ? basilRef : basilRef.id;
+  }
+  const legacyRef = (invoice as Stripe.Invoice & LegacyInvoiceShape)
+    .subscription;
+  if (legacyRef) {
+    return typeof legacyRef === "string" ? legacyRef : legacyRef.id;
+  }
+  return undefined;
+}
+
+type MembershipMeta = ReturnType<typeof membershipSchema.parse>;
+
 async function resolveSubscriptionMembershipMetadata(
   db: Kysely<DB>,
   stripe: Stripe,
   invoice: Stripe.Invoice,
   email: string | null,
   log: FastifyBaseLogger,
-) {
-  if (!invoice.subscription) {
+): Promise<
+  { meta: MembershipMeta; subscription: Stripe.Subscription } | undefined
+> {
+  const subscriptionId = invoiceSubscriptionId(invoice);
+  if (!subscriptionId) {
     return undefined;
   }
-
-  const subscriptionId =
-    typeof invoice.subscription === "string"
-      ? invoice.subscription
-      : invoice.subscription.id;
 
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
 
@@ -206,7 +236,7 @@ async function resolveSubscriptionMembershipMetadata(
 
   const parsed = membershipSchema.safeParse(subscription.metadata);
   if (parsed.success) {
-    return parsed.data;
+    return { meta: parsed.data, subscription };
   }
 
   // Fallback: look up member's existing membership type from DB
@@ -229,7 +259,7 @@ async function resolveSubscriptionMembershipMetadata(
           { email, membershipType: existing.type },
           "Resolved membership type from DB fallback",
         );
-        return fallbackParsed.data;
+        return { meta: fallbackParsed.data, subscription };
       }
     }
   }
@@ -239,6 +269,43 @@ async function resolveSubscriptionMembershipMetadata(
     "Could not resolve membership metadata for subscription",
   );
   return undefined;
+}
+
+/**
+ * Resolve the PaymentIntent ID that paid an invoice.
+ *
+ * Reads both shapes for the same reason as `invoiceSubscriptionId`:
+ *  - Pre-Basil endpoints: `invoice.payment_intent` is the PI directly
+ *  - Basil+ endpoints: PI lives in the (paginated) InvoicePayments list
+ */
+async function invoicePaymentIntentId(
+  stripe: Stripe,
+  invoice: Stripe.Invoice,
+  log: FastifyBaseLogger,
+): Promise<string | undefined> {
+  const legacyPi = (invoice as Stripe.Invoice & LegacyInvoiceShape)
+    .payment_intent;
+  if (legacyPi) {
+    return typeof legacyPi === "string" ? legacyPi : legacyPi.id;
+  }
+
+  try {
+    const payments = await stripe.invoicePayments.list({
+      invoice: invoice.id,
+      limit: 10,
+    });
+    const defaultPayment =
+      payments.data.find((p) => p.is_default) ?? payments.data[0];
+    const pi = defaultPayment?.payment.payment_intent;
+    if (!pi) return undefined;
+    return typeof pi === "string" ? pi : pi.id;
+  } catch (err) {
+    log.warn(
+      { err, invoiceId: invoice.id },
+      "invoice_payment_intent_lookup_failed",
+    );
+    return undefined;
+  }
 }
 
 export function handleInvoicePayment({
@@ -276,7 +343,7 @@ export function handleInvoicePayment({
       throw new Error(`Customer missing email: ${customerId}`);
     }
 
-    const meta = await resolveSubscriptionMembershipMetadata(
+    const resolved = await resolveSubscriptionMembershipMetadata(
       db,
       stripe,
       invoice,
@@ -284,16 +351,17 @@ export function handleInvoicePayment({
       log,
     );
 
-    if (!meta) {
+    if (!resolved) {
       return;
     }
 
+    const { meta, subscription } = resolved;
     const paidAt = stripeDate(eventCreated);
 
     const result = await membership({
       membershipType: meta.membership,
       email,
-      addedDuration: invoiceLinesToDuration(invoice.lines.data),
+      addedDuration: invoiceLinesToDuration(subscription.items.data),
       paidAt,
     });
 
@@ -302,10 +370,7 @@ export function handleInvoicePayment({
       ? `Membership renewal - ${meta.membership}`
       : `Membership payment - ${meta.membership}`;
 
-    const paymentIntentId =
-      typeof invoice.payment_intent === "string"
-        ? invoice.payment_intent
-        : invoice.payment_intent?.id;
+    const paymentIntentId = await invoicePaymentIntentId(stripe, invoice, log);
 
     const chargeResult = await charge({
       memberEmail: email,

--- a/apps/web/src/pages/purchase/purchase.tsx
+++ b/apps/web/src/pages/purchase/purchase.tsx
@@ -109,8 +109,8 @@ export function Component() {
         );
         return {
           clientSecret: result.clientSecret,
-          amount: 0,
-          productName: "Subscription",
+          amount: totalAmount,
+          productName: priceInfo?.productName ?? "Subscription",
         };
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,8 +201,8 @@ importers:
         specifier: ^0.34.5
         version: 0.34.5
       stripe:
-        specifier: ^17.5.0
-        version: 17.7.0
+        specifier: ^22.1.1
+        version: 22.1.1(@types/node@25.9.0)
       ts-pattern:
         specifier: ^5.6.0
         version: 5.9.0
@@ -7360,9 +7360,14 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
-  stripe@17.7.0:
-    resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
-    engines: {node: '>=12.*'}
+  stripe@22.1.1:
+    resolution: {integrity: sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
@@ -15910,10 +15915,9 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  stripe@17.7.0:
-    dependencies:
-      '@types/node': 25.8.0
-      qs: 6.15.0
+  stripe@22.1.1(@types/node@25.9.0):
+    optionalDependencies:
+      '@types/node': 25.9.0
 
   strnum@2.3.0: {}
 


### PR DESCRIPTION
## Summary

- Stripe SDK 17 → 22.1.1 (pinned API version `2026-04-22.dahlia`).
- Migrated all Basil (2025-03-31) field paths:
  - `Subscription.current_period_end` → `items.data[0].current_period_end`
  - `Invoice.subscription` → `parent.subscription_details.subscription`
  - `Invoice.payment_intent` → `InvoicePayments.list(...)` (default payment)
  - `Invoice.lines[].price` → resolved `subscription.items.data[].price`
  - `latest_invoice.payment_intent.client_secret` → `latest_invoice.confirmation_secret.client_secret`
- Field accessors are **dual-path**: read the legacy top-level fields when the webhook endpoint's `api_version` predates Basil (our current prod endpoint is `2023-10-16`), and fall back to the new paths when it has been rotated. Lets us deploy without coordinating a dashboard change.
- Fixed two latent bugs in `createSubscription` that pre-date this PR (since the v1 → v2 port): metadata was missing `type: "membership"` (so `membershipSchema.safeParse` failed and the handler hit the DB-fallback path) and `source: "direct"` (so the `subscription_create` guard always skipped the invoice). Net effect on prod: every direct-API senior subscription paid Stripe but never wrote a membership row. Worth a chat with the treasurer about manual reconciliation.
- Fixed `purchase.tsx` hard-coded `amount: 0` on the subscription branch (the second purchase step rendered "Pay £0.00" even though the first showed £15).
- Integration test added for the legacy invoice shape so the dual-path stays covered.

## Test plan

Local manual verification against live Stripe test mode:

- [x] Webhook regression sweep via `stripe trigger` for `invoice.payment_succeeded`, `invoice.payment_failed`, `customer.subscription.updated`, `payment_intent.succeeded` — all events processed cleanly, no terminal errors
- [x] End-to-end senior subscription purchase (UI → /api/subscribe → Stripe → webhook) — membership + £15 charge written, PI linked, paid_at populated
- [x] End-to-end junior signup (one-off PaymentIntent path) confirmed
- [x] Subscription renewal cycle via Stripe test clock — advanced 31d + 2h, `billing_reason: subscription_cycle` invoice auto-paid, `paid_until` extended by a month, second "Membership renewal" charge written
- [x] `/members` subscription rendering — `paidUntil` derived from `sub.items.data[0].current_period_end` displays correctly
- [x] Game sponsorship flow
- [x] Frontend purchase page shows correct "Pay £15.00" on the payment-method step
- [x] `pnpm test` (507 unit) + `pnpm test:integration` (356 integration) green
- [x] `pnpm build` green across all workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)