### PR TITLE
feat(matchday): in-app membership pay flow + charge push notifications

### DIFF
--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { SendPush } from "../../lib/push-sender.ts";
 import { noopS3Uploader } from "../../lib/s3-upload.ts";
 import {
   seedTestUser,
@@ -28,6 +29,8 @@ import {
 } from "./service.ts";
 
 const noopSendEmail = () => Promise.resolve();
+const noopSendPush: SendPush = (sub) =>
+  Promise.resolve({ ok: true, endpoint: sub.endpoint });
 const testConfig = { BASE_URL: "https://example.test" };
 
 async function finishAsTest(
@@ -43,7 +46,7 @@ async function finishAsTest(
   } = {},
 ) {
   const { createNoopLogger } = await import("../../lib/worker-logger.ts");
-  return finishMatch(ctx.db, noopSendEmail, testConfig)(
+  return finishMatch(ctx.db, noopSendEmail, noopSendPush, testConfig)(
     userId,
     "admin",
     matchdayId,
@@ -531,6 +534,103 @@ describe("matchday service (integration)", () => {
         expect(charge?.amount_pence).toBe(500);
         expect(charge?.type).toBe("match_fee");
       }
+    });
+
+    it("sends a push notification when the recipient prefers push", async () => {
+      const { userId: adminId } = await seedTestUser(ctx.db, {
+        email: `push-admin-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+        withMember: false,
+      });
+      const playerEmail = `push-player-${crypto.randomUUID()}@test.com`;
+      const { userId: playerUserId, memberId } = await seedTestUser(ctx.db, {
+        email: playerEmail,
+        name: "Push Player",
+      });
+      if (!memberId) throw new Error("expected memberId");
+      // seedTestUser inserts a member without a category; finishMatch's
+      // fee resolver keys on member_category so set it explicitly.
+      await ctx.db
+        .updateTable("member")
+        .set({ member_category: "senior" })
+        .where("id", "=", memberId)
+        .execute();
+
+      await ctx.db
+        .insertInto("notification_preferences")
+        .values({ user_id: playerUserId, matchday_channel: "push" })
+        .execute();
+
+      const endpoint = `https://push.test/${crypto.randomUUID()}`;
+      await ctx.db
+        .insertInto("push_subscription")
+        .values({
+          id: crypto.randomUUID(),
+          user_id: playerUserId,
+          endpoint,
+          p256dh: "test-p256dh",
+          auth: "test-auth",
+        })
+        .execute();
+
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: adminId });
+      await seedFeeRate({ teamId, memberCategory: "senior", amountPence: 500 });
+
+      const { id: playerId } = await addPlayer(ctx.db)(
+        adminId,
+        "admin",
+        matchdayId,
+        { memberId, playerName: "Push Player" },
+      );
+
+      const pushCalls: Array<{ endpoint: string; payload: unknown }> = [];
+      const emailCalls: Array<{ to: string }> = [];
+      const recordingSendPush: SendPush = (sub, payload) => {
+        pushCalls.push({ endpoint: sub.endpoint, payload });
+        return Promise.resolve({ ok: true, endpoint: sub.endpoint });
+      };
+      const recordingSendEmail = (e: {
+        to: string;
+        subject: string;
+        html: string;
+      }) => {
+        emailCalls.push({ to: e.to });
+        return Promise.resolve();
+      };
+
+      const { createNoopLogger } = await import("../../lib/worker-logger.ts");
+      const result = await finishMatch(
+        ctx.db,
+        recordingSendEmail,
+        recordingSendPush,
+        testConfig,
+      )(
+        adminId,
+        "admin",
+        matchdayId,
+        {
+          resultType: "W",
+          playerStatuses: [{ matchdayPlayerId: playerId, status: "playing" }],
+          feeOverrides: [],
+        },
+        createNoopLogger(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.emailsSent).toBe(1);
+      expect(emailCalls).toHaveLength(0);
+      expect(pushCalls).toHaveLength(1);
+      expect(pushCalls[0]?.endpoint).toBe(endpoint);
+      const payload = pushCalls[0]?.payload as {
+        title: string;
+        body: string;
+        url: string;
+        tag: string;
+      };
+      expect(payload.title).toBeTruthy();
+      expect(payload.body).toContain("£5.00");
+      expect(payload.tag.startsWith("charge:")).toBe(true);
     });
 
     it("raises a junior-rate charge against the parent when a dependent plays", async () => {

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -372,7 +372,7 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
   const removeP = removePlayer(app.db);
   const setRoles = setMatchRoles(app.db);
   const paid = markFeePaid(app.db);
-  const finish = finishMatch(app.db, app.send, app.config);
+  const finish = finishMatch(app.db, app.send, app.sendPush, app.config);
   const cancel = cancelMatchday(app.db);
 
   // Play-Cricket API client for upcoming matches — wired at registration time

--- a/apps/api/src/features/matchday/service.test.ts
+++ b/apps/api/src/features/matchday/service.test.ts
@@ -402,8 +402,13 @@ describe("expense approval workflow", () => {
 
   describe("finishMatch", () => {
     const mockSendEmail = vi.fn().mockResolvedValue(undefined);
+    const mockSendPush = vi
+      .fn()
+      .mockImplementation((sub: { endpoint: string }) =>
+        Promise.resolve({ ok: true, endpoint: sub.endpoint }),
+      );
     const mockConfig = { BASE_URL: "https://example.com" };
-    const finish = finishMatch(db, mockSendEmail, mockConfig);
+    const finish = finishMatch(db, mockSendEmail, mockSendPush, mockConfig);
 
     it("rejects if matchday not found", async () => {
       mockExecuteTakeFirst.mockResolvedValueOnce(undefined);

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -9,9 +9,19 @@ import {
 } from "date-fns";
 import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
+import type { SendPush } from "../../lib/push-sender.ts";
 import type { S3Uploader } from "../../lib/s3-upload.ts";
 import { applyReliefIfAny } from "../financial-relief/apply-relief.ts";
+import type { MatchdayChannel } from "../notification-preferences/schemas.ts";
+import {
+  DEFAULT_MATCHDAY_CHANNEL,
+  getNotificationPreferencesByUserIds,
+} from "../notification-preferences/service.ts";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
+import {
+  deletePushSubscriptionByEndpoint,
+  listPushSubscriptionsForUsers,
+} from "../push-subscriptions/service.ts";
 import type {
   AddPlayer,
   CancelMatchday,
@@ -1305,8 +1315,12 @@ export function finishMatch(
     subject: string;
     html: string;
   }) => Promise<void>,
+  sendPush: SendPush,
   config: { BASE_URL: string },
 ) {
+  const fetchPrefs = getNotificationPreferencesByUserIds(db);
+  const fetchPushSubs = listPushSubscriptionsForUsers(db);
+  const pruneSubscription = deletePushSubscriptionByEndpoint(db);
   return async (
     userId: string,
     role: string,
@@ -1615,8 +1629,8 @@ export function finishMatch(
     });
 
     if (isFirstFinish) {
-      // Send notification emails AFTER the transaction commits so a
-      // mailer hiccup can't roll back the charges. Join `member` via
+      // Send notifications AFTER the transaction commits so a delivery
+      // hiccup can't roll back the charges. Join `member` via
       // `charge.member_id` (not `matchday_player.member_id`) so junior
       // donations - which sit on the parent's member row - also get a
       // notification.
@@ -1630,6 +1644,7 @@ export function finishMatch(
         // Don't nag members about charges the club has waived.
         .where("charge.relieved_at", "is", null)
         .select([
+          "charge.id as charge_id",
           "member.name as member_name",
           "member.email as member_email",
           "charge.description as charge_description",
@@ -1646,16 +1661,41 @@ export function finishMatch(
       const { render } = await import("react-email");
       const { ChargeNotification } = await import("@percy-main/email");
 
+      // Resolve user ids so we can apply each recipient's matchday_channel
+      // preference. Member rows whose email doesn't match a user (legacy
+      // members who never registered) get email-only delivery, matching
+      // pre-push behavior.
+      const recipientEmails = unpaidPlayers
+        .map((p) => p.member_email?.toLowerCase())
+        .filter((e): e is string => Boolean(e));
+
+      const userRows =
+        recipientEmails.length > 0
+          ? await db
+              .selectFrom("user")
+              .where("email", "in", recipientEmails)
+              .select(["id", "email"])
+              .execute()
+          : [];
+      const userIdByEmail = new Map<string, string>();
+      for (const u of userRows) {
+        userIdByEmail.set(u.email.toLowerCase(), u.id);
+      }
+      const userIds = userRows.map((u) => u.id);
+
+      const [prefs, pushSubsByUser] = await Promise.all([
+        fetchPrefs(userIds),
+        fetchPushSubs(userIds),
+      ]);
+
       let emailsSent = 0;
       const emailErrors: string[] = [];
-      for (const player of unpaidPlayers) {
-        if (!player.member_email) continue;
 
+      const sendOneEmail = async (
+        player: (typeof unpaidPlayers)[number],
+        amountFormatted: string,
+      ): Promise<{ ok: true } | { ok: false; reason: string }> => {
         try {
-          const amountFormatted = currencyFormatter.format(
-            player.amount_pence / 100,
-          );
-
           const element = ChargeNotification.component({
             imageBaseUrl: `${config.BASE_URL}/images`,
             name: player.member_name ?? "Member",
@@ -1664,22 +1704,123 @@ export function finishMatch(
             chargeDate: formatDate(new Date(player.charge_date), "dd/MM/yyyy"),
             loginUrl: `${config.BASE_URL}/auth/login`,
           });
-
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
           const html = await render(element as any);
           await sendEmail({
-            to: player.member_email,
+            to: player.member_email ?? "",
             subject: ChargeNotification.subject,
             html,
           });
-          emailsSent++;
+          return { ok: true };
         } catch (err) {
-          const msg =
-            err instanceof Error ? err.message : "Unknown email error";
-          emailErrors.push(`${player.member_email}: ${msg}`);
+          const reason = err instanceof Error ? err.message : String(err);
           log.error(
-            { err, recipientEmail: player.member_email, matchdayId },
+            {
+              err,
+              recipientEmail: player.member_email,
+              matchdayId,
+              channel: "email",
+            },
             "matchday_charge_notification_failed",
+          );
+          return { ok: false, reason };
+        }
+      };
+
+      for (const player of unpaidPlayers) {
+        if (!player.member_email) continue;
+
+        const amountFormatted = currencyFormatter.format(
+          player.amount_pence / 100,
+        );
+
+        const userId = userIdByEmail.get(player.member_email.toLowerCase());
+        const channel: MatchdayChannel = userId
+          ? (prefs.get(userId) ?? DEFAULT_MATCHDAY_CHANNEL)
+          : "email";
+
+        const wantsEmail = channel === "email" || channel === "both";
+        const wantsPush = channel === "push" || channel === "both";
+
+        const subscriptions = userId ? (pushSubsByUser.get(userId) ?? []) : [];
+        const pushAvailable = wantsPush && subscriptions.length > 0;
+
+        let deliveredAny = false;
+        let recipientFailure: string | null = null;
+
+        // Push-only recipients with no live subscriptions fall back to
+        // email - opt-in subscriptions plus a payment ask is too easy to
+        // miss otherwise.
+        if (wantsEmail || (wantsPush && !pushAvailable)) {
+          const result = await sendOneEmail(player, amountFormatted);
+          if (result.ok) {
+            deliveredAny = true;
+          } else {
+            recipientFailure = result.reason;
+          }
+        }
+
+        if (pushAvailable) {
+          const payload = {
+            title: ChargeNotification.subject,
+            body: `${amountFormatted} - ${player.charge_description}`,
+            url: `${config.BASE_URL}/charges`,
+            tag: `charge:${player.charge_id}`,
+          };
+          let pushDelivered = false;
+          let allGone = true;
+          for (const sub of subscriptions) {
+            const result = await sendPush(sub, payload);
+            if (result.ok) {
+              deliveredAny = true;
+              pushDelivered = true;
+              allGone = false;
+            } else if (result.gone) {
+              await pruneSubscription(result.endpoint);
+              log.info(
+                {
+                  matchdayId,
+                  chargeId: player.charge_id,
+                  endpoint: result.endpoint,
+                },
+                "push_subscription_gone_pruned",
+              );
+            } else {
+              allGone = false;
+              log.warn(
+                {
+                  matchdayId,
+                  chargeId: player.charge_id,
+                  recipientEmail: player.member_email,
+                  endpoint: result.endpoint,
+                  reason: result.reason,
+                  channel: "push",
+                },
+                "matchday_charge_notification_failed",
+              );
+              recipientFailure ??= result.reason;
+            }
+          }
+
+          // Push-only recipient whose every subscription was pruned this
+          // turn looks subscribed in our store but the push service
+          // disagrees - email them so they don't silently miss the charge.
+          if (!wantsEmail && !pushDelivered && allGone) {
+            const fallback = await sendOneEmail(player, amountFormatted);
+            if (fallback.ok) {
+              deliveredAny = true;
+              recipientFailure = null;
+            } else {
+              recipientFailure ??= fallback.reason;
+            }
+          }
+        }
+
+        if (deliveredAny) {
+          emailsSent++;
+        } else {
+          emailErrors.push(
+            `${player.member_email}: ${recipientFailure ?? "no delivery channel"}`,
           );
         }
       }

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -1316,7 +1316,7 @@ export function finishMatch(
     html: string;
   }) => Promise<void>,
   sendPush: SendPush,
-  config: { BASE_URL: string },
+  config: { BASE_URL: string; MATCHDAY_URL?: string },
 ) {
   const fetchPrefs = getNotificationPreferencesByUserIds(db);
   const fetchPushSubs = listPushSubscriptionsForUsers(db);
@@ -1761,10 +1761,17 @@ export function finishMatch(
         }
 
         if (pushAvailable) {
+          // The matchday PWA's service worker registered this subscription,
+          // so opening the URL on that origin keeps the user inside the app
+          // and at the new in-app pay-outstanding flow. Fall back to the
+          // main-site payments tab when MATCHDAY_URL is unset (dev/preview).
+          const payUrl = config.MATCHDAY_URL
+            ? `${config.MATCHDAY_URL}/donations`
+            : `${config.BASE_URL}/members?tab=payments`;
           const payload = {
             title: ChargeNotification.subject,
             body: `${amountFormatted} - ${player.charge_description}`,
-            url: `${config.BASE_URL}/charges`,
+            url: payUrl,
             tag: `charge:${player.charge_id}`,
           };
           let pushDelivered = false;

--- a/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
+++ b/apps/matchday/src/features/donations/pay-outstanding-dialog.tsx
@@ -6,7 +6,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog.js";
 import { fmtMoneyPence } from "@/features/format.js";
-import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
+import {
+  API_BASE,
+  api,
+  callApi,
+  evictResponseFromRuntimeCaches,
+  type ApiResponse,
+} from "@/lib/api-client.js";
 import { cn } from "@/lib/utils.js";
 import {
   Elements,
@@ -137,6 +143,18 @@ function PayBody({
     return <PreparingState />;
   }
 
+  // Without VITE_STRIPE_PUBLIC_KEY, getStripe() resolves to null and the
+  // PaymentElement silently refuses to render - the user just sees a
+  // disabled "Pay" button with no clue why. Surface the misconfig instead.
+  if (!import.meta.env.VITE_STRIPE_PUBLIC_KEY) {
+    return (
+      <p className="text-danger mt-3 text-sm" role="alert">
+        Payments aren&apos;t configured for this build. Please refresh, or get
+        in touch with the club if it keeps happening.
+      </p>
+    );
+  }
+
   return (
     <Elements
       stripe={getStripe()}
@@ -249,8 +267,14 @@ function PayForm({
           ),
         };
       });
-      // Fire-and-forget the refetch so paid_at lands when the webhook does.
-      void queryClient.invalidateQueries({ queryKey: ["charges"] });
+      // Evict the SW's StaleWhileRevalidate copy of /api/charges before
+      // invalidating - otherwise the refetch is served the pre-payment
+      // cached response and overwrites the optimistic update above,
+      // making just-paid donations briefly reappear as Outstanding.
+      const chargesUrl = `${API_BASE.replace(/\/api$/, "")}/api/charges`;
+      void evictResponseFromRuntimeCaches(chargesUrl).then(() =>
+        queryClient.invalidateQueries({ queryKey: ["charges"] }),
+      );
       onPaid();
     },
   });

--- a/apps/matchday/src/lib/api-client.ts
+++ b/apps/matchday/src/lib/api-client.ts
@@ -93,9 +93,13 @@ export async function callApi<T>(
 
 /**
  * Best-effort delete of `url` from every runtime cache. Used to flush
- * stale authenticated responses when the server returns 401.
+ * stale authenticated responses when the server returns 401, and when
+ * a write changes server state that the SW would otherwise keep
+ * serving stale (StaleWhileRevalidate handlers).
  */
-async function evictResponseFromRuntimeCaches(url: string): Promise<void> {
+export async function evictResponseFromRuntimeCaches(
+  url: string,
+): Promise<void> {
   if (typeof caches === "undefined" || !url) return;
   await Promise.all(
     PER_USER_RUNTIME_CACHES.map(async (name) => {


### PR DESCRIPTION
## Summary

- Matchday PWA now lets a member pay outstanding donations inline (Stripe PaymentElement) instead of being kicked to the main site
- "Your membership" card moved from Donations to the Me tab; main-site link collapsed to a single button
- When a matchday is finished and unpaid match-fee charges are raised, members now receive a push notification (if their `matchday_channel` preference is `push` or `both`) on top of the existing email
- Push-only users with no live subscription fall back to email so a charge never goes unannounced; gone (404/410) subscriptions are pruned in the dispatcher loop, matching the availability pattern

## Test plan

- [ ] Integration test exercises the push path end-to-end (member with `push` preference + seeded subscription receives the payload, no email is sent)
- [ ] Existing `finishMatch` integration tests still pass (default behaviour for users with no preference is unchanged)
- [ ] Manually verify pay-outstanding flow in the matchday PWA with a Stripe test card
- [ ] Manually verify a real device receives the push when a captain marks a match finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)