### PR TITLE
fix(matchday): poll for SW updates on visibility change

### DIFF
--- a/apps/matchday/src/components/shell/sw-update.tsx
+++ b/apps/matchday/src/components/shell/sw-update.tsx
@@ -1,22 +1,52 @@
 import { Button } from "@/components/ui/button.js";
+import { useEffect, useRef } from "react";
 import { useRegisterSW } from "virtual:pwa-register/react";
+
+// Browsers only re-fetch sw.js on a fresh page load. On iOS PWAs that
+// means a user has to force-quit before a new deploy is detected, so we
+// nudge the registration to check (a) every time the app comes back to
+// the foreground and (b) every 30 min for tabs that stay open.
+const UPDATE_POLL_MS = 30 * 60 * 1000;
 
 /**
  * Toast shown when a new service worker is waiting. Tapping "Reload"
  * activates the new SW + reloads the page. Workbox is configured with
- * skipWaiting + clientsClaim so this is mostly a courtesy — but visible
+ * skipWaiting + clientsClaim so this is mostly a courtesy - but visible
  * confirmation that the upgrade happened, and a manual escape hatch if
  * the auto-apply ever doesn't kick.
  */
 export function ServiceWorkerUpdate() {
+  const registrationRef = useRef<ServiceWorkerRegistration | null>(null);
   const {
     needRefresh: [needRefresh, setNeedRefresh],
     updateServiceWorker,
   } = useRegisterSW({
+    onRegisteredSW: (_swUrl, registration) => {
+      registrationRef.current = registration ?? null;
+    },
     onRegisterError: (err) => {
       console.warn("SW register failed", err);
     },
   });
+
+  useEffect(() => {
+    const check = () => {
+      const reg = registrationRef.current;
+      if (!reg) return;
+      // Swallow: update() rejects on offline / transient network blips
+      // and there's nothing useful to do about it.
+      reg.update().catch(() => undefined);
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") check();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    const interval = window.setInterval(check, UPDATE_POLL_MS);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.clearInterval(interval);
+    };
+  }, []);
 
   if (!needRefresh) return null;
 


### PR DESCRIPTION
## Summary
- The matchday PWA's "New version available" toast (`apps/matchday/src/components/shell/sw-update.tsx`) only ever rendered when the browser re-fetched `sw.js`, which by default only happens on a cold page load. On iOS PWAs that requires a force-quit before a new deploy is detected, so the toast never showed in practice.
- Stash the `ServiceWorkerRegistration` from `onRegisteredSW`, then call `registration.update()` on every `visibilitychange` (the common "swipe back into the app from background" case) plus a 30-minute interval for sessions left in the foreground.
- No change to the toast itself - still tap-to-reload, which preserves in-progress flows (e.g. captain mid-tap on mark-paid).

## Test plan
- [ ] Build matchday locally, deploy a new version, leave the PWA backgrounded on an iOS device, then swipe it back to the foreground - confirm the "New version available" toast appears within a few seconds.
- [ ] Confirm `registration.update()` failures while offline don't surface as unhandled rejections in the console.
- [ ] Verify the toast still tap-to-reloads correctly (existing behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)