### PR TITLE
feat(matchday): push notifications + per-user channel prefs (#379)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -83,6 +83,14 @@ PHOENIX_API_KEY=phx-placeholder
 PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006
 PHOENIX_PROJECT_NAME=percy-main-scout
 
+# Web Push (VAPID) — required. Generate a keypair with:
+#   npx web-push generate-vapid-keys
+# The same keypair must be used across deploys; rotating it forces every
+# subscribed device to re-subscribe.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:support@notifications.percymain.org
+
 # External services
 SLACK_WEBHOOK_URL=
 PLAY_CRICKET_API_TOKEN=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -67,6 +67,7 @@
     "sharp": "^0.34.5",
     "stripe": "^22.1.1",
     "ts-pattern": "^5.6.0",
+    "web-push": "^3.6.7",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -77,6 +78,7 @@
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
     "@types/supertest": "^7.2.0",
+    "@types/web-push": "^3.6.4",
     "@vitest/coverage-v8": "^4.1.6",
     "dotenv": "^17.4.2",
     "pino-pretty": "^13.1.3",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,7 @@ import type { Kysely, PostgresDialect } from "kysely";
 import type { Config } from "./config.ts";
 import { createAuth, type Auth } from "./features/auth/auth.ts";
 import { createPhoenixTracer } from "./lib/phoenix-tracer.ts";
+import { createPushSender, type SendPush } from "./lib/push-sender.ts";
 import {
   createS3DocumentStore,
   type S3DocumentStore,
@@ -54,10 +55,12 @@ import { marketingRoutes } from "./features/marketing/routes.ts";
 import { matchdayRoutes } from "./features/matchday/routes.ts";
 import { memberRoutes } from "./features/members/routes.ts";
 import { membershipRoutes } from "./features/membership/routes.ts";
+import { notifPrefsRoutes } from "./features/notification-preferences/routes.ts";
 import { ogImageRoutes } from "./features/og-image/routes.ts";
 import { paymentRoutes } from "./features/payments/routes.ts";
 import { webhookRoutes } from "./features/payments/webhook.ts";
 import { playCricketRoutes } from "./features/play-cricket/routes.ts";
+import { pushSubscriptionRoutes } from "./features/push-subscriptions/routes.ts";
 import { recordsRoutes } from "./features/records/routes.ts";
 import { scoutRoutes } from "./features/scout/routes.ts";
 import { sponsorshipRoutes } from "./features/sponsorship/routes.ts";
@@ -72,6 +75,7 @@ declare module "fastify" {
     config: Config;
     auth: Auth;
     send: (email: Email) => Promise<void>;
+    sendPush: SendPush;
     s3: S3Uploader;
     s3Documents: S3DocumentStore;
     scoutReports: ScoutReportStore;
@@ -174,6 +178,16 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
     fromAddress: config.SES_FROM_ADDRESS,
   });
   app.decorate("send", send);
+
+  // Create and decorate the Web Push sender. Same per-app pattern as
+  // sendEmail - features call app.sendPush(subscription, payload) and
+  // we surface a single retry / gone-detection point here.
+  const sendPush = createPushSender({
+    publicKey: config.VAPID_PUBLIC_KEY,
+    privateKey: config.VAPID_PRIVATE_KEY,
+    subject: config.VAPID_SUBJECT,
+  });
+  app.decorate("sendPush", sendPush);
 
   // Create and decorate the auth instance
   const auth = createAuth(config, dialect, db, send, app.log);
@@ -306,6 +320,8 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(financialReliefRoutes, { prefix: "/api" });
   await app.register(userGroupsRoutes, { prefix: "/api" });
   await app.register(marketingRoutes, { prefix: "/api" });
+  await app.register(notifPrefsRoutes, { prefix: "/api" });
+  await app.register(pushSubscriptionRoutes, { prefix: "/api" });
   await app.register(webhookRoutes, { prefix: "/api" });
   await app.register(ogImageRoutes, { prefix: "/api" });
 

--- a/apps/api/src/config.test.ts
+++ b/apps/api/src/config.test.ts
@@ -29,8 +29,12 @@ const baseEnv = {
   PHOENIX_API_KEY: "phx-test",
   PHOENIX_COLLECTOR_ENDPOINT: "http://localhost:6006/v1/traces",
   PHOENIX_PROJECT_NAME: "percy-main-scout-test",
-  VAPID_PUBLIC_KEY: "BTestPublicKey_PlaceholderForUnitTestsOnly",
-  VAPID_PRIVATE_KEY: "TestPrivateKey_PlaceholderForUnitTestsOnly",
+  // Real-shape dummy VAPID keypair (generated via web-push); config now
+  // validates by length/charset so the placeholder strings we used
+  // previously fail at parse time.
+  VAPID_PUBLIC_KEY:
+    "BJk5OBwHXbimx6NVTZT-4dLvrm9PkYCu1n3g-4KfRpkqSefZWi_b34N2JzEqvh0lEXTghy5NI8BLdGfhsa7iPvk",
+  VAPID_PRIVATE_KEY: "5zXXF30AFmWdn5V-K_W8spVINdk405SAyjSp5_a6aek",
   VAPID_SUBJECT: "mailto:test@example.com",
 };
 

--- a/apps/api/src/config.test.ts
+++ b/apps/api/src/config.test.ts
@@ -29,6 +29,9 @@ const baseEnv = {
   PHOENIX_API_KEY: "phx-test",
   PHOENIX_COLLECTOR_ENDPOINT: "http://localhost:6006/v1/traces",
   PHOENIX_PROJECT_NAME: "percy-main-scout-test",
+  VAPID_PUBLIC_KEY: "BTestPublicKey_PlaceholderForUnitTestsOnly",
+  VAPID_PRIVATE_KEY: "TestPrivateKey_PlaceholderForUnitTestsOnly",
+  VAPID_SUBJECT: "mailto:test@example.com",
 };
 
 describe("parseConfig — defaults", () => {

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -176,6 +176,18 @@ const configSchema = z.object({
   // Better Auth Dash (infra plugin — optional, only enabled when API key is set)
   BETTER_AUTH_API_KEY: z.string().optional(),
 
+  // Web Push (VAPID). Public + private keypair identifies this application
+  // server to the browser push services. Generated once via
+  // `npx web-push generate-vapid-keys` and stored: public key in SSM (the
+  // matchday app fetches it from /push/public-key before subscribing),
+  // private key in app_secrets Secrets Manager blob. VAPID_SUBJECT is a
+  // `mailto:` URL push services use to reach us if a push is misbehaving.
+  // All three required so a half-configured deploy fails fast at boot
+  // rather than at first send.
+  VAPID_PUBLIC_KEY: z.string().min(1),
+  VAPID_PRIVATE_KEY: z.string().min(1),
+  VAPID_SUBJECT: z.string().min(1),
+
   // External services
   SLACK_WEBHOOK_URL: z.url().optional(),
   PLAY_CRICKET_API_TOKEN: z.string().optional(),

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -182,11 +182,28 @@ const configSchema = z.object({
   // matchday app fetches it from /push/public-key before subscribing),
   // private key in app_secrets Secrets Manager blob. VAPID_SUBJECT is a
   // `mailto:` URL push services use to reach us if a push is misbehaving.
-  // All three required so a half-configured deploy fails fast at boot
-  // rather than at first send.
-  VAPID_PUBLIC_KEY: z.string().min(1),
-  VAPID_PRIVATE_KEY: z.string().min(1),
-  VAPID_SUBJECT: z.string().min(1),
+  //
+  // All three are validated by *shape* at boot (not just non-empty) so a
+  // deploy that forgets to populate the SSM/Secrets values - Terraform
+  // seeds them as the literal string "placeholder" - fails fast at task
+  // startup instead of silently breaking PushManager.subscribe() in the
+  // browser at first opt-in. Public key is 65 raw bytes (~87 base64url
+  // chars), private key is 32 raw bytes (~43 base64url chars).
+  VAPID_PUBLIC_KEY: z
+    .string()
+    .regex(
+      /^[A-Za-z0-9_-]{80,90}$/,
+      "VAPID_PUBLIC_KEY must be a base64url-encoded P-256 public key (~87 chars)",
+    ),
+  VAPID_PRIVATE_KEY: z
+    .string()
+    .regex(
+      /^[A-Za-z0-9_-]{40,50}$/,
+      "VAPID_PRIVATE_KEY must be a base64url-encoded P-256 private key (~43 chars)",
+    ),
+  VAPID_SUBJECT: z
+    .string()
+    .regex(/^mailto:.+@.+/, "VAPID_SUBJECT must be a mailto: URL"),
 
   // External services
   SLACK_WEBHOOK_URL: z.url().optional(),

--- a/apps/api/src/features/availability/notification.test.ts
+++ b/apps/api/src/features/availability/notification.test.ts
@@ -1,0 +1,240 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type {
+  PushSubscriptionInput,
+  SendPush,
+  SendPushResult,
+} from "../../lib/push-sender.ts";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import { upsertNotificationPreferences } from "../notification-preferences/service.ts";
+import { upsertPushSubscription } from "../push-subscriptions/service.ts";
+import { sendAvailabilityNotification } from "./service.ts";
+
+const log = createNoopLogger();
+
+let ctx: TestContext;
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+});
+
+afterAll(async () => {
+  await stopTestContainer(ctx);
+});
+
+async function seedRequest(userId: string) {
+  const requestId = crypto.randomUUID();
+  const teamId = `team-${crypto.randomUUID()}`;
+  await ctx.db
+    .insertInto("play_cricket_team")
+    .values({
+      id: teamId,
+      site_id: "9999",
+      name: "Test 1st XI",
+    })
+    .execute();
+  await ctx.db
+    .insertInto("availability_request")
+    .values({
+      id: requestId,
+      created_by: userId,
+      date_from: "2026-06-01",
+      date_to: "2026-06-30",
+      status: "open",
+    })
+    .execute();
+  await ctx.db
+    .insertInto("availability_fixture")
+    .values({
+      id: crypto.randomUUID(),
+      availability_request_id: requestId,
+      match_date: "2026-06-07",
+      play_cricket_match_id: `pc-${crypto.randomUUID()}`,
+      play_cricket_team_id: teamId,
+      opposition: "Test CC",
+      is_home: true,
+      competition_name: null,
+      competition_type: null,
+      match_time: "13:00",
+    })
+    .execute();
+  return requestId;
+}
+
+describe("sendAvailabilityNotification channel routing", () => {
+  it("sends email-only when preference is 'email' (default)", async () => {
+    const { userId, email } = await seedTestUser(ctx.db, { withMember: false });
+    const requestId = await seedRequest(userId);
+
+    const sendEmail = vi.fn().mockResolvedValue(undefined);
+    const sendPush: SendPush = vi.fn();
+
+    const result = await sendAvailabilityNotification(
+      ctx.db,
+      sendEmail,
+      sendPush,
+      "https://example.com",
+    )(requestId, { recipients: [{ email, name: "Test" }] }, log);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendPush).not.toHaveBeenCalled();
+    expect(result.sent).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it("sends push-only when preference is 'push' and a subscription exists", async () => {
+    const { userId, email } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertNotificationPreferences(ctx.db)(userId, {
+      matchdayChannel: "push",
+    });
+    await upsertPushSubscription(ctx.db)(userId, {
+      endpoint: "https://push.example/u1",
+      keys: { p256dh: "p", auth: "a" },
+    });
+    const requestId = await seedRequest(userId);
+
+    const sendEmail = vi.fn();
+    const sendPush: SendPush = vi.fn(
+      (sub: PushSubscriptionInput): Promise<SendPushResult> =>
+        Promise.resolve({ ok: true, endpoint: sub.endpoint }),
+    );
+
+    const result = await sendAvailabilityNotification(
+      ctx.db,
+      sendEmail,
+      sendPush,
+      "https://example.com",
+    )(requestId, { recipients: [{ email, name: "Test" }] }, log);
+
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(sendPush).toHaveBeenCalledTimes(1);
+    expect(result.sent).toBe(1);
+  });
+
+  it("falls back to email when preference is 'push' but no subscriptions exist", async () => {
+    const { userId, email } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertNotificationPreferences(ctx.db)(userId, {
+      matchdayChannel: "push",
+    });
+    const requestId = await seedRequest(userId);
+
+    const sendEmail = vi.fn().mockResolvedValue(undefined);
+    const sendPush: SendPush = vi.fn();
+
+    const result = await sendAvailabilityNotification(
+      ctx.db,
+      sendEmail,
+      sendPush,
+      "https://example.com",
+    )(requestId, { recipients: [{ email, name: "Test" }] }, log);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendPush).not.toHaveBeenCalled();
+    expect(result.sent).toBe(1);
+  });
+
+  it("sends both when preference is 'both' and a subscription exists", async () => {
+    const { userId, email } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertNotificationPreferences(ctx.db)(userId, {
+      matchdayChannel: "both",
+    });
+    await upsertPushSubscription(ctx.db)(userId, {
+      endpoint: "https://push.example/u2",
+      keys: { p256dh: "p", auth: "a" },
+    });
+    const requestId = await seedRequest(userId);
+
+    const sendEmail = vi.fn().mockResolvedValue(undefined);
+    const sendPush: SendPush = vi.fn(
+      (sub: PushSubscriptionInput): Promise<SendPushResult> =>
+        Promise.resolve({ ok: true, endpoint: sub.endpoint }),
+    );
+
+    const result = await sendAvailabilityNotification(
+      ctx.db,
+      sendEmail,
+      sendPush,
+      "https://example.com",
+    )(requestId, { recipients: [{ email, name: "Test" }] }, log);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendPush).toHaveBeenCalledTimes(1);
+    expect(result.sent).toBe(1);
+  });
+
+  it("prunes a subscription that returns gone (410)", async () => {
+    const { userId, email } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertNotificationPreferences(ctx.db)(userId, {
+      matchdayChannel: "push",
+    });
+    const endpoint = "https://push.example/gone";
+    await upsertPushSubscription(ctx.db)(userId, {
+      endpoint,
+      keys: { p256dh: "p", auth: "a" },
+    });
+    // Add a second live sub so the recipient is still considered delivered.
+    await upsertPushSubscription(ctx.db)(userId, {
+      endpoint: "https://push.example/live",
+      keys: { p256dh: "p", auth: "a" },
+    });
+    const requestId = await seedRequest(userId);
+
+    const sendEmail = vi.fn();
+    const sendPush: SendPush = vi.fn(
+      (sub: PushSubscriptionInput): Promise<SendPushResult> => {
+        if (sub.endpoint === endpoint) {
+          return Promise.resolve({
+            ok: false,
+            endpoint,
+            gone: true,
+            reason: "Gone",
+          });
+        }
+        return Promise.resolve({ ok: true, endpoint: sub.endpoint });
+      },
+    );
+
+    await sendAvailabilityNotification(
+      ctx.db,
+      sendEmail,
+      sendPush,
+      "https://example.com",
+    )(requestId, { recipients: [{ email, name: "Test" }] }, log);
+
+    const remaining = await ctx.db
+      .selectFrom("push_subscription")
+      .selectAll()
+      .where("user_id", "=", userId)
+      .execute();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.endpoint).toBe("https://push.example/live");
+  });
+
+  it("falls back to email for additional emails that have no matching user", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    const requestId = await seedRequest(userId);
+
+    const sendEmail = vi.fn().mockResolvedValue(undefined);
+    const sendPush: SendPush = vi.fn();
+
+    const result = await sendAvailabilityNotification(
+      ctx.db,
+      sendEmail,
+      sendPush,
+      "https://example.com",
+    )(
+      requestId,
+      { recipients: [{ email: "external@example.com", name: null }] },
+      log,
+    );
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendPush).not.toHaveBeenCalled();
+    expect(result.sent).toBe(1);
+  });
+});

--- a/apps/api/src/features/availability/notification.test.ts
+++ b/apps/api/src/features/availability/notification.test.ts
@@ -215,6 +215,51 @@ describe("sendAvailabilityNotification channel routing", () => {
     expect(remaining[0]?.endpoint).toBe("https://push.example/live");
   });
 
+  it("falls back to email when every push subscription is gone", async () => {
+    const { userId, email } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertNotificationPreferences(ctx.db)(userId, {
+      matchdayChannel: "push",
+    });
+    await upsertPushSubscription(ctx.db)(userId, {
+      endpoint: "https://push.example/zombie-1",
+      keys: { p256dh: "p", auth: "a" },
+    });
+    await upsertPushSubscription(ctx.db)(userId, {
+      endpoint: "https://push.example/zombie-2",
+      keys: { p256dh: "p", auth: "a" },
+    });
+    const requestId = await seedRequest(userId);
+
+    const sendEmail = vi.fn().mockResolvedValue(undefined);
+    const sendPush: SendPush = vi.fn(
+      (sub: PushSubscriptionInput): Promise<SendPushResult> =>
+        Promise.resolve({
+          ok: false,
+          endpoint: sub.endpoint,
+          gone: true,
+          reason: "Gone",
+        }),
+    );
+
+    const result = await sendAvailabilityNotification(
+      ctx.db,
+      sendEmail,
+      sendPush,
+      "https://example.com",
+    )(requestId, { recipients: [{ email, name: "Test" }] }, log);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(result.sent).toBe(1);
+    expect(result.failed).toBe(0);
+
+    const remaining = await ctx.db
+      .selectFrom("push_subscription")
+      .selectAll()
+      .where("user_id", "=", userId)
+      .execute();
+    expect(remaining).toHaveLength(0);
+  });
+
   it("falls back to email for additional emails that have no matching user", async () => {
     const { userId } = await seedTestUser(ctx.db, { withMember: false });
     const requestId = await seedRequest(userId);

--- a/apps/api/src/features/availability/routes.ts
+++ b/apps/api/src/features/availability/routes.ts
@@ -67,7 +67,14 @@ export const availabilityRoutes: FastifyPluginAsyncZod = async (app) => {
 
   const create =
     apiClient && siteId
-      ? createRequest(app.db, apiClient, siteId, app.send, app.config.BASE_URL)
+      ? createRequest(
+          app.db,
+          apiClient,
+          siteId,
+          app.send,
+          app.sendPush,
+          app.config.BASE_URL,
+        )
       : null;
 
   app.post(
@@ -260,6 +267,7 @@ export const availabilityRoutes: FastifyPluginAsyncZod = async (app) => {
   const sendNotification = sendAvailabilityNotification(
     app.db,
     app.send,
+    app.sendPush,
     app.config.BASE_URL,
   );
   app.post(

--- a/apps/api/src/features/availability/service.ts
+++ b/apps/api/src/features/availability/service.ts
@@ -4,7 +4,17 @@ import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import { createElement } from "react";
 import { render } from "react-email";
+import type { SendPush } from "../../lib/push-sender.ts";
+import type { MatchdayChannel } from "../notification-preferences/schemas.ts";
+import {
+  DEFAULT_MATCHDAY_CHANNEL,
+  getNotificationPreferencesByUserIds,
+} from "../notification-preferences/service.ts";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
+import {
+  deletePushSubscriptionByEndpoint,
+  listPushSubscriptionsForUsers,
+} from "../push-subscriptions/service.ts";
 import type {
   AssignPlayer,
   CreateRequest,
@@ -43,11 +53,13 @@ export function createRequest(
   playCricketApi: PlayCricketApiClient,
   siteId: string,
   sendEmail: SendEmail,
+  sendPush: SendPush,
   baseUrl: string,
 ) {
   const dispatchNotifications = sendAvailabilityNotification(
     db,
     sendEmail,
+    sendPush,
     baseUrl,
   );
 
@@ -1088,19 +1100,19 @@ export function previewFixtures(
 
 export function sendAvailabilityNotification(
   db: Kysely<DB>,
-  sendEmail: (email: {
-    to: string;
-    subject: string;
-    html: string;
-  }) => Promise<void>,
+  sendEmail: SendEmail,
+  sendPush: SendPush,
   baseUrl: string,
 ) {
+  const fetchPrefs = getNotificationPreferencesByUserIds(db);
+  const fetchPushSubs = listPushSubscriptionsForUsers(db);
+  const pruneSubscription = deletePushSubscriptionByEndpoint(db);
+
   return async (
     requestId: string,
     data: NotifySend,
     log: FastifyBaseLogger,
   ) => {
-    // Fetch request details
     const request = await db
       .selectFrom("availability_request")
       .where("id", "=", requestId)
@@ -1109,7 +1121,6 @@ export function sendAvailabilityNotification(
 
     if (!request) throwHttpError(404, "Availability request not found");
 
-    // Count fixtures
     const fixtureResult = await db
       .selectFrom("availability_fixture")
       .where("availability_request_id", "=", requestId)
@@ -1120,40 +1131,126 @@ export function sendAvailabilityNotification(
     const imageBaseUrl = `${baseUrl}/images`;
     const url = `${baseUrl}/availability/${requestId}`;
 
+    // Resolve user ids for the recipient emails so we can apply each
+    // recipient's matchday_channel preference. Recipients without a
+    // matching user (additional emails added by an admin) have no
+    // preferences and no push subscriptions - fall back to email-only,
+    // which is what they got pre-#379.
+    const recipientEmails = data.recipients.map((r) => r.email.toLowerCase());
+    const userRows =
+      recipientEmails.length > 0
+        ? await db
+            .selectFrom("user")
+            .where("email", "in", recipientEmails)
+            .select(["id", "email"])
+            .execute()
+        : [];
+    const userIdByEmail = new Map<string, string>();
+    for (const u of userRows) {
+      userIdByEmail.set(u.email.toLowerCase(), u.id);
+    }
+    const userIds = userRows.map((u) => u.id);
+
+    const [prefs, pushSubsByUser] = await Promise.all([
+      fetchPrefs(userIds),
+      fetchPushSubs(userIds),
+    ]);
+
     let sent = 0;
     const failures: Array<{ email: string; reason: string }> = [];
+
     for (const recipient of data.recipients) {
-      // Render INSIDE the try so a render-time failure for one
-      // recipient (template throw, missing locale, etc) doesn't abort
-      // the rest of the batch — same isolation as a SES send failure.
-      try {
-        const html = await render(
-          createElement(AvailabilityRequest.component, {
-            imageBaseUrl,
-            name: recipient.name,
-            dateFrom: request.date_from,
-            dateTo: request.date_to,
-            fixtureCount,
-            url,
-          }),
-        );
-        await sendEmail({
-          to: recipient.email,
-          subject: AvailabilityRequest.subject,
-          html,
-        });
+      const userId = userIdByEmail.get(recipient.email.toLowerCase());
+      const channel: MatchdayChannel = userId
+        ? (prefs.get(userId) ?? DEFAULT_MATCHDAY_CHANNEL)
+        : "email";
+
+      const wantsEmail = channel === "email" || channel === "both";
+      const wantsPush = channel === "push" || channel === "both";
+
+      // A push-only user with no live subscriptions falls back to email
+      // so they don't silently miss the notification - subscribing is
+      // opt-in and we can't tell from the prefs alone whether they
+      // expect a push or simply haven't enabled it on any device yet.
+      const subscriptions = userId ? (pushSubsByUser.get(userId) ?? []) : [];
+      const pushAvailable = wantsPush && subscriptions.length > 0;
+      const sendEmailNow = wantsEmail || (wantsPush && !pushAvailable);
+
+      let deliveredAny = false;
+      let recipientFailure: string | null = null;
+
+      if (sendEmailNow) {
+        try {
+          const html = await render(
+            createElement(AvailabilityRequest.component, {
+              imageBaseUrl,
+              name: recipient.name,
+              dateFrom: request.date_from,
+              dateTo: request.date_to,
+              fixtureCount,
+              url,
+            }),
+          );
+          await sendEmail({
+            to: recipient.email,
+            subject: AvailabilityRequest.subject,
+            html,
+          });
+          deliveredAny = true;
+        } catch (err) {
+          recipientFailure = err instanceof Error ? err.message : String(err);
+          log.warn(
+            {
+              err,
+              requestId,
+              recipientEmail: recipient.email,
+              channel: "email",
+            },
+            "availability_notification_failed",
+          );
+        }
+      }
+
+      if (pushAvailable) {
+        const payload = {
+          title: AvailabilityRequest.subject,
+          body: `${fixtureCount} fixture${fixtureCount === 1 ? "" : "s"} ${request.date_from} - ${request.date_to}`,
+          url,
+          tag: `availability:${requestId}`,
+        };
+        for (const sub of subscriptions) {
+          const result = await sendPush(sub, payload);
+          if (result.ok) {
+            deliveredAny = true;
+          } else if (result.gone) {
+            await pruneSubscription(result.endpoint);
+            log.info(
+              { requestId, endpoint: result.endpoint },
+              "push_subscription_gone_pruned",
+            );
+          } else {
+            log.warn(
+              {
+                requestId,
+                recipientEmail: recipient.email,
+                endpoint: result.endpoint,
+                reason: result.reason,
+                channel: "push",
+              },
+              "availability_notification_failed",
+            );
+            recipientFailure ??= result.reason;
+          }
+        }
+      }
+
+      if (deliveredAny) {
         sent++;
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        failures.push({ email: recipient.email, reason });
-        log.warn(
-          {
-            err,
-            requestId,
-            recipientEmail: recipient.email,
-          },
-          "availability_notification_failed",
-        );
+      } else {
+        failures.push({
+          email: recipient.email,
+          reason: recipientFailure ?? "no delivery channel",
+        });
       }
     }
 

--- a/apps/api/src/features/availability/service.ts
+++ b/apps/api/src/features/availability/service.ts
@@ -1159,6 +1159,42 @@ export function sendAvailabilityNotification(
     let sent = 0;
     const failures: Array<{ email: string; reason: string }> = [];
 
+    const sendOneEmail = async (recipient: {
+      email: string;
+      name: string | null;
+    }): Promise<{ ok: true } | { ok: false; reason: string }> => {
+      try {
+        const html = await render(
+          createElement(AvailabilityRequest.component, {
+            imageBaseUrl,
+            name: recipient.name,
+            dateFrom: request.date_from,
+            dateTo: request.date_to,
+            fixtureCount,
+            url,
+          }),
+        );
+        await sendEmail({
+          to: recipient.email,
+          subject: AvailabilityRequest.subject,
+          html,
+        });
+        return { ok: true };
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        log.warn(
+          {
+            err,
+            requestId,
+            recipientEmail: recipient.email,
+            channel: "email",
+          },
+          "availability_notification_failed",
+        );
+        return { ok: false, reason };
+      }
+    };
+
     for (const recipient of data.recipients) {
       const userId = userIdByEmail.get(recipient.email.toLowerCase());
       const channel: MatchdayChannel = userId
@@ -1174,40 +1210,16 @@ export function sendAvailabilityNotification(
       // expect a push or simply haven't enabled it on any device yet.
       const subscriptions = userId ? (pushSubsByUser.get(userId) ?? []) : [];
       const pushAvailable = wantsPush && subscriptions.length > 0;
-      const sendEmailNow = wantsEmail || (wantsPush && !pushAvailable);
 
       let deliveredAny = false;
       let recipientFailure: string | null = null;
 
-      if (sendEmailNow) {
-        try {
-          const html = await render(
-            createElement(AvailabilityRequest.component, {
-              imageBaseUrl,
-              name: recipient.name,
-              dateFrom: request.date_from,
-              dateTo: request.date_to,
-              fixtureCount,
-              url,
-            }),
-          );
-          await sendEmail({
-            to: recipient.email,
-            subject: AvailabilityRequest.subject,
-            html,
-          });
+      if (wantsEmail || (wantsPush && !pushAvailable)) {
+        const result = await sendOneEmail(recipient);
+        if (result.ok) {
           deliveredAny = true;
-        } catch (err) {
-          recipientFailure = err instanceof Error ? err.message : String(err);
-          log.warn(
-            {
-              err,
-              requestId,
-              recipientEmail: recipient.email,
-              channel: "email",
-            },
-            "availability_notification_failed",
-          );
+        } else {
+          recipientFailure = result.reason;
         }
       }
 
@@ -1218,10 +1230,14 @@ export function sendAvailabilityNotification(
           url,
           tag: `availability:${requestId}`,
         };
+        let pushDelivered = false;
+        let allGone = true;
         for (const sub of subscriptions) {
           const result = await sendPush(sub, payload);
           if (result.ok) {
             deliveredAny = true;
+            pushDelivered = true;
+            allGone = false;
           } else if (result.gone) {
             await pruneSubscription(result.endpoint);
             log.info(
@@ -1229,6 +1245,7 @@ export function sendAvailabilityNotification(
               "push_subscription_gone_pruned",
             );
           } else {
+            allGone = false;
             log.warn(
               {
                 requestId,
@@ -1240,6 +1257,20 @@ export function sendAvailabilityNotification(
               "availability_notification_failed",
             );
             recipientFailure ??= result.reason;
+          }
+        }
+
+        // Push-only recipient whose every subscription was pruned this
+        // turn - they look "subscribed" in our store but the push service
+        // disagrees. Treat it the same as the "no subscriptions" branch
+        // above and email them so they don't silently miss the notice.
+        if (!wantsEmail && !pushDelivered && allGone) {
+          const fallback = await sendOneEmail(recipient);
+          if (fallback.ok) {
+            deliveredAny = true;
+            recipientFailure = null;
+          } else {
+            recipientFailure ??= fallback.reason;
           }
         }
       }

--- a/apps/api/src/features/notification-preferences/integration.test.ts
+++ b/apps/api/src/features/notification-preferences/integration.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import {
+  getNotificationPreferences,
+  getNotificationPreferencesByUserIds,
+  upsertNotificationPreferences,
+} from "./service.ts";
+
+let ctx: TestContext;
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+});
+
+afterAll(async () => {
+  await stopTestContainer(ctx);
+});
+
+describe("notification-preferences service (integration)", () => {
+  it("returns 'email' by default for a user with no row", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    const prefs = await getNotificationPreferences(ctx.db)(userId);
+    expect(prefs.matchdayChannel).toBe("email");
+  });
+
+  it("upserts a fresh preference row", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    const result = await upsertNotificationPreferences(ctx.db)(userId, {
+      matchdayChannel: "push",
+    });
+    expect(result.matchdayChannel).toBe("push");
+
+    const reread = await getNotificationPreferences(ctx.db)(userId);
+    expect(reread.matchdayChannel).toBe("push");
+  });
+
+  it("updates the existing row on subsequent upsert", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertNotificationPreferences(ctx.db)(userId, {
+      matchdayChannel: "push",
+    });
+    await upsertNotificationPreferences(ctx.db)(userId, {
+      matchdayChannel: "both",
+    });
+    const reread = await getNotificationPreferences(ctx.db)(userId);
+    expect(reread.matchdayChannel).toBe("both");
+  });
+
+  it("batches preference reads by user id", async () => {
+    const a = await seedTestUser(ctx.db, { withMember: false });
+    const b = await seedTestUser(ctx.db, { withMember: false });
+    await upsertNotificationPreferences(ctx.db)(a.userId, {
+      matchdayChannel: "push",
+    });
+    await upsertNotificationPreferences(ctx.db)(b.userId, {
+      matchdayChannel: "both",
+    });
+    const map = await getNotificationPreferencesByUserIds(ctx.db)([
+      a.userId,
+      b.userId,
+    ]);
+    expect(map.get(a.userId)).toBe("push");
+    expect(map.get(b.userId)).toBe("both");
+  });
+});

--- a/apps/api/src/features/notification-preferences/routes.ts
+++ b/apps/api/src/features/notification-preferences/routes.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { getAuthSession, requireAuth } from "../auth/middleware.ts";
+import {
+  notificationPreferencesResponseSchema,
+  updateNotificationPreferencesSchema,
+} from "./schemas.ts";
+import {
+  getNotificationPreferences,
+  upsertNotificationPreferences,
+} from "./service.ts";
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const notifPrefsRoutes: FastifyPluginAsyncZod = async (app) => {
+  const get = getNotificationPreferences(app.db);
+  const upsert = upsertNotificationPreferences(app.db);
+
+  app.get(
+    "/me/notification-preferences",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        response: { 200: notificationPreferencesResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await get(user.id);
+    },
+  );
+
+  app.put(
+    "/me/notification-preferences",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        body: updateNotificationPreferencesSchema,
+        response: { 200: notificationPreferencesResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await upsert(user.id, request.body);
+    },
+  );
+};

--- a/apps/api/src/features/notification-preferences/schemas.ts
+++ b/apps/api/src/features/notification-preferences/schemas.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+// Currently a single channel field that applies to "all matchday
+// notifications" (issue #379). Modelled as a discrete enum rather than
+// two booleans so the wire shape stays stable when more notification
+// categories land - a `<category>_channel` field per category is easy
+// to add without renaming anything.
+export const matchdayChannelSchema = z.enum(["email", "push", "both"]);
+export type MatchdayChannel = z.infer<typeof matchdayChannelSchema>;
+
+export const notificationPreferencesResponseSchema = z.object({
+  matchdayChannel: matchdayChannelSchema,
+});
+
+export const updateNotificationPreferencesSchema = z.object({
+  matchdayChannel: matchdayChannelSchema,
+});

--- a/apps/api/src/features/notification-preferences/service.ts
+++ b/apps/api/src/features/notification-preferences/service.ts
@@ -1,0 +1,70 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import type { MatchdayChannel, matchdayChannelSchema } from "./schemas.ts";
+
+const DEFAULT_MATCHDAY_CHANNEL: MatchdayChannel = "email";
+
+// Read the caller's preferences, defaulting to the same shape new users
+// see. Returning a populated default rather than nullable keeps every
+// consumer (UI + send path) from re-implementing the same fallback.
+export function getNotificationPreferences(db: Kysely<DB>) {
+  return async (
+    userId: string,
+  ): Promise<{ matchdayChannel: MatchdayChannel }> => {
+    const row = await db
+      .selectFrom("notification_preferences")
+      .select(["matchday_channel"])
+      .where("user_id", "=", userId)
+      .executeTakeFirst();
+
+    return {
+      matchdayChannel:
+        (row?.matchday_channel as MatchdayChannel | undefined) ??
+        DEFAULT_MATCHDAY_CHANNEL,
+    };
+  };
+}
+
+export function upsertNotificationPreferences(db: Kysely<DB>) {
+  return async (
+    userId: string,
+    prefs: { matchdayChannel: MatchdayChannel },
+  ): Promise<{ matchdayChannel: MatchdayChannel }> => {
+    await db
+      .insertInto("notification_preferences")
+      .values({
+        user_id: userId,
+        matchday_channel: prefs.matchdayChannel,
+      })
+      .onConflict((oc) =>
+        oc.column("user_id").doUpdateSet({
+          matchday_channel: prefs.matchdayChannel,
+          updated_at: new Date(),
+        }),
+      )
+      .execute();
+
+    return { matchdayChannel: prefs.matchdayChannel };
+  };
+}
+
+// Batch read used by the notification dispatcher so it can fetch
+// preferences for a recipient list in one query.
+export function getNotificationPreferencesByUserIds(db: Kysely<DB>) {
+  return async (userIds: string[]): Promise<Map<string, MatchdayChannel>> => {
+    if (userIds.length === 0) return new Map();
+
+    const rows = await db
+      .selectFrom("notification_preferences")
+      .select(["user_id", "matchday_channel"])
+      .where("user_id", "in", userIds)
+      .execute();
+
+    return new Map(
+      rows.map((r) => [r.user_id, r.matchday_channel as MatchdayChannel]),
+    );
+  };
+}
+
+export { DEFAULT_MATCHDAY_CHANNEL };
+export type { matchdayChannelSchema };

--- a/apps/api/src/features/push-subscriptions/integration.test.ts
+++ b/apps/api/src/features/push-subscriptions/integration.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import {
+  deletePushSubscription,
+  deletePushSubscriptionByEndpoint,
+  listPushSubscriptionsForUsers,
+  upsertPushSubscription,
+} from "./service.ts";
+
+let ctx: TestContext;
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+});
+
+afterAll(async () => {
+  await stopTestContainer(ctx);
+});
+
+const SUB_A = {
+  endpoint: "https://push.example.com/abc",
+  keys: { p256dh: "p256dh-A", auth: "auth-A" },
+  userAgent: "Chrome/Mac",
+};
+const SUB_B = {
+  endpoint: "https://push.example.com/def",
+  keys: { p256dh: "p256dh-B", auth: "auth-B" },
+};
+
+describe("push-subscriptions service (integration)", () => {
+  it("creates a subscription and returns an id", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    const result = await upsertPushSubscription(ctx.db)(userId, SUB_A);
+    expect(result.id).toBeDefined();
+
+    const rows = await ctx.db
+      .selectFrom("push_subscription")
+      .selectAll()
+      .where("user_id", "=", userId)
+      .execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.endpoint).toBe(SUB_A.endpoint);
+    expect(rows[0]?.p256dh).toBe(SUB_A.keys.p256dh);
+    expect(rows[0]?.user_agent).toBe("Chrome/Mac");
+  });
+
+  it("updates an existing subscription on conflicting endpoint", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertPushSubscription(ctx.db)(userId, SUB_A);
+    await upsertPushSubscription(ctx.db)(userId, {
+      ...SUB_A,
+      keys: { p256dh: "rotated", auth: "rotated" },
+    });
+
+    const rows = await ctx.db
+      .selectFrom("push_subscription")
+      .selectAll()
+      .where("user_id", "=", userId)
+      .execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.p256dh).toBe("rotated");
+  });
+
+  it("re-keys a subscription onto a different user when the device is shared", async () => {
+    const a = await seedTestUser(ctx.db, { withMember: false });
+    const b = await seedTestUser(ctx.db, { withMember: false });
+    await upsertPushSubscription(ctx.db)(a.userId, SUB_A);
+    await upsertPushSubscription(ctx.db)(b.userId, SUB_A);
+
+    const aRows = await ctx.db
+      .selectFrom("push_subscription")
+      .where("user_id", "=", a.userId)
+      .selectAll()
+      .execute();
+    const bRows = await ctx.db
+      .selectFrom("push_subscription")
+      .where("user_id", "=", b.userId)
+      .selectAll()
+      .execute();
+    expect(aRows).toHaveLength(0);
+    expect(bRows).toHaveLength(1);
+  });
+
+  it("deletes only the caller's own subscription", async () => {
+    const a = await seedTestUser(ctx.db, { withMember: false });
+    const b = await seedTestUser(ctx.db, { withMember: false });
+    await upsertPushSubscription(ctx.db)(a.userId, SUB_A);
+    await upsertPushSubscription(ctx.db)(b.userId, SUB_B);
+
+    const fromOtherUser = await deletePushSubscription(ctx.db)(
+      b.userId,
+      SUB_A.endpoint,
+    );
+    expect(fromOtherUser.deleted).toBe(false);
+
+    const own = await deletePushSubscription(ctx.db)(a.userId, SUB_A.endpoint);
+    expect(own.deleted).toBe(true);
+  });
+
+  it("lists subscriptions grouped by user", async () => {
+    const a = await seedTestUser(ctx.db, { withMember: false });
+    const b = await seedTestUser(ctx.db, { withMember: false });
+    await upsertPushSubscription(ctx.db)(a.userId, SUB_A);
+    await upsertPushSubscription(ctx.db)(b.userId, SUB_B);
+
+    const map = await listPushSubscriptionsForUsers(ctx.db)([
+      a.userId,
+      b.userId,
+    ]);
+    expect(map.get(a.userId)).toHaveLength(1);
+    expect(map.get(b.userId)).toHaveLength(1);
+    expect(map.get(a.userId)?.[0]?.endpoint).toBe(SUB_A.endpoint);
+  });
+
+  it("hard-deletes a subscription by endpoint (gone-410 cleanup)", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertPushSubscription(ctx.db)(userId, SUB_A);
+    await deletePushSubscriptionByEndpoint(ctx.db)(SUB_A.endpoint);
+    const rows = await ctx.db
+      .selectFrom("push_subscription")
+      .selectAll()
+      .where("endpoint", "=", SUB_A.endpoint)
+      .execute();
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/apps/api/src/features/push-subscriptions/routes.ts
+++ b/apps/api/src/features/push-subscriptions/routes.ts
@@ -1,0 +1,61 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { getAuthSession, requireAuth } from "../auth/middleware.ts";
+import {
+  createPushSubscriptionResponseSchema,
+  createPushSubscriptionSchema,
+  deletePushSubscriptionResponseSchema,
+  deletePushSubscriptionSchema,
+  vapidPublicKeyResponseSchema,
+} from "./schemas.ts";
+import { deletePushSubscription, upsertPushSubscription } from "./service.ts";
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const pushSubscriptionRoutes: FastifyPluginAsyncZod = async (app) => {
+  const upsert = upsertPushSubscription(app.db);
+  const remove = deletePushSubscription(app.db);
+
+  // Public: the matchday SPA needs the VAPID public key before it can
+  // call PushManager.subscribe(). Public key is non-secret by design -
+  // it's what identifies us to the push service; anyone with it still
+  // can't send a push without the private half.
+  app.get(
+    "/push/public-key",
+    {
+      schema: {
+        response: { 200: vapidPublicKeyResponseSchema },
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await -- Fastify expects an async handler
+    async () => ({ publicKey: app.config.VAPID_PUBLIC_KEY }),
+  );
+
+  app.post(
+    "/me/push-subscriptions",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        body: createPushSubscriptionSchema,
+        response: { 200: createPushSubscriptionResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await upsert(user.id, request.body);
+    },
+  );
+
+  app.delete(
+    "/me/push-subscriptions",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        body: deletePushSubscriptionSchema,
+        response: { 200: deletePushSubscriptionResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await remove(user.id, request.body.endpoint);
+    },
+  );
+};

--- a/apps/api/src/features/push-subscriptions/schemas.ts
+++ b/apps/api/src/features/push-subscriptions/schemas.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+// Mirrors the PushSubscriptionJSON shape returned by PushManager.subscribe()
+// in the browser. The browser produces keys + endpoint as opaque strings;
+// we store them verbatim and pass them back to web-push at send time.
+export const pushSubscriptionKeysSchema = z.object({
+  p256dh: z.string().min(1),
+  auth: z.string().min(1),
+});
+
+export const createPushSubscriptionSchema = z.object({
+  endpoint: z.url(),
+  keys: pushSubscriptionKeysSchema,
+  userAgent: z.string().max(500).optional(),
+});
+
+export const createPushSubscriptionResponseSchema = z.object({
+  id: z.string(),
+});
+
+export const deletePushSubscriptionSchema = z.object({
+  endpoint: z.url(),
+});
+
+export const deletePushSubscriptionResponseSchema = z.object({
+  deleted: z.boolean(),
+});
+
+export const vapidPublicKeyResponseSchema = z.object({
+  publicKey: z.string().min(1),
+});

--- a/apps/api/src/features/push-subscriptions/schemas.ts
+++ b/apps/api/src/features/push-subscriptions/schemas.ts
@@ -1,15 +1,46 @@
 import { z } from "zod";
 
+// Push-service hostnames we trust as subscription endpoints. Browsers
+// only return endpoints under these domains today; restricting at the
+// API layer stops an authenticated user from registering an attacker-
+// controlled URL that the server would then POST to (SSRF). When a new
+// browser engine ships, add its host suffix here.
+const TRUSTED_PUSH_HOST_SUFFIXES = [
+  "googleapis.com", // FCM (Chrome, Edge, Brave, Opera, Android)
+  "push.apple.com", // Apple Push (Safari / iOS PWA)
+  "mozilla.com", // Mozilla autopush (Firefox)
+  "mozaws.net", // Mozilla autopush (Firefox)
+  "windows.com", // WNS (legacy Edge)
+];
+
+function isTrustedPushEndpoint(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  const host = url.hostname.toLowerCase();
+  return TRUSTED_PUSH_HOST_SUFFIXES.some(
+    (suffix) => host === suffix || host.endsWith(`.${suffix}`),
+  );
+}
+
+const pushEndpointSchema = z
+  .url()
+  .refine(isTrustedPushEndpoint, "Endpoint host is not a known push service");
+
 // Mirrors the PushSubscriptionJSON shape returned by PushManager.subscribe()
 // in the browser. The browser produces keys + endpoint as opaque strings;
 // we store them verbatim and pass them back to web-push at send time.
 export const pushSubscriptionKeysSchema = z.object({
-  p256dh: z.string().min(1),
-  auth: z.string().min(1),
+  p256dh: z.string().min(1).max(200),
+  auth: z.string().min(1).max(200),
 });
 
 export const createPushSubscriptionSchema = z.object({
-  endpoint: z.url(),
+  endpoint: pushEndpointSchema,
   keys: pushSubscriptionKeysSchema,
   userAgent: z.string().max(500).optional(),
 });
@@ -19,7 +50,7 @@ export const createPushSubscriptionResponseSchema = z.object({
 });
 
 export const deletePushSubscriptionSchema = z.object({
-  endpoint: z.url(),
+  endpoint: pushEndpointSchema,
 });
 
 export const deletePushSubscriptionResponseSchema = z.object({

--- a/apps/api/src/features/push-subscriptions/service.ts
+++ b/apps/api/src/features/push-subscriptions/service.ts
@@ -1,0 +1,101 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+
+export interface StoredPushSubscription {
+  id: string;
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}
+
+export function upsertPushSubscription(db: Kysely<DB>) {
+  return async (
+    userId: string,
+    input: {
+      endpoint: string;
+      keys: { p256dh: string; auth: string };
+      userAgent?: string;
+    },
+  ): Promise<{ id: string }> => {
+    // endpoint is globally unique (each PushManager.subscribe() yields a
+    // distinct one). If the same browser re-subscribes we want to refresh
+    // the row in place rather than fail on the unique constraint, and we
+    // want to re-key it onto whoever is currently signed in - a shared
+    // device legitimately rotates users.
+    const row = await db
+      .insertInto("push_subscription")
+      .values({
+        user_id: userId,
+        endpoint: input.endpoint,
+        p256dh: input.keys.p256dh,
+        auth: input.keys.auth,
+        user_agent: input.userAgent ?? null,
+      })
+      .onConflict((oc) =>
+        oc.column("endpoint").doUpdateSet({
+          user_id: userId,
+          p256dh: input.keys.p256dh,
+          auth: input.keys.auth,
+          user_agent: input.userAgent ?? null,
+          updated_at: new Date(),
+        }),
+      )
+      .returning(["id"])
+      .executeTakeFirstOrThrow();
+
+    return { id: row.id };
+  };
+}
+
+export function deletePushSubscription(db: Kysely<DB>) {
+  return async (
+    userId: string,
+    endpoint: string,
+  ): Promise<{ deleted: boolean }> => {
+    const result = await db
+      .deleteFrom("push_subscription")
+      .where("user_id", "=", userId)
+      .where("endpoint", "=", endpoint)
+      .executeTakeFirst();
+
+    return { deleted: Number(result.numDeletedRows) > 0 };
+  };
+}
+
+export function listPushSubscriptionsForUsers(db: Kysely<DB>) {
+  return async (
+    userIds: string[],
+  ): Promise<Map<string, StoredPushSubscription[]>> => {
+    if (userIds.length === 0) return new Map();
+
+    const rows = await db
+      .selectFrom("push_subscription")
+      .select(["id", "user_id", "endpoint", "p256dh", "auth"])
+      .where("user_id", "in", userIds)
+      .execute();
+
+    const byUser = new Map<string, StoredPushSubscription[]>();
+    for (const row of rows) {
+      const list = byUser.get(row.user_id) ?? [];
+      list.push({
+        id: row.id,
+        endpoint: row.endpoint,
+        p256dh: row.p256dh,
+        auth: row.auth,
+      });
+      byUser.set(row.user_id, list);
+    }
+    return byUser;
+  };
+}
+
+// Used by the push dispatcher when the push service returns 404/410 -
+// the subscription is dead and should never be tried again.
+export function deletePushSubscriptionByEndpoint(db: Kysely<DB>) {
+  return async (endpoint: string): Promise<void> => {
+    await db
+      .deleteFrom("push_subscription")
+      .where("endpoint", "=", endpoint)
+      .execute();
+  };
+}

--- a/apps/api/src/generate-openapi.ts
+++ b/apps/api/src/generate-openapi.ts
@@ -44,6 +44,9 @@ const config = parseConfig({
   LOG_LEVEL: "error",
   PLAY_CRICKET_API_TOKEN: "placeholder",
   PLAY_CRICKET_SITE_ID: "0",
+  VAPID_PUBLIC_KEY: "placeholder",
+  VAPID_PRIVATE_KEY: "placeholder",
+  VAPID_SUBJECT: "mailto:placeholder@example.com",
 });
 
 const { client: db, dialect } = createClient(config.DATABASE_URL);

--- a/apps/api/src/generate-openapi.ts
+++ b/apps/api/src/generate-openapi.ts
@@ -44,9 +44,12 @@ const config = parseConfig({
   LOG_LEVEL: "error",
   PLAY_CRICKET_API_TOKEN: "placeholder",
   PLAY_CRICKET_SITE_ID: "0",
-  VAPID_PUBLIC_KEY: "placeholder",
-  VAPID_PRIVATE_KEY: "placeholder",
-  VAPID_SUBJECT: "mailto:placeholder@example.com",
+  // Real-shape dummy VAPID keypair so config's regex validators pass
+  // during spec generation. The OpenAPI run never calls a push service.
+  VAPID_PUBLIC_KEY:
+    "BJk5OBwHXbimx6NVTZT-4dLvrm9PkYCu1n3g-4KfRpkqSefZWi_b34N2JzEqvh0lEXTghy5NI8BLdGfhsa7iPvk",
+  VAPID_PRIVATE_KEY: "5zXXF30AFmWdn5V-K_W8spVINdk405SAyjSp5_a6aek",
+  VAPID_SUBJECT: "mailto:openapi-generator@example.com",
 });
 
 const { client: db, dialect } = createClient(config.DATABASE_URL);

--- a/apps/api/src/lib/push-sender.ts
+++ b/apps/api/src/lib/push-sender.ts
@@ -1,0 +1,71 @@
+import webPush from "web-push";
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  url?: string;
+  // Used by the service worker to coalesce repeated notifications for
+  // the same logical event (e.g. multiple devices receiving the same
+  // availability request) into a single visible toast.
+  tag?: string;
+}
+
+export interface PushSubscriptionInput {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}
+
+export type SendPushResult =
+  | { ok: true; endpoint: string }
+  | { ok: false; endpoint: string; gone: boolean; reason: string };
+
+export type SendPush = (
+  subscription: PushSubscriptionInput,
+  payload: PushPayload,
+) => Promise<SendPushResult>;
+
+export interface CreatePushSenderConfig {
+  publicKey: string;
+  privateKey: string;
+  subject: string;
+}
+
+export function createPushSender(config: CreatePushSenderConfig): SendPush {
+  // VAPID details are passed inline per-send rather than via
+  // setVapidDetails(), which eagerly validates the public key shape -
+  // useful in production, but fatal at OpenAPI-generation boot where
+  // we feed placeholder strings into the same config schema. Inline
+  // details defer validation to the first real send.
+  const vapidDetails = {
+    subject: config.subject,
+    publicKey: config.publicKey,
+    privateKey: config.privateKey,
+  };
+
+  return async (subscription, payload) => {
+    try {
+      await webPush.sendNotification(
+        {
+          endpoint: subscription.endpoint,
+          keys: { p256dh: subscription.p256dh, auth: subscription.auth },
+        },
+        JSON.stringify(payload),
+        { vapidDetails },
+      );
+      return { ok: true, endpoint: subscription.endpoint };
+    } catch (err) {
+      const statusCode =
+        err && typeof err === "object" && "statusCode" in err
+          ? (err as { statusCode?: number }).statusCode
+          : undefined;
+      // 404 (Not Found) and 410 (Gone) mean the push service has dropped
+      // this subscription permanently - the browser uninstalled the SW,
+      // the user revoked permission, or the endpoint expired. Caller
+      // hard-deletes the row so we never retry it.
+      const gone = statusCode === 404 || statusCode === 410;
+      const reason = err instanceof Error ? err.message : String(err);
+      return { ok: false, endpoint: subscription.endpoint, gone, reason };
+    }
+  };
+}

--- a/apps/api/src/test/app.ts
+++ b/apps/api/src/test/app.ts
@@ -41,8 +41,9 @@ export async function buildTestApp(db: Kysely<DB>, dialect: PostgresDialect) {
     PHOENIX_API_KEY: "test-phoenix-key",
     PHOENIX_COLLECTOR_ENDPOINT: "http://localhost:6006/v1/traces",
     PHOENIX_PROJECT_NAME: "percy-main-scout-test",
-    VAPID_PUBLIC_KEY: "BTestPublicKey_PlaceholderForIntegrationTests",
-    VAPID_PRIVATE_KEY: "TestPrivateKey_PlaceholderForIntegrationTests",
+    VAPID_PUBLIC_KEY:
+      "BJk5OBwHXbimx6NVTZT-4dLvrm9PkYCu1n3g-4KfRpkqSefZWi_b34N2JzEqvh0lEXTghy5NI8BLdGfhsa7iPvk",
+    VAPID_PRIVATE_KEY: "5zXXF30AFmWdn5V-K_W8spVINdk405SAyjSp5_a6aek",
     VAPID_SUBJECT: "mailto:test@example.com",
   });
 

--- a/apps/api/src/test/app.ts
+++ b/apps/api/src/test/app.ts
@@ -41,6 +41,9 @@ export async function buildTestApp(db: Kysely<DB>, dialect: PostgresDialect) {
     PHOENIX_API_KEY: "test-phoenix-key",
     PHOENIX_COLLECTOR_ENDPOINT: "http://localhost:6006/v1/traces",
     PHOENIX_PROJECT_NAME: "percy-main-scout-test",
+    VAPID_PUBLIC_KEY: "BTestPublicKey_PlaceholderForIntegrationTests",
+    VAPID_PRIVATE_KEY: "TestPrivateKey_PlaceholderForIntegrationTests",
+    VAPID_SUBJECT: "mailto:test@example.com",
   });
 
   return buildApp({ db, dialect, config });

--- a/apps/matchday/public/push-handler.js
+++ b/apps/matchday/public/push-handler.js
@@ -53,12 +53,18 @@ self.addEventListener("notificationclick", (event) => {
           if ("navigate" in client) {
             try {
               await client.navigate(targetUrl);
+              return;
             } catch {
-              // navigate() is restricted to same-origin; fall back to
-              // opening a new window below.
+              // navigate() is restricted to same-origin and can also be
+              // disallowed if the tab is suspended; fall through to
+              // openWindow rather than leaving the user looking at the
+              // wrong page in the focused tab.
             }
+          } else {
+            // No navigate() (older browsers): focusing the existing tab
+            // is the best we can do.
+            return;
           }
-          return;
         }
       }
       if (clients.openWindow) {

--- a/apps/matchday/public/push-handler.js
+++ b/apps/matchday/public/push-handler.js
@@ -1,0 +1,69 @@
+/* global self, clients */
+// Web Push handler for matchday. Imported by the generateSW-produced
+// service worker via vite-plugin-pwa's workbox.importScripts. Lives as
+// a plain script (not bundled by Vite) because it's loaded with
+// importScripts() into the SW global - no module syntax allowed.
+//
+// Payload contract: the API sends JSON.stringify({ title, body, url, tag }).
+// Anything else is treated as a bare title-only push.
+
+self.addEventListener("push", (event) => {
+  let payload = { title: "Percy Main", body: "" };
+  if (event.data) {
+    try {
+      payload = event.data.json();
+    } catch {
+      payload = { title: "Percy Main", body: event.data.text() };
+    }
+  }
+
+  const title = payload.title || "Percy Main";
+  const options = {
+    body: payload.body || "",
+    icon: "/images/favicon/web-app-manifest-192x192.png",
+    badge: "/images/favicon/web-app-manifest-192x192.png",
+    tag: payload.tag,
+    // Re-alerting on a replaced toast feels right for matchday - new
+    // availability ping or a re-send should re-vibrate even if the old
+    // notification is still on screen.
+    renotify: Boolean(payload.tag),
+    data: { url: payload.url || "/" },
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const targetUrl =
+    (event.notification.data && event.notification.data.url) || "/";
+
+  event.waitUntil(
+    (async () => {
+      const all = await clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      });
+      // Prefer focusing an already-open matchday tab and navigating it
+      // to the target URL - cheaper than spinning a fresh window and
+      // keeps the user's session warm.
+      for (const client of all) {
+        if (client.url && "focus" in client) {
+          await client.focus();
+          if ("navigate" in client) {
+            try {
+              await client.navigate(targetUrl);
+            } catch {
+              // navigate() is restricted to same-origin; fall back to
+              // opening a new window below.
+            }
+          }
+          return;
+        }
+      }
+      if (clients.openWindow) {
+        await clients.openWindow(targetUrl);
+      }
+    })(),
+  );
+});

--- a/apps/matchday/src/features/notifications/notifications-card.tsx
+++ b/apps/matchday/src/features/notifications/notifications-card.tsx
@@ -1,0 +1,188 @@
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardEyebrow,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  disablePushOnThisDevice,
+  enablePushOnThisDevice,
+  usePushState,
+} from "./use-push.js";
+
+type Prefs = ApiResponse<"/api/me/notification-preferences">;
+type Channel = Prefs["matchdayChannel"];
+
+const CHANNELS: Array<{ value: Channel; label: string; hint: string }> = [
+  { value: "email", label: "Email", hint: "Default — what you've always had." },
+  {
+    value: "push",
+    label: "Push",
+    hint: "Phone or desktop alert via this app.",
+  },
+  { value: "both", label: "Both", hint: "Send by email and push." },
+];
+
+export function NotificationsCard() {
+  const qc = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: prefs, isLoading } = useQuery({
+    queryKey: ["me", "notification-preferences"],
+    queryFn: () => callApi(api.GET("/api/me/notification-preferences")),
+  });
+
+  const updatePrefs = useMutation({
+    mutationFn: (matchdayChannel: Channel) =>
+      callApi(
+        api.PUT("/api/me/notification-preferences", {
+          body: { matchdayChannel },
+        }),
+      ),
+    onSuccess: (next) => {
+      qc.setQueryData(["me", "notification-preferences"], next);
+    },
+  });
+
+  const { state: pushState, refresh: refreshPushState } = usePushState();
+
+  const enablePush = useMutation({
+    mutationFn: enablePushOnThisDevice,
+    onSuccess: () => {
+      setError(null);
+      void refreshPushState();
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  const disablePush = useMutation({
+    mutationFn: disablePushOnThisDevice,
+    onSuccess: () => {
+      setError(null);
+      void refreshPushState();
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  const channel = prefs?.matchdayChannel ?? "email";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardEyebrow>Notifications</CardEyebrow>
+        <CardTitle>Matchday alerts</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-text-secondary text-sm">
+          How would you like to be told about new availability requests and
+          other matchday updates?
+        </p>
+
+        <fieldset
+          className="space-y-2"
+          disabled={isLoading || updatePrefs.isPending}
+        >
+          {CHANNELS.map((opt) => {
+            const selected = channel === opt.value;
+            return (
+              <label
+                key={opt.value}
+                className={
+                  "border-border flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors " +
+                  (selected
+                    ? "bg-navy/5 border-navy"
+                    : "hover:bg-surface-raised")
+                }
+              >
+                <input
+                  type="radio"
+                  name="matchday-channel"
+                  value={opt.value}
+                  checked={selected}
+                  onChange={() => updatePrefs.mutate(opt.value)}
+                  className="mt-0.5"
+                />
+                <span className="flex-1">
+                  <span className="block text-sm font-medium">{opt.label}</span>
+                  <span className="text-text-secondary block text-xs">
+                    {opt.hint}
+                  </span>
+                </span>
+              </label>
+            );
+          })}
+        </fieldset>
+
+        <div className="border-border space-y-2 border-t pt-4">
+          <div className="text-sm font-medium">Push on this device</div>
+          <PushStatus
+            pushState={pushState}
+            onEnable={() => enablePush.mutate()}
+            onDisable={() => disablePush.mutate()}
+            busy={enablePush.isPending || disablePush.isPending}
+          />
+          {error && <p className="text-danger text-xs">{error}</p>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PushStatus({
+  pushState,
+  onEnable,
+  onDisable,
+  busy,
+}: {
+  pushState: ReturnType<typeof usePushState>["state"];
+  onEnable: () => void;
+  onDisable: () => void;
+  busy: boolean;
+}) {
+  if (!pushState.support.supported) {
+    return (
+      <p className="text-text-secondary text-xs">
+        Push isn't supported on this browser. On iOS, add Matchday to your home
+        screen first.
+      </p>
+    );
+  }
+  if (pushState.support.permission === "denied") {
+    return (
+      <p className="text-text-secondary text-xs">
+        Notifications are blocked for this site. Re-enable them in the browser
+        site settings, then come back here to subscribe.
+      </p>
+    );
+  }
+  if (pushState.subscribed === null) {
+    return <p className="text-text-secondary text-xs">Checking…</p>;
+  }
+  if (pushState.subscribed) {
+    return (
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-text-secondary text-xs">
+          This device will receive matchday push.
+        </p>
+        <Button size="sm" tone="outline" onClick={onDisable} disabled={busy}>
+          Disable
+        </Button>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <p className="text-text-secondary text-xs">
+        Not subscribed on this device yet.
+      </p>
+      <Button size="sm" onClick={onEnable} disabled={busy}>
+        Enable
+      </Button>
+    </div>
+  );
+}

--- a/apps/matchday/src/features/notifications/use-push.ts
+++ b/apps/matchday/src/features/notifications/use-push.ts
@@ -21,6 +21,16 @@ function detectSupport(): Support {
   return { supported: true, permission: Notification.permission };
 }
 
+function bytesEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  const aView = new Uint8Array(a);
+  const bView = new Uint8Array(b);
+  for (let i = 0; i < aView.length; i++) {
+    if (aView[i] !== bView[i]) return false;
+  }
+  return true;
+}
+
 // Convert the base64url-encoded VAPID public key the API hands us into
 // the raw Uint8Array<ArrayBuffer> that PushManager.subscribe() expects.
 // Backed by a real ArrayBuffer (not ArrayBufferLike) so the DOM types
@@ -101,12 +111,25 @@ export async function enablePushOnThisDevice(): Promise<{
   // Pull the VAPID public key from the API rather than baking it into
   // the bundle - lets us rotate the keypair without a matchday rebuild.
   const { publicKey } = await callApi(api.GET("/api/push/public-key"));
-  const existing = await reg.pushManager.getSubscription();
+  const serverKey = urlBase64ToUint8Array(publicKey);
+
+  // Existing subscription? Reuse it only if it was created with the
+  // *current* VAPID key. After a key rotation the old subscription is
+  // still in PushManager but the push service will reject any sends to
+  // it - so unsubscribe + re-subscribe with the new key transparently.
+  let existing = await reg.pushManager.getSubscription();
+  if (existing) {
+    const existingKey = existing.options.applicationServerKey;
+    if (!existingKey || !bytesEqual(existingKey, serverKey.buffer)) {
+      await existing.unsubscribe();
+      existing = null;
+    }
+  }
   const sub =
     existing ??
     (await reg.pushManager.subscribe({
       userVisibleOnly: true,
-      applicationServerKey: urlBase64ToUint8Array(publicKey),
+      applicationServerKey: serverKey,
     }));
 
   const json = sub.toJSON();

--- a/apps/matchday/src/features/notifications/use-push.ts
+++ b/apps/matchday/src/features/notifications/use-push.ts
@@ -1,0 +1,150 @@
+import { api, callApi } from "@/lib/api-client.js";
+import { useQuery } from "@tanstack/react-query";
+
+type Support =
+  | { supported: true; permission: NotificationPermission }
+  | { supported: false; reason: string };
+
+function detectSupport(): Support {
+  if (typeof window === "undefined") {
+    return { supported: false, reason: "ssr" };
+  }
+  if (!("serviceWorker" in navigator)) {
+    return { supported: false, reason: "no_service_worker" };
+  }
+  if (!("PushManager" in window)) {
+    return { supported: false, reason: "no_push_manager" };
+  }
+  if (!("Notification" in window)) {
+    return { supported: false, reason: "no_notification_api" };
+  }
+  return { supported: true, permission: Notification.permission };
+}
+
+// Convert the base64url-encoded VAPID public key the API hands us into
+// the raw Uint8Array<ArrayBuffer> that PushManager.subscribe() expects.
+// Backed by a real ArrayBuffer (not ArrayBufferLike) so the DOM types
+// accept it as a BufferSource without an `as` escape hatch.
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = window.atob(base64);
+  const buffer = new ArrayBuffer(rawData.length);
+  const output = new Uint8Array(buffer);
+  for (let i = 0; i < rawData.length; ++i) {
+    output[i] = rawData.charCodeAt(i);
+  }
+  return output;
+}
+
+export interface PushState {
+  support: Support;
+  // null while react-query is still resolving the SW registration check.
+  subscribed: boolean | null;
+}
+
+async function readPushState(): Promise<PushState> {
+  const support = detectSupport();
+  if (!support.supported) return { support, subscribed: false };
+  try {
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.getSubscription();
+    return { support, subscribed: Boolean(sub) };
+  } catch {
+    return { support, subscribed: false };
+  }
+}
+
+export const PUSH_STATE_QUERY_KEY = ["me", "push-state"] as const;
+
+export function usePushState(): {
+  state: PushState;
+  refresh: () => Promise<unknown>;
+} {
+  const query = useQuery({
+    queryKey: PUSH_STATE_QUERY_KEY,
+    queryFn: readPushState,
+    // Browser state, not server state - no need to refetch on focus or
+    // mount thrash. Caller invalidates explicitly after enable/disable.
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
+  const state: PushState = query.data ?? {
+    support: detectSupport(),
+    subscribed: null,
+  };
+
+  return { state, refresh: () => query.refetch() };
+}
+
+// Walks the browser through permission -> subscribe -> register on
+// the server. Returns the endpoint on success so callers can show a
+// confirmation chip.
+export async function enablePushOnThisDevice(): Promise<{
+  endpoint: string;
+}> {
+  if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+    throw new Error("Push notifications are not supported on this device.");
+  }
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") {
+    throw new Error(
+      permission === "denied"
+        ? "Notification permission is blocked. Re-enable it in the browser site settings to receive push."
+        : "Notification permission not granted.",
+    );
+  }
+
+  const reg = await navigator.serviceWorker.ready;
+  // Pull the VAPID public key from the API rather than baking it into
+  // the bundle - lets us rotate the keypair without a matchday rebuild.
+  const { publicKey } = await callApi(api.GET("/api/push/public-key"));
+  const existing = await reg.pushManager.getSubscription();
+  const sub =
+    existing ??
+    (await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(publicKey),
+    }));
+
+  const json = sub.toJSON();
+  const keys = json.keys ?? {};
+  if (!json.endpoint || !keys.p256dh || !keys.auth) {
+    throw new Error("Push subscription is missing key material.");
+  }
+
+  await callApi(
+    api.POST("/api/me/push-subscriptions", {
+      body: {
+        endpoint: json.endpoint,
+        keys: { p256dh: keys.p256dh, auth: keys.auth },
+        userAgent: navigator.userAgent.slice(0, 500),
+      },
+    }),
+  );
+
+  return { endpoint: json.endpoint };
+}
+
+export async function disablePushOnThisDevice(): Promise<void> {
+  if (!("serviceWorker" in navigator)) return;
+  const reg = await navigator.serviceWorker.ready;
+  const sub = await reg.pushManager.getSubscription();
+  if (!sub) return;
+
+  // Best-effort server cleanup before we yank the local subscription -
+  // if the server call fails the worst case is a stale row that gets
+  // pruned at first 410 from the push service.
+  try {
+    await callApi(
+      api.DELETE("/api/me/push-subscriptions", {
+        body: { endpoint: sub.endpoint },
+      }),
+    );
+  } catch {
+    // ignore - local unsubscribe still proceeds
+  }
+  await sub.unsubscribe();
+}

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -12638,6 +12638,187 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/me/notification-preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            matchdayChannel: "email" | "push" | "both";
+                        };
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        matchdayChannel: "email" | "push" | "both";
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            matchdayChannel: "email" | "push" | "both";
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/push/public-key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            publicKey: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/me/push-subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uri */
+                        endpoint: string;
+                        keys: {
+                            p256dh: string;
+                            auth: string;
+                        };
+                        userAgent?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uri */
+                        endpoint: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            deleted: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/stripe/webhook": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -22895,6 +22895,221 @@
         }
       }
     },
+    "/api/me/notification-preferences": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "matchdayChannel": {
+                      "type": "string",
+                      "enum": [
+                        "email",
+                        "push",
+                        "both"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "matchdayChannel"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "matchdayChannel": {
+                    "type": "string",
+                    "enum": [
+                      "email",
+                      "push",
+                      "both"
+                    ]
+                  }
+                },
+                "required": [
+                  "matchdayChannel"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "matchdayChannel": {
+                      "type": "string",
+                      "enum": [
+                        "email",
+                        "push",
+                        "both"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "matchdayChannel"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/push/public-key": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "publicKey": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": [
+                    "publicKey"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/me/push-subscriptions": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "keys": {
+                    "type": "object",
+                    "properties": {
+                      "p256dh": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "auth": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "p256dh",
+                      "auth"
+                    ]
+                  },
+                  "userAgent": {
+                    "type": "string",
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "endpoint",
+                  "keys"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": [
+                  "endpoint"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deleted": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "deleted"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stripe/webhook": {
       "post": {
         "responses": {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -23020,11 +23020,13 @@
                     "properties": {
                       "p256dh": {
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 200
                       },
                       "auth": {
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 200
                       }
                     },
                     "required": [

--- a/apps/matchday/src/pages/me.tsx
+++ b/apps/matchday/src/pages/me.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
+import { NotificationsCard } from "@/features/notifications/notifications-card.js";
 import { signOut, useSession, type SessionUser } from "@/lib/auth-client.js";
 import { mainSiteUrl } from "@/lib/main-site.js";
 
@@ -27,6 +28,8 @@ export default function Me() {
           />
         </CardContent>
       </Card>
+
+      <NotificationsCard />
 
       <Card>
         <CardHeader>

--- a/apps/matchday/vite.config.ts
+++ b/apps/matchday/vite.config.ts
@@ -69,6 +69,11 @@ export default defineConfig({
         cleanupOutdatedCaches: true,
         clientsClaim: true,
         skipWaiting: true,
+        // Layer the push + notificationclick handlers on top of the
+        // generated workbox SW via importScripts. Keeps the existing
+        // generateSW pipeline intact - we just need event listeners,
+        // not a hand-rolled SW.
+        importScripts: ["/push-handler.js"],
         // SPA fallback — any navigation request to a path we don't have
         // cached falls back to the precached index.html (offline launch).
         navigateFallback: "/index.html",

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -12638,6 +12638,187 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/me/notification-preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            matchdayChannel: "email" | "push" | "both";
+                        };
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        matchdayChannel: "email" | "push" | "both";
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            matchdayChannel: "email" | "push" | "both";
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/push/public-key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            publicKey: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/me/push-subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uri */
+                        endpoint: string;
+                        keys: {
+                            p256dh: string;
+                            auth: string;
+                        };
+                        userAgent?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uri */
+                        endpoint: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            deleted: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/stripe/webhook": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -22895,6 +22895,221 @@
         }
       }
     },
+    "/api/me/notification-preferences": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "matchdayChannel": {
+                      "type": "string",
+                      "enum": [
+                        "email",
+                        "push",
+                        "both"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "matchdayChannel"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "matchdayChannel": {
+                    "type": "string",
+                    "enum": [
+                      "email",
+                      "push",
+                      "both"
+                    ]
+                  }
+                },
+                "required": [
+                  "matchdayChannel"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "matchdayChannel": {
+                      "type": "string",
+                      "enum": [
+                        "email",
+                        "push",
+                        "both"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "matchdayChannel"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/push/public-key": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "publicKey": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": [
+                    "publicKey"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/me/push-subscriptions": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "keys": {
+                    "type": "object",
+                    "properties": {
+                      "p256dh": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "auth": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "p256dh",
+                      "auth"
+                    ]
+                  },
+                  "userAgent": {
+                    "type": "string",
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "endpoint",
+                  "keys"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": [
+                  "endpoint"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deleted": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "deleted"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stripe/webhook": {
       "post": {
         "responses": {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -23020,11 +23020,13 @@
                     "properties": {
                       "p256dh": {
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 200
                       },
                       "auth": {
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 200
                       }
                     },
                     "required": [

--- a/docs/adrs/044-matchday-notification-channel-modelling.md
+++ b/docs/adrs/044-matchday-notification-channel-modelling.md
@@ -1,0 +1,54 @@
+# ADR 044: Matchday notification channel modelling
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #379 asked us to add push notifications to the matchday app and let users choose email / push / both per matchday notification (currently only "new availability request" - more to follow).
+
+Three shapes were on the table for storing that preference: a single column per channel on the better-auth `user` table, a fan-out of per-notification-type columns, or a separate `notification_preferences` table keyed 1:1 on user.
+
+The user model is managed by better-auth and its schema is the kind of thing better-auth migrations are allowed to touch. The matchday notification list is going to grow - team-sheet published, expense added, fee owed - and we did not want every new category to require an ALTER TABLE plus a frontend type-rev.
+
+## Decision
+
+A new `notification_preferences` table keyed on `user_id` (cascade-delete, PK is the FK), holding a single `matchday_channel` text column constrained to `'email' | 'push' | 'both'`, default `'email'`. Default at the application layer too: callers that read prefs see `'email'` for users with no row.
+
+Wire shape exposed via `GET/PUT /api/me/notification-preferences` returns `{ matchdayChannel }`. Adding a future category is a column add on the same table plus a new field on the response schema - no migration to the user table, no new endpoint.
+
+## Problem
+
+What forced the decision:
+
+- The notification list is open-ended (#379 hints at it explicitly: "for all matchday notifications, currently just ..."). We need somewhere to grow without renaming.
+- The better-auth user table is owned by an upstream library and any column we add lives at our own risk - better-auth's CLI generator does not know about our additions, and renames have bitten the codebase before in places that piggy-backed on it.
+- Defaulting to email matters: every existing user must keep getting email out of the box without a backfill step.
+
+## Options considered
+
+1. **Separate `notification_preferences` table** (chosen). One row per user, columns per category. New categories = new column.
+2. **Column on the `user` table.** Single join elided, but mutates better-auth's table and would need a new column per category.
+3. **JSON column on user or on a prefs row.** Maximally flexible, but loses the CHECK-constraint discipline and we end up validating shape in app code instead of the DB.
+4. **Per-notification-type table (notification_preferences with a `category` column, one row per user-category pair).** Most "future-proof" but premature - there is exactly one category today, and an EAV-shaped table makes the trivial "load all my prefs" query a join-then-pivot.
+
+## Rationale
+
+We picked option 1 because it gives us:
+
+- A clean separation from better-auth's owned table. Migrations of `notification_preferences` cannot collide with library upgrades.
+- A discrete enum constrained by CHECK at the DB layer (`matchday_channel IN ('email','push','both')`) - the validation is in one place.
+- Trivial reads for the current category and a trivial column-add for the next one. Pivoting only becomes worthwhile when we have a handful of categories AND the UI wants to render them generically; we have neither.
+- A `DEFAULT_MATCHDAY_CHANNEL` constant in the service that the read path applies when no row exists, so we never have to backfill on day one.
+
+## Rejected alternatives
+
+- **User-table column** - rejected because (a) mutating a better-auth-managed table is a recurring footgun (the `dont_mutate_db_directly` rule in personal memory exists for a reason) and (b) it does not actually save us anything: the read still happens at recipient-resolution time, and we already join across tables there.
+- **JSON column** - rejected because we lose the CHECK constraint and the next person reading the code has to read the writer to know what values are valid. The enum is small and stable; the cost of a column-per-category is one migration when we add the second category.
+- **EAV-shaped per-category table** - rejected as premature. We would adopt this if/when we have more than ~3 categories AND the matchday UI starts rendering "all your notification settings" generically. Until then, one column per category beats a join.
+
+## Related
+
+- Per [ADR 009](009-dependency-injection.md), the service is a curried factory taking `db` as its first parameter.
+- Recipient resolution in `sendAvailabilityNotification` reads prefs by user id in batch via `getNotificationPreferencesByUserIds(db)`. Additional emails (admin-added external addresses) bypass the prefs lookup and always go to email.

--- a/docs/adrs/045-matchday-service-worker-push-integration.md
+++ b/docs/adrs/045-matchday-service-worker-push-integration.md
@@ -1,0 +1,59 @@
+# ADR 045: Matchday service worker push integration via importScripts
+
+## Status
+
+Accepted
+
+## Context
+
+Matchday's PWA is built by `vite-plugin-pwa` in `generateSW` mode. The generated service worker handles precaching, workbox runtime caching for GET endpoints used pitch-side, BackgroundSync for the captain's write endpoints, and a "tap to reload on new version" toast. None of that machinery is hand-written - it falls out of the existing workbox config in `apps/matchday/vite.config.ts`.
+
+Adding Web Push (#379) means the SW needs two extra event listeners:
+
+```js
+self.addEventListener("push", (event) => { ... });
+self.addEventListener("notificationclick", (event) => { ... });
+```
+
+Workbox-generated service workers do not include those listeners on their own.
+
+## Decision
+
+Keep `generateSW` and layer the push handler in via `workbox.importScripts`. The handler lives at `apps/matchday/public/push-handler.js`, gets served at `/push-handler.js`, and is loaded into the generated SW via `importScripts("/push-handler.js")` at SW boot.
+
+## Problem
+
+Two ways exist to ship custom SW code with `vite-plugin-pwa`:
+
+1. Switch to `injectManifest`, which lets us write the entire SW by hand and import workbox modules à la carte.
+2. Stay on `generateSW` and inject extra scripts via `workbox.importScripts`.
+
+Pushing to (1) is the "standard" migration path the docs nudge you towards for non-trivial custom logic. We deliberately did not.
+
+## Options considered
+
+1. **`generateSW` + `workbox.importScripts: ['/push-handler.js']`** (chosen). Workbox config is unchanged. The push-handler is a plain JS file in `public/`, dropped into the generated SW at boot time.
+2. **Switch to `injectManifest` and write a custom `sw.ts`.** Requires re-implementing the existing precache + runtimeCaching + backgroundSync setup in TypeScript using direct workbox imports.
+3. **Inline the push listener into the React app** via the `useRegisterSW` callback. Does not actually work - push and notificationclick handlers must be on the SW global, not the page.
+
+## Rationale
+
+Option 1 wins because:
+
+- The existing workbox config has eight runtime-caching rules and three BackgroundSync rules, all tuned for pitch-side use (see `vite.config.ts` lines 80-171). Rewriting all of that to call `precacheAndRoute`, `registerRoute`, `NetworkOnly` with `BackgroundSyncPlugin`, etc. by hand is a fair amount of code to maintain forever just to add two listeners.
+- The handler is a flat ~50 LOC of platform API calls (`registration.showNotification`, `clients.matchAll`, `clients.openWindow`). There is no app code to share with it - it does not import from `@/` and does not need bundling.
+- `workbox.importScripts` is a first-class workbox-build option, not a workaround. It maps directly to `self.importScripts(...)` in the generated SW.
+- We get to keep "tap to reload on update" via `vite-plugin-pwa`'s `useRegisterSW` without rewiring the React shell.
+
+The trade-off is that the push handler is plain JS, not bundled or type-checked against our codebase. That is fine: it is a SW global; it cannot import from `@/`; and the payload contract (`{ title, body, url, tag }`) lives in `apps/api/src/lib/push-sender.ts` where the producer side is type-checked. The handler does its own try/catch around `event.data.json()` so a malformed payload does not crash the SW.
+
+## Rejected alternatives
+
+- **`injectManifest`** - rejected on cost. We would adopt this if the SW grew enough TypeScript-shaped logic that the duplication-with-workbox-config became worse than re-implementing the cache rules. As of #379 there is none.
+- **Inline page-side listener** - does not work; mentioned only to flag it as a non-starter so the next person does not try.
+
+## Related
+
+- The push-handler script source: `apps/matchday/public/push-handler.js`. It is loaded into both the dev SW (when enabled) and the production-built SW (`dist/sw.js`).
+- Push payload contract enforced server-side: `apps/api/src/lib/push-sender.ts` `PushPayload`.
+- VAPID public key is fetched at subscribe time rather than baked into the bundle - see [ADR 046](046-vapid-public-key-via-api.md).

--- a/docs/adrs/046-vapid-public-key-via-api.md
+++ b/docs/adrs/046-vapid-public-key-via-api.md
@@ -1,0 +1,50 @@
+# ADR 046: VAPID public key delivered via API, not bundled
+
+## Status
+
+Accepted
+
+## Context
+
+Web Push needs a VAPID keypair on the application server. The private half signs JWTs that authenticate this server to browser push services (FCM, Apple, Mozilla autopush). The public half is sent inside `PushManager.subscribe({ applicationServerKey })` so the push service can verify those signatures later.
+
+The public half is not a secret. It identifies us to the push service; anyone with it still cannot send a push without the matching private key. So we had a choice in how the matchday SPA gets at it before subscribing:
+
+1. Bake into the Vite bundle as `VITE_VAPID_PUBLIC_KEY`.
+2. Fetch from a public API endpoint at subscribe time.
+
+## Decision
+
+The API exposes `GET /api/push/public-key` (no auth required) that returns `{ publicKey }`. The matchday hook `enablePushOnThisDevice()` calls it just before `pushManager.subscribe()` and feeds the result into `applicationServerKey`. The key value lives in SSM (`/<env>/percy-main/VAPID_PUBLIC_KEY`) and is read into the API config at boot.
+
+## Problem
+
+Three constraints shaped the call:
+
+- **Two apps share the API.** Both `apps/web` and `apps/matchday` are Vite builds with their own envs. Baking the public key into the bundle means two `VITE_VAPID_PUBLIC_KEY` slots, two CI-injection points, and two ways for them to drift out of sync with the API's actual keypair.
+- **Key rotation must be cheap.** If we ever rotate VAPID (compromise, key-format migration), we want operators to flip an SSM value and roll the API task. Forcing a matchday rebuild + redeploy to pick up a new bundled constant turns rotation into a multi-step coordination problem.
+- **The fetch is not hot path.** A subscriber calls `pushManager.subscribe()` at most a handful of times per device (first opt-in, occasional re-subscribe). One extra HTTP request before that is invisible cost.
+
+## Options considered
+
+1. **`GET /api/push/public-key` returning `{ publicKey }`** (chosen). Public endpoint, no auth, served from the same API as the rest of matchday.
+2. **`VITE_VAPID_PUBLIC_KEY` baked into the matchday bundle.** Single HTTP request saved on first subscribe; cost paid on every key rotation.
+3. **Include the public key in an existing me-shaped endpoint** (e.g., as a field on `GET /api/me/notification-preferences`). Saves a request but couples two concerns and means anonymous visitors who want to opt in can't read it. Currently moot because we require auth before showing the toggle, but future "subscribe before sign-up" flows would re-open it.
+
+## Rationale
+
+- **One source of truth.** SSM holds the key; both apps and the API read from the API; rotation is "update SSM, redeploy API task." No bundle-rebuild step. No version skew between bundle and API.
+- **Cheap fetch.** Subscribe happens once-ish per device. An extra ~50ms before a permission prompt is unnoticeable next to the prompt itself.
+- **Public-by-design.** The key has no confidentiality requirement and the endpoint has no other side effects. There is nothing to lock behind auth and no rate-limit story to worry about.
+- **Symmetric with the private half.** Private key + subject already come from the same Secrets Manager blob the API reads at boot; the public half routing through the same boot path means all three VAPID values are validated together at startup (per the `feedback_required_env_vars` rule - new env vars must be required, not optional).
+
+## Rejected alternatives
+
+- **Bundle-embedded `VITE_VAPID_PUBLIC_KEY`** - rejected because rotation cost compounds across two apps and CI envs. Would become attractive if we needed offline-first subscription (no API reachable), which we do not.
+- **Embedded in `/me/notification-preferences`** - rejected because it couples user-prefs to a piece of platform config and assumes the caller is authenticated. Easy to merge later if a use case shows up; cheap to keep separate now.
+
+## Related
+
+- Public key SSM parameter: `/staging/percy-main/VAPID_PUBLIC_KEY`, `/production/percy-main/VAPID_PUBLIC_KEY` (defined in `infra/environments/<env>/secrets.tf`).
+- Private key + subject live in the `app_secrets` Secrets Manager blob and are read by `createPushSender` (`apps/api/src/lib/push-sender.ts`).
+- All three VAPID values are required by `apps/api/src/config.ts` - the API will fail fast at boot if any is missing.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -22,3 +22,6 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 | [012](012-prod-db-access.md)                             | Production DB Access via Tailscale                          | 2026-04-20 | Accepted |
 | [042](042-scout-recognition-sources.md)                  | Scout Recognition Sources - Public-Source Discovery         | 2026-05-14 | Accepted |
 | [043](043-db-role-split-principle-of-least-privilege.md) | DB Role Split - Principle of Least Privilege                | 2026-05-15 | Accepted |
+| [044](044-matchday-notification-channel-modelling.md)    | Matchday notification channel modelling                     | 2026-05-21 | Accepted |
+| [045](045-matchday-service-worker-push-integration.md)   | Matchday service worker push integration via importScripts  | 2026-05-21 | Accepted |
+| [046](046-vapid-public-key-via-api.md)                   | VAPID public key delivered via API, not bundled             | 2026-05-21 | Accepted |

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -311,6 +311,13 @@ module "ecs" {
     MATCHDAY_URL  = aws_ssm_parameter.matchday_url.arn
     WWW_URL       = aws_ssm_parameter.www_url.arn
     COOKIE_DOMAIN = aws_ssm_parameter.cookie_domain.arn
+
+    # Web Push (VAPID). Public half from SSM, private + subject from
+    # app_secrets. The private half MUST be populated in app_secrets
+    # before this task definition redeploys or ECS will fail to start.
+    VAPID_PUBLIC_KEY  = aws_ssm_parameter.vapid_public_key.arn
+    VAPID_PRIVATE_KEY = "${aws_secretsmanager_secret.app_secrets.arn}:VAPID_PRIVATE_KEY::"
+    VAPID_SUBJECT     = "${aws_secretsmanager_secret.app_secrets.arn}:VAPID_SUBJECT::"
   }
 }
 

--- a/infra/environments/production/secrets.tf
+++ b/infra/environments/production/secrets.tf
@@ -4,7 +4,7 @@
 #   STRIPE_WEBHOOK_SECRET, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET,
 #   PLAY_CRICKET_API_TOKEN, SLACK_WEBHOOK_URL, NEW_RELIC_LICENSE_KEY,
 #   ANTHROPIC_API_KEY, DEEPSEEK_API_KEY, VOYAGE_API_KEY, TAVILY_API_KEY,
-#   SCOUT_DB_URL, PHOENIX_API_KEY
+#   SCOUT_DB_URL, PHOENIX_API_KEY, VAPID_PRIVATE_KEY, VAPID_SUBJECT
 
 resource "aws_secretsmanager_secret" "app_secrets" {
   name = "production/percy-main/app"
@@ -173,6 +173,31 @@ resource "aws_ssm_parameter" "www_url" {
 
 resource "aws_ssm_parameter" "cookie_domain" {
   name  = "/production/percy-main/COOKIE_DOMAIN"
+  type  = "String"
+  value = "placeholder"
+
+  tags = {
+    Environment = "production"
+    Project     = "percy-main"
+    ManagedBy   = "terraform"
+  }
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# Web Push (VAPID) public key. The private half + subject live in the
+# app_secrets blob (Secrets Manager). Generate the keypair once with
+# `npx web-push generate-vapid-keys` and set both halves before the API
+# first redeploys with the push code wired in - the API fails fast at
+# boot if any of the three are missing.
+#
+#   aws --profile percy-main ssm put-parameter --overwrite \
+#     --name /production/percy-main/VAPID_PUBLIC_KEY \
+#     --value "<public key from web-push generate-vapid-keys>"
+resource "aws_ssm_parameter" "vapid_public_key" {
+  name  = "/production/percy-main/VAPID_PUBLIC_KEY"
   type  = "String"
   value = "placeholder"
 

--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -199,6 +199,13 @@ module "ecs" {
     BETTER_AUTH_RP_NAME  = aws_ssm_parameter.better_auth_rp_name.arn
     PLAY_CRICKET_SITE_ID = aws_ssm_parameter.play_cricket_site_id.arn
     SES_FROM_ADDRESS     = aws_ssm_parameter.ses_from_address.arn
+
+    # Web Push (VAPID). Public half from SSM, private + subject from
+    # app_secrets. All three required by config — populate both halves
+    # in app_secrets before this task definition redeploys.
+    VAPID_PUBLIC_KEY  = aws_ssm_parameter.vapid_public_key.arn
+    VAPID_PRIVATE_KEY = "${aws_secretsmanager_secret.app_secrets.arn}:VAPID_PRIVATE_KEY::"
+    VAPID_SUBJECT     = "${aws_secretsmanager_secret.app_secrets.arn}:VAPID_SUBJECT::"
   }
 }
 

--- a/infra/environments/staging/secrets.tf
+++ b/infra/environments/staging/secrets.tf
@@ -124,8 +124,10 @@ resource "aws_ssm_parameter" "ses_from_address" {
 }
 
 # Web Push (VAPID) public key. The private half + subject live in the
-# app_secrets blob. Use the same keypair as production - matchday subscribers
-# can roam between environments only if the keys match.
+# app_secrets blob. Generate a fresh keypair per environment - subscriptions
+# are origin-scoped, so there's no benefit to sharing keys with production,
+# and a separate staging keypair means a leaked staging private key cannot
+# be used to push to production subscribers.
 resource "aws_ssm_parameter" "vapid_public_key" {
   name  = "/staging/percy-main/VAPID_PUBLIC_KEY"
   type  = "String"

--- a/infra/environments/staging/secrets.tf
+++ b/infra/environments/staging/secrets.tf
@@ -9,7 +9,7 @@
 #       STRIPE_WEBHOOK_SECRET, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET,
 #       PLAY_CRICKET_API_TOKEN, SLACK_WEBHOOK_URL,
 #       ANTHROPIC_API_KEY, DEEPSEEK_API_KEY, VOYAGE_API_KEY, TAVILY_API_KEY,
-#       SCOUT_DB_URL, PHOENIX_API_KEY
+#       SCOUT_DB_URL, PHOENIX_API_KEY, VAPID_PRIVATE_KEY, VAPID_SUBJECT
 
 resource "aws_secretsmanager_secret" "app_secrets" {
   name = "staging/percy-main/app"
@@ -109,6 +109,25 @@ resource "aws_ssm_parameter" "play_cricket_site_id" {
 
 resource "aws_ssm_parameter" "ses_from_address" {
   name  = "/staging/percy-main/SES_FROM_ADDRESS"
+  type  = "String"
+  value = "placeholder"
+
+  tags = {
+    Environment = "staging"
+    Project     = "percy-main"
+    ManagedBy   = "terraform"
+  }
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# Web Push (VAPID) public key. The private half + subject live in the
+# app_secrets blob. Use the same keypair as production - matchday subscribers
+# can roam between environments only if the keys match.
+resource "aws_ssm_parameter" "vapid_public_key" {
+  name  = "/staging/percy-main/VAPID_PUBLIC_KEY"
   type  = "String"
   value = "placeholder"
 

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -667,6 +667,13 @@ export interface Membership {
   type: string | null;
 }
 
+export interface NotificationPreferences {
+  created_at: Generated<Timestamp>;
+  matchday_channel: Generated<string>;
+  updated_at: Generated<Timestamp>;
+  user_id: string;
+}
+
 export interface Passkey {
   backedUp: boolean;
   counter: number;
@@ -723,6 +730,17 @@ export interface PlayerSponsorship {
   sponsor_phone: string | null;
   sponsor_website: string | null;
   stripe_payment_intent_id: string | null;
+}
+
+export interface PushSubscription {
+  auth: string;
+  created_at: Generated<Timestamp>;
+  endpoint: string;
+  id: Generated<string>;
+  p256dh: string;
+  updated_at: Generated<Timestamp>;
+  user_agent: string | null;
+  user_id: string;
 }
 
 export interface RvPlayerMapping {
@@ -996,11 +1014,13 @@ export interface DB {
   member: Member;
   member_parent_link: MemberParentLink;
   membership: Membership;
+  notification_preferences: NotificationPreferences;
   passkey: Passkey;
   play_cricket_match_cache: PlayCricketMatchCache;
   play_cricket_sync_log: PlayCricketSyncLog;
   play_cricket_team: PlayCricketTeam;
   player_sponsorship: PlayerSponsorship;
+  push_subscription: PushSubscription;
   rv_player_mapping: RvPlayerMapping;
   scout_attachment: ScoutAttachment;
   scout_attachment_cache: ScoutAttachmentCache;

--- a/packages/db/src/migrations/2026-05-21T21:13:05.080Z.ts
+++ b/packages/db/src/migrations/2026-05-21T21:13:05.080Z.ts
@@ -1,0 +1,64 @@
+import { type Kysely, sql } from "kysely";
+
+// Matchday push notifications: per-user channel preference + per-device push
+// subscription store.
+//
+// notification_preferences keys 1:1 on user_id and currently holds a single
+// "matchday_channel" enum (email|push|both). Lives in its own table to keep
+// better-auth's user row untouched and leave room for per-category prefs.
+//
+// push_subscription holds the Web Push endpoint + key material returned by
+// PushManager.subscribe() in the browser. One row per device per user.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("notification_preferences")
+    .addColumn("user_id", "text", (col) =>
+      col.primaryKey().references("user.id").onDelete("cascade"),
+    )
+    .addColumn("matchday_channel", "text", (col) =>
+      col.notNull().defaultTo("email"),
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addCheckConstraint(
+      "notification_preferences_matchday_channel_check",
+      sql`matchday_channel IN ('email','push','both')`,
+    )
+    .execute();
+
+  await db.schema
+    .createTable("push_subscription")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("user_id", "text", (col) =>
+      col.notNull().references("user.id").onDelete("cascade"),
+    )
+    .addColumn("endpoint", "text", (col) => col.notNull().unique())
+    .addColumn("p256dh", "text", (col) => col.notNull())
+    .addColumn("auth", "text", (col) => col.notNull())
+    .addColumn("user_agent", "text")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("push_subscription_user_id_idx")
+    .on("push_subscription")
+    .column("user_id")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("push_subscription").execute();
+  await db.schema.dropTable("notification_preferences").execute();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       ts-pattern:
         specifier: ^5.6.0
         version: 5.9.0
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -231,6 +234,9 @@ importers:
       '@types/supertest':
         specifier: ^7.2.0
         version: 7.2.0
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -3932,6 +3938,9 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -4204,6 +4213,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
@@ -4442,6 +4454,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -5507,6 +5522,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -6291,6 +6310,9 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -7875,6 +7897,11 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -11627,7 +11654,7 @@ snapshots:
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -11636,13 +11663,13 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@types/cookiejar@2.1.5': {}
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@types/css-font-loading-module@0.0.7': {}
 
@@ -11678,7 +11705,7 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
@@ -11715,7 +11742,7 @@ snapshots:
 
   '@types/memcached@2.2.10':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@types/methods@1.1.4': {}
 
@@ -11723,7 +11750,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@types/node@18.19.130':
     dependencies:
@@ -11741,7 +11768,7 @@ snapshots:
 
   '@types/oracledb@6.5.2':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@types/pg-pool@2.0.7':
     dependencies:
@@ -11749,7 +11776,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -11771,11 +11798,11 @@ snapshots:
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
@@ -11796,7 +11823,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@types/trusted-types@2.0.7': {}
 
@@ -11806,9 +11833,13 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 25.9.0
+
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
 
   '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -12146,6 +12177,13 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   asn1@0.2.6:
     dependencies:
       safer-buffer: 2.1.2
@@ -12340,6 +12378,8 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bn.js@4.12.3: {}
 
   bowser@2.14.1: {}
 
@@ -12811,7 +12851,7 @@ snapshots:
   engine.io@6.6.7:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
       '@types/ws': 8.18.1
       accepts: 1.3.8
       base64id: 2.0.0
@@ -13675,6 +13715,8 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  http_ece@1.2.0: {}
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
@@ -14657,6 +14699,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -15106,7 +15150,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.8.0
+      '@types/node': 25.9.0
       long: 5.3.2
 
   proxy-from-env@2.1.0: {}
@@ -16462,6 +16506,16 @@ snapshots:
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
     transitivePeerDependencies:
       - msw
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
Closes #379.

## Summary

- Adds Web Push to the matchday PWA. Users pick email / push / both for matchday notifications (currently scoped to "new availability request"; designed to grow).
- Defaults to email so no existing recipient loses their notification. Push falls back to email if the user picks push but has no live device subscription.
- 410/404 from the push service prunes the subscription row automatically.

## What ships

**Backend**
- New tables `notification_preferences` (1:1 with user, enum-checked `matchday_channel`) and `push_subscription` (per-device).
- New endpoints under `/api/me/notification-preferences` (GET/PUT) and `/api/me/push-subscriptions` (POST/DELETE), plus public `GET /api/push/public-key`.
- `web-push` wrapped behind `app.sendPush`; `sendAvailabilityNotification` resolves recipients to user ids and honours each one's channel preference.
- Three new required env vars: `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` — staging + prod Terraform provisions SSM/Secrets Manager slots for all three.

**Matchday**
- Service worker stays on workbox `generateSW`; `workbox.importScripts: ['/push-handler.js']` layers in the `push` + `notificationclick` listeners without rewriting the cache config.
- `me.tsx` gains a Notifications card: radio for email/push/both, plus Enable/Disable on this device (requests permission, subscribes via PushManager, registers the subscription server-side).

**ADRs**
- 044 — channel modelling (separate table, single enum column)
- 045 — generateSW + importScripts over injectManifest
- 046 — VAPID public key over the API rather than bundled

## Test plan

- [x] `pnpm typecheck` clean across all packages
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] `pnpm --filter api test` — 513/513 pass, including six new integration tests for channel routing (email-only, push-only, push→email fallback, both, gone-prune, additional-email fallback) plus prefs + subscription lifecycle coverage
- [x] `pnpm --filter matchday build` produces `dist/sw.js` with `importScripts("/push-handler.js")` present
- [ ] Manual smoke after merge: subscribe on a desktop Chrome, trigger an availability request, confirm push lands and click opens the right URL

## Pre-deploy steps

The API will fail to boot until the three VAPID env vars are populated:

1. Generate a fresh VAPID keypair locally: `npx web-push generate-vapid-keys`.
2. In each of staging and production `app_secrets` Secrets Manager blobs, add `VAPID_PRIVATE_KEY` and `VAPID_SUBJECT` (e.g., `mailto:support@notifications.percymain.org`).
3. Set the SSM parameters `/staging/percy-main/VAPID_PUBLIC_KEY` and `/production/percy-main/VAPID_PUBLIC_KEY` to the public half.
4. Apply Terraform (creates the SSM resources and wires the new env keys into the ECS task def).
5. Add the same three to your local `apps/api/.env` (any test keypair is fine for dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)