### PR TITLE
fix(matchday): prompt-to-reload SW + lazy chunk safety net

### DIFF
--- a/apps/matchday/src/components/route-error-boundary.tsx
+++ b/apps/matchday/src/components/route-error-boundary.tsx
@@ -1,0 +1,75 @@
+import { Button } from "@/components/ui/button.js";
+import { AlertTriangleIcon, RefreshCwIcon } from "lucide-react";
+import { isRouteErrorResponse, useNavigate, useRouteError } from "react-router";
+
+function isLikelyStaleChunk(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = `${error.name}: ${error.message}`.toLowerCase();
+  return (
+    message.includes("failed to fetch dynamically imported module") ||
+    message.includes("importing a module script failed") ||
+    message.includes("error loading dynamically imported module") ||
+    message.includes("loading chunk") ||
+    message.includes("loading css chunk")
+  );
+}
+
+/**
+ * Catches anything thrown in a child route and shows a friendly screen
+ * instead of React Router's developer-mode default. The most common
+ * cause in production is a stale shell trying to import a chunk that
+ * the new deploy no longer serves — for that case we surface a clear
+ * "the app updated" message and a one-tap reload.
+ */
+export function RouteErrorBoundary() {
+  const error = useRouteError();
+  const navigate = useNavigate();
+  const staleChunk = isLikelyStaleChunk(error);
+
+  const status = isRouteErrorResponse(error) ? error.status : undefined;
+  const title = staleChunk
+    ? "Matchday just updated"
+    : status === 404
+      ? "Page not found"
+      : "Something went wrong";
+  const detail = staleChunk
+    ? "We've got a newer version ready. Reload to pick it up."
+    : status === 404
+      ? "That page isn't here. Head back to the home screen."
+      : "An unexpected error stopped the page from loading. Try again, or head home if the problem sticks around.";
+
+  return (
+    <div className="bg-surface-raised text-text flex min-h-dvh flex-col items-center justify-center px-6 py-12">
+      <div className="flex w-full max-w-md flex-col items-center text-center">
+        <div className="bg-navy/10 text-navy mb-5 flex size-14 items-center justify-center rounded-full">
+          <AlertTriangleIcon className="size-7" />
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+        <p className="text-text-muted mt-2 text-sm leading-relaxed">{detail}</p>
+        <div className="mt-6 flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
+          <Button
+            tone="primary"
+            size="lg"
+            onClick={() => window.location.reload()}
+            className="w-full sm:w-auto"
+          >
+            <RefreshCwIcon />
+            Reload
+          </Button>
+          {!staleChunk && (
+            <Button
+              tone="outline"
+              size="lg"
+              onClick={() => {
+                void navigate("/", { replace: true });
+              }}
+              className="w-full sm:w-auto"
+            >
+              Go home
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/matchday/src/components/shell/sw-update.tsx
+++ b/apps/matchday/src/components/shell/sw-update.tsx
@@ -10,10 +10,12 @@ const UPDATE_POLL_MS = 30 * 60 * 1000;
 
 /**
  * Toast shown when a new service worker is waiting. Tapping "Reload"
- * activates the new SW + reloads the page. Workbox is configured with
- * skipWaiting + clientsClaim so this is mostly a courtesy - but visible
- * confirmation that the upgrade happened, and a manual escape hatch if
- * the auto-apply ever doesn't kick.
+ * sends SKIP_WAITING + reloads the page, which is the ONLY moment we
+ * swap to the new build. Until then the old SW keeps serving the old
+ * precache so the currently-loaded shell's lazy route chunks still
+ * resolve. (Earlier versions enabled skipWaiting + clientsClaim, which
+ * caused mid-session "Importing a module script failed" errors when
+ * navigation hit a chunk the new precache no longer carried.)
  */
 export function ServiceWorkerUpdate() {
   const registrationRef = useRef<ServiceWorkerRegistration | null>(null);

--- a/apps/matchday/src/lib/lazy-with-reload.ts
+++ b/apps/matchday/src/lib/lazy-with-reload.ts
@@ -1,0 +1,58 @@
+import { lazy, type ComponentType } from "react";
+
+const RELOADED_KEY = "matchday:chunk-reload-attempted";
+
+// A chunk-load error from Vite's dynamic import has no stable error
+// class - the spec wording varies by browser. We sniff the message
+// instead (covers Chrome / Safari / Firefox).
+function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = `${error.name}: ${error.message}`.toLowerCase();
+  return (
+    message.includes("failed to fetch dynamically imported module") ||
+    message.includes("importing a module script failed") ||
+    message.includes("error loading dynamically imported module") ||
+    message.includes("loading chunk") ||
+    message.includes("loading css chunk")
+  );
+}
+
+/**
+ * `lazy()` with a one-shot hard reload on chunk-load failure.
+ *
+ * When a new build deploys, the running shell still references the
+ * previous build's chunk filenames. If the user navigates to a route
+ * whose chunk has been purged, the dynamic import 404s. The service
+ * worker prompt-to-reload pattern is meant to prevent this, but it's
+ * not bulletproof (fresh tabs, SW unregistered, deploy mid-session,
+ * etc.) — so on the first chunk failure we reload once to pick up the
+ * new shell. If that *still* fails, we let the error propagate to the
+ * route-level error boundary so the user gets a clear message instead
+ * of a reload loop.
+ */
+export function lazyWithReload<T extends ComponentType<unknown>>(
+  factory: () => Promise<{ default: T }>,
+): ReturnType<typeof lazy<T>> {
+  return lazy(async () => {
+    try {
+      const mod = await factory();
+      // A lazy import succeeded, so we're definitively on a build whose
+      // chunks resolve. Reset the guard so the *next* deploy gets a
+      // fresh one-shot retry rather than skipping straight to the
+      // error boundary. Clearing on entrypoint mount would break this:
+      // a post-reload failure would re-set the flag, then reload, then
+      // clear again, and loop forever.
+      sessionStorage.removeItem(RELOADED_KEY);
+      return mod;
+    } catch (error) {
+      if (!isChunkLoadError(error)) throw error;
+      const alreadyReloaded = sessionStorage.getItem(RELOADED_KEY) === "1";
+      if (alreadyReloaded) throw error;
+      sessionStorage.setItem(RELOADED_KEY, "1");
+      window.location.reload();
+      // Return a never-resolving promise so React doesn't try to
+      // render anything in the split-second before reload kicks in.
+      return await new Promise<{ default: T }>(() => undefined);
+    }
+  });
+}

--- a/apps/matchday/src/router.tsx
+++ b/apps/matchday/src/router.tsx
@@ -1,84 +1,92 @@
 import { RequireAuth } from "@/components/require-auth.js";
+import { RouteErrorBoundary } from "@/components/route-error-boundary.js";
 import { AppShell } from "@/components/shell/app-shell.js";
-import { lazy } from "react";
+import { lazyWithReload } from "@/lib/lazy-with-reload.js";
 import { createBrowserRouter, type RouteObject } from "react-router";
 
 const routes: RouteObject[] = [
   {
     element: <RequireAuth />,
+    errorElement: <RouteErrorBoundary />,
     children: [
       {
         element: <AppShell />,
         children: [
           {
             index: true,
-            Component: lazy(() => import("./pages/home.js")),
+            Component: lazyWithReload(() => import("./pages/home.js")),
           },
           {
             path: "me",
-            Component: lazy(() => import("./pages/me.js")),
+            Component: lazyWithReload(() => import("./pages/me.js")),
           },
           {
             path: "availability/respond",
-            Component: lazy(() => import("./pages/availability-respond.js")),
+            Component: lazyWithReload(
+              () => import("./pages/availability-respond.js"),
+            ),
           },
           {
             path: "fixtures",
-            Component: lazy(() => import("./pages/fixtures.js")),
+            Component: lazyWithReload(() => import("./pages/fixtures.js")),
           },
           {
             path: "fixture/:matchId",
-            Component: lazy(() => import("./pages/fixture-detail.js")),
+            Component: lazyWithReload(
+              () => import("./pages/fixture-detail.js"),
+            ),
           },
           {
             path: "matchday/:matchdayId",
-            Component: lazy(() => import("./pages/team-sheet.js")),
+            Component: lazyWithReload(() => import("./pages/team-sheet.js")),
           },
           {
             path: "donations",
-            Component: lazy(() => import("./pages/donations.js")),
+            Component: lazyWithReload(() => import("./pages/donations.js")),
           },
           // Phase 3 official surfaces — lazy-loaded.
           {
             path: "matchday/:matchdayId/edit",
-            Component: lazy(() => import("./pages/matchday-edit.js")),
+            Component: lazyWithReload(() => import("./pages/matchday-edit.js")),
           },
           {
             path: "matchday/:matchdayId/wrap",
-            Component: lazy(() => import("./pages/matchday-live.js")),
+            Component: lazyWithReload(() => import("./pages/matchday-live.js")),
           },
           // Old /live path stays as an alias so any bookmarked or
           // in-flight links land on the new wrap screen until UI links
           // are updated.
           {
             path: "matchday/:matchdayId/live",
-            Component: lazy(() => import("./pages/matchday-live.js")),
+            Component: lazyWithReload(() => import("./pages/matchday-live.js")),
           },
           {
             path: "official/availability",
-            Component: lazy(() => import("./pages/official-availability.js")),
+            Component: lazyWithReload(
+              () => import("./pages/official-availability.js"),
+            ),
           },
           {
             path: "official/availability/new",
-            Component: lazy(
+            Component: lazyWithReload(
               () => import("./pages/official-availability-new.js"),
             ),
           },
           {
             path: "official/availability/:requestId",
-            Component: lazy(
+            Component: lazyWithReload(
               () => import("./pages/official-availability-detail.js"),
             ),
           },
           {
             path: "official/availability/:requestId/date/:date",
-            Component: lazy(
+            Component: lazyWithReload(
               () => import("./pages/official-availability-date.js"),
             ),
           },
           {
             path: "expenses/mine",
-            Component: lazy(() => import("./pages/expenses-mine.js")),
+            Component: lazyWithReload(() => import("./pages/expenses-mine.js")),
           },
         ],
       },

--- a/apps/matchday/vite.config.ts
+++ b/apps/matchday/vite.config.ts
@@ -13,11 +13,12 @@ export default defineConfig({
     }),
     tailwindcss(),
     VitePWA({
-      // Register an auto-updating service worker. Phase 1 ships the
-      // skeleton only — no offline caching yet (that's phase 5). The
-      // important part is that the SW is registered and we can roll
-      // a new version with a "tap to reload" toast.
-      registerType: "autoUpdate",
+      // Prompt mode: a waiting SW stays waiting until the user taps
+      // Reload on the toast — never auto-applies. Pairs with the
+      // workbox config below (no skipWaiting / no clientsClaim) so
+      // the live session keeps resolving its lazy chunks against the
+      // old precache until the user opts in.
+      registerType: "prompt",
       injectRegister: "auto",
       manifest: {
         name: "Percy Main Matchday",
@@ -63,12 +64,16 @@ export default defineConfig({
         ],
       },
       workbox: {
-        // Pre-cache the app shell. New deploys win immediately via
-        // skipWaiting + clientsClaim; cleanupOutdatedCaches keeps the
-        // old SW's caches from sticking around as zombies.
+        // Prompt-to-reload, NOT auto-takeover. The old SW keeps serving
+        // the old precache (and therefore the old route chunks) until
+        // the user taps Reload on the toast — at which point we send
+        // SKIP_WAITING and reload the page, fetching the new shell + new
+        // chunks together. Setting skipWaiting/clientsClaim to true here
+        // (an earlier attempt) caused mid-session chunk 404s: the new SW
+        // would claim live clients and cleanupOutdatedCaches would purge
+        // the old precache while the old shell was still navigating to
+        // lazy routes that no longer existed under the new build hashes.
         cleanupOutdatedCaches: true,
-        clientsClaim: true,
-        skipWaiting: true,
         // Layer the push + notificationclick handlers on top of the
         // generated workbox SW via importScripts. Keeps the existing
         // generateSW pipeline intact - we just need event listeners,


### PR DESCRIPTION
## Summary

- Switch the matchday PWA from auto-takeover to prompt-to-reload so the old SW keeps serving the old precache (and its lazy chunks) until the user taps the existing update toast.
- Add `lazyWithReload` around every route lazy import: on a chunk-load failure (stale shell vs new deploy), do one hard reload (sessionStorage-guarded to prevent loops), then fall through to the error boundary if the next load still fails.
- Add `RouteErrorBoundary` as the top-level `errorElement` with friendly copy (a stale-chunk variant, a 404 variant, and a generic case), replacing React Router's developer-mode default error screen.

## Why

Live users were hitting "Unexpected Application Error! Importing a module script failed." on iOS PWA shortly after a new deploy. Root cause: `skipWaiting: true` + `clientsClaim: true` + `cleanupOutdatedCaches: true` in `workbox` meant the new SW would activate, claim the open client, and purge the old precache while the loaded shell was still navigating to lazy routes (e.g. `assets/donations-<oldhash>.js`) that the new precache no longer carried.

## Test plan

- [ ] Deploy to staging
- [ ] On an open session, ship a new build and verify the toast appears without the page immediately breaking
- [ ] Tap Reload, confirm new build picks up cleanly
- [ ] As a separate verification, throw a synthetic error from within a route component and confirm `RouteErrorBoundary` renders the friendly UI
- [ ] Force a chunk 404 (e.g. by manually unregistering the SW and deleting a precached chunk in DevTools) and confirm: first hit triggers a single reload, second hit lands on the error boundary's "Matchday just updated" copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)