### PR TITLE
fix(financial-relief): apply membership relief atomically on approval

### DIFF
--- a/apps/api/src/features/financial-relief/integration.test.ts
+++ b/apps/api/src/features/financial-relief/integration.test.ts
@@ -896,6 +896,89 @@ describe("financial-relief (integration)", () => {
     expect(event.note).toContain("senior_player");
   });
 
+  it("decideReliefRequest with membershipApply atomically applies membership relief", async () => {
+    const admin = await seedTestUser(ctx.db, { role: "admin" });
+    const member = await seedMember();
+    const send = vi.fn().mockResolvedValue(undefined);
+    const submit = submitReliefRequest(ctx.db, {
+      baseUrl: "https://percymain.org",
+      send,
+    });
+    const { id: requestId } = await submit(
+      member.userId,
+      member.email,
+      validSubmission({
+        memberId: member.memberId,
+        requestedMembershipFull: true,
+        requestedMatchFees: false,
+      }),
+      log,
+    );
+    const stripeStub = {
+      paymentIntents: { retrieve: vi.fn() },
+    } as unknown as import("stripe").default;
+
+    const result = await decideReliefRequest(ctx.db, {
+      stripe: stripeStub,
+      baseUrl: "https://percymain.org",
+      send,
+    })(
+      admin.userId,
+      requestId,
+      {
+        decision: "approved_temporary",
+        coversMembership: true,
+        coversMatchFees: false,
+        membershipPartialPence: null,
+        effectiveFrom: "2026-05-21",
+        effectiveToExclusive: "2026-12-31",
+        adminNotes: null,
+        memberFacingNote: null,
+        membershipApply: {
+          amountPence: 2500,
+          membershipPaidUntil: "2026-12-31",
+          membershipType: "concessionary",
+          description: "Concessionary membership (relief)",
+        },
+      },
+      log,
+    );
+
+    expect(result.grantId).toBeTruthy();
+
+    // Relieved charge created with the right grant linkage.
+    const charge = await ctx.db
+      .selectFrom("charge")
+      .where("relief_grant_id", "=", result.grantId)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(charge.type).toBe("membership");
+    expect(charge.amount_pence).toBe(2500);
+    expect(charge.relieved_at).not.toBeNull();
+    expect(charge.charge_date).toContain("2026-05-21");
+
+    // Membership row upserted with paid_until.
+    const membership = await ctx.db
+      .selectFrom("membership")
+      .where("member_id", "=", member.memberId)
+      .where("type", "=", "concessionary")
+      .select(["paid_until"])
+      .executeTakeFirstOrThrow();
+    expect(membership.paid_until).toContain("2026-12-31");
+
+    // Audit event emitted alongside grant_created in the same tx.
+    const events = await ctx.db
+      .selectFrom("financial_relief_event")
+      .where("request_id", "=", requestId)
+      .select(["event_type"])
+      .orderBy("created_at", "asc")
+      .execute();
+    expect(events.map((e) => e.event_type)).toEqual([
+      "grant_created",
+      "membership_relief_applied",
+    ]);
+  });
+
   it("applyMembershipRelief rejects when the grant does not cover membership or is closed", async () => {
     const admin = await seedTestUser(ctx.db, { role: "admin" });
     const member = await seedMember();

--- a/apps/api/src/features/financial-relief/schemas.ts
+++ b/apps/api/src/features/financial-relief/schemas.ts
@@ -95,6 +95,14 @@ export type DeclineRequest = z.infer<typeof declineRequestSchema>;
 
 // --- Admin decide --------------------------------------------------------
 
+const membershipApplySchema = z.object({
+  amountPence: z.number().int().nonnegative(),
+  membershipPaidUntil: z.string().min(1), // ISO date
+  membershipType: z.string().min(1).max(100),
+  description: z.string().min(1).max(500),
+});
+export type MembershipApply = z.infer<typeof membershipApplySchema>;
+
 export const decideReliefRequestSchema = z
   .object({
     decision: grantDecisionSchema,
@@ -110,10 +118,20 @@ export const decideReliefRequestSchema = z
     effectiveToExclusive: z.string().nullable().optional(),
     adminNotes: z.string().max(4000).nullable().optional(),
     memberFacingNote: z.string().max(2000).nullable().optional(),
+    // Required when coversMembership=true: rolls the existing
+    // applyMembershipRelief work into the decide transaction so the
+    // member's paid_until + relieved charge land atomically with the
+    // grant. Kept optional at the schema level so the refine below
+    // owns the error message.
+    membershipApply: membershipApplySchema.nullable().optional(),
   })
   .refine((d) => d.coversMembership || d.coversMatchFees, {
     message: "Approval must cover at least one of membership or match fees",
     path: ["coversMatchFees"],
+  })
+  .refine((d) => !d.coversMembership || !!d.membershipApply, {
+    message: "Membership details are required when coversMembership is true",
+    path: ["membershipApply"],
   });
 export type DecideReliefRequest = z.infer<typeof decideReliefRequestSchema>;
 

--- a/apps/api/src/features/financial-relief/service.ts
+++ b/apps/api/src/features/financial-relief/service.ts
@@ -6,7 +6,7 @@ import {
 } from "@percy-main/email";
 import type { RequestStatus } from "@percy-main/shared";
 import type { FastifyBaseLogger } from "fastify";
-import { sql, type Kysely } from "kysely";
+import { sql, type Kysely, type Transaction } from "kysely";
 import { createElement } from "react";
 import { render } from "react-email";
 import type Stripe from "stripe";
@@ -16,6 +16,7 @@ import type {
   DecideReliefRequest,
   DeclineRequest,
   ListReliefRequests,
+  MembershipApply,
   ReliefReport,
   SubmitReliefRequest,
   TransitionStatus,
@@ -700,6 +701,102 @@ export function declineReliefRequest(db: Kysely<DB>) {
   };
 }
 
+/**
+ * Inserts a relieved membership charge, upserts the member's
+ * membership.paid_until, and emits a membership_relief_applied
+ * audit event. Shared between the inline-from-decide path (when a
+ * grant covering membership is created with membership details in
+ * one round-trip) and the legacy /grants/:id/apply-membership route
+ * used to retro-apply against existing grants.
+ *
+ * Must be invoked inside an existing transaction so the grant +
+ * membership rows commit together.
+ */
+async function applyMembershipReliefInTrx(
+  trx: Transaction<DB>,
+  args: {
+    adminUserId: string;
+    grantId: string;
+    requestId: string;
+    memberId: string;
+    chargeDate: string; // ISO date for the synthetic charge
+    apply: MembershipApply;
+  },
+): Promise<{ chargeId: string }> {
+  const chargeId = crypto.randomUUID();
+  const nowIso = new Date().toISOString();
+
+  await trx
+    .insertInto("charge")
+    .values({
+      id: chargeId,
+      member_id: args.memberId,
+      description: args.apply.description,
+      amount_pence: args.apply.amountPence,
+      charge_date: args.chargeDate,
+      created_by: args.adminUserId,
+      type: "membership",
+      source: "financial_relief",
+      relieved_at: nowIso,
+      relieved_by: args.adminUserId,
+      relieved_reason: "financial relief",
+      relief_grant_id: args.grantId,
+    })
+    .execute();
+
+  const existing = await trx
+    .selectFrom("membership")
+    .where("member_id", "=", args.memberId)
+    .where((eb) =>
+      eb.or([
+        eb("type", "=", args.apply.membershipType),
+        eb("type", "is", null),
+      ]),
+    )
+    .select(["id", "type", "paid_until"])
+    .executeTakeFirst();
+
+  if (existing) {
+    const nextPaidUntil =
+      new Date(args.apply.membershipPaidUntil) > new Date(existing.paid_until)
+        ? args.apply.membershipPaidUntil
+        : existing.paid_until;
+    await trx
+      .updateTable("membership")
+      .set({
+        paid_until: nextPaidUntil,
+        ...(existing.type ? {} : { type: args.apply.membershipType }),
+      })
+      .where("id", "=", existing.id)
+      .execute();
+  } else {
+    await trx
+      .insertInto("membership")
+      .values({
+        id: crypto.randomUUID(),
+        member_id: args.memberId,
+        type: args.apply.membershipType,
+        paid_until: args.apply.membershipPaidUntil,
+      })
+      .execute();
+  }
+
+  await trx
+    .insertInto("financial_relief_event")
+    .values({
+      id: crypto.randomUUID(),
+      request_id: args.requestId,
+      event_type: "membership_relief_applied",
+      from_status: null,
+      to_status: null,
+      note: `${args.apply.membershipType} until ${args.apply.membershipPaidUntil} (£${(args.apply.amountPence / 100).toFixed(2)})`,
+      actor_user_id: args.adminUserId,
+    })
+    .execute();
+
+  return { chargeId };
+}
+
 interface DecideDeps {
   stripe: Stripe;
   baseUrl: string;
@@ -810,6 +907,21 @@ export function decideReliefRequest(db: Kysely<DB>, deps: DecideDeps) {
           actor_user_id: adminUserId,
         })
         .execute();
+
+      // If the grant covers membership, apply it atomically here so
+      // the member's paid_until + relieved charge land together with
+      // the grant. The decide schema's refine guarantees that
+      // `membershipApply` is present whenever `coversMembership`.
+      if (data.coversMembership && data.membershipApply) {
+        await applyMembershipReliefInTrx(trx, {
+          adminUserId,
+          grantId,
+          requestId,
+          memberId: request.member_id,
+          chargeDate: data.effectiveFrom,
+          apply: data.membershipApply,
+        });
+      }
 
       // Retroactively forgive unpaid match-fee charges issued on or
       // after `effective_from`, with no live Stripe PI. A PI in
@@ -1041,82 +1153,21 @@ export function applyMembershipRelief(db: Kysely<DB>) {
       httpError(400, "This grant does not cover membership");
     }
 
-    const chargeId = crypto.randomUUID();
-    const nowIso = new Date().toISOString();
-
-    await db.transaction().execute(async (trx) => {
-      // 1. Relieved membership charge — keeps amount_pence for reporting.
-      await trx
-        .insertInto("charge")
-        .values({
-          id: chargeId,
-          member_id: grant.member_id,
+    return db.transaction().execute((trx) =>
+      applyMembershipReliefInTrx(trx, {
+        adminUserId,
+        grantId,
+        requestId: grant.request_id,
+        memberId: grant.member_id,
+        chargeDate: data.effectiveDate,
+        apply: {
+          amountPence: data.amountPence,
+          membershipPaidUntil: data.membershipPaidUntil,
+          membershipType: data.membershipType,
           description: data.description,
-          amount_pence: data.amountPence,
-          charge_date: data.effectiveDate,
-          created_by: adminUserId,
-          type: "membership",
-          source: "financial_relief",
-          relieved_at: nowIso,
-          relieved_by: adminUserId,
-          relieved_reason: "financial relief",
-          relief_grant_id: grantId,
-        })
-        .execute();
-
-      // 2. Upsert membership.paid_until.
-      const existing = await trx
-        .selectFrom("membership")
-        .where("member_id", "=", grant.member_id)
-        .where((eb) =>
-          eb.or([eb("type", "=", data.membershipType), eb("type", "is", null)]),
-        )
-        .select(["id", "type", "paid_until"])
-        .executeTakeFirst();
-
-      if (existing) {
-        // Only extend, never shorten. (Admins occasionally call this
-        // twice in a session; second call shouldn't roll back paid_until.)
-        const nextPaidUntil =
-          new Date(data.membershipPaidUntil) > new Date(existing.paid_until)
-            ? data.membershipPaidUntil
-            : existing.paid_until;
-        await trx
-          .updateTable("membership")
-          .set({
-            paid_until: nextPaidUntil,
-            ...(existing.type ? {} : { type: data.membershipType }),
-          })
-          .where("id", "=", existing.id)
-          .execute();
-      } else {
-        await trx
-          .insertInto("membership")
-          .values({
-            id: crypto.randomUUID(),
-            member_id: grant.member_id,
-            type: data.membershipType,
-            paid_until: data.membershipPaidUntil,
-          })
-          .execute();
-      }
-
-      // 3. Audit event.
-      await trx
-        .insertInto("financial_relief_event")
-        .values({
-          id: crypto.randomUUID(),
-          request_id: grant.request_id,
-          event_type: "membership_relief_applied",
-          from_status: null,
-          to_status: null,
-          note: `${data.membershipType} until ${data.membershipPaidUntil} (£${(data.amountPence / 100).toFixed(2)})`,
-          actor_user_id: adminUserId,
-        })
-        .execute();
-    });
-
-    return { chargeId };
+        },
+      }),
+    );
   };
 }
 

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -11793,6 +11793,12 @@ export interface paths {
                         effectiveToExclusive?: string | null;
                         adminNotes?: string | null;
                         memberFacingNote?: string | null;
+                        membershipApply?: {
+                            amountPence: number;
+                            membershipPaidUntil: string;
+                            membershipType: string;
+                            description: string;
+                        } | null;
                     };
                 };
             };

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -21385,6 +21385,37 @@
                     "nullable": true,
                     "type": "string",
                     "maxLength": 2000
