### PR TITLE
feat(matchday): your upcoming games + recent performance cards

### DIFF
--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -23,6 +23,8 @@ import {
   listTeamsResponseSchema,
   markPaidSchema,
   matchIdParamSchema,
+  myRecentPerformanceResponseSchema,
+  myUpcomingMatchesResponseSchema,
   pastUnfinishedMatchdaysResponseSchema,
   playerIdParamSchema,
   publicMatchdayResponseSchema,
@@ -50,6 +52,8 @@ import {
   getAllPastUnfinishedMatchdays,
   getMatch,
   getMatchPublic,
+  getMyRecentPerformance,
+  getMyUpcomingMatches,
   getPastUnfinishedMatchdays,
   getTeamNewsData,
   getUpcomingMatches,
@@ -82,6 +86,39 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
   const record = recordExpense(app.db, app.s3);
   const update = updateExpense(app.db);
   const remove = deleteExpense(app.db);
+  const myUpcoming = getMyUpcomingMatches(app.db);
+  const myPerformance = getMyRecentPerformance(app.db);
+
+  // Static "mine" routes — registered before /matchday/:matchId so the
+  // radix router resolves them as exact matches, not as a matchId of
+  // "mine". They expose only the signed-in member's own data.
+  app.get(
+    "/matchday/mine/upcoming",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        response: { 200: myUpcomingMatchesResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await myUpcoming(user.email);
+    },
+  );
+
+  app.get(
+    "/matchday/mine/recent-performance",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        response: { 200: myRecentPerformanceResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await myPerformance(user.email);
+    },
+  );
 
   app.get(
     "/matchday",

--- a/apps/api/src/features/matchday/schemas.ts
+++ b/apps/api/src/features/matchday/schemas.ts
@@ -386,6 +386,28 @@ export const finishMatchResponseSchema = z.object({
   emailErrors: z.array(z.string()),
 });
 
+// ── "Mine" routes — per-user home cards ──
+
+const myUpcomingMatchSchema = z.object({
+  matchdayId: z.string(),
+  matchDate: z.string(),
+  opposition: z.string(),
+  teamName: z.string().nullable(),
+  competitionType: z.string().nullable(),
+  isCaptain: z.boolean(),
+  isWicketkeeper: z.boolean(),
+});
+
+export const myUpcomingMatchesResponseSchema = z.array(myUpcomingMatchSchema);
+
+export const myRecentPerformanceResponseSchema = z.object({
+  windowDays: z.number().int().positive(),
+  matchesPlayed: z.number().int().nonnegative(),
+  runs: z.number().int().nonnegative(),
+  wickets: z.number().int().nonnegative(),
+  catches: z.number().int().nonnegative(),
+});
+
 // ── Types ──
 
 export type ListMatches = z.infer<typeof listMatchesSchema>;

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -387,6 +387,153 @@ export function getMatchPublic(db: Kysely<DB>) {
   };
 }
 
+/**
+ * Upcoming matchdays the signed-in user has been picked for.
+ *
+ * "Picked" = matchday_player row exists for this user's member, with
+ * status "selected" or "playing" (matches getMatchPublic's squad
+ * projection). Matchday itself must be in "confirmed" status — pending
+ * means the squad isn't announced; finished/cancelled drop off this
+ * list naturally.
+ *
+ * Privacy: callers only see their own selections — resolved through
+ * the member.email = user.email link used elsewhere (e.g.
+ * charges/service.ts). If a member row doesn't exist for the user's
+ * email yet, returns an empty list.
+ */
+export function getMyUpcomingMatches(db: Kysely<DB>) {
+  return async (email: string) => {
+    const member = await db
+      .selectFrom("member")
+      .where("email", "=", email)
+      .select(["id"])
+      .executeTakeFirst();
+    if (!member) return [];
+
+    const todayIso = formatDate(new Date(), "yyyy-MM-dd");
+
+    const rows = await db
+      .selectFrom("matchday_player")
+      .innerJoin("matchday", "matchday.id", "matchday_player.matchday_id")
+      .leftJoin(
+        "play_cricket_team",
+        "play_cricket_team.id",
+        "matchday.play_cricket_team_id",
+      )
+      .where("matchday_player.member_id", "=", member.id)
+      .where("matchday_player.status", "in", ["selected", "playing"])
+      .where("matchday.status", "=", "confirmed")
+      .where("matchday.match_date", ">=", todayIso)
+      .select([
+        "matchday.id as matchdayId",
+        "matchday.match_date as matchDate",
+        "matchday.opposition",
+        "matchday.competition_type as competitionType",
+        "play_cricket_team.name as teamName",
+        "matchday_player.is_captain as isCaptain",
+        "matchday_player.is_wicketkeeper as isWicketkeeper",
+      ])
+      .orderBy("matchday.match_date", "asc")
+      .execute();
+
+    return rows;
+  };
+}
+
+/**
+ * Aggregate runs / wickets / catches for the signed-in user across
+ * matches in the trailing `windowDays` window (default 28).
+ *
+ * Performance rows are keyed by Play-Cricket player_id (string), so we
+ * resolve email → member.play_cricket_id. Members without a linked
+ * Play-Cricket ID get zeros — they exist in the DB but no historical
+ * stats can be attributed to them.
+ *
+ * matchesPlayed is the count of distinct match_ids the player appears
+ * in across any of the three perf tables (a member can have no
+ * batting row but still be on the team sheet's bowling/fielding card).
+ */
+export function getMyRecentPerformance(db: Kysely<DB>) {
+  return async (email: string, windowDays = 28) => {
+    const empty = {
+      windowDays,
+      matchesPlayed: 0,
+      runs: 0,
+      wickets: 0,
+      catches: 0,
+    };
+
+    const member = await db
+      .selectFrom("member")
+      .where("email", "=", email)
+      .select(["play_cricket_id"])
+      .executeTakeFirst();
+    if (!member?.play_cricket_id) return empty;
+
+    const sinceIso = formatDate(subDays(new Date(), windowDays), "yyyy-MM-dd");
+    const playerId = member.play_cricket_id;
+
+    const batting = await db
+      .selectFrom("match_performance_batting")
+      .where("player_id", "=", playerId)
+      .where("match_date", ">=", sinceIso)
+      .select((eb) => eb.fn.sum<string>("runs").as("runs"))
+      .executeTakeFirst();
+
+    const bowling = await db
+      .selectFrom("match_performance_bowling")
+      .where("player_id", "=", playerId)
+      .where("match_date", ">=", sinceIso)
+      .select((eb) => eb.fn.sum<string>("wickets").as("wickets"))
+      .executeTakeFirst();
+
+    const fielding = await db
+      .selectFrom("match_performance_fielding")
+      .where("player_id", "=", playerId)
+      .where("match_date", ">=", sinceIso)
+      .select((eb) => eb.fn.sum<string>("catches").as("catches"))
+      .executeTakeFirst();
+
+    // matchesPlayed: distinct match_ids across all three tables, since
+    // a player can appear in bowling/fielding but not batting (and
+    // vice versa). Cheap separate query; the three aggregates above
+    // can't capture this without UNION gymnastics.
+    const distinctMatches = await db
+      .selectFrom(
+        db
+          .selectFrom("match_performance_batting")
+          .where("player_id", "=", playerId)
+          .where("match_date", ">=", sinceIso)
+          .select("match_id")
+          .union(
+            db
+              .selectFrom("match_performance_bowling")
+              .where("player_id", "=", playerId)
+              .where("match_date", ">=", sinceIso)
+              .select("match_id"),
+          )
+          .union(
+            db
+              .selectFrom("match_performance_fielding")
+              .where("player_id", "=", playerId)
+              .where("match_date", ">=", sinceIso)
+              .select("match_id"),
+          )
+          .as("m"),
+      )
+      .select((eb) => eb.fn.count<string>("match_id").as("matches"))
+      .executeTakeFirst();
+
+    return {
+      windowDays,
+      matchesPlayed: Number(distinctMatches?.matches ?? 0),
+      runs: Number(batting?.runs ?? 0),
+      wickets: Number(bowling?.wickets ?? 0),
+      catches: Number(fielding?.catches ?? 0),
+    };
+  };
+}
+
 export function recordExpense(db: Kysely<DB>, s3: S3Uploader) {
   return async (
     userId: string,

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -3966,6 +3966,90 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/matchday/mine/upcoming": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            matchdayId: string;
+                            matchDate: string;
+                            opposition: string;
+                            teamName: string | null;
+                            competitionType: string | null;
+                            isCaptain: boolean;
+                            isWicketkeeper: boolean;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/matchday/mine/recent-performance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            windowDays: number;
+                            matchesPlayed: number;
+                            runs: number;
+                            wickets: number;
+                            catches: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/matchday": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -6836,6 +6836,112 @@
         }
       }
     },
+    "/api/matchday/mine/upcoming": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "matchdayId": {
+                        "type": "string"
+                      },
+                      "matchDate": {
+                        "type": "string"
+                      },
+                      "opposition": {
+                        "type": "string"
+                      },
+                      "teamName": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "competitionType": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "isCaptain": {
+                        "type": "boolean"
+                      },
+                      "isWicketkeeper": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "matchdayId",
+                      "matchDate",
+                      "opposition",
+                      "teamName",
+                      "competitionType",
+                      "isCaptain",
+                      "isWicketkeeper"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/matchday/mine/recent-performance": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "windowDays": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991
+                    },
+                    "matchesPlayed": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "runs": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "wickets": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "catches": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "windowDays",
+                    "matchesPlayed",
+                    "runs",
+                    "wickets",
+                    "catches"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/matchday": {
       "get": {
         "parameters": [

--- a/apps/matchday/src/pages/home.tsx
+++ b/apps/matchday/src/pages/home.tsx
@@ -22,6 +22,8 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowRightIcon, CalendarDaysIcon } from "lucide-react";
 import { Link } from "react-router";
 
+type MyUpcomingMatch = ApiResponse<"/api/matchday/mine/upcoming">[number];
+
 type ActiveAvailability = ApiResponse<"/api/availability/active">;
 type ChargesResponse = ApiResponse<"/api/charges">;
 type Charge = ChargesResponse["charges"][number];
@@ -56,8 +58,10 @@ export default function Home() {
       <div className="space-y-3">
         <NeedsAttentionCard />
         <AvailabilityAwaitingCard />
+        <YourUpcomingGamesCard />
         <OutstandingDonationsCard />
         <UpcomingFixturesCard />
+        <YourRecentPerformanceCard />
         <RecentResultsCard />
         <InstallPrompt />
       </div>
@@ -146,6 +150,126 @@ function AvailabilityAwaitingCard() {
         </Button>
       </CardContent>
     </Card>
+  );
+}
+
+function YourUpcomingGamesCard() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["matchday", "mine", "upcoming"],
+    queryFn: () => callApi(api.GET("/api/matchday/mine/upcoming")),
+  });
+  if (isLoading) return <CardSkeleton />;
+  if (isError) return <CardError label="Couldn't load your selection" />;
+  const games = data ?? [];
+  if (games.length === 0) return null;
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardEyebrow>Your upcoming games</CardEyebrow>
+          <StatusPill tone="success" dot>
+            You're in{" "}
+            {games.length === 1 ? "1 squad" : `${games.length} squads`}
+          </StatusPill>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-0">
+        {games.map((g) => (
+          <MyMatchRow key={g.matchdayId} match={g} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MyMatchRow({ match }: { match: MyUpcomingMatch }) {
+  const d = new Date(match.matchDate);
+  const day = Number.isNaN(d.getTime()) ? "" : d.getDate();
+  const dayName = Number.isNaN(d.getTime())
+    ? ""
+    : d.toLocaleDateString("en-GB", { weekday: "short" });
+  const role = match.isCaptain
+    ? "Captain"
+    : match.isWicketkeeper
+      ? "Keeper"
+      : null;
+  return (
+    <Link
+      to={`/matchday/${match.matchdayId}`}
+      className="border-border-light grid grid-cols-[44px_1fr_auto] items-center gap-3 border-t py-2.5 first:border-t-0"
+    >
+      <div className="bg-surface-raised flex flex-col items-center justify-center rounded-md py-1">
+        <div className="text-navy text-base leading-none font-bold dark:text-white">
+          {day}
+        </div>
+        <div className="text-text-secondary text-[10px] tracking-wide uppercase">
+          {dayName}
+        </div>
+      </div>
+      <div className="min-w-0">
+        <div className="truncate text-sm leading-tight font-medium">
+          vs {match.opposition}
+        </div>
+        <div className="text-text-secondary mt-0.5 text-xs">
+          {[match.teamName, match.competitionType].filter(Boolean).join(" · ")}
+        </div>
+      </div>
+      {role ? (
+        <StatusPill tone="navy">{role}</StatusPill>
+      ) : (
+        <StatusPill tone="neutral">Selected</StatusPill>
+      )}
+    </Link>
+  );
+}
+
+function YourRecentPerformanceCard() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["matchday", "mine", "recent-performance"],
+    queryFn: () => callApi(api.GET("/api/matchday/mine/recent-performance")),
+  });
+  if (isLoading) return null;
+  if (isError) return null;
+  if (!data) return null;
+  // Quiet card — hide when there's nothing to celebrate. A member who
+  // played but scored 0/0/0 stays visible because matchesPlayed > 0
+  // still tells a story ("you played 2 games").
+  if (data.matchesPlayed === 0) return null;
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardEyebrow>Your recent performance</CardEyebrow>
+          <span className="text-text-secondary text-xs">
+            Last {data.windowDays} days
+          </span>
+        </div>
+        <CardTitle>
+          {data.matchesPlayed} {data.matchesPlayed === 1 ? "match" : "matches"}{" "}
+          played
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-3 gap-2">
+          <PerfStat label="Runs" value={data.runs} />
+          <PerfStat label="Wickets" value={data.wickets} />
+          <PerfStat label="Catches" value={data.catches} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PerfStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="bg-surface-raised rounded-md py-3 text-center">
+      <div className="text-navy text-2xl font-bold tracking-[-0.02em] dark:text-white">
+        {value}
+      </div>
+      <div className="text-text-secondary mt-0.5 text-[11px] tracking-wide uppercase">
+        {label}
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -3966,6 +3966,90 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/matchday/mine/upcoming": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            matchdayId: string;
+                            matchDate: string;
+                            opposition: string;
+                            teamName: string | null;
+                            competitionType: string | null;
+                            isCaptain: boolean;
+                            isWicketkeeper: boolean;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/matchday/mine/recent-performance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            windowDays: number;
+                            matchesPlayed: number;
+                            runs: number;
+                            wickets: number;
+                            catches: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/matchday": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -6836,6 +6836,112 @@
         }
       }
     },
