### PR TITLE
fix(matchday): fee-free teams + visible API errors on wrap

### DIFF
--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -602,6 +602,55 @@ describe("matchday service (integration)", () => {
         .executeTakeFirst();
       expect(link?.dependent_id).toBe(dependentId);
     });
+
+    it("treats a team with no team-scoped fee rates as fee-free and finishes cleanly", async () => {
+      // Women's softball case: the club deliberately leaves no
+      // match_fee_rate row for the team. A global / null-team default
+      // rate may exist for guests, but seniors on this team aren't
+      // covered by anything, so the validation must not fire and the
+      // charge loop just skips them.
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `nofees-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: userId });
+      // Use a category no prior test has seeded a global rate for, so
+      // the shared DB state from other tests can't accidentally make a
+      // rate "applicable" to this player.
+      const memberId = await seedMember(
+        "Free Player",
+        `free-${crypto.randomUUID()}@test.com`,
+        "no_fee_test_category",
+      );
+
+      const { id: playerId } = await addPlayer(ctx.db)(
+        userId,
+        "admin",
+        matchdayId,
+        { memberId, playerName: "Free Player" },
+      );
+
+      // No seedFeeRate call for teamId - the team has zero team-specific
+      // rates, so the captain can finish without inline overrides.
+      await finishAsTest(matchdayId, userId, {
+        playerStatuses: [{ matchdayPlayerId: playerId, status: "playing" }],
+      });
+
+      const md = await ctx.db
+        .selectFrom("matchday")
+        .where("id", "=", matchdayId)
+        .selectAll()
+        .executeTakeFirst();
+      expect(md?.status).toBe("finished");
+
+      const player = await ctx.db
+        .selectFrom("matchday_player")
+        .where("id", "=", playerId)
+        .selectAll()
+        .executeTakeFirst();
+      expect(player?.charge_id).toBeNull();
+    });
   });
 
   describe("markFeePaid", () => {

--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -603,26 +603,41 @@ describe("matchday service (integration)", () => {
       expect(link?.dependent_id).toBe(dependentId);
     });
 
-    it("treats a team with no team-scoped fee rates as fee-free and finishes cleanly", async () => {
+    it("treats a team with no team-scoped fee rates as fee-free even when a global rate exists", async () => {
       // Women's softball case: the club deliberately leaves no
-      // match_fee_rate row for the team. A global / null-team default
-      // rate may exist for guests, but seniors on this team aren't
-      // covered by anything, so the validation must not fire and the
-      // charge loop just skips them.
+      // match_fee_rate row for the team. A global (null-team) default
+      // rate exists for the player's category, but it must NOT raise a
+      // charge here - that's the bug codex flagged. The team having no
+      // own rates is the signal that it's fee-free.
       const { userId } = await seedTestUser(ctx.db, {
         email: `nofees-${crypto.randomUUID()}@test.com`,
         role: "admin",
       });
       const teamId = await seedTeam();
       const matchdayId = await seedMatchday({ teamId, createdBy: userId });
-      // Use a category no prior test has seeded a global rate for, so
-      // the shared DB state from other tests can't accidentally make a
-      // rate "applicable" to this player.
+      // Stamp a unique competition_type so the global rate below is
+      // uniquely scoped (the unique constraint on match_fee_rate covers
+      // (team, competition, category)).
+      const competitionType = `FeeFreeTest-${crypto.randomUUID().slice(0, 8)}`;
+      await ctx.db
+        .updateTable("matchday")
+        .set({ competition_type: competitionType })
+        .where("id", "=", matchdayId)
+        .execute();
       const memberId = await seedMember(
         "Free Player",
         `free-${crypto.randomUUID()}@test.com`,
-        "no_fee_test_category",
+        "senior",
       );
+
+      // Global null-team senior rate exists for this competition -
+      // mirrors the production null-team guest default. The fee-free
+      // team must still skip it.
+      await seedFeeRate({
+        competitionType,
+        memberCategory: "senior",
+        amountPence: 1000,
+      });
 
       const { id: playerId } = await addPlayer(ctx.db)(
         userId,
@@ -631,8 +646,6 @@ describe("matchday service (integration)", () => {
         { memberId, playerName: "Free Player" },
       );
 
-      // No seedFeeRate call for teamId - the team has zero team-specific
-      // rates, so the captain can finish without inline overrides.
       await finishAsTest(matchdayId, userId, {
         playerStatuses: [{ matchdayPlayerId: playerId, status: "playing" }],
       });

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -1248,37 +1248,50 @@ export function finishMatch(
         )
         .selectAll()
         .execute();
-      const missing: string[] = [];
-      for (const p of players) {
-        // "selected" is the pre-finish squad-picked state; if the captain
-        // submits the wrap without an explicit per-player status, default
-        // to playing so we still charge them.
-        const effectiveStatus =
-          statusOverrides.get(p.matchdayPlayerId) ?? p.current_status;
-        const willPlay =
-          effectiveStatus === "playing" || effectiveStatus === "selected";
-        if (!willPlay) continue;
-        let category: string | null = null;
-        if (p.member_id) {
-          category = p.member_category ?? "guest";
-        } else if (p.dependent_id && p.dependentParentId) {
-          category = "junior";
+      // A team with zero team-specific fee rates is intentionally
+      // fee-free (e.g. women's softball - the club deliberately leaves
+      // no match_fee_rate row for that team). Global / null-team rates
+      // still apply to guests, but they shouldn't force "missing fee"
+      // errors on the captains of fee-free teams. Only validate when
+      // the team has at least one rate of its own configured - that's
+      // when "we charge most of the team but accidentally skipped a
+      // category" becomes the likely interpretation.
+      const teamHasOwnRate = feeRates.some(
+        (r) => r.play_cricket_team_id === matchday.play_cricket_team_id,
+      );
+      if (teamHasOwnRate) {
+        const missing: string[] = [];
+        for (const p of players) {
+          // "selected" is the pre-finish squad-picked state; if the captain
+          // submits the wrap without an explicit per-player status, default
+          // to playing so we still charge them.
+          const effectiveStatus =
+            statusOverrides.get(p.matchdayPlayerId) ?? p.current_status;
+          const willPlay =
+            effectiveStatus === "playing" || effectiveStatus === "selected";
+          if (!willPlay) continue;
+          let category: string | null = null;
+          if (p.member_id) {
+            category = p.member_category ?? "guest";
+          } else if (p.dependent_id && p.dependentParentId) {
+            category = "junior";
+          }
+          if (!category) continue;
+          if (overrides.has(p.matchdayPlayerId)) continue;
+          const rate = findFeeRate(
+            feeRates,
+            matchday.play_cricket_team_id,
+            matchday.competition_type,
+            category,
+          );
+          if (!rate) missing.push(p.player_name);
         }
-        if (!category) continue;
-        if (overrides.has(p.matchdayPlayerId)) continue;
-        const rate = findFeeRate(
-          feeRates,
-          matchday.play_cricket_team_id,
-          matchday.competition_type,
-          category,
-        );
-        if (!rate) missing.push(p.player_name);
-      }
-      if (missing.length > 0) {
-        throwHttpError(
-          400,
-          `Missing fee for: ${missing.join(", ")}. Captain must enter an amount inline.`,
-        );
+        if (missing.length > 0) {
+          throwHttpError(
+            400,
+            `Missing fee for: ${missing.join(", ")}. Captain must enter an amount inline.`,
+          );
+        }
       }
     }
 

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -1385,6 +1385,14 @@ export function finishMatch(
         .selectAll()
         .execute();
 
+      // A team with zero team-specific rates is fee-free by design:
+      // ignore global / null-team fallback rates entirely so a generic
+      // guest-default doesn't sneak a charge onto a women's softball
+      // match. Inline overrides from the captain still apply.
+      const teamHasOwnRateForCharges = feeRates.some(
+        (r) => r.play_cricket_team_id === matchday.play_cricket_team_id,
+      );
+
       const applyRelief = applyReliefIfAny(trx);
       for (const player of uncharged) {
         let chargeMemberId: string;
@@ -1406,12 +1414,14 @@ export function finishMatch(
           continue;
         }
 
-        const rate = findFeeRate(
-          feeRates,
-          matchday.play_cricket_team_id,
-          matchday.competition_type,
-          category,
-        );
+        const rate = teamHasOwnRateForCharges
+          ? findFeeRate(
+              feeRates,
+              matchday.play_cricket_team_id,
+              matchday.competition_type,
+              category,
+            )
+          : undefined;
         const overrideAmount = overrides.get(player.matchdayPlayerId);
         const amountPence = overrideAmount ?? rate?.amount_pence ?? 0;
 

--- a/apps/matchday/src/lib/api-client.ts
+++ b/apps/matchday/src/lib/api-client.ts
@@ -37,6 +37,23 @@ export type ApiResponse<P extends keyof paths, M extends string = "get"> =
     ? R
     : never;
 
+/**
+ * Pull a human-readable message out of openapi-fetch's `error` slot. The
+ * Fastify error handler in apps/api/src/app.ts replies with
+ * `{ error: <message> }`, but the legacy shape `{ message: <...> }` shows
+ * up too (e.g. better-auth, validation plugins). Bare strings are sent by
+ * a few hand-rolled error paths. Anything else falls back to the HTTP
+ * status text so the user at least sees something useful.
+ */
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && error !== null) {
+    if ("error" in error && typeof error.error === "string") return error.error;
+    if ("message" in error) return String(error.message);
+  }
+  return fallback;
+}
+
 class ApiError extends Error {
   constructor(
     public status: number,
@@ -69,14 +86,7 @@ export async function callApi<T>(
       // for sign-in.
       void evictResponseFromRuntimeCaches(res.url);
     }
-    throw new ApiError(
-      res.status,
-      typeof error === "string"
-        ? error
-        : typeof error === "object" && error !== null && "message" in error
-          ? String(error.message)
-          : res.statusText,
-    );
+    throw new ApiError(res.status, extractErrorMessage(error, res.statusText));
   }
   return data as T;
 }

--- a/apps/matchday/src/pages/matchday-live.tsx
+++ b/apps/matchday/src/pages/matchday-live.tsx
@@ -139,17 +139,19 @@ export default function MatchdayLive() {
   const finished = md.matchday.status === "finished";
   const playing = md.players.filter((p) => resolveStatus(p) === "playing");
   const dropouts = md.players.filter((p) => resolveStatus(p) !== "playing");
-  // "Settled" means the captain doesn't need to chase the player — either
+  // "Settled" means the captain doesn't need to chase the player - either
   // they've paid or the treasurer's already waived the donation via the
   // financial-relief workflow (charge.relieved_at, projected as
   // chargeStatus === "waived"). Either way, the row shows green and is
-  // unactionable.
+  // unactionable. chargeStatus === null means there's no charge to
+  // settle at all (fee-free teams like women's softball, or a player
+  // whose category resolves to 0 pence), so they shouldn't count as
+  // unpaid and shouldn't get a mark-paid affordance.
   const isSettled = (status: string | null) =>
     status === "paid" || status === "waived";
+  const hasCharge = (p: MatchdayPlayer) => p.chargeStatus !== null;
   const paid = playing.filter((p) => isSettled(p.chargeStatus)).length;
-  const unpaid = playing.filter(
-    (p) => p.chargeStatus === "unpaid" || p.chargeStatus === null,
-  ).length;
+  const unpaid = playing.filter((p) => p.chargeStatus === "unpaid").length;
 
   return (
     <div className="bg-surface flex min-h-dvh flex-col">
@@ -215,7 +217,7 @@ export default function MatchdayLive() {
               {finished ? (
                 <button
                   type="button"
-                  disabled={isPaid || status !== "playing"}
+                  disabled={isPaid || status !== "playing" || !hasCharge(p)}
                   onClick={() =>
                     markPaid.mutate({ playerId: p.id, paymentMethod: method })
                   }
@@ -255,11 +257,13 @@ export default function MatchdayLive() {
                         ? p.chargePaidAt
                           ? `Paid · ${new Date(p.chargePaidAt).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })}`
                           : "Paid"
-                        : `${resolveCategory(p)} · donation due`
+                        : hasCharge(p)
+                          ? `${resolveCategory(p)} · donation due`
+                          : resolveCategory(p)
                     : resolveCategory(p)}
                 </p>
               </div>
-              {finished && status === "playing" && !isPaid && (
+              {finished && status === "playing" && !isPaid && hasCharge(p) && (
                 <select
                   aria-label="Payment method"
                   value={method}

--- a/apps/matchday/src/pages/matchday-live.tsx
+++ b/apps/matchday/src/pages/matchday-live.tsx
@@ -664,6 +664,15 @@ function FinishSheet({
         no-result
       </p>
 
+      {errorText && (
+        <div
+          role="alert"
+          className="border-danger bg-danger-bg/40 text-danger mt-4 rounded-xl border p-3 text-sm"
+        >
+          {errorText}
+        </div>
+      )}
+
       <div className="bg-surface-raised mt-4 space-y-1 rounded-xl p-3 text-sm">
         <Row label={`${playingPlayers.length} playing`}>
           will be charged · donation emails sent
@@ -709,7 +718,6 @@ function FinishSheet({
       <Button tone="outline" className="mt-2 w-full" onClick={onClose}>
         Cancel
       </Button>
-      {errorText && <p className="text-danger mt-2 text-sm">{errorText}</p>}
     </Sheet>
   );
 }
@@ -784,7 +792,7 @@ function Sheet({
       <div
         ref={panelRef}
         onClick={(e) => e.stopPropagation()}
-        className="bg-surface w-full max-w-md rounded-t-3xl p-5 pb-[max(env(safe-area-inset-bottom),24px)] shadow-2xl md:rounded-3xl"
+        className="bg-surface max-h-[90dvh] w-full max-w-md overflow-y-auto rounded-t-3xl p-5 pb-[max(env(safe-area-inset-bottom),24px)] shadow-2xl md:rounded-3xl"
       >
         <div className="bg-border mx-auto mb-3 h-1 w-9 rounded-full" />
         <div className="flex items-center justify-between">

--- a/apps/matchday/src/pages/matchday-live.tsx
+++ b/apps/matchday/src/pages/matchday-live.tsx
@@ -127,6 +127,15 @@ export default function MatchdayLive() {
     return "playing";
   };
 
+  // Juniors live in the `dependent` table - they have no member row of
+  // their own, so member_category comes back null and the row would
+  // otherwise label as the generic "Adult" fallback. Match the
+  // server-side fee derivation in finishMatch (see service.ts:1382).
+  const resolveCategory = (p: MatchdayPlayer): string => {
+    if (p.dependent_id) return "junior";
+    return p.member_category ?? "adult";
+  };
+
   const finished = md.matchday.status === "finished";
   const playing = md.players.filter((p) => resolveStatus(p) === "playing");
   const dropouts = md.players.filter((p) => resolveStatus(p) !== "playing");
@@ -246,8 +255,8 @@ export default function MatchdayLive() {
                         ? p.chargePaidAt
                           ? `Paid · ${new Date(p.chargePaidAt).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })}`
                           : "Paid"
-                        : `${p.member_category ?? "Adult"} · donation due`
-                    : (p.member_category ?? "Adult")}
+                        : `${resolveCategory(p)} · donation due`
+                    : resolveCategory(p)}
                 </p>
               </div>
               {finished && status === "playing" && !isPaid && (

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -19,6 +19,23 @@
 import createClient from "openapi-fetch";
 import type { paths } from "./api.gen.js";
 
+/**
+ * Pull a human-readable message out of openapi-fetch's `error` slot. The
+ * Fastify error handler in apps/api/src/app.ts replies with
+ * `{ error: <message> }`, but the legacy shape `{ message: <...> }` shows
+ * up too (e.g. better-auth, validation plugins). Bare strings are sent by
+ * a few hand-rolled error paths. Anything else falls back to the HTTP
+ * status text so the user at least sees something useful.
+ */
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && error !== null) {
+    if ("error" in error && typeof error.error === "string") return error.error;
+    if ("message" in error) return String(error.message);
+  }
+  return fallback;
+}
+
 class ApiError extends Error {
   constructor(
     public status: number,
@@ -49,14 +66,7 @@ export async function callApi<T>(
 ): Promise<T> {
   const { data, error, response: res } = await response;
   if (error !== undefined) {
-    throw new ApiError(
-      res.status,
-      typeof error === "string"
-        ? error
-        : typeof error === "object" && error !== null && "message" in error
-          ? String(error.message)
-          : res.statusText,
-    );
+    throw new ApiError(res.status, extractErrorMessage(error, res.statusText));
   }
   return data as T;
 }


### PR DESCRIPTION
## Summary
- finishMatch: only require fee_rate coverage when the team has at least one team-scoped rate. Women's softball (no team rates, just a global guest default) was hitting 400 every wrap.
- callApi (both web + matchday): pull the message out of Fastify's \`{error: <msg>}\` envelope. Every API error in both apps was surfacing as "Bad Request" because the client only looked for \`error.message\`.
- Wrap modal: move the error alert above the summary box, make the sheet scrollable (max-h: 90dvh). Previously the alert was rendered below the Cancel button and the donation-rows pushed the whole thing off-screen on mobile.

## Test plan
- [x] New integration test: team with no team-scoped rates finishes cleanly, no charge raised, even with a global default rate present.
- [x] All 30 matchday integration tests + 21 unit tests pass.
- [x] Typecheck + lint clean.
- [ ] On staging: reproduce the women's softball wrap and confirm Confirm goes green, charges row stays at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)