### PR TITLE
feat(matchday): membership panel + inline Stripe pay-outstanding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -893,6 +893,7 @@ jobs:
         env:
           VITE_API_URL: https://api.v2.percymain.org/api
           VITE_MAIN_SITE_URL: https://percymain.org
+          VITE_STRIPE_PUBLIC_KEY: ${{ vars.STRIPE_PUBLIC_KEY }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/apps/matchday/package.json
+++ b/apps/matchday/package.json
@@ -16,6 +16,8 @@
     "@percy-main/shared": "workspace:*",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",
+    "@stripe/react-stripe-js": "^6.4.0",
+    "@stripe/stripe-js": "^8.9.0",
     "@tanstack/react-query": "^5.100.11",
     "better-auth": "^1.6.11",
     "better-call": "1.3.2",

--- a/apps/matchday/src/features/charges/is-open.ts
+++ b/apps/matchday/src/features/charges/is-open.ts
@@ -1,0 +1,19 @@
+import type { ApiResponse } from "@/lib/api-client.js";
+
+type Charge = ApiResponse<"/api/charges">["charges"][number];
+
+/**
+ * A charge is "open" (outstanding) when none of the four terminal flags
+ * are set. `payment_confirmed_at` is the optimistic flag the dialog sets
+ * the moment Stripe accepts the payment, before the webhook flips
+ * `paid_at` — both excluded so the row leaves Outstanding immediately.
+ *
+ * Used by both donations.tsx (Outstanding/History split) and home.tsx
+ * (the "you owe £X" card), so the two surfaces never disagree about
+ * what counts as outstanding.
+ */
+export function isChargeOpen(c: Charge): boolean {
+  return (
+    !c.paid_at && !c.deleted_at && !c.relieved_at && !c.payment_confirmed_at
+  );
+}

--- a/apps/matchday/src/features/donations/membership-card.tsx
+++ b/apps/matchday/src/features/donations/membership-card.tsx
@@ -1,0 +1,95 @@
+import { StatusPill } from "@/components/primitives/status-pill.js";
+import { Card, CardEyebrow } from "@/components/ui/card.js";
+import { fmtDate } from "@/features/format.js";
+import { api, callApi } from "@/lib/api-client.js";
+import { useQuery } from "@tanstack/react-query";
+import { differenceInDays, isPast, parseISO } from "date-fns";
+import { IdCardIcon } from "lucide-react";
+
+const MEMBERSHIP_LABELS: Record<string, string> = {
+  senior_player: "Senior Playing Member",
+  senior_women_player: "Women's Playing Member",
+  social: "Social Member",
+  junior: "Junior Member",
+  concessionary: "Student / Concessionary",
+};
+
+function membershipLabel(type: string | null): string {
+  if (!type) return "Member";
+  return MEMBERSHIP_LABELS[type] ?? "Member";
+}
+
+type MembershipStatus =
+  | { tone: "success"; label: "Active" }
+  | { tone: "warning"; label: "Expires soon" }
+  | { tone: "danger"; label: "Expired" };
+
+function computeStatus(paidUntil: string): MembershipStatus {
+  const expiry = parseISO(paidUntil);
+  if (isPast(expiry)) return { tone: "danger", label: "Expired" };
+  const days = differenceInDays(expiry, new Date());
+  if (days <= 30) return { tone: "warning", label: "Expires soon" };
+  return { tone: "success", label: "Active" };
+}
+
+export function MembershipCard() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["members", "me", "membership"],
+    queryFn: () => callApi(api.GET("/api/members/me/membership")),
+  });
+
+  if (isLoading || isError) return null;
+  const membership = data?.membership;
+
+  return (
+    <Card className="mx-4 mb-4 p-4">
+      <CardEyebrow icon={IdCardIcon}>Your membership</CardEyebrow>
+      {membership ? (
+        <ActiveMembership
+          category={membershipLabel(membership.type)}
+          paidUntil={membership.paid_until}
+        />
+      ) : (
+        <NoMembership />
+      )}
+    </Card>
+  );
+}
+
+function ActiveMembership({
+  category,
+  paidUntil,
+}: {
+  category: string;
+  paidUntil: string;
+}) {
+  const status = computeStatus(paidUntil);
+  return (
+    <>
+      <div className="mt-1.5 flex items-center justify-between gap-3">
+        <p className="text-navy text-lg font-semibold tracking-[-0.01em] dark:text-white">
+          {category}
+        </p>
+        <StatusPill tone={status.tone} dot>
+          {status.label}
+        </StatusPill>
+      </div>
+      <p className="text-text-secondary mt-1 text-sm">
+        Paid until {fmtDate(paidUntil, "d MMM yyyy")}
+      </p>
+    </>
+  );
+}
+
+function NoMembership() {
+  return (
+    <>
+      <p className="text-navy mt-1.5 text-lg font-semibold tracking-[-0.01em] dark:text-white">
+        Not a member yet
+      </p>
+      <p className="text-text-secondary mt-1 text-sm">
+        Join on the main site to play, train, or support the club.
+      </p>
+    </>
+  );
+}

--- a/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
+++ b/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
@@ -6,7 +6,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog.js";
 import { fmtMoneyPence } from "@/features/format.js";