+    "/api/matchday/mine/upcoming": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "matchdayId": {
+                        "type": "string"
+                      },
+                      "matchDate": {
+                        "type": "string"
+                      },
+                      "opposition": {
+                        "type": "string"
+                      },
+                      "teamName": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "competitionType": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "isCaptain": {
+                        "type": "boolean"
+                      },
+                      "isWicketkeeper": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "matchdayId",
+                      "matchDate",
+                      "opposition",
+                      "teamName",
+                      "competitionType",
+                      "isCaptain",
+                      "isWicketkeeper"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/matchday/mine/recent-performance": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "windowDays": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991
+                    },
+                    "matchesPlayed": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "runs": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "wickets": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "catches": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "windowDays",
+                    "matchesPlayed",
+                    "runs",
+                    "wickets",
+                    "catches"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/matchday": {
       "get": {
         "parameters": [


### PR DESCRIPTION
## Summary

- Two new per-user home cards on the matchday app:
  - **Your upcoming games** - confirmed matchdays the signed-in member has been picked for (status `selected`/`playing`), with date pill and Captain/Keeper marker where applicable, linking to the team sheet.
  - **Your recent performance** - runs, wickets, catches over the last 28 days as three big-number tiles. Hidden when the member played zero matches in the window.
- Two new member-scoped endpoints to back them:
  - `GET /api/matchday/mine/upcoming` - resolves identity via the standard `user.email` -> `member.email` lookup, joins `matchday_player` -> `matchday` -> `play_cricket_team`.
  - `GET /api/matchday/mine/recent-performance` - aggregates from `match_performance_batting|bowling|fielding` keyed on `member.play_cricket_id`. `matchesPlayed` is the count of distinct `match_id`s across the three tables (a player can appear in bowling/fielding but not batting).

Static `/matchday/mine/*` routes are registered before `/matchday/:matchId` so Fastify's radix router resolves them as exact matches.

## Test plan

- [ ] Sign in as a member known to be on an upcoming team sheet - "Your upcoming games" card lists the fixtures and tapping a row opens the team sheet.
- [ ] Sign in as a member who isn't on any upcoming team sheet - card is hidden (not "no games").
- [ ] Sign in as a member with linked `play_cricket_id` who has runs/wickets/catches in the last 28 days - "Your recent performance" shows the totals and match count.
- [ ] Sign in as a member with no recent performances - card is hidden.
- [ ] Captain / keeper pill renders on the matching row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)