+                  },
+                  "membershipApply": {
+                    "nullable": true,
+                    "type": "object",
+                    "properties": {
+                      "amountPence": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "membershipPaidUntil": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "membershipType": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 100
+                      },
+                      "description": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 500
+                      }
+                    },
+                    "required": [
+                      "amountPence",
+                      "membershipPaidUntil",
+                      "membershipType",
+                      "description"
+                    ]
                   }
                 },
                 "required": [

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -11793,6 +11793,12 @@ export interface paths {
                         effectiveToExclusive?: string | null;
                         adminNotes?: string | null;
                         memberFacingNote?: string | null;
+                        membershipApply?: {
+                            amountPence: number;
+                            membershipPaidUntil: string;
+                            membershipType: string;
+                            description: string;
+                        } | null;
                     };
                 };
             };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -21385,6 +21385,37 @@
                     "nullable": true,
                     "type": "string",
                     "maxLength": 2000
+                  },
+                  "membershipApply": {
+                    "nullable": true,
+                    "type": "object",
+                    "properties": {
+                      "amountPence": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "membershipPaidUntil": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "membershipType": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 100
+                      },
+                      "description": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 500
+                      }
+                    },
+                    "required": [
+                      "amountPence",
+                      "membershipPaidUntil",
+                      "membershipType",
+                      "description"
+                    ]
                   }
                 },
                 "required": [

--- a/apps/web/src/pages/admin/financial-relief-tab.tsx
+++ b/apps/web/src/pages/admin/financial-relief-tab.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { api, callApi } from "@/lib/api-client";
+import type { paths } from "@/lib/api.gen";
 import {
   CONTACT_PREFERENCE_LABELS,
   CONTRIBUTION_ABILITY_LABELS,
@@ -573,9 +574,10 @@ function RequestDetailDialog({
             onClose={() => setDeclineDialogOpen(false)}
           />
         ) : null}
-        {decideDialogOpen ? (
+        {decideDialogOpen && detailQuery.data ? (
           <DecideDialog
             requestId={requestId}
+            request={detailQuery.data.request}
             onClose={() => setDecideDialogOpen(false)}
           />
         ) : null}
@@ -688,7 +690,19 @@ interface DecideFormState {
   effectiveToExclusive: string;
   adminNotes: string;
   memberFacingNote: string;
+  // Membership apply fields — only sent when coversMembership=true.
+  membershipPresetKey: string;
+  membershipAmountPounds: string;
+  membershipPaidUntil: string;
+  membershipType: string;
+  membershipDescription: string;
 }
+
+type ReliefRequestDetail =
+  paths["/api/admin/financial-relief/requests/{requestId}"]["get"]["responses"]["200"]["content"]["application/json"]["request"];
+
+type MembershipPrices =
+  paths["/api/membership/prices"]["get"]["responses"]["200"]["content"]["application/json"];
 
 function todayIso(): string {
   const d = new Date();
@@ -704,24 +718,214 @@ function poundsToPenceOrNull(input: string): number | null {
   return Math.round(parsed * 100);
 }
 
+const FREEFORM_PRESET_KEY = "__freeform__";
+
+interface MembershipPreset {
+  key: string;
+  label: string;
+  amountPounds: string;
+  membershipType: string;
+  description: string;
+}
+
+function buildMembershipPresets(
+  prices: MembershipPrices | undefined,
+): MembershipPreset[] {
+  if (!prices) return [];
+  const presets: MembershipPreset[] = [];
+  const categories: Array<keyof MembershipPrices> = [
+    "senior_player",
+    "senior_women_player",
+    "social",
+    "concessionary",
+  ];
+  for (const key of categories) {
+    const product = prices[key];
+    for (const period of ["annually", "monthly"] as const) {
+      const price = product[period];
+      const periodLabel = period === "annually" ? "annual" : "monthly";
+      presets.push({
+        key: `${key}__${period}`,
+        label: `${product.name} (${periodLabel}) - ${price.formattedPrice}`,
+        amountPounds: (price.unitAmount / 100).toFixed(2),
+        membershipType: key,
+        description: `${product.name} (${periodLabel}) - financial relief`,
+      });
+    }
+  }
+  return presets;
+}
+
+interface MembershipFieldsValue {
+  presetKey: string;
+  amountPounds: string;
+  paidUntil: string;
+  type: string;
+  description: string;
+}
+
+function MembershipReliefFields({
+  value,
+  onChange,
+}: {
+  value: MembershipFieldsValue;
+  onChange: (patch: Partial<MembershipFieldsValue>) => void;
+}) {
+  const pricesQuery = useQuery({
+    queryKey: ["membership-prices"],
+    queryFn: () => callApi(api.GET("/api/membership/prices")),
+    staleTime: 5 * 60 * 1000,
+  });
+  const presets = useMemo(
+    () => buildMembershipPresets(pricesQuery.data),
+    [pricesQuery.data],
+  );
+
+  const applyPreset = (presetKey: string) => {
+    if (presetKey === FREEFORM_PRESET_KEY) {
+      onChange({ presetKey: FREEFORM_PRESET_KEY });
+      return;
+    }
+    const preset = presets.find((p) => p.key === presetKey);
+    if (!preset) return;
+    onChange({
+      presetKey: preset.key,
+      amountPounds: preset.amountPounds,
+      type: preset.membershipType,
+      description: preset.description,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded border border-stone-200 p-3">
+      <p className="text-sm font-medium">Membership relief details</p>
+      <p className="text-xs text-stone-600">
+        Applied atomically with the grant - creates a relieved membership charge
+        for reporting and extends the member&apos;s paid-until date.
+      </p>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="membershipPresetKey">Category</Label>
+        <Select
+          value={value.presetKey}
+          onValueChange={applyPreset}
+          disabled={pricesQuery.isLoading}
+        >
+          <SelectTrigger id="membershipPresetKey">
+            <SelectValue
+              placeholder={
+                pricesQuery.isLoading
+                  ? "Loading categories..."
+                  : "Choose category"
+              }
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {presets.map((p) => (
+              <SelectItem key={p.key} value={p.key}>
+                {p.label}
+              </SelectItem>
+            ))}
+            <SelectItem value={FREEFORM_PRESET_KEY}>Other (custom)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="membershipAmountPounds">Amount (in £)</Label>
+          <Input
+            id="membershipAmountPounds"
+            type="number"
+            min="0"
+            step="0.01"
+            value={value.amountPounds}
+            onChange={(e) =>
+              onChange({
+                amountPounds: e.target.value,
+                presetKey: FREEFORM_PRESET_KEY,
+              })
+            }
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="membershipPaidUntil">Paid until</Label>
+          <Input
+            id="membershipPaidUntil"
+            type="date"
+            value={value.paidUntil}
+            onChange={(e) => onChange({ paidUntil: e.target.value })}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="membershipType">Membership type</Label>
+        <Input
+          id="membershipType"
+          placeholder="e.g. concessionary"
+          value={value.type}
+          onChange={(e) =>
+            onChange({
+              type: e.target.value,
+              presetKey: FREEFORM_PRESET_KEY,
+            })
+          }
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="membershipDescription">Description</Label>
+        <Input
+          id="membershipDescription"
+          placeholder="e.g. Senior membership (relief)"
+          value={value.description}
+          onChange={(e) =>
+            onChange({
+              description: e.target.value,
+              presetKey: FREEFORM_PRESET_KEY,
+            })
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
 function DecideDialog({
   requestId,
+  request,
   onClose,
 }: {
   requestId: string;
+  request: ReliefRequestDetail;
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
-  const [form, update] = useState<DecideFormState>({
+  const requestedMembership =
+    request.requestedMembershipFull || request.requestedMembershipPartial;
+  const [form, update] = useState<DecideFormState>(() => ({
     decision: "approved_temporary",
-    coversMembership: false,
-    coversMatchFees: true,
+    coversMembership: requestedMembership,
+    coversMatchFees: request.requestedMatchFees,
     membershipPartialPounds: "",
     effectiveFrom: todayIso(),
-    effectiveToExclusive: "",
+    effectiveToExclusive: endOfYearIso(),
     adminNotes: "",
     memberFacingNote: "",
-  });
+    membershipPresetKey: FREEFORM_PRESET_KEY,
+    membershipAmountPounds: "",
+    membershipPaidUntil: endOfYearIso(),
+    membershipType: "",
+    membershipDescription: "",
+  }));
+
+  const membershipAmountPence = poundsToPenceOrNull(
+    form.membershipAmountPounds,
+  );
+  const membershipApplyValid =
+    !form.coversMembership ||
+    (membershipAmountPence !== null &&
+      membershipAmountPence > 0 &&
+      !!form.membershipPaidUntil &&
+      !!form.membershipType &&
+      !!form.membershipDescription);
 
   const decide = useMutation({
     mutationFn: () =>
@@ -740,6 +944,14 @@ function DecideDialog({
             effectiveToExclusive: form.effectiveToExclusive || null,
             adminNotes: form.adminNotes || null,
             memberFacingNote: form.memberFacingNote || null,
+            membershipApply: form.coversMembership
+              ? {
+                  amountPence: membershipAmountPence ?? 0,
+                  membershipPaidUntil: form.membershipPaidUntil,
+                  membershipType: form.membershipType,
+                  description: form.membershipDescription,
+                }
+              : null,
           },
         }),
       ),
@@ -755,6 +967,7 @@ function DecideDialog({
   const canSubmit =
     (form.coversMembership || form.coversMatchFees) &&
     !!form.effectiveFrom &&
+    membershipApplyValid &&
     !decide.isPending;
 
   return (
@@ -845,6 +1058,37 @@ function DecideDialog({
                 }
               />
             </div>
+          ) : null}
+          {form.coversMembership ? (
+            <MembershipReliefFields
+              value={{
+                presetKey: form.membershipPresetKey,
+                amountPounds: form.membershipAmountPounds,
+                paidUntil: form.membershipPaidUntil,
+                type: form.membershipType,
+                description: form.membershipDescription,
+              }}
+              onChange={(patch) =>
+                update((s) => ({
+                  ...s,
+                  ...(patch.presetKey !== undefined
+                    ? { membershipPresetKey: patch.presetKey }
+                    : {}),
+                  ...(patch.amountPounds !== undefined
+                    ? { membershipAmountPounds: patch.amountPounds }
+                    : {}),
+                  ...(patch.paidUntil !== undefined
+                    ? { membershipPaidUntil: patch.paidUntil }
+                    : {}),
+                  ...(patch.type !== undefined
+                    ? { membershipType: patch.type }
+                    : {}),
+                  ...(patch.description !== undefined
+                    ? { membershipDescription: patch.description }
+                    : {}),
+                }))
+              }
+            />
           ) : null}
           <div className="grid grid-cols-2 gap-3">
             <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Summary

Four issues, one root cause: approving a relief grant that covers membership did not create the membership row, extend `paid_until`, or insert a relieved charge — a second "Apply membership relief" click was needed. When skipped, the relief summary showed £0, admin saw "No membership record found" on the member, and the member's own area showed "No Membership / Join Now". The Approve dialog also pre-selected the wrong checkboxes (always match fees).

- Decide dialog seeds `coversMembership` / `coversMatchFees` from the member's request flags.
- `decideReliefRequestSchema` gains a `membershipApply { amountPence, membershipPaidUntil, membershipType, description }` block, required (via refine) when `coversMembership=true`. The decide tx now inserts the relieved charge, upserts `membership.paid_until`, and emits the `membership_relief_applied` event in the same tx as the grant.
- New `MembershipReliefFields` sub-component: category dropdown sourced from `/api/membership/prices` (4 categories × annually/monthly) + "Other (custom)". Selecting a preset auto-fills amount/type/description; manual edits flip back to freeform.
- Both `effectiveToExclusive` (grant end) and `membershipPaidUntil` default to end-of-calendar-year, both editable, both independent.
- Legacy `/grants/:id/apply-membership` route still works for retro-applying against grants approved before this change (shared `applyMembershipReliefInTrx` helper).

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [x] Financial-relief integration suite — 23 tests pass, including new atomic-apply coverage
- [ ] After deploy: open an existing relief request (e.g. Alfie Hancock's `ae2993c3-bba2-48fc-a0dd-0ee4ca795e0a`), click "Apply membership relief" to backfill (legacy two-step path)
- [ ] After deploy: submit a new request → approve via the dialog with Concessionary preset → confirm relief summary updates, admin sees membership row, member sees their membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)