### PR TITLE
fix(matchday): strip ' - <suffix>' from team names in team news image

### DIFF
--- a/apps/api/src/features/matchday/team-news-image.ts
+++ b/apps/api/src/features/matchday/team-news-image.ts
@@ -73,9 +73,13 @@ function shortTeamLabel(teamName: string): string {
   return teamName.replace(/^Percy Main\s*/i, "").trim() || teamName;
 }
 
+function stripTeamSuffix(name: string): string {
+  return name.replace(/\s+-\s+.*$/, "").trim() || name;
+}
+
 function venueLabel(data: TeamNewsData): string {
   if (data.isHome) return "PERCY MAIN";
-  const first = data.opposition.split(" ")[0];
+  const first = stripTeamSuffix(data.opposition).split(" ")[0];
   return first.toUpperCase();
 }
 
@@ -133,8 +137,10 @@ function textPath(
 }
 
 function buildSvg(data: TeamNewsData, hasMatchSponsorLogo: boolean): string {
-  const teamShort = shortTeamLabel(data.teamName).toUpperCase();
-  const opposition = data.opposition.toUpperCase();
+  const teamShort = stripTeamSuffix(
+    shortTeamLabel(data.teamName),
+  ).toUpperCase();
+  const opposition = stripTeamSuffix(data.opposition).toUpperCase();
   const homeAway = data.isHome ? "H" : "A";
   const title = `${teamShort} V ${opposition} (${homeAway})`;
 


### PR DESCRIPTION
## Summary
- Long opposition names like "Tynemouth CC Tynemouth Willows - Women's Softball" overflow the team news image header.
- Strip any ` - <something>` suffix from both team and opposition before rendering the title; also applies to the away venue label so it still uses the first word of the cleaned name.

## Test plan
- [ ] Regenerate the team news image for a Women's Softball home fixture and confirm the header reads "WOMENS SOFTBALL V TYNEMOUTH CC TYNEMOUTH WILLOWS (H)".
- [ ] Confirm other fixtures (without a ` - ` suffix) still render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)