### PR TITLE
feat(matchday): UI polish pass — page context, animated tab, scannable cards

### DIFF
--- a/apps/matchday/index.html
+++ b/apps/matchday/index.html
@@ -25,6 +25,7 @@
       href="/images/favicon/apple-touch-icon.png"
     />
     <meta name="apple-mobile-web-app-title" content="Matchday" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta
       name="theme-color"

--- a/apps/matchday/src/components/primitives/date-square.tsx
+++ b/apps/matchday/src/components/primitives/date-square.tsx
@@ -1,0 +1,92 @@
+import { fmtDate } from "@/features/format.js";
+import { cn } from "@/lib/utils";
+
+/**
+ * 44pt date square used across home/fixtures/donations rows.
+ *
+ * `tone` is computed from how close the match is:
+ *   - "today"  → strong navy bg, white text. Match day energy.
+ *   - "soon"   → tinted navy bg, navy text. Tomorrow → "this match"
+ *                signal so the next game stands out from the rest of
+ *                the fixture list.
+ *   - default  → stone bg, navy number. Standard treatment.
+ *
+ * Pass an ISO `YYYY-MM-DD` (or null) — `compareIso` does the comparison
+ * against today's local-time ISO date, no timezone shenanigans.
+ *
+ * `dayLabel` defaults to the abbreviated weekday ("SAT") but can be
+ * overridden to show month ("MAY") on the fixtures list where multiple
+ * weeks are visible.
+ */
+export type DateSquareTone = "today" | "soon" | "default";
+
+export function dateSquareTone(iso: string | null | undefined): DateSquareTone {
+  if (!iso) return "default";
+  const today = todayIso();
+  if (iso === today) return "today";
+  if (iso === addDaysIso(today, 1)) return "soon";
+  return "default";
+}
+
+export function DateSquare({
+  iso,
+  dayLabel = "weekday",
+  className,
+}: {
+  iso: string | null | undefined;
+  /** "weekday" → SAT, "month" → MAY. Defaults to weekday. */
+  dayLabel?: "weekday" | "month";
+  className?: string;
+}) {
+  const tone = dateSquareTone(iso);
+  const d = iso ? new Date(iso) : null;
+  const day = d && !isNaN(d.getTime()) ? d.getDate() : "";
+  const sub =
+    d && !isNaN(d.getTime())
+      ? dayLabel === "month"
+        ? fmtDate(iso, "MMM")
+        : fmtDate(iso, "EEE")
+      : "";
+  return (
+    <div
+      className={cn(
+        "flex size-11 flex-col items-center justify-center rounded-md py-1 transition-colors",
+        tone === "today"
+          ? "bg-navy dark:text-navy text-white dark:bg-white"
+          : tone === "soon"
+            ? "bg-info-bg text-navy dark:bg-white/10 dark:text-white"
+            : "bg-surface-raised text-navy dark:text-white",
+        className,
+      )}
+    >
+      <div className="text-base leading-none font-bold">{day}</div>
+      <div
+        className={cn(
+          "text-[10px] tracking-wide uppercase",
+          tone === "today"
+            ? "dark:text-navy/70 text-white/75"
+            : tone === "soon"
+              ? "text-navy/70 dark:text-white/70"
+              : "text-text-secondary",
+        )}
+      >
+        {sub}
+      </div>
+    </div>
+  );
+}
+
+function todayIso(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function addDaysIso(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00`);
+  d.setDate(d.getDate() + days);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}

--- a/apps/matchday/src/components/primitives/status-pill.tsx
+++ b/apps/matchday/src/components/primitives/status-pill.tsx
@@ -11,7 +11,7 @@ import { cva, type VariantProps } from "class-variance-authority";
  *   dot:   prefix with a 6px filled dot for emphasis
  */
 const pillStyles = cva(
-  "inline-flex items-center gap-1 rounded-full px-2 py-[3px] text-[11px] font-semibold tracking-[0.02em] leading-none whitespace-nowrap",
+  "inline-flex items-center gap-1 rounded-full font-semibold tracking-[0.02em] leading-none whitespace-nowrap",
   {
     variants: {
       tone: {
@@ -21,8 +21,15 @@ const pillStyles = cva(
         warning: "bg-warning-bg text-warning",
         danger: "bg-danger-bg text-danger",
       },
+      size: {
+        // Default — fits inside a row, alongside other text.
+        default: "px-2 py-[3px] text-[11px]",
+        // Result badges — bigger type, bigger pill, room for a score
+        // description like "Won by 4 wickets" without feeling cramped.
+        lg: "px-2.5 py-1 text-xs",
+      },
     },
-    defaultVariants: { tone: "neutral" },
+    defaultVariants: { tone: "neutral", size: "default" },
   },
 );
 
@@ -35,13 +42,14 @@ export interface StatusPillProps
 
 export function StatusPill({
   tone,
+  size,
   dot,
   className,
   children,
   ...props
 }: StatusPillProps) {
   return (
-    <span className={cn(pillStyles({ tone }), className)} {...props}>
+    <span className={cn(pillStyles({ tone, size }), className)} {...props}>
       {dot && (
         <span aria-hidden className="size-[6px] rounded-full bg-current" />
       )}

--- a/apps/matchday/src/components/shell/app-shell.tsx
+++ b/apps/matchday/src/components/shell/app-shell.tsx
@@ -6,7 +6,7 @@ import { DesktopSideNav } from "@/components/shell/desktop-side-nav.js";
 import { OfflineIndicator } from "@/components/shell/offline-indicator.js";
 import { ServiceWorkerUpdate } from "@/components/shell/sw-update.js";
 import { TopBar } from "@/components/shell/top-bar.js";
-import { useSession, type SessionUser } from "@/lib/auth-client.js";
+import { canViewMatchdayAdmin, useSession } from "@/lib/auth-client.js";
 import { Outlet } from "react-router";
 
 /**
@@ -22,16 +22,13 @@ import { Outlet } from "react-router";
  */
 export function AppShell() {
   const { data: session } = useSession();
-  // Coarse role detection. better-auth's admin plugin stores role on the
-  // user. Anyone with `official` (or any admin-ish role that's also a
-  // team official) sees the extra Squad + Availability tabs. Pure
-  // members see the player view. Admin-only matchday admin surfaces
-  // stay on the main site, so we don't branch on them here.
-  const role: "player" | "official" = (() => {
-    const r = (session?.user as SessionUser | undefined)?.role ?? "";
-    if (r === "official" || r.includes("admin")) return "official";
-    return "player";
-  })();
+  // Anyone with the matchday:view permission gets the official surfaces
+  // (Availability tab, past-unfinished card, etc.) - same source of
+  // truth as the server-side `requirePermission("matchday", "view")`
+  // preHandler, so the UI never offers something the API will 403.
+  const role: "player" | "official" = canViewMatchdayAdmin(session?.user)
+    ? "official"
+    : "player";
   const tabs = tabsForRole(role);
   return (
     <div className="bg-surface-raised text-text flex min-h-dvh">

--- a/apps/matchday/src/components/shell/bottom-tab-bar.tsx
+++ b/apps/matchday/src/components/shell/bottom-tab-bar.tsx
@@ -7,7 +7,7 @@ import {
   UserIcon,
   WalletIcon,
 } from "lucide-react";
-import { NavLink } from "react-router";
+import { matchPath, NavLink, useLocation } from "react-router";
 
 export interface TabDef {
   to: string;
@@ -61,11 +61,34 @@ export function tabsForRole(role: "player" | "official"): TabDef[] {
 }
 
 export function BottomTabBar({ tabs }: { tabs: TabDef[] }) {
+  // Resolve the active tab index ourselves so we can animate a single
+  // shared accent across the bar. NavLink's per-link `isActive` is
+  // fine for colouring, but we need a global "which one is on" to
+  // position the sliding indicator.
+  const { pathname } = useLocation();
+  const activeIdx = tabs.findIndex((t) =>
+    matchPath({ path: t.to, end: t.end }, pathname),
+  );
+  // Centre of cell N in an N-tab grid: (idx + 0.5) * 100/N percent.
+  const indicatorLeft =
+    activeIdx >= 0 ? `${((activeIdx + 0.5) * 100) / tabs.length}%` : "-100%";
   return (
     <nav
       className="border-border bg-surface/95 fixed inset-x-0 bottom-0 z-30 grid auto-cols-fr grid-flow-col border-t pt-1 pb-[max(env(safe-area-inset-bottom),6px)] backdrop-blur md:hidden"
       aria-label="Matchday navigation"
     >
+      {/* Single sliding accent bar shared across the row. CSS
+          transition on `left` gives a smooth glide between tabs. The
+          `motion-reduce` variant disables the animation for users
+          with prefers-reduced-motion. */}
+      <span
+        aria-hidden
+        className={cn(
+          "bg-navy pointer-events-none absolute top-0 h-[3px] w-8 -translate-x-1/2 rounded-b-full transition-[left,opacity] duration-300 ease-out motion-reduce:transition-none dark:bg-white",
+          activeIdx >= 0 ? "opacity-100" : "opacity-0",
+        )}
+        style={{ left: indicatorLeft }}
+      />
       {tabs.map((tab) => (
         <NavLink
           key={tab.to}
@@ -77,17 +100,24 @@ export function BottomTabBar({ tabs }: { tabs: TabDef[] }) {
               // / "Donations" on a single line even in the 6-tab official
               // layout on a 360px phone. Slight horizontal overspill into
               // the px-1 buffer is fine; wrapping looks worse.
-              "relative flex flex-col items-center justify-center gap-0.5 overflow-hidden px-0.5 py-2 text-[10px] font-medium tracking-tight whitespace-nowrap",
+              "group relative flex flex-col items-center justify-center gap-0.5 overflow-hidden px-0.5 py-2 text-[10px] font-medium tracking-tight whitespace-nowrap transition-colors",
               isActive ? "text-navy dark:text-white" : "text-text-secondary",
             )
           }
         >
-          <tab.icon className="size-[22px]" strokeWidth={2.1} />
-          {tab.label}
-          {tab.badge !== undefined && tab.badge > 0 && (
-            <span className="bg-red absolute top-1.5 right-[calc(50%-22px)] rounded-full px-1.5 py-px text-[9px] font-bold text-white">
-              {tab.badge > 99 ? "99+" : tab.badge}
-            </span>
+          {({ isActive }) => (
+            <>
+              <tab.icon
+                className="size-[22px]"
+                strokeWidth={isActive ? 2.4 : 2.1}
+              />
+              {tab.label}
+              {tab.badge !== undefined && tab.badge > 0 && (
+                <span className="bg-red absolute top-1.5 right-[calc(50%-22px)] rounded-full px-1.5 py-px text-[9px] font-bold text-white">
+                  {tab.badge > 99 ? "99+" : tab.badge}
+                </span>
+              )}
+            </>
           )}
         </NavLink>
       ))}

--- a/apps/matchday/src/components/shell/top-bar.tsx
+++ b/apps/matchday/src/components/shell/top-bar.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/dropdown-menu.js";
 import { signOut, useSession } from "@/lib/auth-client.js";
 import { mainSiteUrl } from "@/lib/main-site.js";
+import { useLocation } from "react-router";
 
 function initials(name: string | null | undefined, email: string | undefined) {
   const source = (name ?? email ?? "?").trim();
@@ -17,25 +18,50 @@ function initials(name: string | null | undefined, email: string | undefined) {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
+/**
+ * Page title shown next to the club mark on mobile. Falls back to
+ * "Matchday" for anything not in the table — fixture detail and
+ * matchday-edit have their own in-page headers, so the generic label
+ * is the right behaviour there.
+ */
+function pageTitle(pathname: string): { title: string; subtitle: string } {
+  if (pathname === "/") return { title: "Home", subtitle: "Percy Main CSC" };
+  if (pathname.startsWith("/fixtures"))
+    return { title: "Fixtures", subtitle: "Percy Main CSC" };
+  if (pathname.startsWith("/donations"))
+    return { title: "Donations", subtitle: "Percy Main CSC" };
+  if (pathname.startsWith("/me"))
+    return { title: "Account", subtitle: "Percy Main CSC" };
+  if (pathname.startsWith("/availability"))
+    return { title: "Availability", subtitle: "Your matches" };
+  if (pathname.startsWith("/official/availability"))
+    return { title: "Availability", subtitle: "Squad responses" };
+  return { title: "Matchday", subtitle: "Percy Main CSC" };
+}
+
 export function TopBar() {
   const { data: session } = useSession();
   const user = session?.user;
+  const { pathname } = useLocation();
+  const { title, subtitle } = pageTitle(pathname);
   return (
     <header className="border-border bg-surface sticky top-0 z-20 flex items-center justify-between border-b px-4 py-2.5 md:hidden">
-      <div className="flex items-center gap-2">
+      <div className="flex min-w-0 items-center gap-2.5">
         <img
           src="/images/club_logo.png"
           alt="Percy Main CSC"
-          width={28}
-          height={28}
-          className="size-7 rounded-md object-contain"
+          width={32}
+          height={32}
+          className="size-8 shrink-0 rounded-md object-contain"
           loading="eager"
           fetchPriority="high"
         />
-        <div>
-          <div className="text-[14px] leading-none font-bold">Matchday</div>
-          <div className="text-text-secondary mt-0.5 text-[11px]">
-            Percy Main CSC
+        <div className="min-w-0">
+          <div className="truncate text-[15px] leading-none font-bold tracking-[-0.01em]">
+            {title}
+          </div>
+          <div className="text-text-secondary mt-0.5 truncate text-[11px]">
+            {subtitle}
           </div>
         </div>
       </div>

--- a/apps/matchday/src/components/ui/card.tsx
+++ b/apps/matchday/src/components/ui/card.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react";
 import * as React from "react";
 
 type DivProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -80,22 +81,39 @@ export function CardFooter({ className, ref, ...props }: DivProps) {
 /**
  * Eyebrow label used above a CardTitle. Matches the design mocks —
  * 11px, 600-weight, tracking-wide, uppercase, secondary text colour.
+ *
+ * Optional `icon` prop renders a small lucide glyph in a tinted square
+ * to the left of the label, so a stack of cards can be scanned by
+ * shape rather than reading every uppercase eyebrow.
  */
 export function CardEyebrow({
   className,
+  icon: Icon,
+  children,
   ref,
   ...props
 }: React.HTMLAttributes<HTMLSpanElement> & {
   ref?: React.Ref<HTMLSpanElement>;
+  icon?: LucideIcon;
 }) {
   return (
     <span
       ref={ref}
       className={cn(
-        "text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase",
+        "text-text-secondary inline-flex items-center gap-1.5 text-[11px] font-semibold tracking-[0.06em] uppercase",
         className,
       )}
       {...props}
-    />
+    >
+      {Icon && (
+        <span
+          aria-hidden
+          className="bg-surface-raised text-navy grid size-5 place-items-center rounded-md dark:bg-white/10 dark:text-white"
+        >
+          <Icon className="size-3" strokeWidth={2.4} />
+        </span>
+      )}
+      {children}
+    </span>
   );
 }

--- a/apps/matchday/src/lib/auth-client.ts
+++ b/apps/matchday/src/lib/auth-client.ts
@@ -1,5 +1,9 @@
 import { passkeyClient } from "@better-auth/passkey/client";
-import { ac, roles } from "@percy-main/shared/auth/permissions";
+import {
+  ac,
+  checkPermission,
+  roles,
+} from "@percy-main/shared/auth/permissions";
 import { adminClient, twoFactorClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
@@ -32,6 +36,20 @@ export interface SessionUser {
   name: string;
   email: string;
   role?: string | null;
+}
+
+/**
+ * True iff the user has the `matchday:view` permission — i.e. access to
+ * the officials-only surfaces (extra Availability tab,
+ * /api/matchday/past-unfinished, etc.). Mirrors the server-side
+ * `requirePermission("matchday", "view")` preHandler so client-side
+ * gates (`enabled:` on queries, tab visibility) and server-side
+ * authorization use the same source of truth.
+ */
+export function canViewMatchdayAdmin(
+  user: { role?: string | null } | null | undefined,
+): boolean {
+  return checkPermission(user?.role ?? null, "matchday", "view");
 }
 
 /**

--- a/apps/matchday/src/pages/donations.tsx
+++ b/apps/matchday/src/pages/donations.tsx
@@ -6,6 +6,7 @@ import { mainSiteUrl } from "@/lib/main-site.js";
 import { cn } from "@/lib/utils.js";
 import { useQuery } from "@tanstack/react-query";
 import { parseISO } from "date-fns";
+import { CheckIcon, ReceiptIcon } from "lucide-react";
 import { useState } from "react";
 
 type Tab = "outstanding" | "history";
@@ -89,8 +90,10 @@ export default function Donations() {
           <>
             {outstanding.length === 0 ? (
               <EmptyState
-                title="No outstanding donations"
-                body="Everything is up to date."
+                tone="success"
+                icon={<CheckIcon className="size-7" strokeWidth={2.4} />}
+                title="All paid up"
+                body="No outstanding donations. Thanks for keeping your match donations square."
               />
             ) : (
               outstanding.map((c) => <ChargeRowItem key={c.id} c={c} />)
@@ -101,8 +104,10 @@ export default function Donations() {
           <>
             {history.length === 0 ? (
               <EmptyState
+                tone="neutral"
+                icon={<ReceiptIcon className="size-7" strokeWidth={1.8} />}
                 title="No history yet"
-                body="Your paid donations will show here."
+                body="Your paid donations will show here once you've made one."
               />
             ) : (
               history.map((c) => <ChargeRowItem key={c.id} c={c} muted />)
@@ -216,11 +221,31 @@ function ChargeSkeleton() {
   );
 }
 
-function EmptyState({ title, body }: { title: string; body: string }) {
+function EmptyState({
+  tone,
+  icon,
+  title,
+  body,
+}: {
+  tone: "success" | "neutral";
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}) {
   return (
-    <div className="px-6 py-10 text-center">
-      <p className="text-sm font-semibold">{title}</p>
-      <p className="text-text-secondary mt-1 text-sm">{body}</p>
+    <div className="mx-auto flex max-w-sm flex-col items-center px-6 py-12 text-center">
+      <div
+        className={cn(
+          "grid size-14 place-items-center rounded-full",
+          tone === "success"
+            ? "bg-success-bg text-success"
+            : "bg-border text-text-secondary",
+        )}
+      >
+        {icon}
+      </div>
+      <p className="mt-4 text-base font-semibold tracking-[-0.01em]">{title}</p>
+      <p className="text-text-secondary mt-1 text-sm leading-relaxed">{body}</p>
     </div>
   );
 }

--- a/apps/matchday/src/pages/fixture-detail.tsx
+++ b/apps/matchday/src/pages/fixture-detail.tsx
@@ -3,14 +3,14 @@ import { Button } from "@/components/ui/button.js";
 import { fmtDate, toIsoDate } from "@/features/format.js";
 import { oppositionName, played, type GameDetail } from "@/features/games.js";
 import { api, callApi } from "@/lib/api-client.js";
-import { useSession, type SessionUser } from "@/lib/auth-client.js";
+import {
+  canViewMatchdayAdmin,
+  useSession,
+  type SessionUser,
+} from "@/lib/auth-client.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeftIcon } from "lucide-react";
 import { Link, useNavigate, useParams } from "react-router";
-
-function isOfficial(role: string | null | undefined): boolean {
-  return role === "official" || role === "admin";
-}
 
 export default function FixtureDetail() {
   const { matchId } = useParams();
@@ -32,7 +32,7 @@ export default function FixtureDetail() {
   const qc = useQueryClient();
   const { data: session } = useSession();
   const user = session?.user as SessionUser | undefined;
-  const showOfficialActions = isOfficial(user?.role ?? null);
+  const showOfficialActions = canViewMatchdayAdmin(user);
   const create = useMutation({
     mutationFn: (vars: {
       teamId: string;

--- a/apps/matchday/src/pages/fixtures.tsx
+++ b/apps/matchday/src/pages/fixtures.tsx
@@ -1,5 +1,5 @@
+import { DateSquare } from "@/components/primitives/date-square.js";
 import { StatusPill } from "@/components/primitives/status-pill.js";
-import { fmtDate } from "@/features/format.js";
 import {
   gameIsoDate,
   oppositionName,
@@ -95,10 +95,10 @@ export default function Fixtures() {
   const groups = groupByBucket(filtered);
   return (
     <div className="mx-auto w-full max-w-2xl pb-6">
-      <header className="px-4 pt-6 pb-2">
+      <header className="hidden px-4 pt-6 pb-2 md:block">
         <h1 className="text-2xl font-semibold tracking-[-0.015em]">Fixtures</h1>
       </header>
-      <div className="flex gap-2 overflow-x-auto px-4 py-2">
+      <div className="flex gap-2 overflow-x-auto px-4 py-3 md:py-2">
         {FILTERS.map((f) => (
           <button
             key={f.key}
@@ -168,20 +168,12 @@ function FixtureItem({ game }: { game: Game }) {
   // Play-Cricket sends DD/MM/YYYY — normalise to ISO before passing to
   // new Date(), which is otherwise locale-dependent.
   const iso = gameIsoDate(game);
-  const d = iso ? new Date(iso) : null;
   return (
     <Link
       to={`/fixture/${game.id}`}
       className="border-border-light bg-surface grid grid-cols-[44px_1fr_auto] items-center gap-3 border-t px-4 py-3 first:border-t-0"
     >
-      <div className="bg-surface-raised flex flex-col items-center justify-center rounded-md py-1">
-        <div className="text-navy text-base leading-none font-bold dark:text-white">
-          {d ? d.getDate() : ""}
-        </div>
-        <div className="text-text-secondary text-[10px] tracking-wide uppercase">
-          {fmtDate(game.matchDate, "MMM")}
-        </div>
-      </div>
+      <DateSquare iso={iso} dayLabel="month" />
       <div className="min-w-0">
         <div className="truncate text-sm font-medium">
           {oppositionName(game)}
@@ -203,12 +195,20 @@ function FixtureItem({ game }: { game: Game }) {
 
 function FixtureResultPill({ game }: { game: Game }) {
   const o = game.outcome;
+  const tone =
+    o === "W"
+      ? ("success" as const)
+      : o === "L"
+        ? ("danger" as const)
+        : o === "D" || o === "T"
+          ? ("warning" as const)
+          : ("neutral" as const);
   const label = game.scoreDescription ?? o ?? "—";
-  if (o === "W") return <StatusPill tone="success">{label}</StatusPill>;
-  if (o === "L") return <StatusPill tone="danger">{label}</StatusPill>;
-  if (o === "D" || o === "T")
-    return <StatusPill tone="warning">{label}</StatusPill>;
-  return <StatusPill tone="neutral">{label}</StatusPill>;
+  return (
+    <StatusPill tone={tone} size="lg">
+      {label}
+    </StatusPill>
+  );
 }
 
 function FixtureSkeleton() {

--- a/apps/matchday/src/pages/home.tsx
+++ b/apps/matchday/src/pages/home.tsx
@@ -1,4 +1,5 @@
 import { InstallPrompt } from "@/components/install-prompt.js";
+import { DateSquare } from "@/components/primitives/date-square.js";
 import { StatusPill } from "@/components/primitives/status-pill.js";
 import { Button } from "@/components/ui/button.js";
 import {
@@ -16,10 +17,20 @@ import {
   type Game,
 } from "@/features/games.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
-import { useSession } from "@/lib/auth-client.js";
+import { canViewMatchdayAdmin, useSession } from "@/lib/auth-client.js";
 import { mainSiteUrl } from "@/lib/main-site.js";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRightIcon, CalendarDaysIcon } from "lucide-react";
+import { format } from "date-fns";
+import {
+  ArrowRightIcon,
+  CalendarDaysIcon,
+  CircleAlertIcon,
+  CircleCheckIcon,
+  HistoryIcon,
+  TrophyIcon,
+  UsersIcon,
+  WalletIcon,
+} from "lucide-react";
 import { Link } from "react-router";
 
 type MyUpcomingMatch = ApiResponse<"/api/matchday/mine/upcoming">[number];
@@ -50,10 +61,13 @@ export default function Home() {
   const firstName = userName.split(/\s+/)[0];
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-4 md:py-8">
-      <div className="mb-4 hidden md:block">
-        <h1 className="text-2xl font-semibold tracking-[-0.015em]">
+      <div className="mb-4 flex items-baseline justify-between">
+        <h1 className="text-xl font-semibold tracking-[-0.015em] md:text-2xl">
           Hi {firstName}
         </h1>
+        <span className="text-text-secondary text-xs md:text-sm">
+          {format(new Date(), "EEEE, d MMM")}
+        </span>
       </div>
       <div className="space-y-3">
         <NeedsAttentionCard />
@@ -70,15 +84,18 @@ export default function Home() {
 }
 
 function NeedsAttentionCard() {
-  // Officials-only endpoint - a 403 just means the card stays hidden,
-  // so we swallow the error rather than surfacing it. Used to be a
-  // per-team roll-up on the dropped /squad tab.
+  // Officials-only endpoint — gate the query on the matchday:view
+  // permission so non-officials never fire a request that's destined
+  // for a 403. Used to be a per-team roll-up on the dropped /squad tab.
+  const { data: session } = useSession();
+  const enabled = canViewMatchdayAdmin(session?.user);
   const { data, isError } = useQuery({
     queryKey: ["matchday", "past-unfinished"],
     queryFn: () => callApi(api.GET("/api/matchday/past-unfinished")),
+    enabled,
     retry: false,
   });
-  if (isError) return null;
+  if (!enabled || isError) return null;
   const items = data ?? [];
   if (items.length === 0) return null;
   const oldest = items[items.length - 1];
@@ -86,7 +103,7 @@ function NeedsAttentionCard() {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardEyebrow>Needs attention</CardEyebrow>
+          <CardEyebrow icon={CircleAlertIcon}>Needs attention</CardEyebrow>
           <StatusPill tone="warning" dot>
             {items.length} match{items.length === 1 ? "" : "es"}
           </StatusPill>
@@ -129,7 +146,7 @@ function AvailabilityAwaitingCard() {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardEyebrow>Availability</CardEyebrow>
+          <CardEyebrow icon={CircleCheckIcon}>Availability</CardEyebrow>
           <StatusPill tone="warning" dot>
             {count} to answer
           </StatusPill>
@@ -166,7 +183,7 @@ function YourUpcomingGamesCard() {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardEyebrow>Your upcoming games</CardEyebrow>
+          <CardEyebrow icon={UsersIcon}>Your upcoming games</CardEyebrow>
           <StatusPill tone="success" dot>
             You're in{" "}
             {games.length === 1 ? "1 squad" : `${games.length} squads`}
@@ -183,11 +200,6 @@ function YourUpcomingGamesCard() {
 }
 
 function MyMatchRow({ match }: { match: MyUpcomingMatch }) {
-  const d = new Date(match.matchDate);
-  const day = Number.isNaN(d.getTime()) ? "" : d.getDate();
-  const dayName = Number.isNaN(d.getTime())
-    ? ""
-    : d.toLocaleDateString("en-GB", { weekday: "short" });
   const role = match.isCaptain
     ? "Captain"
     : match.isWicketkeeper
@@ -198,14 +210,7 @@ function MyMatchRow({ match }: { match: MyUpcomingMatch }) {
       to={`/matchday/${match.matchdayId}`}
       className="border-border-light grid grid-cols-[44px_1fr_auto] items-center gap-3 border-t py-2.5 first:border-t-0"
     >
-      <div className="bg-surface-raised flex flex-col items-center justify-center rounded-md py-1">
-        <div className="text-navy text-base leading-none font-bold dark:text-white">
-          {day}
-        </div>
-        <div className="text-text-secondary text-[10px] tracking-wide uppercase">
-          {dayName}
-        </div>
-      </div>
+      <DateSquare iso={match.matchDate} />
       <div className="min-w-0">
         <div className="truncate text-sm leading-tight font-medium">
           vs {match.opposition}
@@ -239,7 +244,7 @@ function YourRecentPerformanceCard() {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardEyebrow>Your recent performance</CardEyebrow>
+          <CardEyebrow icon={TrophyIcon}>Your recent performance</CardEyebrow>
           <span className="text-text-secondary text-xs">
             Last {data.windowDays} days
           </span>
@@ -308,7 +313,7 @@ function OutstandingDonationsCard() {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardEyebrow>Outstanding donations</CardEyebrow>
+          <CardEyebrow icon={WalletIcon}>Outstanding donations</CardEyebrow>
           {overdueCount > 0 ? (
             <StatusPill tone="danger" dot>
               Overdue ×{overdueCount}
@@ -366,7 +371,7 @@ function UpcomingFixturesCard() {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardEyebrow>Upcoming fixtures</CardEyebrow>
+          <CardEyebrow icon={CalendarDaysIcon}>Upcoming fixtures</CardEyebrow>
           <Link to="/fixtures" className="text-text-secondary text-xs">
             See all
           </Link>
@@ -400,7 +405,7 @@ function RecentResultsCard() {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardEyebrow>Recent results</CardEyebrow>
+          <CardEyebrow icon={HistoryIcon}>Recent results</CardEyebrow>
         </div>
       </CardHeader>
       <CardContent className="space-y-0">
@@ -416,22 +421,12 @@ function FixtureRow({ game }: { game: Game }) {
   // Use the normalised ISO form for date math — game.matchDate is
   // Play-Cricket's DD/MM/YYYY which `new Date(...)` parses wrong.
   const iso = gameIsoDate(game);
-  const d = iso ? new Date(iso) : null;
-  const day = d ? d.getDate() : "";
-  const dayName = d ? d.toLocaleDateString("en-GB", { weekday: "short" }) : "";
   return (
     <Link
       to={`/fixture/${game.id}`}
       className="border-border-light grid grid-cols-[44px_1fr_auto] items-center gap-3 border-t py-2.5 first:border-t-0"
     >
-      <div className="bg-surface-raised flex flex-col items-center justify-center rounded-md py-1">
-        <div className="text-navy text-base leading-none font-bold dark:text-white">
-          {day}
-        </div>
-        <div className="text-text-secondary text-[10px] tracking-wide uppercase">
-          {dayName}
-        </div>
-      </div>
+      <DateSquare iso={iso} />
       <div className="min-w-0">
         <div className="truncate text-sm leading-tight font-medium">
           vs {oppositionName(game)}
@@ -453,17 +448,23 @@ function TimePill({ game }: { game: Game }) {
 
 function ResultPill({ game }: { game: Game }) {
   const o = game.outcome;
-  if (o === "W")
-    return (
-      <StatusPill tone="success">{game.scoreDescription ?? "W"}</StatusPill>
-    );
-  if (o === "L")
-    return (
-      <StatusPill tone="danger">{game.scoreDescription ?? "L"}</StatusPill>
-    );
-  if (o === "D" || o === "T")
-    return <StatusPill tone="warning">{game.scoreDescription ?? o}</StatusPill>;
-  return <StatusPill tone="neutral">{o ?? "—"}</StatusPill>;
+  // Bigger, clearly-typed pill — recent results should read like a
+  // result, not a status. Falls back to the single-letter outcome
+  // when Play-Cricket hasn't populated a score description yet.
+  const tone =
+    o === "W"
+      ? ("success" as const)
+      : o === "L"
+        ? ("danger" as const)
+        : o === "D" || o === "T"
+          ? ("warning" as const)
+          : ("neutral" as const);
+  const label = game.scoreDescription ?? o ?? "—";
+  return (
+    <StatusPill tone={tone} size="lg">
+      {label}
+    </StatusPill>
+  );
 }
 
 function CardSkeleton() {

--- a/apps/matchday/src/pages/me.tsx
+++ b/apps/matchday/src/pages/me.tsx
@@ -9,6 +9,7 @@ import {
 import { NotificationsCard } from "@/features/notifications/notifications-card.js";
 import { signOut, useSession, type SessionUser } from "@/lib/auth-client.js";
 import { mainSiteUrl } from "@/lib/main-site.js";
+import { ExternalLinkIcon, UserIcon } from "lucide-react";
 
 export default function Me() {
   const { data: session } = useSession();
@@ -17,7 +18,7 @@ export default function Me() {
     <div className="mx-auto w-full max-w-md space-y-3 px-4 py-6">
       <Card>
         <CardHeader>
-          <CardEyebrow>Account</CardEyebrow>
+          <CardEyebrow icon={UserIcon}>Account</CardEyebrow>
           <CardTitle>{user?.name ?? "You"}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
@@ -33,7 +34,7 @@ export default function Me() {
 
       <Card>
         <CardHeader>
-          <CardEyebrow>Main site</CardEyebrow>
+          <CardEyebrow icon={ExternalLinkIcon}>Main site</CardEyebrow>
           <CardTitle>Membership & payments</CardTitle>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
## Summary

A focused polish pass over the matchday app — no data layer, schema, or routing changes.

**Shell**
- Mobile top bar now reads the current route name instead of always "Matchday"
- Bottom tab bar gained a single shared accent that slides between tabs on route change (`motion-reduce` respected)

**Cards & rows**
- `CardEyebrow` accepts a semantic icon; every home/me card got one so the page is scannable by shape
- New `DateSquare` primitive — today gets navy bg, tomorrow gets info-bg tint, rest stay neutral. Used on home + fixtures
- `StatusPill` gained an `lg` size variant; result pills on home + fixtures use it so a match result reads like a result
- Donations empty state replaced two grey lines with a tinted circle + icon + warm headline

**Home**
- Mobile gets the "Hi {firstName}" greeting + today's date line that was desktop-only

**Role gating fix**
- `/api/matchday/past-unfinished` is officials-only but home was firing it for every player and silently swallowing the 403. Gated the query's `enabled` on a new `canViewMatchdayAdmin(user)` that delegates to the shared `checkPermission(role, "matchday", "view")` from `@percy-main/shared` — same source of truth as the server preHandler
- Replaced the brittle `r === "official" || r.includes("admin")` pattern in `app-shell.tsx` and the local `isOfficial` in `fixture-detail.tsx` with the same helper

**Misc**
- Silenced the Chrome `apple-mobile-web-app-capable` deprecation warning by adding the modern `mobile-web-app-capable` meta tag (kept apple- for iOS Safari)

## Test plan

- [ ] Mobile (390px): top bar shows the current page name on `/`, `/fixtures`, `/donations`, `/me`
- [ ] Bottom-tab accent slides smoothly between tabs on navigation
- [ ] Home cards have their semantic icons; no card looks visually identical to its neighbour
- [ ] Saturday fixtures (when today is Friday) show the tinted "soon" date square; later dates stay neutral
- [ ] Donations page with zero outstanding shows the green check empty state
- [ ] Console is clean of the previous `/api/matchday/past-unfinished` 403 on the home page for non-officials
- [ ] Officials still see the Availability tab and the NeedsAttentionCard
- [ ] No `apple-mobile-web-app-capable is deprecated` warning in Chrome devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)