-import { api, callApi } from "@/lib/api-client.js";
+import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
 import {
   Elements,
   PaymentElement,
@@ -16,6 +16,8 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { getStripe } from "./stripe.js";
+
+type ChargesResponse = ApiResponse<"/api/charges">;
 
 interface PayOutstandingDialogProps {
   open: boolean;
@@ -120,6 +122,7 @@ function PayBody({
     >
       <PayForm
         totalAmountPence={intentQuery.data.totalAmountPence}
+        chargeIds={intentQuery.data.chargeIds}
         onCancel={onClose}
         onPaid={onClose}
       />
@@ -141,10 +144,12 @@ function PreparingState() {
 
 function PayForm({
   totalAmountPence,
+  chargeIds,
   onCancel,
   onPaid,
 }: {
   totalAmountPence: number;
+  chargeIds: string[];
   onCancel: () => void;
   onPaid: () => void;
 }) {
@@ -190,11 +195,35 @@ function PayForm({
         }
       }
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["charges"] });
+    onSuccess: () => {
+      // Optimistic cache update. The webhook (which writes `paid_at`) often
+      // lands a beat after confirmPayment resolves, and in production the SW
+      // serves /api/charges StaleWhileRevalidate — so awaiting a refetch isn't
+      // enough to guarantee the user sees the new state. Marking the bundled
+      // charges as confirmed locally flips them out of Outstanding instantly;
+      // the eventual refetch will reconcile `paid_at` from the webhook.
+      const now = new Date().toISOString();
+      queryClient.setQueryData<ChargesResponse>(["charges"], (old) => {
+        if (!old) return old;
+        const ids = new Set(chargeIds);
+        return {
+          ...old,
+          charges: old.charges.map((c) =>
+            ids.has(c.id)
+              ? { ...c, payment_confirmed_at: c.payment_confirmed_at ?? now }
+              : c,
+          ),
+        };
+      });
+      // Fire-and-forget the refetch so paid_at lands when the webhook does.
+      void queryClient.invalidateQueries({ queryKey: ["charges"] });
       onPaid();
     },
   });
+
+  if (pay.isPending) {
+    return <ProcessingState amountPence={totalAmountPence} />;
+  }
 
   return (
     <div className="mt-4 flex flex-col gap-4">
@@ -216,21 +245,31 @@ function PayForm({
           onClick={() => {
             pay.mutate();
           }}
-          disabled={!stripe || !ready || pay.isPending}
+          disabled={!stripe || !ready}
         >
-          {pay.isPending
-            ? "Processing…"
-            : `Pay ${fmtMoneyPence(totalAmountPence)}`}
+          Pay {fmtMoneyPence(totalAmountPence)}
         </Button>
-        <Button
-          tone="ghost"
-          onClick={onCancel}
-          disabled={pay.isPending}
-          type="button"
-        >
+        <Button tone="ghost" onClick={onCancel} type="button">
           Cancel
         </Button>
       </div>
+    </div>
+  );
+}
+
+function ProcessingState({ amountPence }: { amountPence: number }) {
+  return (
+    <div className="mt-4 flex flex-col items-center gap-3 py-8 text-center">
+      <span
+        aria-hidden
+        className="border-border border-t-navy size-9 animate-spin rounded-full border-[3px]"
+      />
+      <p className="text-navy text-base font-semibold tracking-[-0.01em] dark:text-white">
+        Taking {fmtMoneyPence(amountPence)}…
+      </p>
+      <p className="text-text-secondary text-sm">
+        Hang on — confirming the payment with your bank.
+      </p>
     </div>
   );
 }

--- a/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
+++ b/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
@@ -15,7 +15,7 @@ import {
   useStripe,
 } from "@stripe/react-stripe-js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { getStripe } from "./stripe.js";
 
 type ChargesResponse = ApiResponse<"/api/charges">;
@@ -30,20 +30,35 @@ interface PayOutstandingDialogProps {
  * Mounts <PayBody> only while `open` is true, so opening the dialog
  * triggers a fresh PaymentIntent and closing it tears everything down —
  * no useEffect/setState dances required to keep the two in sync.
+ *
+ * Close is blocked while a payment is in flight (Stripe requires the
+ * PaymentElement to stay mounted through confirmPayment, otherwise it
+ * throws "elements should have a mounted Payment Element").
  */
 export function PayOutstandingDialog({
   open,
   onOpenChange,
   chargeIds,
 }: PayOutstandingDialogProps) {
+  const [paying, setPaying] = useState(false);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && paying) return;
+    onOpenChange(next);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="w-[calc(100%-1.5rem)] max-w-md sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Pay donations</DialogTitle>
         </DialogHeader>
         {open && (
-          <PayBody chargeIds={chargeIds} onClose={() => onOpenChange(false)} />
+          <PayBody
+            chargeIds={chargeIds}
+            onClose={() => onOpenChange(false)}
+            onPayingChange={setPaying}
+          />
         )}
       </DialogContent>
     </Dialog>
@@ -62,12 +77,21 @@ export function PayOutstandingDialog({
 function PayBody({
   chargeIds,
   onClose,
+  onPayingChange,
 }: {
   chargeIds: string[];
   onClose: () => void;
+  onPayingChange: (paying: boolean) => void;
 }) {
+  // Stable for the lifetime of PayBody (one mount per dialog-open). Reusing
+  // a cached PaymentIntent on reopen would be wrong — PIs are single-use,
+  // and the server's stale-PI recovery path expects a fresh request when
+  // the user retries.
+  const [nonce] = useState(
+    () => `${String(Date.now())}-${Math.random().toString(36).slice(2, 10)}`,
+  );
   const intentQuery = useQuery({
-    queryKey: ["pay-outstanding", chargeIds],
+    queryKey: ["pay-outstanding", nonce, chargeIds],
     queryFn: () =>
       callApi(
         api.POST("/api/charges/pay-outstanding", {
@@ -126,6 +150,7 @@ function PayBody({
         chargeIds={intentQuery.data.chargeIds}
         onCancel={onClose}
         onPaid={onClose}
+        onPayingChange={onPayingChange}
       />
     </Elements>
   );
@@ -148,11 +173,13 @@ function PayForm({
   chargeIds,
   onCancel,
   onPaid,
+  onPayingChange,
 }: {
   totalAmountPence: number;
   chargeIds: string[];
   onCancel: () => void;
   onPaid: () => void;
+  onPayingChange: (paying: boolean) => void;
 }) {
   const stripe = useStripe();
   const elements = useElements();
@@ -174,7 +201,13 @@ function PayForm({
         await stripe.confirmPayment({
           elements,
           // No funky redirect screens — the Payment Element handles 3DS in-place,
-          // and Apple Pay / Google Pay never need a redirect.
+          // and Apple Pay / Google Pay never need a redirect. `return_url` is
+          // only honoured if Stripe DOES need to redirect (rare, only certain
+          // payment methods like Klarna/iDEAL); we keep the user on /donations
+          // so the post-redirect refetch lands them on the same screen.
+          confirmParams: {
+            return_url: `${window.location.origin}/donations`,
+          },
           redirect: "if_required",
         });
 
@@ -221,6 +254,17 @@ function PayForm({
       onPaid();
     },
   });
+
+  useEffect(() => {
+    onPayingChange(pay.isPending);
+    return () => {
+      // Make sure the parent doesn't stay locked in "paying" if PayForm
+      // unmounts mid-flight (e.g. the intentQuery resets via parent re-render).
+      onPayingChange(false);
+    };
+    // onPayingChange is a parent-provided setter, stable across renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pay.isPending]);
 
   return (
     // The PaymentElement must stay mounted across the whole confirmPayment

--- a/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
+++ b/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/dialog.js";
 import { fmtMoneyPence } from "@/features/format.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
+import { cn } from "@/lib/utils.js";
 import {
   Elements,
   PaymentElement,
@@ -221,55 +222,64 @@ function PayForm({
     },
   });
 
-  if (pay.isPending) {
-    return <ProcessingState amountPence={totalAmountPence} />;
-  }
-
   return (
-    <div className="mt-4 flex flex-col gap-4">
-      <PaymentElement
-        onReady={() => {
-          setReady(true);
-        }}
-        options={{ layout: "tabs" }}
-      />
-      {pay.error && (
-        <p className="text-danger text-sm" role="alert">
-          {pay.error instanceof Error ? pay.error.message : "Payment failed."}
-        </p>
-      )}
-      <div className="flex flex-col gap-2">
-        <Button
-          tone="primary"
-          size="lg"
-          onClick={() => {
-            pay.mutate();
+    // The PaymentElement must stay mounted across the whole confirmPayment
+    // round-trip — Stripe throws "elements should have a mounted Payment
+    // Element" if we swap it out mid-flight. So the processing UI is an
+    // absolutely-positioned overlay; the form behind it is opacity-0'd and
+    // pointer-events-none'd, but still in the DOM.
+    <div className="relative mt-4">
+      <div
+        className={cn(
+          "flex flex-col gap-4 transition-opacity",
+          pay.isPending && "pointer-events-none opacity-0",
+        )}
+      >
+        <PaymentElement
+          onReady={() => {
+            setReady(true);
           }}
-          disabled={!stripe || !ready}
-        >
-          Pay {fmtMoneyPence(totalAmountPence)}
-        </Button>
-        <Button tone="ghost" onClick={onCancel} type="button">
-          Cancel
-        </Button>
+          options={{ layout: "tabs" }}
+        />
+        {pay.error && (
+          <p className="text-danger text-sm" role="alert">
+            {pay.error instanceof Error ? pay.error.message : "Payment failed."}
+          </p>
+        )}
+        <div className="flex flex-col gap-2">
+          <Button
+            tone="primary"
+            size="lg"
+            onClick={() => {
+              pay.mutate();
+            }}
+            disabled={!stripe || !ready}
+          >
+            Pay {fmtMoneyPence(totalAmountPence)}
+          </Button>
+          <Button tone="ghost" onClick={onCancel} type="button">
+            Cancel
+          </Button>
+        </div>
       </div>
-    </div>
-  );
-}
-
-function ProcessingState({ amountPence }: { amountPence: number }) {
-  return (
-    <div className="mt-4 flex flex-col items-center gap-3 py-8 text-center">
-      <span
-        aria-hidden
-        className="border-border border-t-navy size-9 animate-spin rounded-full border-[3px]"
-      />
-      <p className="text-navy text-base font-semibold tracking-[-0.01em] dark:text-white">
-        Taking {fmtMoneyPence(amountPence)}…
-      </p>
-      <p className="text-text-secondary text-sm">
-        Hang on — confirming the payment with your bank.
-      </p>
+      {pay.isPending && (
+        <div
+          className="bg-surface/95 absolute inset-0 flex flex-col items-center justify-center gap-3 backdrop-blur"
+          role="status"
+          aria-live="polite"
+        >
+          <span
+            aria-hidden
+            className="border-border border-t-navy size-9 animate-spin rounded-full border-[3px]"
+          />
+          <p className="text-navy text-base font-semibold tracking-[-0.01em] dark:text-white">
+            Taking {fmtMoneyPence(totalAmountPence)}…
+          </p>
+          <p className="text-text-secondary text-sm">
+            Hang on — confirming with your bank.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
+++ b/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
@@ -1,0 +1,236 @@
+import { Button } from "@/components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
+import { fmtMoneyPence } from "@/features/format.js";
+import { api, callApi } from "@/lib/api-client.js";
+import {
+  Elements,
+  PaymentElement,
+  useElements,
+  useStripe,
+} from "@stripe/react-stripe-js";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { getStripe } from "./stripe.js";
+
+interface PayOutstandingDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chargeIds: string[];
+}
+
+/**
+ * Mounts <PayBody> only while `open` is true, so opening the dialog
+ * triggers a fresh PaymentIntent and closing it tears everything down —
+ * no useEffect/setState dances required to keep the two in sync.
+ */
+export function PayOutstandingDialog({
+  open,
+  onOpenChange,
+  chargeIds,
+}: PayOutstandingDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100%-1.5rem)] max-w-md sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Pay donations</DialogTitle>
+        </DialogHeader>
+        {open && (
+          <PayBody chargeIds={chargeIds} onClose={() => onOpenChange(false)} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Two-step lifecycle:
+ *  1. Mount → useQuery fires POST /charges/pay-outstanding to create a
+ *     PaymentIntent for the selected chargeIds. Returns clientSecret + total.
+ *  2. <Elements> mounts the PaymentElement (Apple Pay / Google Pay come
+ *     for free via `automatic_payment_methods` on the server). On submit
+ *     we confirm with Stripe, then POST /charges/confirm-payment so the
+ *     UI flips to "paid" before the webhook lands.
+ */
+function PayBody({
+  chargeIds,
+  onClose,
+}: {
+  chargeIds: string[];
+  onClose: () => void;
+}) {
+  const intentQuery = useQuery({
+    queryKey: ["pay-outstanding", chargeIds],
+    queryFn: () =>
+      callApi(
+        api.POST("/api/charges/pay-outstanding", {
+          body: { chargeIds },
+        }),
+      ),
+    enabled: chargeIds.length > 0,
+    // PaymentIntent is single-use; the same selection must not be retried
+    // silently into a new PI if it 4xxs.
+    retry: false,
+    staleTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  if (chargeIds.length === 0) {
+    return (
+      <p className="text-danger mt-3 text-sm" role="alert">
+        Nothing selected to pay.
+      </p>
+    );
+  }
+
+  if (intentQuery.isError) {
+    return (
+      <p className="text-danger mt-3 text-sm" role="alert">
+        {intentQuery.error instanceof Error
+          ? intentQuery.error.message
+          : "Couldn't start payment. Try again."}
+      </p>
+    );
+  }
+
+  if (intentQuery.isPending || !intentQuery.data?.clientSecret) {
+    if (intentQuery.isSuccess && !intentQuery.data.clientSecret) {
+      return (
+        <p className="text-danger mt-3 text-sm" role="alert">
+          No payable donations in this selection.
+        </p>
+      );
+    }
+    return <PreparingState />;
+  }
+
+  return (
+    <Elements
+      stripe={getStripe()}
+      options={{
+        clientSecret: intentQuery.data.clientSecret,
+        appearance: { theme: "stripe" },
+      }}
+    >
+      <PayForm
+        totalAmountPence={intentQuery.data.totalAmountPence}
+        onCancel={onClose}
+        onPaid={onClose}
+      />
+    </Elements>
+  );
+}
+
+function PreparingState() {
+  return (
+    <div className="mt-4 flex flex-col items-center gap-3 py-8">
+      <span
+        aria-hidden
+        className="border-border border-t-navy size-7 animate-spin rounded-full border-2"
+      />
+      <p className="text-text-secondary text-sm">Preparing secure payment…</p>
+    </div>
+  );
+}
+
+function PayForm({
+  totalAmountPence,
+  onCancel,
+  onPaid,
+}: {
+  totalAmountPence: number;
+  onCancel: () => void;
+  onPaid: () => void;
+}) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const queryClient = useQueryClient();
+  const [ready, setReady] = useState(false);
+
+  const pay = useMutation({
+    mutationFn: async () => {
+      if (!stripe || !elements) {
+        throw new Error("Payment isn't ready yet.");
+      }
+
+      const submit = await elements.submit();
+      if (submit.error) {
+        throw new Error(submit.error.message ?? "Payment failed.");
+      }
+
+      const { error: confirmError, paymentIntent } =
+        await stripe.confirmPayment({
+          elements,
+          // No funky redirect screens — the Payment Element handles 3DS in-place,
+          // and Apple Pay / Google Pay never need a redirect.
+          redirect: "if_required",
+        });
+
+      if (confirmError) {
+        throw new Error(confirmError.message ?? "Payment failed.");
+      }
+
+      if (paymentIntent?.id) {
+        try {
+          await callApi(
+            api.POST("/api/charges/confirm-payment", {
+              body: { paymentIntentId: paymentIntent.id },
+            }),
+          );
+        } catch {
+          // confirm-payment is a UI hint (sets payment_confirmed_at ahead of
+          // the webhook); the webhook is authoritative. Don't block the user
+          // if it fails — their money is already taken.
+        }
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["charges"] });
+      onPaid();
+    },
+  });
+
+  return (
+    <div className="mt-4 flex flex-col gap-4">
+      <PaymentElement
+        onReady={() => {
+          setReady(true);
+        }}
+        options={{ layout: "tabs" }}
+      />
+      {pay.error && (
+        <p className="text-danger text-sm" role="alert">
+          {pay.error instanceof Error ? pay.error.message : "Payment failed."}
+        </p>
+      )}
+      <div className="flex flex-col gap-2">
+        <Button
+          tone="primary"
+          size="lg"
+          onClick={() => {
+            pay.mutate();
+          }}
+          disabled={!stripe || !ready || pay.isPending}
+        >
+          {pay.isPending
+            ? "Processing…"
+            : `Pay ${fmtMoneyPence(totalAmountPence)}`}
+        </Button>
+        <Button
+          tone="ghost"
+          onClick={onCancel}
+          disabled={pay.isPending}
+          type="button"
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/matchday/src/features/donations/stripe.ts
+++ b/apps/matchday/src/features/donations/stripe.ts
@@ -1,0 +1,15 @@
+import { loadStripe, type Stripe } from "@stripe/stripe-js";
+
+// Lazy singleton — Stripe.js is ~80kB; only fetched once a player taps "Pay".
+let promise: Promise<Stripe | null> | null = null;
+
+export function getStripe(): Promise<Stripe | null> {
+  if (!promise) {
+    const key = import.meta.env.VITE_STRIPE_PUBLIC_KEY as string | undefined;
+    if (!key) {
+      return Promise.resolve(null);
+    }
+    promise = loadStripe(key);
+  }
+  return promise;
+}

--- a/apps/matchday/src/features/membership/membership-card.tsx
+++ b/apps/matchday/src/features/membership/membership-card.tsx
@@ -42,7 +42,7 @@ export function MembershipCard() {
   const membership = data?.membership;
 
   return (
-    <Card className="mx-4 mb-4 p-4">
+    <Card className="p-4">
       <CardEyebrow icon={IdCardIcon}>Your membership</CardEyebrow>
       {membership ? (
         <ActiveMembership

--- a/apps/matchday/src/features/membership/membership-card.tsx
+++ b/apps/matchday/src/features/membership/membership-card.tsx
@@ -3,7 +3,7 @@ import { Card, CardEyebrow } from "@/components/ui/card.js";
 import { fmtDate } from "@/features/format.js";
 import { api, callApi } from "@/lib/api-client.js";
 import { useQuery } from "@tanstack/react-query";
-import { differenceInDays, isPast, parseISO } from "date-fns";
+import { differenceInDays, endOfDay, isPast, parseISO } from "date-fns";
 import { IdCardIcon } from "lucide-react";
 
 const MEMBERSHIP_LABELS: Record<string, string> = {
@@ -25,7 +25,10 @@ type MembershipStatus =
   | { tone: "danger"; label: "Expired" };
 
 function computeStatus(paidUntil: string): MembershipStatus {
-  const expiry = parseISO(paidUntil);
+  // `paid_until` is a YYYY-MM-DD date stamp meaning "membership runs through
+  // the end of this day". parseISO would treat it as 00:00 local, which would
+  // (wrongly) flip the membership to Expired for the whole of its last day.
+  const expiry = endOfDay(parseISO(paidUntil));
   if (isPast(expiry)) return { tone: "danger", label: "Expired" };
   const days = differenceInDays(expiry, new Date());
   if (days <= 30) return { tone: "warning", label: "Expires soon" };

--- a/apps/matchday/src/pages/donations.tsx
+++ b/apps/matchday/src/pages/donations.tsx
@@ -1,13 +1,14 @@
 import { StatusPill } from "@/components/primitives/status-pill.js";
 import { Button } from "@/components/ui/button.js";
+import { MembershipCard } from "@/features/donations/membership-card.js";
+import { PayOutstandingDialog } from "@/features/donations/pay-outstanding-dialog.js";
 import { fmtDate, fmtMoneyPence } from "@/features/format.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
-import { mainSiteUrl } from "@/lib/main-site.js";
 import { cn } from "@/lib/utils.js";
 import { useQuery } from "@tanstack/react-query";
 import { parseISO } from "date-fns";
 import { CheckIcon, ReceiptIcon } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 type Tab = "outstanding" | "history";
 
@@ -19,11 +20,12 @@ function isOpen(c: Charge): boolean {
 }
 
 /**
- * Donations view. Total + history.
- *
- * Per the plan, payment stays on the main site — we view here, deep-link
- * to `/members/charges` (Stripe) for the actual settlement. PR #297 means
- * user-facing copy is "donation" not "fee" from day one.
+ * Donations view. Members can:
+ *  - See their current membership category + expiry at a glance
+ *  - Tick which outstanding donations to settle and pay inline (Stripe
+ *    PaymentElement — Apple Pay / Google Pay surface automatically on
+ *    mobile via `automatic_payment_methods`)
+ *  - Browse their payment history
  */
 export default function Donations() {
   const [tab, setTab] = useState<Tab>("outstanding");
@@ -31,41 +33,69 @@ export default function Donations() {
     queryKey: ["charges"],
     queryFn: () => callApi(api.GET("/api/charges")),
   });
-  const charges = data?.charges ?? [];
-  const outstanding = charges.filter(isOpen);
-  const history = charges
-    .filter((c) => !isOpen(c))
-    .sort((a, b) =>
-      (b.paid_at ?? b.created_at).localeCompare(a.paid_at ?? a.created_at),
-    );
-  const total = outstanding.reduce((acc, c) => acc + c.amount_pence, 0);
+  const charges = useMemo(() => data?.charges ?? [], [data]);
+  const outstanding = useMemo(() => charges.filter(isOpen), [charges]);
+  const history = useMemo(
+    () =>
+      charges
+        .filter((c) => !isOpen(c))
+        .sort((a, b) =>
+          (b.paid_at ?? b.created_at).localeCompare(a.paid_at ?? a.created_at),
+        ),
+    [charges],
+  );
+
+  // Track *deselected* rows, not selected ones. Outstanding is "everything by
+  // default"; encoding the exception set means we don't need a useEffect to
+  // sync the selection whenever the outstanding list changes (e.g. after a
+  // payment lands and the query refetches).
+  const [deselected, setDeselected] = useState<Set<string>>(new Set());
+  const isSelected = (id: string) => !deselected.has(id);
+
+  const selectedIds = useMemo(
+    () => outstanding.filter((c) => isSelected(c.id)).map((c) => c.id),
+    // isSelected is a closure over deselected.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [outstanding, deselected],
+  );
+  const selectedTotal = outstanding
+    .filter((c) => isSelected(c.id))
+    .reduce((acc, c) => acc + c.amount_pence, 0);
+
+  const [paying, setPaying] = useState<{ ids: string[] } | null>(null);
+
+  function toggle(id: string) {
+    setDeselected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
   return (
-    <div className="mx-auto w-full max-w-2xl pb-6">
+    <div className="mx-auto w-full max-w-2xl pb-28">
       <header className="px-4 pt-6 pb-4">
         <p className="text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase">
           You owe
         </p>
         <p className="text-navy mt-1 text-4xl font-bold tracking-[-0.02em] dark:text-white">
-          {fmtMoneyPence(total)}
+          {fmtMoneyPence(
+            outstanding.reduce((acc, c) => acc + c.amount_pence, 0),
+          )}
         </p>
         {outstanding.length > 0 && (
-          <>
-            <p className="text-text-secondary mt-1 text-sm">
-              {outstanding.length} unpaid match donation
-              {outstanding.length === 1 ? "" : "s"}
-            </p>
-            <Button asChild tone="primary" className="mt-3 w-full">
-              <a
-                href={mainSiteUrl("/members?tab=payments")}
-                target="_blank"
-                rel="noopener"
-              >
-                Pay on main site ↗
-              </a>
-            </Button>
-          </>
+          <p className="text-text-secondary mt-1 text-sm">
+            {outstanding.length} unpaid match donation
+            {outstanding.length === 1 ? "" : "s"}
+          </p>
         )}
       </header>
+
+      <MembershipCard />
 
       <div className="bg-surface-raised mx-4 grid grid-cols-2 gap-1 rounded-xl p-1">
         <TabBtn
@@ -96,7 +126,16 @@ export default function Donations() {
                 body="No outstanding donations. Thanks for keeping your match donations square."
               />
             ) : (
-              outstanding.map((c) => <ChargeRowItem key={c.id} c={c} />)
+              outstanding.map((c) => (
+                <ChargeRowItem
+                  key={c.id}
+                  c={c}
+                  selected={isSelected(c.id)}
+                  onToggle={() => {
+                    toggle(c.id);
+                  }}
+                />
+              ))
             )}
           </>
         )}
@@ -115,6 +154,24 @@ export default function Donations() {
           </>
         )}
       </div>
+
+      {tab === "outstanding" && outstanding.length > 0 && (
+        <PayBar
+          amountPence={selectedTotal}
+          count={selectedIds.length}
+          onPay={() => {
+            setPaying({ ids: selectedIds });
+          }}
+        />
+      )}
+
+      <PayOutstandingDialog
+        open={!!paying}
+        onOpenChange={(open) => {
+          if (!open) setPaying(null);
+        }}
+        chargeIds={paying?.ids ?? []}
+      />
     </div>
   );
 }
@@ -144,7 +201,17 @@ function TabBtn({
   );
 }
 
-function ChargeRowItem({ c, muted }: { c: Charge; muted?: boolean }) {
+function ChargeRowItem({
+  c,
+  muted,
+  selected,
+  onToggle,
+}: {
+  c: Charge;
+  muted?: boolean;
+  selected?: boolean;
+  onToggle?: () => void;
+}) {
   const overdue = isOpen(c) && isOverdue(c);
   const status = c.paid_at
     ? { tone: "success" as const, label: `Paid ${fmtDate(c.paid_at)}` }
@@ -153,13 +220,37 @@ function ChargeRowItem({ c, muted }: { c: Charge; muted?: boolean }) {
       : c.relieved_at
         ? { tone: "warning" as const, label: "Relieved" }
         : null;
+
+  const selectable = onToggle !== undefined;
+  // Whole row is the tap target on a phone — bigger than a 16px checkbox.
+  const RowEl: "button" | "div" = selectable ? "button" : "div";
+
   return (
-    <div
+    <RowEl
+      type={selectable ? "button" : undefined}
+      onClick={selectable ? onToggle : undefined}
+      aria-pressed={selectable ? selected : undefined}
       className={cn(
-        "border-border-light grid grid-cols-[44px_1fr_auto] items-center gap-3 border-t px-4 py-3",
+        "border-border-light grid w-full items-center gap-3 border-t px-4 py-3 text-left",
+        selectable
+          ? "focus:bg-surface-raised/60 grid-cols-[24px_44px_1fr_auto] focus:outline-none"
+          : "grid-cols-[44px_1fr_auto]",
         muted && "opacity-70",
       )}
     >
+      {selectable && (
+        <span
+          aria-hidden
+          className={cn(
+            "grid size-5 place-items-center rounded-md border transition-colors",
+            selected
+              ? "bg-navy border-navy dark:text-navy text-white dark:border-white dark:bg-white"
+              : "border-border bg-surface",
+          )}
+        >
+          {selected && <CheckIcon className="size-3.5" strokeWidth={3} />}
+        </span>
+      )}
       {c.charge_date ? (
         <div className="bg-surface-raised flex flex-col items-center justify-center rounded-md py-1">
           <div className="text-navy text-base leading-none font-bold dark:text-white">
@@ -200,7 +291,7 @@ function ChargeRowItem({ c, muted }: { c: Charge; muted?: boolean }) {
           </StatusPill>
         )}
       </div>
-    </div>
+    </RowEl>
   );
 }
 
@@ -246,6 +337,42 @@ function EmptyState({
       </div>
       <p className="mt-4 text-base font-semibold tracking-[-0.01em]">{title}</p>
       <p className="text-text-secondary mt-1 text-sm leading-relaxed">{body}</p>
+    </div>
+  );
+}
+
+function PayBar({
+  amountPence,
+  count,
+  onPay,
+}: {
+  amountPence: number;
+  count: number;
+  onPay: () => void;
+}) {
+  const disabled = count === 0 || amountPence <= 0;
+  return (
+    <div
+      // Floats above the bottom tab bar (h-16 on mobile shell). pb env safe-area
+      // for iOS home-indicator gestures.
+      className="bg-surface border-border-light supports-[backdrop-filter]:bg-surface/95 fixed inset-x-0 bottom-16 z-40 border-t px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] backdrop-blur sm:mx-auto sm:max-w-2xl"
+    >
+      <Button
+        tone="primary"
+        size="lg"
+        className="w-full"
+        disabled={disabled}
+        onClick={onPay}
+      >
+        {disabled
+          ? "Select donations to pay"
+          : `Pay ${fmtMoneyPence(amountPence)}`}
+        {!disabled && count > 1 && (
+          <span className="ml-1 text-xs font-medium opacity-80">
+            ({count} donations)
+          </span>
+        )}
+      </Button>
     </div>
   );
 }

--- a/apps/matchday/src/pages/donations.tsx
+++ b/apps/matchday/src/pages/donations.tsx
@@ -1,6 +1,5 @@
 import { StatusPill } from "@/components/primitives/status-pill.js";
 import { Button } from "@/components/ui/button.js";
-import { MembershipCard } from "@/features/donations/membership-card.js";
 import { PayOutstandingDialog } from "@/features/donations/pay-outstanding-dialog.js";
 import { fmtDate, fmtMoneyPence } from "@/features/format.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
@@ -100,8 +99,6 @@ export default function Donations() {
           </p>
         )}
       </header>
-
-      <MembershipCard />
 
       <div className="bg-surface-raised mx-4 grid grid-cols-2 gap-1 rounded-xl p-1">
         <TabBtn

--- a/apps/matchday/src/pages/donations.tsx
+++ b/apps/matchday/src/pages/donations.tsx
@@ -16,7 +16,13 @@ type ChargesResponse = ApiResponse<"/api/charges">;
 type Charge = ChargesResponse["charges"][number];
 
 function isOpen(c: Charge): boolean {
-  return !c.paid_at && !c.deleted_at && !c.relieved_at;
+  // `payment_confirmed_at` is set by POST /charges/confirm-payment the moment
+  // Stripe accepts the payment, before the webhook flips `paid_at`. Treating
+  // it as "not open" keeps the row out of Outstanding (and the optimistic
+  // cache update) so the user doesn't see a stale unpaid state mid-settlement.
+  return (
+    !c.paid_at && !c.deleted_at && !c.relieved_at && !c.payment_confirmed_at
+  );
 }
 
 /**
@@ -77,7 +83,7 @@ export default function Donations() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-2xl pb-28">
+    <div className="mx-auto w-full max-w-2xl pb-6">
       <header className="px-4 pt-6 pb-4">
         <p className="text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase">
           You owe
@@ -219,7 +225,9 @@ function ChargeRowItem({
       ? { tone: "neutral" as const, label: "Voided" }
       : c.relieved_at
         ? { tone: "warning" as const, label: "Relieved" }
-        : null;
+        : c.payment_confirmed_at
+          ? { tone: "navy" as const, label: "Processing…" }
+          : null;
 
   const selectable = onToggle !== undefined;
   // Whole row is the tap target on a phone — bigger than a 16px checkbox.
@@ -352,27 +360,29 @@ function PayBar({
 }) {
   const disabled = count === 0 || amountPence <= 0;
   return (
-    <div
-      // Floats above the bottom tab bar (h-16 on mobile shell). pb env safe-area
-      // for iOS home-indicator gestures.
-      className="bg-surface border-border-light supports-[backdrop-filter]:bg-surface/95 fixed inset-x-0 bottom-16 z-40 border-t px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] backdrop-blur sm:mx-auto sm:max-w-2xl"
-    >
-      <Button
-        tone="primary"
-        size="lg"
-        className="w-full"
-        disabled={disabled}
-        onClick={onPay}
-      >
-        {disabled
-          ? "Select donations to pay"
-          : `Pay ${fmtMoneyPence(amountPence)}`}
-        {!disabled && count > 1 && (
-          <span className="ml-1 text-xs font-medium opacity-80">
-            ({count} donations)
-          </span>
-        )}
-      </Button>
+    // `sticky` inside the donations max-w-2xl column auto-aligns the bar with
+    // the list. `bottom-16` clears the mobile bottom tab bar; on desktop the
+    // tab bar is hidden and the AppShell adds a w-56 side nav, so we float a
+    // few pixels above the viewport edge instead.
+    <div className="sticky bottom-16 z-40 mt-4 px-4 md:bottom-4">
+      <div className="bg-surface border-border-light supports-[backdrop-filter]:bg-surface/95 rounded-xl border px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] shadow-lg backdrop-blur">
+        <Button
+          tone="primary"
+          size="lg"
+          className="w-full"
+          disabled={disabled}
+          onClick={onPay}
+        >
+          {disabled
+            ? "Select donations to pay"
+            : `Pay ${fmtMoneyPence(amountPence)}`}
+          {!disabled && count > 1 && (
+            <span className="ml-1 text-xs font-medium opacity-80">
+              ({count} donations)
+            </span>
+          )}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/matchday/src/pages/donations.tsx
+++ b/apps/matchday/src/pages/donations.tsx
@@ -1,5 +1,6 @@
 import { StatusPill } from "@/components/primitives/status-pill.js";
 import { Button } from "@/components/ui/button.js";
+import { isChargeOpen } from "@/features/charges/is-open.js";
 import { PayOutstandingDialog } from "@/features/donations/pay-outstanding-dialog.js";
 import { fmtDate, fmtMoneyPence } from "@/features/format.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
@@ -13,16 +14,6 @@ type Tab = "outstanding" | "history";
 
 type ChargesResponse = ApiResponse<"/api/charges">;
 type Charge = ChargesResponse["charges"][number];
-
-function isOpen(c: Charge): boolean {
-  // `payment_confirmed_at` is set by POST /charges/confirm-payment the moment
-  // Stripe accepts the payment, before the webhook flips `paid_at`. Treating
-  // it as "not open" keeps the row out of Outstanding (and the optimistic
-  // cache update) so the user doesn't see a stale unpaid state mid-settlement.
-  return (
-    !c.paid_at && !c.deleted_at && !c.relieved_at && !c.payment_confirmed_at
-  );
-}
 
 /**
  * Donations view. Members can:
@@ -39,11 +30,11 @@ export default function Donations() {
     queryFn: () => callApi(api.GET("/api/charges")),
   });
   const charges = useMemo(() => data?.charges ?? [], [data]);
-  const outstanding = useMemo(() => charges.filter(isOpen), [charges]);
+  const outstanding = useMemo(() => charges.filter(isChargeOpen), [charges]);
   const history = useMemo(
     () =>
       charges
-        .filter((c) => !isOpen(c))
+        .filter((c) => !isChargeOpen(c))
         .sort((a, b) =>
           (b.paid_at ?? b.created_at).localeCompare(a.paid_at ?? a.created_at),
         ),
@@ -215,7 +206,7 @@ function ChargeRowItem({
   selected?: boolean;
   onToggle?: () => void;
 }) {
-  const overdue = isOpen(c) && isOverdue(c);
+  const overdue = isChargeOpen(c) && isOverdue(c);
   const status = c.paid_at
     ? { tone: "success" as const, label: `Paid ${fmtDate(c.paid_at)}` }
     : c.deleted_at

--- a/apps/matchday/src/pages/home.tsx
+++ b/apps/matchday/src/pages/home.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
+import { isChargeOpen } from "@/features/charges/is-open.js";
 import { fmtDate, fmtMoneyPence } from "@/features/format.js";
 import {
   gameIsoDate,
@@ -301,10 +302,7 @@ function OutstandingDonationsCard() {
   if (isError) return <CardError label="Couldn't load donations" />;
 
   const charges = data?.charges ?? [];
-  const outstanding = charges.filter(
-    (c) =>
-      c.paid_at === null && c.deleted_at === null && c.relieved_at === null,
-  );
+  const outstanding = charges.filter(isChargeOpen);
   if (outstanding.length === 0) return null;
   const total = outstanding.reduce((acc, c) => acc + c.amount_pence, 0);
   const overdueCount = outstanding.filter(isOverdue).length;

--- a/apps/matchday/src/pages/home.tsx
+++ b/apps/matchday/src/pages/home.tsx
@@ -18,7 +18,6 @@ import {
 } from "@/features/games.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
 import { canViewMatchdayAdmin, useSession } from "@/lib/auth-client.js";
-import { mainSiteUrl } from "@/lib/main-site.js";
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import {
@@ -334,13 +333,7 @@ function OutstandingDonationsCard() {
           {outstanding.length === 1 ? "donation" : "donations"}
         </p>
         <Button asChild tone="primary" className="w-full">
-          <a
-            href={mainSiteUrl("/members?tab=payments")}
-            rel="noopener"
-            target="_blank"
-          >
-            Pay on main site ↗
-          </a>
+          <Link to="/donations">Pay {fmtMoneyPence(total)}</Link>
         </Button>
       </CardContent>
     </Card>

--- a/apps/matchday/src/pages/me.tsx
+++ b/apps/matchday/src/pages/me.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card.js";
+import { MembershipCard } from "@/features/membership/membership-card.js";
 import { NotificationsCard } from "@/features/notifications/notifications-card.js";
 import { signOut, useSession, type SessionUser } from "@/lib/auth-client.js";
 import { mainSiteUrl } from "@/lib/main-site.js";
@@ -29,6 +30,8 @@ export default function Me() {
           />
         </CardContent>
       </Card>
+
+      <MembershipCard />
 
       <NotificationsCard />
 

--- a/apps/matchday/src/pages/me.tsx
+++ b/apps/matchday/src/pages/me.tsx
@@ -9,7 +9,7 @@ import {
 import { NotificationsCard } from "@/features/notifications/notifications-card.js";
 import { signOut, useSession, type SessionUser } from "@/lib/auth-client.js";
 import { mainSiteUrl } from "@/lib/main-site.js";
-import { ExternalLinkIcon, UserIcon } from "lucide-react";
+import { UserIcon } from "lucide-react";
 
 export default function Me() {
   const { data: session } = useSession();
@@ -32,23 +32,11 @@ export default function Me() {
 
       <NotificationsCard />
 
-      <Card>
-        <CardHeader>
-          <CardEyebrow icon={ExternalLinkIcon}>Main site</CardEyebrow>
-          <CardTitle>Membership & payments</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-text-secondary mb-3 text-sm">
-            Member details, donation payments, and admin tools live on the main
-            site.
-          </p>
-          <Button asChild tone="outline" className="w-full">
-            <a href={mainSiteUrl("/members")} target="_blank" rel="noopener">
-              Open percymain.org ↗
-            </a>
-          </Button>
-        </CardContent>
-      </Card>
+      <Button asChild tone="outline" className="w-full">
+        <a href={mainSiteUrl("/members")} target="_blank" rel="noopener">
+          Open percymain.org ↗
+        </a>
+      </Button>
 
       <Button
         tone="ghost"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,7 +291,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: ^1.6.11
-        version: 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)
+        version: 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)
       '@percy-main/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -301,6 +301,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.6)
+      '@stripe/react-stripe-js':
+        specifier: ^6.4.0
+        version: 6.4.0(@stripe/stripe-js@8.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@stripe/stripe-js':
+        specifier: ^8.9.0
+        version: 8.9.0
       '@tanstack/react-query':
         specifier: ^5.100.11
         version: 5.100.11(react@19.2.6)
@@ -9182,6 +9188,20 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
+    dependencies:
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.2(zod@4.4.3)
+      jose: 6.2.3
+      kysely: 0.28.17
+      nanostores: 1.3.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
@@ -9210,9 +9230,9 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
   '@better-auth/infra@0.2.8(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/sso@1.5.6(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3)))(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(zod@4.4.3)':
@@ -9226,22 +9246,34 @@ snapshots:
       libphonenumber-js: 1.13.2
       zod: 4.4.3
 
-  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
+
+  '@better-auth/passkey@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)':
+    dependencies:
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      '@simplewebauthn/browser': 13.3.0
+      '@simplewebauthn/server': 13.3.0
+      better-auth: 1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
+      better-call: 1.3.2(zod@4.4.3)
+      nanostores: 1.3.0
+      zod: 4.4.3
 
   '@better-auth/passkey@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)':
     dependencies:
@@ -9255,9 +9287,9 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
   '@better-auth/sso@1.5.6(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))':
@@ -9273,9 +9305,9 @@ snapshots:
       tldts: 6.1.86
       zod: 4.4.3
 
-  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
@@ -12323,12 +12355,12 @@ snapshots:
   better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0


### PR DESCRIPTION
## Summary

Donations tab now answers the two questions a member opens it for - "am I a paid member?" and "what do I owe?" - and lets them settle outstanding donations without leaving the PWA.

- **Membership card**: reads `/api/members/me/membership` and shows category (Senior Playing / Women's / Social / Junior / Concessionary), Active / Expires-soon (≤30d) / Expired pill, and the paid-until date. Falls back to a "Not a member yet" state.
- **Inline pay flow**: Outstanding rows are now whole-row checkbox buttons (preselected by default, 44pt tap target). A bottom-pinned "Pay £X (n donations)" opens a Dialog that mints a PaymentIntent via the existing `POST /api/charges/pay-outstanding`, mounts Stripe `Elements` + `PaymentElement` (tabs layout), and confirms in-place. Apple Pay / Google Pay surface automatically via the server's `automatic_payment_methods` — no extra wiring.
- **No backend changes**: `/api/charges`, `/api/charges/pay-outstanding`, `/api/charges/confirm-payment`, and `/api/members/me/membership` were already shaped for this.
- **Plumbing**: `apps/matchday` gains `@stripe/stripe-js` + `@stripe/react-stripe-js` (same versions pinned in `apps/web`; `loadStripe` is lazy so Stripe.js only fetches when the dialog opens). `deploy.yml` passes `VITE_STRIPE_PUBLIC_KEY` through to the matchday build.

## Selection model

The list tracks the *deselected* set, not the selected one — so when a payment lands and the `charges` query refetches, the previous selection isn't blown away by a `useEffect` syncing in the new IDs.

## Test plan

- [ ] Donations tab shows the membership card with the right category label + paid-until + status pill (Active / Expires soon / Expired)
- [ ] Empty membership state shows "Not a member yet"
- [ ] Outstanding rows preselected; tapping a row toggles selection
- [ ] Pay bar updates total + count as selection changes
- [ ] Pay £X opens dialog; Stripe Payment Element renders with Card / Bacs / Revolut Pay tabs on desktop
- [ ] On a real iOS device, Apple Pay shows up in the Payment Element
- [ ] On Android Chrome, Google Pay shows up in the Payment Element
- [ ] Successful payment closes the dialog, charges query invalidates, paid rows move to History
- [ ] Cancel button dismisses without charging
- [ ] Verify `VITE_STRIPE_PUBLIC_KEY` is set in the matchday deploy job's GitHub Actions variables