### PR TITLE
feat(play-cricket): Women's Softball (Pairs) scorecards and stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ test-results/
 
 # Claude Code
 .claude/settings.local.json
+.claude/tmp/
 
 # JetBrains IDEs
 .idea/

--- a/apps/api/src/features/cricket-leaderboard/integration.test.ts
+++ b/apps/api/src/features/cricket-leaderboard/integration.test.ts
@@ -67,7 +67,11 @@ async function seedBattingPerformance(overrides: {
   fours?: number;
   sixes?: number;
   competitionType?: string;
+  gameType?: string;
+  timesOut?: number;
+  dismissalPenalty?: number;
 }) {
+  const notOut = overrides.notOut ?? false;
   await ctx.db
     .insertInto("match_performance_batting")
     .values({
@@ -80,7 +84,13 @@ async function seedBattingPerformance(overrides: {
       season: overrides.season,
       runs: overrides.runs,
       balls: overrides.balls ?? 30,
-      not_out: overrides.notOut ?? false,
+      not_out: notOut,
+      // Default to "dismissed once if not_out=false, never if not_out=true" so
+      // existing hardball seeds continue to behave the same after the softball
+      // schema additions. Tests covering softball can pass timesOut directly.
+      times_out: overrides.timesOut ?? (notOut ? 0 : 1),
+      dismissal_penalty: overrides.dismissalPenalty ?? 0,
+      game_type: overrides.gameType ?? "Standard",
       fours: overrides.fours ?? 0,
       sixes: overrides.sixes ?? 0,
       competition_type: overrides.competitionType ?? "League",
@@ -150,6 +160,7 @@ describe("cricket leaderboard service (integration)", () => {
       const result = await listBattingLeaderboard(ctx.db)({
         season: 2024,
         limit: 50,
+        gameType: "Standard",
       });
 
       const entry = result.entries.find((e) => e.playerId === playerId);
@@ -186,6 +197,7 @@ describe("cricket leaderboard service (integration)", () => {
       const result = await listBattingLeaderboard(ctx.db)({
         season: 2024,
         limit: 50,
+        gameType: "Standard",
       });
 
       const entry = result.entries.find((e) => e.playerId === playerId);
@@ -219,11 +231,13 @@ describe("cricket leaderboard service (integration)", () => {
         season: 2024,
         isJunior: false,
         limit: 50,
+        gameType: "Standard",
       });
       const juniorsOnly = await listBattingLeaderboard(ctx.db)({
         season: 2024,
         isJunior: true,
         limit: 50,
+        gameType: "Standard",
       });
 
       expect(
@@ -262,6 +276,7 @@ describe("cricket leaderboard service (integration)", () => {
         season: 2024,
         competitionTypes: "League",
         limit: 50,
+        gameType: "Standard",
       });
 
       const entry = leagueOnly.entries.find((e) => e.playerId === playerId);
@@ -289,6 +304,7 @@ describe("cricket leaderboard service (integration)", () => {
       const result = await listBattingLeaderboard(ctx.db)({
         season: 2024,
         limit: 50,
+        gameType: "Standard",
       });
 
       const entry = result.entries.find((e) => e.playerId === playerId);
@@ -326,6 +342,7 @@ describe("cricket leaderboard service (integration)", () => {
       const result = await listBowlingLeaderboard(ctx.db)({
         season: 2024,
         limit: 50,
+        gameType: "Standard",
       });
 
       const entry = result.entries.find((e) => e.playerId === playerId);
@@ -362,6 +379,7 @@ describe("cricket leaderboard service (integration)", () => {
       const result = await listBowlingLeaderboard(ctx.db)({
         season: 2024,
         limit: 50,
+        gameType: "Standard",
       });
 
       const entry = result.entries.find((e) => e.playerId === playerId);

--- a/apps/api/src/features/cricket-leaderboard/schemas.ts
+++ b/apps/api/src/features/cricket-leaderboard/schemas.ts
@@ -8,6 +8,9 @@ export const cricketLeaderboardQuerySchema = z.object({
     .optional(),
   teamId: z.string().optional(),
   competitionTypes: z.string().optional(),
+  // "Standard" (hardball) is the default; "Pairs" returns Women's Softball
+  // leaderboards using the same unified average formula.
+  gameType: z.enum(["Standard", "Pairs"]).default("Standard"),
   limit: z.coerce.number().int().min(1).max(50).default(50),
 });
 

--- a/apps/api/src/features/cricket-leaderboard/service.ts
+++ b/apps/api/src/features/cricket-leaderboard/service.ts
@@ -11,17 +11,23 @@ export function listBattingLeaderboard(db: Kysely<DB>) {
       .selectFrom("match_performance_batting as b")
       .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
       .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
+      .where("b.game_type", "=", params.gameType)
       .groupBy(["b.player_id", "m.slug"])
       .select(["b.player_id as playerId", "m.slug"])
       .select((eb) => [
         eb.fn.max("b.player_name").as("playerName"),
         eb.fn.countAll().as("innings"),
         eb.fn.sum<string>("b.runs").as("totalRuns"),
+        // Sum of dismissals across all innings: 0/1 per innings in hardball,
+        // 0..n per innings in Pairs (a batter can be out twice). Drives the
+        // unified average formula below.
+        eb.fn.sum<string>("b.times_out").as("totalTimesOut"),
+        // Net-runs penalty applied by Play Cricket for Pairs games (5 runs
+        // per dismissal in a 200-base game). 0 for hardball, so the unified
+        // formula collapses to standard runs / dismissals.
         eb.fn
-          .sum<string>(
-            sql<number>`CASE WHEN ${eb.ref("b.not_out")} THEN 1 ELSE 0 END`,
-          )
-          .as("notOuts"),
+          .sum<string>(sql<number>`b.times_out * b.dismissal_penalty`)
+          .as("totalPenaltyRuns"),
         eb.fn.max("b.runs").as("highScore"),
         eb.fn.sum<string>("b.balls").as("totalBalls"),
         eb.fn.sum<string>("b.fours").as("totalFours"),
@@ -67,23 +73,30 @@ export function listBattingLeaderboard(db: Kysely<DB>) {
     return {
       entries: rows.map((row) => {
         const innings = Number(row.innings);
-        const notOuts = Number(row.notOuts);
+        const timesOut = Number(row.totalTimesOut);
+        const penaltyRuns = Number(row.totalPenaltyRuns);
         const runs = Number(row.totalRuns);
         const totalBalls = Number(row.totalBalls);
-        const dismissals = innings - notOuts;
+
+        // Unified average: (runs − times_out × penalty_per_out) / times_out.
+        // For hardball the penalty is 0, so this is the conventional average.
+        // For Pairs it matches Play Cricket's "Net average" calculation.
+        const average =
+          innings >= 3 && timesOut > 0
+            ? Number(((runs - penaltyRuns) / timesOut).toFixed(2))
+            : null;
 
         return {
           playerId: row.playerId,
           playerName: row.playerName,
           slug: row.slug,
           innings,
-          notOuts,
+          // Innings where the batter was never dismissed (could include
+          // softball innings where they batted out their balls).
+          notOuts: Math.max(innings - timesOut, 0),
           runs,
           highScore: row.highScore,
-          average:
-            innings >= 3 && dismissals > 0
-              ? Number((runs / dismissals).toFixed(2))
-              : null,
+          average,
           strikeRate:
             totalBalls > 0
               ? Number(((runs / totalBalls) * 100).toFixed(2))
@@ -118,6 +131,7 @@ export function listBowlingLeaderboard(db: Kysely<DB>) {
       .selectFrom("match_performance_bowling as b")
       .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
       .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
+      .where("b.game_type", "=", params.gameType)
       .groupBy(["b.player_id", "m.slug"])
       .select(["b.player_id as playerId", "m.slug"])
       .select((eb) => [

--- a/apps/api/src/features/cricket-leaderboard/service.ts
+++ b/apps/api/src/features/cricket-leaderboard/service.ts
@@ -22,6 +22,12 @@ export function listBattingLeaderboard(db: Kysely<DB>) {
         // 0..n per innings in Pairs (a batter can be out twice). Drives the
         // unified average formula below.
         eb.fn.sum<string>("b.times_out").as("totalTimesOut"),
+        // Innings where the batter was never dismissed. Can't be derived
+        // from innings − Σ times_out because Pairs allows times_out > 1 in
+        // a single innings.
+        eb.fn
+          .sum<string>(sql<number>`CASE WHEN b.times_out = 0 THEN 1 ELSE 0 END`)
+          .as("notOutInnings"),
         // Net-runs penalty applied by Play Cricket for Pairs games (5 runs
         // per dismissal in a 200-base game). 0 for hardball, so the unified
         // formula collapses to standard runs / dismissals.
@@ -74,6 +80,7 @@ export function listBattingLeaderboard(db: Kysely<DB>) {
       entries: rows.map((row) => {
         const innings = Number(row.innings);
         const timesOut = Number(row.totalTimesOut);
+        const notOuts = Number(row.notOutInnings);
         const penaltyRuns = Number(row.totalPenaltyRuns);
         const runs = Number(row.totalRuns);
         const totalBalls = Number(row.totalBalls);
@@ -91,9 +98,9 @@ export function listBattingLeaderboard(db: Kysely<DB>) {
           playerName: row.playerName,
           slug: row.slug,
           innings,
-          // Innings where the batter was never dismissed (could include
-          // softball innings where they batted out their balls).
-          notOuts: Math.max(innings - timesOut, 0),
+          // Innings where the batter was never dismissed. Counted directly
+          // because Pairs allows times_out > 1 per innings.
+          notOuts,
           runs,
           highScore: row.highScore,
           average,

--- a/apps/api/src/features/games/schemas.ts
+++ b/apps/api/src/features/games/schemas.ts
@@ -65,6 +65,9 @@ const inningsSchema = z.object({
   overs: z.string(),
   declared: z.boolean(),
   allOut: z.boolean(),
+  // Play Cricket net score for Women's Softball (Pairs): starting_runs +
+  // runs - wickets * dismissal_penalty. Null for hardball.
+  netScore: z.number().nullable(),
 });
 
 const resultSchema = z
@@ -72,6 +75,9 @@ const resultSchema = z
     outcome: outcomeSchema,
     description: z.string(),
     toss: z.string(),
+    // "Standard" hardball or "Pairs" Women's Softball - drives Net Score
+    // display on the result summary card.
+    gameType: z.string(),
     innings: z.array(inningsSchema),
   })
   .nullable();

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -53,6 +53,7 @@ export interface GameDetail extends GameListItem {
     outcome: Outcome | null;
     description: string;
     toss: string;
+    gameType: string;
     innings: Array<{
       teamBattingId: string;
       teamName: string;
@@ -61,6 +62,7 @@ export interface GameDetail extends GameListItem {
       overs: string;
       declared: boolean;
       allOut: boolean;
+      netScore: number | null;
     }>;
   } | null;
   sponsor: {
@@ -315,6 +317,14 @@ export function getGame(
     }
 
     if (detail.innings.some((inn) => inn.bat.length > 0)) {
+      const gameType = detail.game_type || "Standard";
+      const startingRuns = parseInt(detail.starting_runs || "");
+      const dismissalPenalty = parseInt(detail.dismissal_penalty || "");
+      const hasNetScore =
+        gameType === "Pairs" &&
+        Number.isFinite(startingRuns) &&
+        Number.isFinite(dismissalPenalty);
+
       const innings = detail.innings.map((inn) => {
         const isHome = inn.team_batting_id === detail.home_team_id;
         const teamName = isHome
@@ -331,6 +341,11 @@ export function getGame(
           overs: inn.overs,
           declared: inn.declared ?? false,
           allOut: wickets >= 10,
+          // Play Cricket's "Net Score" for Pairs games. Hardball innings
+          // get null and the UI hides the column.
+          netScore: hasNetScore
+            ? startingRuns + runs - wickets * dismissalPenalty
+            : null,
         };
       });
 
@@ -338,6 +353,7 @@ export function getGame(
         outcome,
         description: detail.result_description ?? "",
         toss: detail.toss ?? "",
+        gameType,
         innings,
       };
     }

--- a/apps/api/src/features/play-cricket/api-schemas.ts
+++ b/apps/api/src/features/play-cricket/api-schemas.ts
@@ -126,8 +126,12 @@ export const MatchDetailInnings = z.object({
 // hardball and softball matches. For Pairs games the only populated entry is
 // `game_points` (e.g. winning side gets 15); for hardball there are also
 // batting / bowling bonus point breakdowns.
+//
+// team_id is observed as a number in real responses but every other team_id
+// in this API is a string - the union guards against PC emitting a string
+// here in the future without breaking the whole match-detail parse.
 export const MatchDetailPoints = z.object({
-  team_id: z.number(),
+  team_id: z.union([z.number(), z.string()]),
   game_points: z.string().optional().default(""),
   penalty_points: z.string().optional().default(""),
   bonus_points_together: z.string().optional().default(""),

--- a/apps/api/src/features/play-cricket/api-schemas.ts
+++ b/apps/api/src/features/play-cricket/api-schemas.ts
@@ -64,6 +64,9 @@ export const MatchDetailBat = z.object({
   fours: z.string(),
   sixes: z.string(),
   balls: z.string(),
+  // Pairs / Women's Softball: per-batter dismissal count (can be 0, 1, 2+).
+  // Empty string for "did not bat". Absent on older / non-Pairs responses.
+  times_out: z.string().optional().default(""),
 });
 
 export type MatchDetailBat = z.output<typeof MatchDetailBat>;
@@ -119,6 +122,20 @@ export const MatchDetailInnings = z.object({
   fow: z.array(MatchDetailFoW),
 });
 
+// Per-team scoring metadata (game points, bonus points, etc.) returned for both
+// hardball and softball matches. For Pairs games the only populated entry is
+// `game_points` (e.g. winning side gets 15); for hardball there are also
+// batting / bowling bonus point breakdowns.
+export const MatchDetailPoints = z.object({
+  team_id: z.number(),
+  game_points: z.string().optional().default(""),
+  penalty_points: z.string().optional().default(""),
+  bonus_points_together: z.string().optional().default(""),
+  bonus_points_batting: z.string().optional().default(""),
+  bonus_points_bowling: z.string().optional().default(""),
+  bonus_points_2nd_innings_together: z.string().optional().default(""),
+});
+
 export const MatchDetail = z.object({
   id: z.number(),
   home_team_name: z.string(),
@@ -138,6 +155,17 @@ export const MatchDetail = z.object({
   competition_type: z.string().optional().default(""),
   match_date: z.string().optional().default(""),
   season: z.string().optional().default(""),
+  // "Standard" for hardball, "Pairs" for Women's Softball etc. Drives scoring
+  // rules (starting_runs + dismissal_penalty are only populated for Pairs).
+  game_type: z.string().optional().default(""),
+  // Pairs-specific: the team's starting score before runs are added (e.g. 200)
+  // and the runs deducted per dismissal (e.g. 5). Net score is
+  // starting_runs + innings.runs - innings.wickets * dismissal_penalty.
+  starting_runs: z.string().optional().default(""),
+  dismissal_penalty: z.string().optional().default(""),
+  league_name: z.string().optional().default(""),
+  competition_name: z.string().optional().default(""),
+  points: z.array(MatchDetailPoints).optional().default([]),
   players: z.array(
     z.object({
       home_team: z.array(MatchDetailPlayer).optional(),

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -148,7 +148,7 @@ describe("play-cricket service (integration)", () => {
       expect(result).toBeNull();
     });
 
-    it("aggregates batting and bowling stats correctly", async () => {
+    it("aggregates hardball batting and bowling stats correctly", async () => {
       const email = `career-${crypto.randomUUID()}@test.com`;
       const { memberId } = await seedTestUser(ctx.db, { email });
 
@@ -164,7 +164,6 @@ describe("play-cricket service (integration)", () => {
         .where("id", "=", memberId ?? "")
         .execute();
 
-      // Seed batting performances across two seasons
       await ctx.db
         .insertInto("match_performance_batting")
         .values([
@@ -182,6 +181,9 @@ describe("play-cricket service (integration)", () => {
             sixes: 1,
             how_out: "caught",
             not_out: false,
+            times_out: 1,
+            dismissal_penalty: 0,
+            game_type: "Standard",
             competition_type: "league",
           },
           {
@@ -196,14 +198,16 @@ describe("play-cricket service (integration)", () => {
             balls: 80,
             fours: 10,
             sixes: 3,
-            how_out: "not out",
+            how_out: "no",
             not_out: true,
+            times_out: 0,
+            dismissal_penalty: 0,
+            game_type: "Standard",
             competition_type: "league",
           },
         ])
         .execute();
 
-      // Seed bowling performances
       await ctx.db
         .insertInto("match_performance_bowling")
         .values([
@@ -221,6 +225,7 @@ describe("play-cricket service (integration)", () => {
             wickets: 3,
             wides: 1,
             no_balls: 0,
+            game_type: "Standard",
             competition_type: "league",
           },
         ])
@@ -230,23 +235,142 @@ describe("play-cricket service (integration)", () => {
       expect(result).not.toBeNull();
       expect(result?.playCricketId).toBe(playCricketId);
 
-      // Career batting totals
-      expect(result?.career.batting.runs).toBe(150); // 50 + 100
-      expect(result?.career.batting.matches).toBe(2);
-      expect(result?.career.batting.highScore).toBe(100);
-      expect(result?.career.batting.notOuts).toBe(1);
+      // Hardball-only player → exactly one format section
+      expect(result?.formats).toHaveLength(1);
+      const hardball = result?.formats.find((f) => f.gameType === "Standard");
+      expect(hardball).toBeDefined();
 
-      // Career bowling totals
-      expect(result?.career.bowling.wickets).toBe(3);
-      expect(result?.career.bowling.innings).toBe(1);
+      expect(hardball?.career.batting.runs).toBe(150);
+      expect(hardball?.career.batting.matches).toBe(2);
+      expect(hardball?.career.batting.highScore).toBe(100);
+      expect(hardball?.career.batting.notOuts).toBe(1);
 
-      // Per-season batting breakdown
-      expect(result?.battingSeasons).toHaveLength(2);
-      expect(result?.bowlingSeasons).toHaveLength(1);
+      expect(hardball?.career.bowling.wickets).toBe(3);
+      expect(hardball?.career.bowling.innings).toBe(1);
 
-      // Seasons list
-      expect(result?.seasons).toContain(2025);
-      expect(result?.seasons).toContain(2026);
+      expect(hardball?.battingSeasons).toHaveLength(2);
+      expect(hardball?.bowlingSeasons).toHaveLength(1);
+
+      expect(hardball?.seasons).toContain(2025);
+      expect(hardball?.seasons).toContain(2026);
+    });
+
+    it("partitions softball stats into a separate format section with Play Cricket net average", async () => {
+      const email = `softball-${crypto.randomUUID()}@test.com`;
+      const { memberId } = await seedTestUser(ctx.db, { email });
+
+      const slug = `slug-${crypto.randomUUID()}`;
+      const playCricketId = `pc-${crypto.randomUUID()}`;
+
+      await ctx.db
+        .updateTable("member")
+        .set({
+          slug,
+          play_cricket_id: playCricketId,
+        })
+        .where("id", "=", memberId ?? "")
+        .execute();
+
+      // Three Women's Softball innings: raw runs 30, all out twice with a
+      // 5-run penalty per dismissal. Net average should match Play Cricket:
+      //   (30 − 2 × 5) / 2 = 10.00
+      await ctx.db
+        .insertInto("match_performance_batting")
+        .values([
+          {
+            id: crypto.randomUUID(),
+            match_id: `m-${crypto.randomUUID()}`,
+            match_date: "2026-05-20",
+            season: 2026,
+            team_id: "team-sb",
+            player_id: playCricketId,
+            player_name: "Test Player",
+            runs: 12,
+            balls: 10,
+            fours: 1,
+            sixes: 0,
+            how_out: "",
+            not_out: true,
+            times_out: 0,
+            dismissal_penalty: 5,
+            game_type: "Pairs",
+            competition_type: "league",
+          },
+          {
+            id: crypto.randomUUID(),
+            match_id: `m-${crypto.randomUUID()}`,
+            match_date: "2026-06-03",
+            season: 2026,
+            team_id: "team-sb",
+            player_id: playCricketId,
+            player_name: "Test Player",
+            runs: 6,
+            balls: 12,
+            fours: 0,
+            sixes: 0,
+            how_out: "",
+            not_out: false,
+            times_out: 1,
+            dismissal_penalty: 5,
+            game_type: "Pairs",
+            competition_type: "league",
+          },
+          {
+            id: crypto.randomUUID(),
+            match_id: `m-${crypto.randomUUID()}`,
+            match_date: "2026-06-17",
+            season: 2026,
+            team_id: "team-sb",
+            player_id: playCricketId,
+            player_name: "Test Player",
+            runs: 12,
+            balls: 14,
+            fours: 1,
+            sixes: 0,
+            how_out: "",
+            not_out: false,
+            times_out: 1,
+            dismissal_penalty: 5,
+            game_type: "Pairs",
+            competition_type: "league",
+          },
+        ])
+        .execute();
+
+      const result = await getPlayerCareerStats(ctx.db)(slug);
+      expect(result?.formats).toHaveLength(1);
+      const softball = result?.formats.find((f) => f.gameType === "Pairs");
+      expect(softball).toBeDefined();
+      expect(softball?.label).toBe("Softball");
+
+      expect(softball?.battingSeasons).toHaveLength(1);
+      const season = softball?.battingSeasons[0];
+      expect(season?.season).toBe(2026);
+      expect(season?.innings).toBe(3);
+      expect(season?.runs).toBe(30);
+      expect(season?.notOuts).toBe(1);
+      // (runs − times_out × penalty) / times_out = (30 − 2*5) / 2 = 10.00
+      expect(season?.average).toBe(10);
+    });
+
+    it("returns an empty formats array for a player with no batting or bowling rows", async () => {
+      const email = `nodata-${crypto.randomUUID()}@test.com`;
+      const { memberId } = await seedTestUser(ctx.db, { email });
+
+      const slug = `slug-${crypto.randomUUID()}`;
+      const playCricketId = `pc-${crypto.randomUUID()}`;
+
+      await ctx.db
+        .updateTable("member")
+        .set({
+          slug,
+          play_cricket_id: playCricketId,
+        })
+        .where("id", "=", memberId ?? "")
+        .execute();
+
+      const result = await getPlayerCareerStats(ctx.db)(slug);
+      expect(result?.formats).toEqual([]);
     });
   });
 });
@@ -448,6 +572,188 @@ function makeMatchDetail(matchId: number) {
   };
 }
 
+// Women's Softball ("Pairs") fixture modeled on the real Play Cricket
+// response for match 7660052 (saved in .claude/tmp). The shape is the same
+// as hardball plus game_type, starting_runs, dismissal_penalty, and the
+// per-batter times_out field — and every how_out is null because softball
+// batters rotate at their balls limit instead of being dismissed by code.
+function makeSoftballMatchSummary(id: number, matchDate = "20/05/2026") {
+  return {
+    id,
+    status: "Completed",
+    published: "Yes",
+    last_updated: "2026-05-20",
+    season: "2026",
+    match_date: matchDate,
+    match_type: "Limited Overs",
+    game_type: "Pairs",
+    home_club_name: "Percy Main",
+    home_team_name: "Womens Softball",
+    home_team_id: OUR_TEAM_ID,
+    home_club_id: SITE_ID,
+    away_club_name: "Tynemouth CC",
+    away_team_name: "Womens Softball",
+    away_team_id: OPPONENT_TEAM_ID,
+    away_club_id: "999",
+  };
+}
+
+function makeSoftballMatchDetail(matchId: number) {
+  return {
+    match_details: [
+      {
+        id: matchId,
+        home_team_name: "Womens Softball",
+        home_team_id: OUR_TEAM_ID,
+        home_club_name: "Percy Main",
+        home_club_id: SITE_ID,
+        away_team_name: "Womens Softball",
+        away_team_id: OPPONENT_TEAM_ID,
+        away_club_name: "Tynemouth CC",
+        away_club_id: "999",
+        result: "L",
+        result_description: "Tynemouth CC won",
+        result_applied_to: OPPONENT_TEAM_ID,
+        match_type: "Limited Overs",
+        competition_type: "League",
+        game_type: "Pairs",
+        starting_runs: "200",
+        dismissal_penalty: "5",
+        players: [
+          {
+            home_team: [
+              {
+                position: 1,
+                player_name: "Eve Hage",
+                player_id: 1101,
+                captain: false,
+                wicket_keeper: false,
+              },
+            ],
+          },
+        ],
+        innings: [
+          {
+            team_batting_name: "Percy Main CC - Womens Softball",
+            team_batting_id: OUR_TEAM_ID,
+            innings_number: 1,
+            extra_byes: "10",
+            extra_leg_byes: "0",
+            extra_wides: "14",
+            extra_no_balls: "2",
+            extra_penalty_runs: "0",
+            penalties_runs_awarded_in_other_innings: "0",
+            total_extras: "26",
+            runs: "77",
+            wickets: "3",
+            overs: "15.0",
+            declared: false,
+            revised_target_runs: "",
+            revised_target_overs: "",
+            bat: [
+              {
+                position: "1",
+                batsman_name: "Eve Hage",
+                batsman_id: "1101",
+                how_out: null,
+                fielder_name: "",
+                fielder_id: "",
+                bowler_name: "",
+                bowler_id: "",
+                runs: "5",
+                fours: "0",
+                sixes: "0",
+                balls: "8",
+                times_out: "0",
+              },
+              {
+                position: "2",
+                batsman_name: "Lyndsey Surrey",
+                batsman_id: "1102",
+                how_out: null,
+                fielder_name: "",
+                fielder_id: "",
+                bowler_name: "",
+                bowler_id: "",
+                runs: "4",
+                fours: "0",
+                sixes: "0",
+                balls: "8",
+                times_out: "1",
+              },
+              {
+                position: "3",
+                batsman_name: "Tim Grimshaw",
+                batsman_id: "1103",
+                how_out: null,
+                fielder_name: "",
+                fielder_id: "",
+                bowler_name: "",
+                bowler_id: "",
+                runs: "1",
+                fours: "0",
+                sixes: "0",
+                balls: "9",
+                times_out: "2",
+              },
+              {
+                // DNB-style empty row that we expect to be skipped.
+                position: "4",
+                batsman_name: "Did Not Bat",
+                batsman_id: "1199",
+                how_out: null,
+                fielder_name: "",
+                fielder_id: "",
+                bowler_name: "",
+                bowler_id: "",
+                runs: "0",
+                fours: "",
+                sixes: "",
+                balls: "",
+                times_out: "",
+              },
+            ],
+            bowl: [],
+            fow: [],
+          },
+          {
+            team_batting_name: "Tynemouth - Women's Softball",
+            team_batting_id: OPPONENT_TEAM_ID,
+            innings_number: 1,
+            extra_byes: "1",
+            extra_leg_byes: "0",
+            extra_wides: "49",
+            extra_no_balls: "6",
+            extra_penalty_runs: "0",
+            penalties_runs_awarded_in_other_innings: "0",
+            total_extras: "56",
+            runs: "113",
+            wickets: "0",
+            overs: "15.0",
+            declared: false,
+            revised_target_runs: "",
+            revised_target_overs: "",
+            bat: [],
+            bowl: [
+              {
+                bowler_name: "Eve Hage",
+                bowler_id: "1101",
+                overs: "1.0",
+                maidens: "0",
+                runs: "9",
+                wickets: "0",
+                wides: "6",
+                no_balls: "2",
+              },
+            ],
+            fow: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
 describe("play-cricket sync (integration)", () => {
   it("syncs teams from API", async () => {
     const api = createMockApi({
@@ -584,6 +890,74 @@ describe("play-cricket sync (integration)", () => {
     expect(result.home_club_name).toBe("Percy Main");
     expect(result.away_club_id).toBe("999");
     expect(result.away_club_name).toBe("Opposition CC");
+  });
+
+  it("ingests Women's Softball (Pairs) batting with null how_out and per-batter times_out", async () => {
+    const matchId = 76600 + Math.floor(Math.random() * 1000);
+    const api = createMockApi({
+      getMatchesSummary: vi
+        .fn()
+        .mockResolvedValue({ matches: [makeSoftballMatchSummary(matchId)] }),
+      getMatchDetail: vi
+        .fn()
+        .mockResolvedValue(makeSoftballMatchDetail(matchId)),
+    });
+
+    const sync = runSync(ctx.db, api, null, log);
+    const syncResult = await sync({ siteId: SITE_ID });
+    expect(syncResult.matchesProcessed).toBe(1);
+    expect(syncResult.errors).toHaveLength(0);
+
+    // Every batter who took strike (all how_out = null) should be persisted —
+    // the previous didBat() returned false for null how_out and dropped them.
+    const batting = await ctx.db
+      .selectFrom("match_performance_batting")
+      .where("match_id", "=", matchId.toString())
+      .selectAll()
+      .execute();
+
+    expect(batting).toHaveLength(3);
+    expect(batting.map((b) => b.player_id).sort()).toEqual([
+      "1101",
+      "1102",
+      "1103",
+    ]);
+
+    for (const row of batting) {
+      expect(row.game_type).toBe("Pairs");
+      expect(row.dismissal_penalty).toBe(5);
+    }
+
+    const surrey = batting.find((b) => b.player_id === "1102");
+    assert(surrey, "Expected batting record for Lyndsey Surrey");
+    expect(surrey.runs).toBe(4);
+    expect(surrey.times_out).toBe(1);
+
+    const grimshaw = batting.find((b) => b.player_id === "1103");
+    assert(grimshaw, "Expected batting record for Tim Grimshaw");
+    // Pairs lets a single batter be dismissed more than once — the API field
+    // is the source of truth, not the not_out boolean.
+    expect(grimshaw.times_out).toBe(2);
+
+    // No fielding rows: Pairs scorecards have no how_out attribution.
+    const fielding = await ctx.db
+      .selectFrom("match_performance_fielding")
+      .where("match_id", "=", matchId.toString())
+      .selectAll()
+      .execute();
+    expect(fielding).toHaveLength(0);
+
+    // match_result captures format + softball scoring constants for the
+    // scorecard's Net Score rendering.
+    const matchResult = await ctx.db
+      .selectFrom("match_result")
+      .where("match_id", "=", matchId.toString())
+      .selectAll()
+      .executeTakeFirst();
+    assert(matchResult, "Expected match_result row for softball match");
+    expect(matchResult.game_type).toBe("Pairs");
+    expect(matchResult.starting_runs).toBe(200);
+    expect(matchResult.dismissal_penalty).toBe(5);
   });
 
   it("logs sync to play_cricket_sync_log", async () => {

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -1181,10 +1181,17 @@ describe("ingestRvDataForMatch (integration)", () => {
       l_desc: " K Pattison to S Knight: 4 runs",
       s_desc: " 4",
       match_highlight_events: [{ event_id: 1002, metric: 4 }],
+      // Sample shot vector + Pairs-style 2nd-trip inst_num so we cover both
+      // visualisation fields and the new instance-number columns end-to-end.
+      shot_angle: 67.88,
+      shot_length: 34.21,
+      batter_inst_num: 2,
+      batter_ns_inst_num: 1,
     });
     const wicket = makeBall(0, 3, {
       runs_bat: 0,
       dismissed_batter_id: 11680433,
+      dismissed_batter_inst_num: 2,
       l_desc: " K Pattison to S Knight: dismissed",
       s_desc: " W",
     });
@@ -1220,7 +1227,12 @@ describe("ingestRvDataForMatch (integration)", () => {
     expect(balls[0]?.s_desc).toBe(" .");
     expect(balls[1]?.runs_bat).toBe(4);
     expect(balls[1]?.highlight_events).toEqual([{ event_id: 1002, metric: 4 }]);
+    expect(balls[1]?.shot_angle).toBeCloseTo(67.88, 1);
+    expect(balls[1]?.shot_length).toBeCloseTo(34.21, 1);
+    expect(balls[1]?.batter_inst_num).toBe(2);
+    expect(balls[1]?.batter_ns_inst_num).toBe(1);
     expect(balls[2]?.dismissed_batter_rv_id).toBe(11680433);
+    expect(balls[2]?.dismissed_batter_inst_num).toBe(2);
     expect(balls[2]?.s_desc).toBe(" W");
 
     // ball_offset_seconds is rounded(ball_time - recording_started_utc).

--- a/apps/api/src/features/play-cricket/routes.ts
+++ b/apps/api/src/features/play-cricket/routes.ts
@@ -148,8 +148,8 @@ export const playCricketRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      const { slug, season } = request.query;
-      return await seasonStats(slug, season);
+      const { slug, season, gameType } = request.query;
+      return await seasonStats(slug, season, gameType);
     },
   );
 };

--- a/apps/api/src/features/play-cricket/rv-ingest.ts
+++ b/apps/api/src/features/play-cricket/rv-ingest.ts
@@ -262,6 +262,9 @@ async function upsertBalls(
       ball_spot_y: b.ball_spot_y ?? null,
       shot_angle: b.shot_angle ?? null,
       shot_length: b.shot_length ?? null,
+      batter_inst_num: b.batter_inst_num ?? null,
+      batter_ns_inst_num: b.batter_ns_inst_num ?? null,
+      dismissed_batter_inst_num: b.dismissed_batter_inst_num ?? null,
     };
   });
 
@@ -293,6 +296,10 @@ async function upsertBalls(
         ball_spot_y: (eb) => eb.ref("excluded.ball_spot_y"),
         shot_angle: (eb) => eb.ref("excluded.shot_angle"),
         shot_length: (eb) => eb.ref("excluded.shot_length"),
+        batter_inst_num: (eb) => eb.ref("excluded.batter_inst_num"),
+        batter_ns_inst_num: (eb) => eb.ref("excluded.batter_ns_inst_num"),
+        dismissed_batter_inst_num: (eb) =>
+          eb.ref("excluded.dismissed_batter_inst_num"),
       }),
     )
     .execute();

--- a/apps/api/src/features/play-cricket/rv-schemas.ts
+++ b/apps/api/src/features/play-cricket/rv-schemas.ts
@@ -205,6 +205,13 @@ export const RvBall = z.looseObject({
   ball_spot_y: z.number().nullable().optional(),
   shot_angle: z.number().nullable().optional(),
   shot_length: z.number().nullable().optional(),
+  // Per-batter instance counter within an innings. Always 1 in hardball;
+  // in Pairs a batter can be dismissed and return later, so the second
+  // trip-to-the-crease carries inst_num = 2. Required to split a player's
+  // wagon-wheel between instances.
+  batter_inst_num: z.number().nullable().optional(),
+  batter_ns_inst_num: z.number().nullable().optional(),
+  dismissed_batter_inst_num: z.number().nullable().optional(),
 });
 export type RvBall = z.output<typeof RvBall>;
 

--- a/apps/api/src/features/play-cricket/schemas.ts
+++ b/apps/api/src/features/play-cricket/schemas.ts
@@ -79,6 +79,9 @@ const battingPerformanceSchema = z.object({
   sixes: z.number(),
   how_out: z.string(),
   not_out: z.boolean(),
+  times_out: z.number(),
+  dismissal_penalty: z.number(),
+  game_type: z.string(),
   created_at: z.string(),
 });
 
@@ -97,6 +100,7 @@ const bowlingPerformanceSchema = z.object({
   wickets: z.number(),
   wides: z.number(),
   no_balls: z.number(),
+  game_type: z.string(),
   created_at: z.string(),
 });
 
@@ -139,30 +143,40 @@ const bowlingSeasonSchema = z.object({
   bestBowling: z.string().nullable(),
 });
 
+// Stats are partitioned by game_type so hardball and Women's Softball
+// (Play Cricket "Pairs") get their own section on the profile. A format is
+// omitted entirely when the player has no batting and no bowling data for it,
+// so the UI never renders an empty card.
+const playerFormatStatsSchema = z.object({
+  gameType: z.enum(["Standard", "Pairs"]),
+  label: z.string(),
+  seasons: z.array(z.number()),
+  battingSeasons: z.array(battingSeasonSchema),
+  bowlingSeasons: z.array(bowlingSeasonSchema),
+  career: z.object({
+    batting: z.object({
+      matches: z.number(),
+      runs: z.number(),
+      highScore: z.number(),
+      notOuts: z.number(),
+    }),
+    bowling: z.object({
+      innings: z.number(),
+      wickets: z.number(),
+      bestBowling: z
+        .object({
+          wickets: z.number(),
+          runs: z.number(),
+        })
+        .nullable(),
+    }),
+  }),
+});
+
 export const playerCareerStatsResponseSchema = z
   .object({
     playCricketId: z.string(),
-    seasons: z.array(z.number()),
-    battingSeasons: z.array(battingSeasonSchema),
-    bowlingSeasons: z.array(bowlingSeasonSchema),
-    career: z.object({
-      batting: z.object({
-        matches: z.number(),
-        runs: z.number(),
-        highScore: z.number(),
-        notOuts: z.number(),
-      }),
-      bowling: z.object({
-        innings: z.number(),
-        wickets: z.number(),
-        bestBowling: z
-          .object({
-            wickets: z.number(),
-            runs: z.number(),
-          })
-          .nullable(),
-      }),
-    }),
+    formats: z.array(playerFormatStatsSchema),
   })
   .nullable();
 

--- a/apps/api/src/features/play-cricket/schemas.ts
+++ b/apps/api/src/features/play-cricket/schemas.ts
@@ -21,6 +21,11 @@ export const playerStatsSchema = z.object({
 export const playerSeasonStatsSchema = z.object({
   slug: z.string(),
   season: z.coerce.number().int(),
+  // Career stats are partitioned by game_type; season stats default to
+  // hardball ("Standard") and accept "Pairs" for Women's Softball. Without
+  // a filter a dual-format player's averages would mix incompatible units
+  // (hardball runs / softball net runs).
+  gameType: z.enum(["Standard", "Pairs"]).default("Standard"),
 });
 
 // Response schemas

--- a/apps/api/src/features/play-cricket/service.test.ts
+++ b/apps/api/src/features/play-cricket/service.test.ts
@@ -187,6 +187,7 @@ describe("play-cricket service", () => {
           total_runs: "350",
           high_score: "85",
           total_times_out: "8",
+          not_outs: "2",
           total_penalty_runs: "0",
           total_balls: "300",
           total_fours: "30",
@@ -201,6 +202,7 @@ describe("play-cricket service", () => {
           total_runs: "200",
           high_score: "62",
           total_times_out: "7",
+          not_outs: "1",
           total_penalty_runs: "0",
           total_balls: "200",
           total_fours: "15",
@@ -234,11 +236,10 @@ describe("play-cricket service", () => {
         },
       ]);
 
-      // Best bowling overall, per format (now an .execute() array, not
-      // executeTakeFirst — we need one entry per format the player has
-      // bowled in).
+      // All bowling rows (for per-format overall best — reduced in JS now).
       mockExecute.mockResolvedValueOnce([
         { game_type: "Standard", wickets: 5, runs: 28 },
+        { game_type: "Standard", wickets: 3, runs: 40 },
       ]);
 
       const result = await getPlayerCareerStats(db)("entry-123");

--- a/apps/api/src/features/play-cricket/service.test.ts
+++ b/apps/api/src/features/play-cricket/service.test.ts
@@ -171,20 +171,23 @@ describe("play-cricket service", () => {
       expect(result).toBeNull();
     });
 
-    it("returns career stats when player found", async () => {
-      // Member lookup
+    it("returns career stats partitioned by game_type, hardball only", async () => {
       mockExecuteTakeFirst.mockResolvedValueOnce({
         play_cricket_id: "pc-100",
       });
 
-      // Batting by season (full columns)
+      // Batting aggregated by (season, game_type). Hardball rows only —
+      // dismissal_penalty is 0 so the unified average collapses to
+      // runs / times_out.
       mockExecute.mockResolvedValueOnce([
         {
           season: 2024,
+          game_type: "Standard",
           innings: "10",
           total_runs: "350",
           high_score: "85",
-          not_outs: "2",
+          total_times_out: "8",
+          total_penalty_runs: "0",
           total_balls: "300",
           total_fours: "30",
           total_sixes: "5",
@@ -193,10 +196,12 @@ describe("play-cricket service", () => {
         },
         {
           season: 2023,
+          game_type: "Standard",
           innings: "8",
           total_runs: "200",
           high_score: "62",
-          not_outs: "1",
+          total_times_out: "7",
+          total_penalty_runs: "0",
           total_balls: "200",
           total_fours: "15",
           total_sixes: "2",
@@ -205,10 +210,11 @@ describe("play-cricket service", () => {
         },
       ]);
 
-      // Bowling by season (ball-based)
+      // Bowling aggregated by (season, game_type)
       mockExecute.mockResolvedValueOnce([
         {
           season: 2024,
+          game_type: "Standard",
           innings: "9",
           total_maidens: "15",
           total_runs_conceded: "280",
@@ -218,29 +224,39 @@ describe("play-cricket service", () => {
         },
       ]);
 
-      // Best bowling per season
+      // Best bowling per (season, game_type)
       mockExecute.mockResolvedValueOnce([
-        { season: 2024, wickets: "5", runs: "28" },
+        {
+          season: 2024,
+          game_type: "Standard",
+          wickets: "5",
+          runs: "28",
+        },
       ]);
 
-      // Best bowling figures overall
-      mockExecuteTakeFirst.mockResolvedValueOnce({
-        wickets: 5,
-        runs: 28,
-        overs: "8",
-      });
+      // Best bowling overall, per format (now an .execute() array, not
+      // executeTakeFirst — we need one entry per format the player has
+      // bowled in).
+      mockExecute.mockResolvedValueOnce([
+        { game_type: "Standard", wickets: 5, runs: 28 },
+      ]);
 
       const result = await getPlayerCareerStats(db)("entry-123");
 
       assert(result !== null);
       expect(result.playCricketId).toBe("pc-100");
-      expect(result.career.batting.runs).toBe(550);
-      expect(result.career.batting.highScore).toBe(85);
-      expect(result.career.batting.matches).toBe(18);
-      expect(result.career.bowling.wickets).toBe(22);
-      expect(result.battingSeasons).toHaveLength(2);
-      expect(result.bowlingSeasons).toHaveLength(1);
-      expect(result.bowlingSeasons[0].bestBowling).toBe("5/28");
+      // Hardball-only player → exactly one format section, no empty card.
+      expect(result.formats).toHaveLength(1);
+      const hardball = result.formats[0];
+      expect(hardball.gameType).toBe("Standard");
+      expect(hardball.label).toBe("Hardball");
+      expect(hardball.career.batting.runs).toBe(550);
+      expect(hardball.career.batting.highScore).toBe(85);
+      expect(hardball.career.batting.matches).toBe(18);
+      expect(hardball.career.bowling.wickets).toBe(22);
+      expect(hardball.battingSeasons).toHaveLength(2);
+      expect(hardball.bowlingSeasons).toHaveLength(1);
+      expect(hardball.bowlingSeasons[0].bestBowling).toBe("5/28");
     });
   });
 });

--- a/apps/api/src/features/play-cricket/service.ts
+++ b/apps/api/src/features/play-cricket/service.ts
@@ -266,6 +266,14 @@ export function getLiveScores(db: Kysely<DB>) {
   };
 }
 
+// Game types we expose on the player profile. Hardball ("Standard") first so
+// it renders above softball when a player has both. Format labels surface in
+// section headings on the frontend.
+const GAME_TYPES = [
+  { code: "Standard", label: "Hardball" },
+  { code: "Pairs", label: "Softball" },
+] as const;
+
 export function getPlayerCareerStats(db: Kysely<DB>) {
   return async (slug: string) => {
     // Look up play_cricket_id via member table
@@ -292,17 +300,21 @@ export function getPlayerCareerStats(db: Kysely<DB>) {
       END
     `;
 
-    // Aggregate batting stats grouped by season (full columns)
+    // Aggregate batting stats grouped by (season, game_type). The unified
+    // average formula collapses to standard runs/dismissals for hardball
+    // because dismissal_penalty is 0 there.
     const battingBySeasonRows = await db
       .selectFrom("match_performance_batting")
       .where("player_id", "=", playCricketId)
       .select([
         "season",
+        "game_type",
         sql<string>`count(*)`.as("innings"),
         sql<string>`sum(runs)`.as("total_runs"),
         sql<string>`max(runs)`.as("high_score"),
-        sql<string>`count(case when how_out = 'not out' then 1 end)`.as(
-          "not_outs",
+        sql<string>`sum(times_out)`.as("total_times_out"),
+        sql<string>`sum(times_out * dismissal_penalty)`.as(
+          "total_penalty_runs",
         ),
         sql<string>`sum(balls)`.as("total_balls"),
         sql<string>`sum(fours)`.as("total_fours"),
@@ -314,16 +326,16 @@ export function getPlayerCareerStats(db: Kysely<DB>) {
           "hundreds",
         ),
       ])
-      .groupBy("season")
+      .groupBy(["season", "game_type"])
       .orderBy("season", "desc")
       .execute();
 
-    // Aggregate bowling stats grouped by season (with ball-based overs + best bowling)
     const bowlingBySeasonRows = await db
       .selectFrom("match_performance_bowling")
       .where("player_id", "=", playCricketId)
       .select([
         "season",
+        "game_type",
         sql<string>`count(*)`.as("innings"),
         sql<string>`sum(maidens)`.as("total_maidens"),
         sql<string>`sum(runs)`.as("total_runs_conceded"),
@@ -331,144 +343,185 @@ export function getPlayerCareerStats(db: Kysely<DB>) {
         sql<string>`SUM(${oversToBalls})`.as("total_balls"),
         sql<string>`max(wickets)`.as("best_wickets"),
       ])
-      .groupBy("season")
+      .groupBy(["season", "game_type"])
       .orderBy("season", "desc")
       .execute();
 
-    // Best bowling figures per season (need a separate query for W/R)
+    // Best bowling figures per (season, game_type)
     const bestBowlingPerSeason = await db
       .selectFrom("match_performance_bowling")
       .where("player_id", "=", playCricketId)
       .select([
         "season",
+        "game_type",
         sql<string>`wickets`.as("wickets"),
         sql<string>`runs`.as("runs"),
       ])
       .where(
-        sql`(season, wickets, runs)`,
+        sql`(season, game_type, wickets, runs)`,
         "in",
         sql`(
-          SELECT season, wickets, MIN(runs)
+          SELECT season, game_type, wickets, MIN(runs)
           FROM match_performance_bowling
           WHERE player_id = ${playCricketId}
           AND wickets = (
             SELECT MAX(wickets) FROM match_performance_bowling b2
-            WHERE b2.player_id = ${playCricketId} AND b2.season = match_performance_bowling.season
+            WHERE b2.player_id = ${playCricketId}
+              AND b2.season = match_performance_bowling.season
+              AND b2.game_type = match_performance_bowling.game_type
           )
-          GROUP BY season, wickets
+          GROUP BY season, game_type, wickets
         )`,
       )
       .execute();
 
-    const bestBowlingMap = new Map<number, string>();
+    const bestBowlingPerSeasonByFormat = new Map<string, Map<number, string>>();
     for (const row of bestBowlingPerSeason) {
-      bestBowlingMap.set(row.season, `${row.wickets}/${row.runs}`);
+      const key = row.game_type;
+      let inner = bestBowlingPerSeasonByFormat.get(key);
+      if (!inner) {
+        inner = new Map();
+        bestBowlingPerSeasonByFormat.set(key, inner);
+      }
+      inner.set(row.season, `${row.wickets}/${row.runs}`);
     }
 
-    // Best bowling figures overall
-    const bestBowlingRow = await db
+    // Best bowling figures overall, per format
+    const bestBowlingOverallRows = await db
       .selectFrom("match_performance_bowling")
       .where("player_id", "=", playCricketId)
-      .select(["wickets", "runs", "overs"])
-      .orderBy("wickets", "desc")
-      .orderBy("runs", "asc")
-      .orderBy(sql`cast(overs as numeric)`, "asc")
-      .limit(1)
-      .executeTakeFirst();
+      .select([
+        "game_type",
+        sql<string>`wickets`.as("wickets"),
+        sql<string>`runs`.as("runs"),
+      ])
+      .where(
+        sql`(game_type, wickets, runs, overs)`,
+        "in",
+        sql`(
+          SELECT game_type, wickets, runs, overs
+          FROM match_performance_bowling
+          WHERE player_id = ${playCricketId}
+          ORDER BY wickets DESC, runs ASC, cast(overs as numeric) ASC
+          LIMIT 1
+        )`,
+      )
+      .execute();
 
-    // Distinct seasons with data (batting or bowling)
-    const seasons = [
-      ...new Set([
-        ...battingBySeasonRows.map((r) => r.season),
-        ...bowlingBySeasonRows.map((r) => r.season),
-      ]),
-    ].sort((a, b) => b - a);
+    const bestBowlingOverallByFormat = new Map<
+      string,
+      { wickets: number; runs: number }
+    >();
+    for (const row of bestBowlingOverallRows) {
+      bestBowlingOverallByFormat.set(row.game_type, {
+        wickets: Number(row.wickets ?? 0),
+        runs: Number(row.runs ?? 0),
+      });
+    }
 
-    // Build per-season batting rows for the response
-    const battingSeasons = battingBySeasonRows.map((row) => {
-      const innings = Number(row.innings);
-      const notOuts = Number(row.not_outs);
-      const runs = Number(row.total_runs);
-      const totalBalls = Number(row.total_balls);
-      const dismissals = innings - notOuts;
-      return {
-        season: row.season,
-        innings,
-        notOuts,
-        runs,
-        highScore: Number(row.high_score),
-        average:
-          innings >= 3 && dismissals > 0
-            ? Number((runs / dismissals).toFixed(2))
-            : null,
-        strikeRate:
-          totalBalls > 0
-            ? Number(((runs / totalBalls) * 100).toFixed(1))
-            : null,
-        fours: Number(row.total_fours),
-        sixes: Number(row.total_sixes),
-        fifties: Number(row.fifties),
-        hundreds: Number(row.hundreds),
+    const formats = GAME_TYPES.map(({ code, label }) => {
+      const battingSeasons = battingBySeasonRows
+        .filter((r) => r.game_type === code)
+        .map((row) => {
+          const innings = Number(row.innings);
+          const timesOut = Number(row.total_times_out);
+          const penaltyRuns = Number(row.total_penalty_runs);
+          const runs = Number(row.total_runs);
+          const totalBalls = Number(row.total_balls);
+          // Unified: (runs − times_out × penalty_per_out) / times_out.
+          // Hardball has dismissal_penalty = 0 so this is the standard
+          // batting average; softball matches Play Cricket's net average.
+          const average =
+            innings >= 3 && timesOut > 0
+              ? Number(((runs - penaltyRuns) / timesOut).toFixed(2))
+              : null;
+          return {
+            season: row.season,
+            innings,
+            notOuts: Math.max(innings - timesOut, 0),
+            runs,
+            highScore: Number(row.high_score),
+            average,
+            strikeRate:
+              totalBalls > 0
+                ? Number(((runs / totalBalls) * 100).toFixed(1))
+                : null,
+            fours: Number(row.total_fours),
+            sixes: Number(row.total_sixes),
+            fifties: Number(row.fifties),
+            hundreds: Number(row.hundreds),
+          };
+        });
+
+      const bowlingSeasons = bowlingBySeasonRows
+        .filter((r) => r.game_type === code)
+        .map((row) => {
+          const totalBalls = Number(row.total_balls);
+          const wickets = Number(row.total_wickets);
+          const runs = Number(row.total_runs_conceded);
+          const totalOvers = Math.floor(totalBalls / 6);
+          const remainingBalls = totalBalls % 6;
+          return {
+            season: row.season,
+            innings: Number(row.innings),
+            overs: `${totalOvers}.${remainingBalls}`,
+            maidens: Number(row.total_maidens),
+            runs,
+            wickets,
+            average:
+              totalBalls >= 60 && wickets > 0
+                ? Number((runs / wickets).toFixed(2))
+                : null,
+            economy:
+              totalBalls > 0
+                ? Number((runs / (totalBalls / 6)).toFixed(2))
+                : null,
+            strikeRate:
+              totalBalls >= 60 && wickets > 0
+                ? Number((totalBalls / wickets).toFixed(1))
+                : null,
+            bestBowling:
+              bestBowlingPerSeasonByFormat.get(code)?.get(row.season) ?? null,
+          };
+        });
+
+      const seasons = [
+        ...new Set([
+          ...battingSeasons.map((s) => s.season),
+          ...bowlingSeasons.map((s) => s.season),
+        ]),
+      ].sort((a, b) => b - a);
+
+      const careerBatting = {
+        matches: battingSeasons.reduce((sum, s) => sum + s.innings, 0),
+        runs: battingSeasons.reduce((sum, s) => sum + s.runs, 0),
+        highScore: Math.max(0, ...battingSeasons.map((s) => s.highScore)),
+        notOuts: battingSeasons.reduce((sum, s) => sum + s.notOuts, 0),
       };
-    });
 
-    // Build per-season bowling rows for the response
-    const bowlingSeasons = bowlingBySeasonRows.map((row) => {
-      const totalBalls = Number(row.total_balls);
-      const wickets = Number(row.total_wickets);
-      const runs = Number(row.total_runs_conceded);
-      const totalOvers = Math.floor(totalBalls / 6);
-      const remainingBalls = totalBalls % 6;
-      return {
-        season: row.season,
-        innings: Number(row.innings),
-        overs: `${totalOvers}.${remainingBalls}`,
-        maidens: Number(row.total_maidens),
-        runs,
-        wickets,
-        average:
-          totalBalls >= 60 && wickets > 0
-            ? Number((runs / wickets).toFixed(2))
-            : null,
-        economy:
-          totalBalls > 0 ? Number((runs / (totalBalls / 6)).toFixed(2)) : null,
-        strikeRate:
-          totalBalls >= 60 && wickets > 0
-            ? Number((totalBalls / wickets).toFixed(1))
-            : null,
-        bestBowling: bestBowlingMap.get(row.season) ?? null,
+      const careerBowling = {
+        innings: bowlingSeasons.reduce((sum, s) => sum + s.innings, 0),
+        wickets: bowlingSeasons.reduce((sum, s) => sum + s.wickets, 0),
+        bestBowling: bestBowlingOverallByFormat.get(code) ?? null,
       };
-    });
 
-    // Calculate career totals
-    // PostgreSQL sum()/count() return bigint (string in node-pg), so Number() each
-    const careerBatting = {
-      matches: battingSeasons.reduce((sum, s) => sum + s.innings, 0),
-      runs: battingSeasons.reduce((sum, s) => sum + s.runs, 0),
-      highScore: Math.max(0, ...battingSeasons.map((s) => s.highScore)),
-      notOuts: battingSeasons.reduce((sum, s) => sum + s.notOuts, 0),
-    };
-
-    const careerBowling = {
-      innings: bowlingSeasons.reduce((sum, s) => sum + s.innings, 0),
-      wickets: bowlingSeasons.reduce((sum, s) => sum + s.wickets, 0),
-      bestBowling: bestBowlingRow
-        ? {
-            wickets: bestBowlingRow.wickets ?? 0,
-            runs: bestBowlingRow.runs ?? 0,
-          }
-        : null,
-    };
+      return {
+        gameType: code,
+        label,
+        seasons,
+        battingSeasons,
+        bowlingSeasons,
+        career: { batting: careerBatting, bowling: careerBowling },
+      };
+      // Drop formats with no batting and no bowling — the profile renders one
+      // section per remaining format, never an empty "Softball" card.
+    }).filter(
+      (f) => f.battingSeasons.length > 0 || f.bowlingSeasons.length > 0,
+    );
 
     return {
       playCricketId,
-      seasons,
-      battingSeasons,
-      bowlingSeasons,
-      career: {
-        batting: careerBatting,
-        bowling: careerBowling,
-      },
+      formats,
     };
   };
 }
@@ -501,13 +554,25 @@ export function getPlayerSeasonStats(db: Kysely<DB>) {
       .selectAll()
       .execute();
 
-    // Calculate batting aggregates
+    // Calculate batting aggregates using the unified formula:
+    //   avg = (runs − times_out × dismissal_penalty) / times_out
+    // For hardball dismissal_penalty is 0 so this collapses to the standard
+    // runs / dismissals. For Pairs it matches Play Cricket's net average.
     const totalRuns = battingRows.reduce((sum, r) => sum + (r.runs ?? 0), 0);
     const innings = battingRows.length;
-    const notOuts = battingRows.filter((r) => r.how_out === "not out").length;
-    const dismissals = innings - notOuts;
+    const totalTimesOut = battingRows.reduce(
+      (sum, r) => sum + (r.times_out ?? 0),
+      0,
+    );
+    const totalPenaltyRuns = battingRows.reduce(
+      (sum, r) => sum + (r.times_out ?? 0) * (r.dismissal_penalty ?? 0),
+      0,
+    );
+    const notOuts = Math.max(innings - totalTimesOut, 0);
     const battingAverage =
-      innings >= 3 && dismissals > 0 ? totalRuns / dismissals : null;
+      innings >= 3 && totalTimesOut > 0
+        ? (totalRuns - totalPenaltyRuns) / totalTimesOut
+        : null;
     const highScore =
       innings > 0 ? Math.max(...battingRows.map((r) => r.runs ?? 0)) : 0;
     const totalBalls = battingRows.reduce((sum, r) => sum + (r.balls ?? 0), 0);

--- a/apps/api/src/features/play-cricket/service.ts
+++ b/apps/api/src/features/play-cricket/service.ts
@@ -313,6 +313,12 @@ export function getPlayerCareerStats(db: Kysely<DB>) {
         sql<string>`sum(runs)`.as("total_runs"),
         sql<string>`max(runs)`.as("high_score"),
         sql<string>`sum(times_out)`.as("total_times_out"),
+        // Innings where the batter was never dismissed. Pairs allows
+        // times_out > 1 in a single innings so we can't derive this from
+        // innings − Σ times_out.
+        sql<string>`sum(case when times_out = 0 then 1 else 0 end)`.as(
+          "not_outs",
+        ),
         sql<string>`sum(times_out * dismissal_penalty)`.as(
           "total_penalty_runs",
         ),
@@ -386,37 +392,32 @@ export function getPlayerCareerStats(db: Kysely<DB>) {
       inner.set(row.season, `${row.wickets}/${row.runs}`);
     }
 
-    // Best bowling figures overall, per format
-    const bestBowlingOverallRows = await db
+    // Best bowling figures overall, computed per game_type. A player can
+    // have rows in both Standard and Pairs and we want the top figures
+    // for each, not a single global winner. Reduce in JS - small data,
+    // and the subquery / window patterns are awkward to mock in
+    // service.test.ts.
+    const allBowlingRows = await db
       .selectFrom("match_performance_bowling")
       .where("player_id", "=", playCricketId)
-      .select([
-        "game_type",
-        sql<string>`wickets`.as("wickets"),
-        sql<string>`runs`.as("runs"),
-      ])
-      .where(
-        sql`(game_type, wickets, runs, overs)`,
-        "in",
-        sql`(
-          SELECT game_type, wickets, runs, overs
-          FROM match_performance_bowling
-          WHERE player_id = ${playCricketId}
-          ORDER BY wickets DESC, runs ASC, cast(overs as numeric) ASC
-          LIMIT 1
-        )`,
-      )
+      .select(["game_type", "wickets", "runs"])
       .execute();
 
     const bestBowlingOverallByFormat = new Map<
       string,
       { wickets: number; runs: number }
     >();
-    for (const row of bestBowlingOverallRows) {
-      bestBowlingOverallByFormat.set(row.game_type, {
-        wickets: Number(row.wickets ?? 0),
-        runs: Number(row.runs ?? 0),
-      });
+    for (const row of allBowlingRows) {
+      const wickets = row.wickets ?? 0;
+      const runs = row.runs ?? 0;
+      const current = bestBowlingOverallByFormat.get(row.game_type);
+      const isBetter =
+        !current ||
+        wickets > current.wickets ||
+        (wickets === current.wickets && runs < current.runs);
+      if (isBetter) {
+        bestBowlingOverallByFormat.set(row.game_type, { wickets, runs });
+      }
     }
 
     const formats = GAME_TYPES.map(({ code, label }) => {
@@ -438,7 +439,7 @@ export function getPlayerCareerStats(db: Kysely<DB>) {
           return {
             season: row.season,
             innings,
-            notOuts: Math.max(innings - timesOut, 0),
+            notOuts: Number(row.not_outs),
             runs,
             highScore: Number(row.high_score),
             average,
@@ -527,7 +528,11 @@ export function getPlayerCareerStats(db: Kysely<DB>) {
 }
 
 export function getPlayerSeasonStats(db: Kysely<DB>) {
-  return async (slug: string, season: number) => {
+  return async (
+    slug: string,
+    season: number,
+    gameType: "Standard" | "Pairs" = "Standard",
+  ) => {
     const member = await db
       .selectFrom("member")
       .where("slug", "=", slug)
@@ -544,6 +549,7 @@ export function getPlayerSeasonStats(db: Kysely<DB>) {
       .selectFrom("match_performance_batting")
       .where("player_id", "=", playCricketId)
       .where("season", "=", season)
+      .where("game_type", "=", gameType)
       .selectAll()
       .execute();
 
@@ -551,6 +557,7 @@ export function getPlayerSeasonStats(db: Kysely<DB>) {
       .selectFrom("match_performance_bowling")
       .where("player_id", "=", playCricketId)
       .where("season", "=", season)
+      .where("game_type", "=", gameType)
       .selectAll()
       .execute();
 
@@ -568,7 +575,9 @@ export function getPlayerSeasonStats(db: Kysely<DB>) {
       (sum, r) => sum + (r.times_out ?? 0) * (r.dismissal_penalty ?? 0),
       0,
     );
-    const notOuts = Math.max(innings - totalTimesOut, 0);
+    // Count innings where the batter was never dismissed. Pairs allows
+    // times_out > 1 in a single innings so we can't subtract from innings.
+    const notOuts = battingRows.filter((r) => (r.times_out ?? 0) === 0).length;
     const battingAverage =
       innings >= 3 && totalTimesOut > 0
         ? (totalRuns - totalPenaltyRuns) / totalTimesOut

--- a/apps/api/src/features/play-cricket/sync.test.ts
+++ b/apps/api/src/features/play-cricket/sync.test.ts
@@ -63,17 +63,43 @@ describe("sync helpers", () => {
   });
 
   describe("didBat", () => {
-    it("returns false for null/undefined/empty/dnb", () => {
-      expect(didBat(null)).toBe(false);
-      expect(didBat(undefined)).toBe(false);
-      expect(didBat("")).toBe(false);
-      expect(didBat("dnb")).toBe(false);
+    it("returns false when how_out is dnb regardless of stats", () => {
+      expect(didBat({ how_out: "dnb" })).toBe(false);
+      // Even if Play Cricket sends quantitative fields for a DNB row, "dnb"
+      // is the explicit signal that they didn't take strike.
+      expect(didBat({ how_out: "dnb", runs: "5", balls: "10" })).toBe(false);
     });
 
-    it("returns true for batting dismissals", () => {
-      expect(didBat("caught")).toBe(true);
-      expect(didBat("bowled")).toBe(true);
-      expect(didBat("no")).toBe(true);
+    it("returns false for null/empty how_out with no runs / balls / times_out", () => {
+      expect(didBat({ how_out: null })).toBe(false);
+      expect(didBat({ how_out: undefined })).toBe(false);
+      expect(didBat({ how_out: "" })).toBe(false);
+      expect(didBat({ how_out: "", runs: "", balls: "", times_out: "" })).toBe(
+        false,
+      );
+      expect(
+        didBat({ how_out: "", runs: "0", balls: "0", times_out: "0" }),
+      ).toBe(false);
+    });
+
+    it("returns true for hardball dismissals", () => {
+      expect(didBat({ how_out: "caught" })).toBe(true);
+      expect(didBat({ how_out: "bowled" })).toBe(true);
+      expect(didBat({ how_out: "no" })).toBe(true);
+    });
+
+    it("returns true for softball batters (null how_out with runs/balls)", () => {
+      // Women's Softball: every batter has how_out=null; runs/balls/times_out
+      // tell us they actually batted.
+      expect(
+        didBat({ how_out: null, runs: "5", balls: "8", times_out: "0" }),
+      ).toBe(true);
+      expect(
+        didBat({ how_out: null, runs: "0", balls: "11", times_out: "1" }),
+      ).toBe(true);
+      expect(
+        didBat({ how_out: null, runs: "0", balls: "0", times_out: "1" }),
+      ).toBe(true);
     });
   });
 

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -22,17 +22,44 @@ function isJuniorTeam(teamName: string): boolean {
   return JUNIOR_PATTERNS.some((p) => p.test(teamName));
 }
 
-const NOT_OUT_CODES = new Set(["no", "dnb", "rtd", "ro", "ret out", ""]);
+const NOT_OUT_CODES = new Set([
+  "no",
+  "dnb",
+  "rtd",
+  "ro",
+  "ret out",
+  "rtno",
+  "",
+]);
 
 function isNotOut(howOut: string | null | undefined): boolean {
   if (!howOut) return true;
   return NOT_OUT_CODES.has(howOut.toLowerCase().trim());
 }
 
-function didBat(howOut: string | null | undefined): boolean {
-  if (!howOut) return false;
-  const code = howOut.toLowerCase().trim();
-  return code !== "dnb" && code !== "";
+// In Pairs (Women's Softball) every batter rotates after their allotted balls
+// without a per-player dismissal code, so `how_out` is null for everyone who
+// played. We can't use it as the sole "did this player bat" signal — fall
+// back to runs, balls, and times_out, which softball does populate.
+function didBat(bat: {
+  how_out?: string | null;
+  runs?: string | null;
+  balls?: string | null;
+  times_out?: string | null;
+}): boolean {
+  const code = (bat.how_out ?? "").toLowerCase().trim();
+  if (code === "dnb") return false;
+  if (code !== "") return true;
+  // Empty / null how_out: must have at least one quantitative signal that
+  // this player took strike.
+  const runs = parseInt(bat.runs ?? "");
+  const balls = parseInt(bat.balls ?? "");
+  const timesOut = parseInt(bat.times_out ?? "");
+  return (
+    (Number.isFinite(runs) && runs !== 0) ||
+    (Number.isFinite(balls) && balls > 0) ||
+    (Number.isFinite(timesOut) && timesOut > 0)
+  );
 }
 
 function parseDismissalType(
@@ -215,9 +242,22 @@ async function storeBattingPerformances(
   competitionType: string,
   matchDate: string,
   season: number,
+  gameType: string,
+  dismissalPenalty: number,
 ): Promise<void> {
   for (const bat of innings) {
-    if (!didBat(bat.how_out)) continue;
+    if (!didBat(bat)) continue;
+
+    // For Pairs games trust the API's per-batter times_out (can be 2+); for
+    // Standard, derive it from not_out so the column stays consistent across
+    // formats. The unified average formula relies on this column for both.
+    const apiTimesOut = parseInt(bat.times_out ?? "");
+    const timesOut =
+      gameType === "Pairs" && Number.isFinite(apiTimesOut)
+        ? apiTimesOut
+        : isNotOut(bat.how_out)
+          ? 0
+          : 1;
 
     await db
       .insertInto("match_performance_batting")
@@ -236,6 +276,9 @@ async function storeBattingPerformances(
         sixes: parseInt(bat.sixes) || 0,
         how_out: bat.how_out ?? "",
         not_out: isNotOut(bat.how_out),
+        times_out: timesOut,
+        dismissal_penalty: dismissalPenalty,
+        game_type: gameType,
       })
       .onConflict((oc) =>
         oc.columns(["match_id", "player_id"]).doUpdateSet({
@@ -247,6 +290,9 @@ async function storeBattingPerformances(
           sixes: parseInt(bat.sixes) || 0,
           how_out: bat.how_out ?? "",
           not_out: isNotOut(bat.how_out),
+          times_out: timesOut,
+          dismissal_penalty: dismissalPenalty,
+          game_type: gameType,
         }),
       )
       .execute();
@@ -270,6 +316,7 @@ async function storeBowlingPerformances(
   competitionType: string,
   matchDate: string,
   season: number,
+  gameType: string,
 ): Promise<void> {
   for (const bowl of bowlers) {
     await db
@@ -289,6 +336,7 @@ async function storeBowlingPerformances(
         wickets: parseInt(bowl.wickets) || 0,
         wides: parseInt(bowl.wides) || 0,
         no_balls: parseInt(bowl.no_balls) || 0,
+        game_type: gameType,
       })
       .onConflict((oc) =>
         oc.columns(["match_id", "player_id"]).doUpdateSet({
@@ -300,6 +348,7 @@ async function storeBowlingPerformances(
           wickets: parseInt(bowl.wickets) || 0,
           wides: parseInt(bowl.wides) || 0,
           no_balls: parseInt(bowl.no_balls) || 0,
+          game_type: gameType,
         }),
       )
       .execute();
@@ -314,6 +363,7 @@ async function storeFieldingPerformances(
   competitionType: string,
   matchDate: string,
   season: number,
+  gameType: string,
 ): Promise<void> {
   for (const [fielderId, agg] of fieldingCredits) {
     await db
@@ -331,6 +381,7 @@ async function storeFieldingPerformances(
         run_outs: agg.runOuts,
         stumpings: agg.stumpings,
         is_wicketkeeper: agg.isWicketkeeper,
+        game_type: gameType,
       })
       .onConflict((oc) =>
         oc.columns(["match_id", "player_id"]).doUpdateSet({
@@ -340,6 +391,7 @@ async function storeFieldingPerformances(
           run_outs: agg.runOuts,
           stumpings: agg.stumpings,
           is_wicketkeeper: agg.isWicketkeeper,
+          game_type: gameType,
         }),
       )
       .execute();
@@ -464,6 +516,13 @@ async function syncMatches(
       const homeKeeperIds = getWicketkeeperIds(detail.players, "home");
       const awayKeeperIds = getWicketkeeperIds(detail.players, "away");
 
+      // "Standard" hardball or "Pairs" (Women's Softball). Drives the
+      // unified scoring formula and decides whether to attempt fielding
+      // attribution.
+      const gameType = detail.game_type || "Standard";
+      const dismissalPenalty = parseInt(detail.dismissal_penalty || "") || 0;
+      const startingRuns = parseInt(detail.starting_runs || "");
+
       for (const innings of detail.innings) {
         const battingTeamId = innings.team_batting_id;
         const isBattingTeamOurs = ourTeamIds.has(battingTeamId);
@@ -486,6 +545,8 @@ async function syncMatches(
             match.competition_type ?? "",
             matchDateIso,
             season,
+            gameType,
+            dismissalPenalty,
           );
         }
 
@@ -498,21 +559,29 @@ async function syncMatches(
             match.competition_type ?? "",
             matchDateIso,
             season,
+            gameType,
           );
 
-          const fieldingCredits = extractFieldingCredits(
-            innings.bat,
-            fieldingKeeperIds,
-          );
-          await storeFieldingPerformances(
-            db,
-            fieldingCredits,
-            matchId,
-            fieldingTeamId,
-            match.competition_type ?? "",
-            matchDateIso,
-            season,
-          );
+          // Pairs scorecards don't carry per-dismissal fielder attribution
+          // (how_out is null for every batter), so we can't credit catches /
+          // run-outs / stumpings to individuals. Skip rather than write zero
+          // rows that would shadow real attribution from any future format.
+          if (gameType !== "Pairs") {
+            const fieldingCredits = extractFieldingCredits(
+              innings.bat,
+              fieldingKeeperIds,
+            );
+            await storeFieldingPerformances(
+              db,
+              fieldingCredits,
+              matchId,
+              fieldingTeamId,
+              match.competition_type ?? "",
+              matchDateIso,
+              season,
+              gameType,
+            );
+          }
         }
       }
 
@@ -522,6 +591,12 @@ async function syncMatches(
       const shouldWriteResult = matchResult || !isRecent;
 
       if (shouldWriteResult) {
+        const startingRunsForResult = Number.isFinite(startingRuns)
+          ? startingRuns
+          : null;
+        const dismissalPenaltyForResult =
+          gameType === "Pairs" ? dismissalPenalty : null;
+
         await db
           .insertInto("match_result")
           .values({
@@ -545,6 +620,9 @@ async function syncMatches(
             competition_type: match.competition_type ?? "",
             match_date: matchDateIso,
             season,
+            game_type: gameType,
+            starting_runs: startingRunsForResult,
+            dismissal_penalty: dismissalPenaltyForResult,
           })
           .onConflict((oc) =>
             oc.column("match_id").doUpdateSet({
@@ -556,6 +634,9 @@ async function syncMatches(
               home_club_name: match.home_club_name,
               away_club_id: match.away_club_id,
               away_club_name: match.away_club_name,
+              game_type: gameType,
+              starting_runs: startingRunsForResult,
+              dismissal_penalty: dismissalPenaltyForResult,
             }),
           )
           .execute();

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -258,6 +258,11 @@ async function storeBattingPerformances(
         : isNotOut(bat.how_out)
           ? 0
           : 1;
+    // Derive not_out from times_out for both formats. In Pairs, how_out is
+    // null for every batter so the old how_out-based check would mark a
+    // dismissed Pairs batter as not out, which would corrupt any consumer
+    // still reading the legacy column.
+    const notOut = timesOut === 0;
 
     await db
       .insertInto("match_performance_batting")
@@ -275,7 +280,7 @@ async function storeBattingPerformances(
         fours: parseInt(bat.fours) || 0,
         sixes: parseInt(bat.sixes) || 0,
         how_out: bat.how_out ?? "",
-        not_out: isNotOut(bat.how_out),
+        not_out: notOut,
         times_out: timesOut,
         dismissal_penalty: dismissalPenalty,
         game_type: gameType,
@@ -289,7 +294,7 @@ async function storeBattingPerformances(
           fours: parseInt(bat.fours) || 0,
           sixes: parseInt(bat.sixes) || 0,
           how_out: bat.how_out ?? "",
-          not_out: isNotOut(bat.how_out),
+          not_out: notOut,
           times_out: timesOut,
           dismissal_penalty: dismissalPenalty,
           game_type: gameType,

--- a/apps/api/src/features/records/service.ts
+++ b/apps/api/src/features/records/service.ts
@@ -87,6 +87,7 @@ async function getHighestScore(
     .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
     .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
     .where("t.is_junior", "=", isJunior)
+    .where("b.game_type", "=", "Standard")
     .select([
       "b.player_name as playerName",
       "m.slug",
@@ -118,6 +119,7 @@ async function getBestBowling(
     .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
     .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
     .where("t.is_junior", "=", isJunior)
+    .where("b.game_type", "=", "Standard")
     .select([
       "b.player_name as playerName",
       "m.slug",
@@ -149,6 +151,7 @@ async function getMostRunsSeason(
     .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
     .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
     .where("t.is_junior", "=", isJunior)
+    .where("b.game_type", "=", "Standard")
     .groupBy(["b.player_id", "b.season", "m.slug"])
     .select([
       sql<string>`MAX(b.player_name)`.as("playerName"),
@@ -179,6 +182,7 @@ async function getMostWicketsSeason(
     .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
     .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
     .where("t.is_junior", "=", isJunior)
+    .where("b.game_type", "=", "Standard")
     .groupBy(["b.player_id", "b.season", "m.slug"])
     .select([
       sql<string>`MAX(b.player_name)`.as("playerName"),
@@ -209,6 +213,7 @@ async function getMostCareerRuns(
     .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
     .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
     .where("t.is_junior", "=", isJunior)
+    .where("b.game_type", "=", "Standard")
     .groupBy(["b.player_id", "m.slug"])
     .select([
       sql<string>`MAX(b.player_name)`.as("playerName"),
@@ -238,6 +243,7 @@ async function getMostCareerWickets(
     .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
     .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
     .where("t.is_junior", "=", isJunior)
+    .where("b.game_type", "=", "Standard")
     .groupBy(["b.player_id", "m.slug"])
     .select([
       sql<string>`MAX(b.player_name)`.as("playerName"),
@@ -267,6 +273,7 @@ async function getMostCareerMatches(
     .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
     .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
     .where("t.is_junior", "=", isJunior)
+    .where("b.game_type", "=", "Standard")
     .groupBy(["b.player_id", "m.slug"])
     .select([
       sql<string>`MAX(b.player_name)`.as("playerName"),
@@ -298,6 +305,7 @@ async function getCenturies(
     .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
     .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
     .where("t.is_junior", "=", isJunior)
+    .where("b.game_type", "=", "Standard")
     .where("b.runs", ">=", 100)
     .select([
       "b.player_name as playerName",
@@ -329,6 +337,7 @@ async function getFiveWicketHauls(
     .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
     .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
     .where("t.is_junior", "=", isJunior)
+    .where("b.game_type", "=", "Standard")
     .where("b.wickets", ">=", 5)
     .select([
       "b.player_name as playerName",

--- a/apps/api/src/scripts/dump-rv-balls.ts
+++ b/apps/api/src/scripts/dump-rv-balls.ts
@@ -1,0 +1,106 @@
+/**
+ * One-off: fetch RV ball-by-ball + match overview for a single PC match and
+ * dump as JSON files. Used to inspect raw RV data for new fixtures (e.g. the
+ * Women's Softball game 7660052) without going through the sync ingest.
+ *
+ * Usage:
+ *   RV_SHARED_SECRET=$(cat /tmp/.rv_secret) \
+ *     pnpm --filter api exec tsx src/scripts/dump-rv-balls.ts 7660052 \
+ *     /Users/alexyoung/Code/website-v2/.claude/tmp
+ */
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createRvClient } from "../features/play-cricket/rv-client.ts";
+
+async function main() {
+  const matchId = process.argv[2];
+  const outDir = process.argv[3];
+  if (!matchId || !outDir) {
+    console.error("usage: dump-rv-balls.ts <pcMatchId> <outDir>");
+    process.exit(2);
+  }
+
+  const secret = process.env.RV_SHARED_SECRET;
+  if (!secret) {
+    console.error("RV_SHARED_SECRET not set");
+    process.exit(2);
+  }
+
+  const rv = createRvClient({ sharedSecret: secret });
+
+  const mapping = await rv.getMatchMapping(matchId);
+  writeFileSync(
+    join(outDir, `rv_mapping_${matchId}.json`),
+    JSON.stringify(mapping, null, 2),
+  );
+  if (!mapping) {
+    console.log(`no RV mapping for PC match ${matchId}`);
+    return;
+  }
+
+  const overview = await rv.getMatch(mapping.rvMatchId);
+  writeFileSync(
+    join(outDir, `rv_match_${matchId}.json`),
+    JSON.stringify(overview, null, 2),
+  );
+  if (!overview) {
+    console.log(`no RV overview for ${mapping.rvMatchId}`);
+    return;
+  }
+
+  // RV's MatchTeams[].Innings[] enumerates each team-innings. The
+  // getballs endpoint wants the team's `result_id` plus the innings_number.
+  const teams = (overview as unknown as { MatchTeams?: unknown[] }).MatchTeams;
+  const allInnings: Array<{
+    teamName: string;
+    entityId: number;
+    inningsNumber: number;
+    resultId: number;
+    inningsId: number;
+  }> = [];
+  if (Array.isArray(teams)) {
+    for (const t of teams) {
+      const team = t as {
+        team_name?: string;
+        entity_id?: number;
+        result_id?: number;
+        Innings?: Array<{
+          innings_number?: number;
+          innings_id?: number;
+        }>;
+      };
+      for (const inn of team.Innings ?? []) {
+        if (inn.innings_number != null && team.result_id != null) {
+          allInnings.push({
+            teamName: team.team_name ?? "",
+            entityId: team.entity_id ?? 0,
+            inningsNumber: inn.innings_number,
+            resultId: team.result_id,
+            inningsId: inn.innings_id ?? 0,
+          });
+        }
+      }
+    }
+  }
+
+  for (const inn of allInnings) {
+    const balls = await rv.getBalls(
+      mapping.rvMatchId,
+      inn.resultId,
+      inn.inningsNumber,
+    );
+    const fname = `rv_balls_${matchId}_team${inn.entityId}_inn${inn.inningsNumber}.json`;
+    writeFileSync(
+      join(outDir, fname),
+      JSON.stringify({ team: inn, balls }, null, 2),
+    );
+    console.log(`  → ${fname}: ${balls.length} balls`);
+  }
+
+  console.log("done");
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -2955,6 +2955,7 @@ export interface paths {
                 query: {
                     slug: string;
                     season: number;
+                    gameType?: "Standard" | "Pairs";
                 };
                 header?: never;
                 path?: never;

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -2526,6 +2526,7 @@ export interface paths {
                                 outcome: "W" | "L" | "D" | "T" | "A" | "C" | "N" | null;
                                 description: string;
                                 toss: string;
+                                gameType: string;
                                 innings: {
                                     teamBattingId: string;
                                     teamName: string;
@@ -2534,6 +2535,7 @@ export interface paths {
                                     overs: string;
                                     declared: boolean;
                                     allOut: boolean;
+                                    netScore: number | null;
                                 }[];
                             } | null;
                             sponsor: {

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -2817,6 +2817,9 @@ export interface paths {
                                     sixes: number;
                                     how_out: string;
                                     not_out: boolean;
+                                    times_out: number;
+                                    dismissal_penalty: number;
+                                    game_type: string;
                                     created_at: string;
                                 }[];
                                 bowling: {
@@ -2834,6 +2837,7 @@ export interface paths {
                                     wickets: number;
                                     wides: number;
                                     no_balls: number;
+                                    game_type: string;
                                     created_at: string;
                                 }[];
                                 status: string;
@@ -2877,48 +2881,53 @@ export interface paths {
                     content: {
                         "application/json": {
                             playCricketId: string;
-                            seasons: number[];
-                            battingSeasons: {
-                                season: number;
-                                innings: number;
-                                notOuts: number;
-                                runs: number;
-                                highScore: number;
-                                average: number | null;
-                                strikeRate: number | null;
-                                fours: number;
-                                sixes: number;
-                                fifties: number;
-                                hundreds: number;
-                            }[];
-                            bowlingSeasons: {
-                                season: number;
-                                innings: number;
-                                overs: string;
-                                maidens: number;
-                                runs: number;
-                                wickets: number;
-                                average: number | null;
-                                economy: number | null;
-                                strikeRate: number | null;
-                                bestBowling: string | null;
-                            }[];
-                            career: {
-                                batting: {
-                                    matches: number;
+                            formats: {
+                                /** @enum {string} */
+                                gameType: "Standard" | "Pairs";
+                                label: string;
+                                seasons: number[];
+                                battingSeasons: {
+                                    season: number;
+                                    innings: number;
+                                    notOuts: number;
                                     runs: number;
                                     highScore: number;
-                                    notOuts: number;
-                                };
-                                bowling: {
+                                    average: number | null;
+                                    strikeRate: number | null;
+                                    fours: number;
+                                    sixes: number;
+                                    fifties: number;
+                                    hundreds: number;
+                                }[];
+                                bowlingSeasons: {
+                                    season: number;
                                     innings: number;
+                                    overs: string;
+                                    maidens: number;
+                                    runs: number;
                                     wickets: number;
-                                    bestBowling: {
-                                        wickets: number;
+                                    average: number | null;
+                                    economy: number | null;
+                                    strikeRate: number | null;
+                                    bestBowling: string | null;
+                                }[];
+                                career: {
+                                    batting: {
+                                        matches: number;
                                         runs: number;
-                                    } | null;
+                                        highScore: number;
+                                        notOuts: number;
+                                    };
+                                    bowling: {
+                                        innings: number;
+                                        wickets: number;
+                                        bestBowling: {
+                                            wickets: number;
+                                            runs: number;
+                                        } | null;
+                                    };
                                 };
-                            };
+                            }[];
                         } | null;
                     };
                 };
@@ -9269,6 +9278,7 @@ export interface paths {
                     isJunior?: "true" | "false";
                     teamId?: string;
                     competitionTypes?: string;
+                    gameType?: "Standard" | "Pairs";
                     limit?: number;
                 };
                 header?: never;
@@ -9326,6 +9336,7 @@ export interface paths {
                     isJunior?: "true" | "false";
                     teamId?: string;
                     competitionTypes?: string;
+                    gameType?: "Standard" | "Pairs";
                     limit?: number;
                 };
                 header?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -5291,6 +5291,19 @@
             "in": "query",
             "name": "season",
             "required": true
+          },
+          {
+            "schema": {
+              "default": "Standard",
+              "type": "string",
+              "enum": [
+                "Standard",
+                "Pairs"
+              ]
+            },
+            "in": "query",
+            "name": "gameType",
+            "required": false
           }
         ],
         "responses": {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -4875,6 +4875,15 @@
                                 "not_out": {
                                   "type": "boolean"
                                 },
+                                "times_out": {
+                                  "type": "number"
+                                },
+                                "dismissal_penalty": {
+                                  "type": "number"
+                                },
+                                "game_type": {
+                                  "type": "string"
+                                },
                                 "created_at": {
                                   "type": "string"
                                 }
@@ -4894,6 +4903,9 @@
                                 "sixes",
                                 "how_out",
                                 "not_out",
+                                "times_out",
+                                "dismissal_penalty",
+                                "game_type",
                                 "created_at"
                               ],
                               "additionalProperties": false
@@ -4946,6 +4958,9 @@
                                 "no_balls": {
                                   "type": "number"
                                 },
+                                "game_type": {
+                                  "type": "string"
+                                },
                                 "created_at": {
                                   "type": "string"
                                 }
@@ -4965,6 +4980,7 @@
                                 "wickets",
                                 "wides",
                                 "no_balls",
+                                "game_type",
                                 "created_at"
                               ],
                               "additionalProperties": false
@@ -5020,199 +5036,223 @@
                     "playCricketId": {
                       "type": "string"
                     },
-                    "seasons": {
-                      "type": "array",
-                      "items": {
-                        "type": "number"
-                      }
-                    },
-                    "battingSeasons": {
+                    "formats": {
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
-                          "season": {
-                            "type": "number"
+                          "gameType": {
+                            "type": "string",
+                            "enum": [
+                              "Standard",
+                              "Pairs"
+                            ]
                           },
-                          "innings": {
-                            "type": "number"
-                          },
-                          "notOuts": {
-                            "type": "number"
-                          },
-                          "runs": {
-                            "type": "number"
-                          },
-                          "highScore": {
-                            "type": "number"
-                          },
-                          "average": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "strikeRate": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "fours": {
-                            "type": "number"
-                          },
-                          "sixes": {
-                            "type": "number"
-                          },
-                          "fifties": {
-                            "type": "number"
-                          },
-                          "hundreds": {
-                            "type": "number"
-                          }
-                        },
-                        "required": [
-                          "season",
-                          "innings",
-                          "notOuts",
-                          "runs",
-                          "highScore",
-                          "average",
-                          "strikeRate",
-                          "fours",
-                          "sixes",
-                          "fifties",
-                          "hundreds"
-                        ],
-                        "additionalProperties": false
-                      }
-                    },
-                    "bowlingSeasons": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "season": {
-                            "type": "number"
-                          },
-                          "innings": {
-                            "type": "number"
-                          },
-                          "overs": {
+                          "label": {
                             "type": "string"
                           },
-                          "maidens": {
-                            "type": "number"
-                          },
-                          "runs": {
-                            "type": "number"
-                          },
-                          "wickets": {
-                            "type": "number"
-                          },
-                          "average": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "economy": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "strikeRate": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "bestBowling": {
-                            "nullable": true,
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "season",
-                          "innings",
-                          "overs",
-                          "maidens",
-                          "runs",
-                          "wickets",
-                          "average",
-                          "economy",
-                          "strikeRate",
-                          "bestBowling"
-                        ],
-                        "additionalProperties": false
-                      }
-                    },
-                    "career": {
-                      "type": "object",
-                      "properties": {
-                        "batting": {
-                          "type": "object",
-                          "properties": {
-                            "matches": {
-                              "type": "number"
-                            },
-                            "runs": {
-                              "type": "number"
-                            },
-                            "highScore": {
-                              "type": "number"
-                            },
-                            "notOuts": {
+                          "seasons": {
+                            "type": "array",
+                            "items": {
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "matches",
-                            "runs",
-                            "highScore",
-                            "notOuts"
-                          ],
-                          "additionalProperties": false
-                        },
-                        "bowling": {
-                          "type": "object",
-                          "properties": {
-                            "innings": {
-                              "type": "number"
-                            },
-                            "wickets": {
-                              "type": "number"
-                            },
-                            "bestBowling": {
-                              "nullable": true,
+                          "battingSeasons": {
+                            "type": "array",
+                            "items": {
                               "type": "object",
                               "properties": {
-                                "wickets": {
+                                "season": {
+                                  "type": "number"
+                                },
+                                "innings": {
+                                  "type": "number"
+                                },
+                                "notOuts": {
                                   "type": "number"
                                 },
                                 "runs": {
                                   "type": "number"
+                                },
+                                "highScore": {
+                                  "type": "number"
+                                },
+                                "average": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "strikeRate": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "fours": {
+                                  "type": "number"
+                                },
+                                "sixes": {
+                                  "type": "number"
+                                },
+                                "fifties": {
+                                  "type": "number"
+                                },
+                                "hundreds": {
+                                  "type": "number"
                                 }
                               },
                               "required": [
-                                "wickets",
-                                "runs"
+                                "season",
+                                "innings",
+                                "notOuts",
+                                "runs",
+                                "highScore",
+                                "average",
+                                "strikeRate",
+                                "fours",
+                                "sixes",
+                                "fifties",
+                                "hundreds"
                               ],
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "innings",
-                            "wickets",
-                            "bestBowling"
-                          ],
-                          "additionalProperties": false
-                        }
-                      },
-                      "required": [
-                        "batting",
-                        "bowling"
-                      ],
-                      "additionalProperties": false
+                          "bowlingSeasons": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "season": {
+                                  "type": "number"
+                                },
+                                "innings": {
+                                  "type": "number"
+                                },
+                                "overs": {
+                                  "type": "string"
+                                },
+                                "maidens": {
+                                  "type": "number"
+                                },
+                                "runs": {
+                                  "type": "number"
+                                },
+                                "wickets": {
+                                  "type": "number"
+                                },
+                                "average": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "economy": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "strikeRate": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "bestBowling": {
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "season",
+                                "innings",
+                                "overs",
+                                "maidens",
+                                "runs",
+                                "wickets",
+                                "average",
+                                "economy",
+                                "strikeRate",
+                                "bestBowling"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "career": {
+                            "type": "object",
+                            "properties": {
+                              "batting": {
+                                "type": "object",
+                                "properties": {
+                                  "matches": {
+                                    "type": "number"
+                                  },
+                                  "runs": {
+                                    "type": "number"
+                                  },
+                                  "highScore": {
+                                    "type": "number"
+                                  },
+                                  "notOuts": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "matches",
+                                  "runs",
+                                  "highScore",
+                                  "notOuts"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "bowling": {
+                                "type": "object",
+                                "properties": {
+                                  "innings": {
+                                    "type": "number"
+                                  },
+                                  "wickets": {
+                                    "type": "number"
+                                  },
+                                  "bestBowling": {
+                                    "nullable": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "wickets": {
+                                        "type": "number"
+                                      },
+                                      "runs": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "wickets",
+                                      "runs"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "innings",
+                                  "wickets",
+                                  "bestBowling"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "batting",
+                              "bowling"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "gameType",
+                          "label",
+                          "seasons",
+                          "battingSeasons",
+                          "bowlingSeasons",
+                          "career"
+                        ],
+                        "additionalProperties": false
+                      }
                     }
                   },
                   "required": [
                     "playCricketId",
-                    "seasons",
-                    "battingSeasons",
-                    "bowlingSeasons",
-                    "career"
+                    "formats"
                   ],
                   "additionalProperties": false
                 }
@@ -16200,6 +16240,19 @@
           },
           {
             "schema": {
+              "default": "Standard",
+              "type": "string",
+              "enum": [
+                "Standard",
+                "Pairs"
+              ]
+            },
+            "in": "query",
+            "name": "gameType",
+            "required": false
+          },
+          {
+            "schema": {
               "default": 50,
               "type": "integer",
               "minimum": 1,
@@ -16337,6 +16390,19 @@
             },
             "in": "query",
             "name": "competitionTypes",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": "Standard",
+              "type": "string",
+              "enum": [
+                "Standard",
+                "Pairs"
+              ]
+            },
+            "in": "query",
+            "name": "gameType",
             "required": false
           },
           {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -4398,6 +4398,9 @@
                         "toss": {
                           "type": "string"
                         },
+                        "gameType": {
+                          "type": "string"
+                        },
                         "innings": {
                           "type": "array",
                           "items": {
@@ -4423,6 +4426,10 @@
                               },
                               "allOut": {
                                 "type": "boolean"
+                              },
+                              "netScore": {
+                                "nullable": true,
+                                "type": "number"
                               }
                             },
                             "required": [
@@ -4432,7 +4439,8 @@
                               "wickets",
                               "overs",
                               "declared",
-                              "allOut"
+                              "allOut",
+                              "netScore"
                             ],
                             "additionalProperties": false
                           }
@@ -4442,6 +4450,7 @@
                         "outcome",
                         "description",
                         "toss",
+                        "gameType",
                         "innings"
                       ],
                       "additionalProperties": false

--- a/apps/web/src/components/scorecard.tsx
+++ b/apps/web/src/components/scorecard.tsx
@@ -34,6 +34,9 @@ interface BattingEntry {
   balls: number;
   fours: number;
   sixes: number;
+  // Women's Softball (Play Cricket "Pairs") only: count of dismissals for
+  // this batter in this innings (can be 0, 1, or 2+). Always 0 for hardball.
+  timesOut: number;
 }
 
 interface BowlingEntry {
@@ -79,6 +82,18 @@ interface ScorecardInnings {
   total: InningsTotal;
 }
 
+// Per-team points entry from Play Cricket — game points + bonus point
+// breakdown for the match. Bonus rows are hardball-only; Pairs returns
+// game_points alone.
+interface PointsEntry {
+  teamId: string;
+  gamePoints: number;
+  bonusPointsBatting: number;
+  bonusPointsBowling: number;
+  bonusPointsTogether: number;
+  penaltyPoints: number;
+}
+
 interface MatchDetailData {
   homeTeamName: string;
   homeTeamId: string;
@@ -92,6 +107,14 @@ interface MatchDetailData {
   result: string;
   resultDescription: string;
   resultAppliedTo: string;
+  // "Standard" hardball or "Pairs" Women's Softball. Drives Net Score
+  // rendering + dismissal-label fallbacks.
+  gameType: string;
+  // Pairs only: starting score added to runs, penalty subtracted per
+  // dismissal. Null for hardball — Net Score is not displayed.
+  startingRuns: number | null;
+  dismissalPenalty: number | null;
+  points: PointsEntry[];
   innings: ScorecardInnings[];
 }
 
@@ -107,6 +130,13 @@ function fetchMatchDetail(matchId: string) {
 
 function formatDismissal(entry: BattingEntry): string {
   const { howOut, fielderName, bowlerName } = entry;
+  // Play Cricket leaves how_out null for every batter in a Pairs (Women's
+  // Softball) innings — players rotate at their balls limit instead of being
+  // dismissed individually. Show "retired not out" to match Play Cricket's
+  // own UI label.
+  if (howOut === null || howOut === "" || howOut === "rtno") {
+    return "retired not out";
+  }
   switch (howOut) {
     case "b":
       return `b ${bowlerName}`;
@@ -129,7 +159,7 @@ function formatDismissal(entry: BattingEntry): string {
     case "dnb":
       return "did not bat";
     default:
-      return howOut ?? "unknown";
+      return howOut;
   }
 }
 
@@ -194,6 +224,7 @@ function transformMatchDetail(
       balls: parseInt(b.balls) || 0,
       fours: parseInt(b.fours) || 0,
       sixes: parseInt(b.sixes) || 0,
+      timesOut: parseInt(b.times_out ?? "") || 0,
     }));
 
     const bowling: BowlingEntry[] = bowl.map((b) => ({
@@ -239,6 +270,31 @@ function transformMatchDetail(
     };
   });
 
+  // Play Cricket emits points as { team_id: number, game_points: string, ... }
+  // for both hardball and softball. Bonus rows are populated for hardball only.
+  const rawPoints =
+    (d.points as
+      | Array<{
+          team_id?: number | string;
+          game_points?: string;
+          bonus_points_batting?: string;
+          bonus_points_bowling?: string;
+          bonus_points_together?: string;
+          penalty_points?: string;
+        }>
+      | undefined) ?? [];
+  const points: PointsEntry[] = rawPoints.map((p) => ({
+    teamId: p.team_id === undefined ? "" : String(p.team_id),
+    gamePoints: parseInt(p.game_points ?? "") || 0,
+    bonusPointsBatting: parseFloat(p.bonus_points_batting ?? "") || 0,
+    bonusPointsBowling: parseFloat(p.bonus_points_bowling ?? "") || 0,
+    bonusPointsTogether: parseFloat(p.bonus_points_together ?? "") || 0,
+    penaltyPoints: parseFloat(p.penalty_points ?? "") || 0,
+  }));
+
+  const startingRunsRaw = parseInt((d.starting_runs as string) ?? "");
+  const dismissalPenaltyRaw = parseInt((d.dismissal_penalty as string) ?? "");
+
   return {
     homeTeamName: d.home_team_name as string,
     homeTeamId: d.home_team_id as string,
@@ -252,8 +308,22 @@ function transformMatchDetail(
     result: (d.result as string) ?? "",
     resultDescription: (d.result_description as string) ?? "",
     resultAppliedTo: (d.result_applied_to as string) ?? "",
+    gameType: (d.game_type as string) ?? "Standard",
+    startingRuns: Number.isFinite(startingRunsRaw) ? startingRunsRaw : null,
+    dismissalPenalty: Number.isFinite(dismissalPenaltyRaw)
+      ? dismissalPenaltyRaw
+      : null,
+    points,
     innings,
   };
+}
+
+function netScore(
+  total: InningsTotal,
+  startingRuns: number,
+  dismissalPenalty: number,
+): number {
+  return startingRuns + total.runs - total.wickets * dismissalPenalty;
 }
 
 // --- Sub-components ---
@@ -288,13 +358,19 @@ function BattingCard({
   batting,
   extras,
   total,
+  isPairs,
 }: {
   batting: BattingEntry[];
   extras: Extras;
   total: InningsTotal;
+  isPairs: boolean;
 }) {
   const activeBatters = batting.filter((b) => b.howOut !== "dnb");
   const didNotBat = batting.filter((b) => b.howOut === "dnb");
+  // Pairs swaps the SR column for "TO" (times out) — softball batters don't
+  // get individual dismissal codes, so SR adds less than a per-batter
+  // dismissal count.
+  const totalColSpan = isPairs ? 5 : 5;
 
   return (
     <div>
@@ -306,7 +382,9 @@ function BattingCard({
             <TableHead className="text-right">B</TableHead>
             <TableHead className="text-right">4s</TableHead>
             <TableHead className="text-right">6s</TableHead>
-            <TableHead className="text-right">SR</TableHead>
+            <TableHead className="text-right">
+              {isPairs ? "TO" : "SR"}
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -337,7 +415,11 @@ function BattingCard({
                 {b.sixes}
               </TableCell>
               <TableCell className="text-right font-mono tabular-nums">
-                {b.balls > 0 ? ((b.runs / b.balls) * 100).toFixed(1) : "-"}
+                {isPairs
+                  ? b.timesOut
+                  : b.balls > 0
+                    ? ((b.runs / b.balls) * 100).toFixed(1)
+                    : "-"}
               </TableCell>
             </TableRow>
           ))}
@@ -356,7 +438,7 @@ function BattingCard({
             <TableCell>Total</TableCell>
             <TableCell
               className="text-right font-mono tabular-nums"
-              colSpan={5}
+              colSpan={totalColSpan}
             >
               {formatTotalScore(total)}
             </TableCell>
@@ -443,7 +525,19 @@ function FallOfWickets({ fow }: { fow: FoWEntry[] }) {
   );
 }
 
-function InningsCard({ innings }: { innings: ScorecardInnings }) {
+function InningsCard({
+  innings,
+  isPairs,
+  startingRuns,
+  dismissalPenalty,
+}: {
+  innings: ScorecardInnings;
+  isPairs: boolean;
+  startingRuns: number | null;
+  dismissalPenalty: number | null;
+}) {
+  const showNetScore =
+    isPairs && startingRuns !== null && dismissalPenalty !== null;
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -451,12 +545,18 @@ function InningsCard({ innings }: { innings: ScorecardInnings }) {
         <div className="text-sm font-semibold text-stone-700">
           {formatTotalScore(innings.total)}
         </div>
+        {showNetScore && (
+          <div className="text-base font-bold text-stone-800">
+            Net Score {netScore(innings.total, startingRuns, dismissalPenalty)}
+          </div>
+        )}
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         <BattingCard
           batting={innings.batting}
           extras={innings.extras}
           total={innings.total}
+          isPairs={isPairs}
         />
         <FallOfWickets fow={innings.fallOfWickets} />
         <div className="border-t pt-4">
@@ -494,12 +594,26 @@ function ScorecardSkeleton() {
 }
 
 function ScorecardDisplay({ data }: { data: MatchDetailData }) {
+  const isPairs = data.gameType === "Pairs";
   return (
     <div className="flex flex-col gap-4">
-      <h4 className="text-lg font-semibold md:text-xl">Scorecard</h4>
+      <div className="flex items-center gap-2">
+        <h4 className="text-lg font-semibold md:text-xl">Scorecard</h4>
+        {isPairs && (
+          <span className="rounded-full bg-stone-700 px-2 py-0.5 text-xs font-semibold text-white">
+            Women&apos;s Softball
+          </span>
+        )}
+      </div>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         {data.innings.map((inn) => (
-          <InningsCard key={inn.inningsNumber} innings={inn} />
+          <InningsCard
+            key={inn.inningsNumber}
+            innings={inn}
+            isPairs={isPairs}
+            startingRuns={data.startingRuns}
+            dismissalPenalty={data.dismissalPenalty}
+          />
         ))}
       </div>
     </div>

--- a/apps/web/src/components/scorecard.tsx
+++ b/apps/web/src/components/scorecard.tsx
@@ -213,7 +213,25 @@ function transformMatchDetail(
     const bowl = (inn.bowl as Array<Record<string, string>>) ?? [];
     const fow = (inn.fow as Array<Record<string, unknown>>) ?? [];
 
-    const batting: BattingEntry[] = bat.map((b) => ({
+    // Mirror the server-side didBat() filter: drop rows the API includes
+    // for players who didn't take strike. In Pairs every batter has a null
+    // how_out, so we have to use the quantitative fields - otherwise empty
+    // DNB-style rows ("0" runs, empty balls / times_out) would render as
+    // ghost "retired not out" batters.
+    const battingRaw = bat.filter((b) => {
+      const code = (b.how_out ?? "").toLowerCase().trim();
+      if (code === "dnb") return false;
+      if (code !== "") return true;
+      const runs = parseInt(b.runs);
+      const balls = parseInt(b.balls);
+      const timesOut = parseInt(b.times_out ?? "");
+      return (
+        (Number.isFinite(runs) && runs !== 0) ||
+        (Number.isFinite(balls) && balls > 0) ||
+        (Number.isFinite(timesOut) && timesOut > 0)
+      );
+    });
+    const batting: BattingEntry[] = battingRaw.map((b) => ({
       position: b.position,
       name: b.batsman_name,
       memberSlug: b.batsman_member_slug ?? null,

--- a/apps/web/src/components/scorecard.tsx
+++ b/apps/web/src/components/scorecard.tsx
@@ -213,14 +213,13 @@ function transformMatchDetail(
     const bowl = (inn.bowl as Array<Record<string, string>>) ?? [];
     const fow = (inn.fow as Array<Record<string, unknown>>) ?? [];
 
-    // Mirror the server-side didBat() filter: drop rows the API includes
-    // for players who didn't take strike. In Pairs every batter has a null
-    // how_out, so we have to use the quantitative fields - otherwise empty
-    // DNB-style rows ("0" runs, empty balls / times_out) would render as
-    // ghost "retired not out" batters.
+    // Drop empty Pairs ghost rows but keep explicit "dnb" rows so the
+    // "Did not bat" section below can still render them. In Pairs every
+    // batter has a null how_out, so we can't tell DNB from "took strike"
+    // by how_out alone - fall back to the quantitative fields. Hardball
+    // DNB rows arrive with how_out = "dnb" and pass through untouched.
     const battingRaw = bat.filter((b) => {
       const code = (b.how_out ?? "").toLowerCase().trim();
-      if (code === "dnb") return false;
       if (code !== "") return true;
       const runs = parseInt(b.runs);
       const balls = parseInt(b.balls);

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -2955,6 +2955,7 @@ export interface paths {
                 query: {
                     slug: string;
                     season: number;
+                    gameType?: "Standard" | "Pairs";
                 };
                 header?: never;
                 path?: never;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -2526,6 +2526,7 @@ export interface paths {
                                 outcome: "W" | "L" | "D" | "T" | "A" | "C" | "N" | null;
                                 description: string;
                                 toss: string;
+                                gameType: string;
                                 innings: {
                                     teamBattingId: string;
                                     teamName: string;
@@ -2534,6 +2535,7 @@ export interface paths {
                                     overs: string;
                                     declared: boolean;
                                     allOut: boolean;
+                                    netScore: number | null;
                                 }[];
                             } | null;
                             sponsor: {

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -2817,6 +2817,9 @@ export interface paths {
                                     sixes: number;
                                     how_out: string;
                                     not_out: boolean;
+                                    times_out: number;
+                                    dismissal_penalty: number;
+                                    game_type: string;
                                     created_at: string;
                                 }[];
                                 bowling: {
@@ -2834,6 +2837,7 @@ export interface paths {
                                     wickets: number;
                                     wides: number;
                                     no_balls: number;
+                                    game_type: string;
                                     created_at: string;
                                 }[];
                                 status: string;
@@ -2877,48 +2881,53 @@ export interface paths {
                     content: {
                         "application/json": {
                             playCricketId: string;
-                            seasons: number[];
-                            battingSeasons: {
-                                season: number;
-                                innings: number;
-                                notOuts: number;
-                                runs: number;
-                                highScore: number;
-                                average: number | null;
-                                strikeRate: number | null;
-                                fours: number;
-                                sixes: number;
-                                fifties: number;
-                                hundreds: number;
-                            }[];
-                            bowlingSeasons: {
-                                season: number;
-                                innings: number;
-                                overs: string;
-                                maidens: number;
-                                runs: number;
-                                wickets: number;
-                                average: number | null;
-                                economy: number | null;
-                                strikeRate: number | null;
-                                bestBowling: string | null;
-                            }[];
-                            career: {
-                                batting: {
-                                    matches: number;
+                            formats: {
+                                /** @enum {string} */
+                                gameType: "Standard" | "Pairs";
+                                label: string;
+                                seasons: number[];
+                                battingSeasons: {
+                                    season: number;
+                                    innings: number;
+                                    notOuts: number;
                                     runs: number;
                                     highScore: number;
-                                    notOuts: number;
-                                };
-                                bowling: {
+                                    average: number | null;
+                                    strikeRate: number | null;
+                                    fours: number;
+                                    sixes: number;
+                                    fifties: number;
+                                    hundreds: number;
+                                }[];
+                                bowlingSeasons: {
+                                    season: number;
                                     innings: number;
+                                    overs: string;
+                                    maidens: number;
+                                    runs: number;
                                     wickets: number;
-                                    bestBowling: {
-                                        wickets: number;
+                                    average: number | null;
+                                    economy: number | null;
+                                    strikeRate: number | null;
+                                    bestBowling: string | null;
+                                }[];
+                                career: {
+                                    batting: {
+                                        matches: number;
                                         runs: number;
-                                    } | null;
+                                        highScore: number;
+                                        notOuts: number;
+                                    };
+                                    bowling: {
+                                        innings: number;
+                                        wickets: number;
+                                        bestBowling: {
+                                            wickets: number;
+                                            runs: number;
+                                        } | null;
+                                    };
                                 };
-                            };
+                            }[];
                         } | null;
                     };
                 };
@@ -9269,6 +9278,7 @@ export interface paths {
                     isJunior?: "true" | "false";
                     teamId?: string;
                     competitionTypes?: string;
+                    gameType?: "Standard" | "Pairs";
                     limit?: number;
                 };
                 header?: never;
@@ -9326,6 +9336,7 @@ export interface paths {
                     isJunior?: "true" | "false";
                     teamId?: string;
                     competitionTypes?: string;
+                    gameType?: "Standard" | "Pairs";
                     limit?: number;
                 };
                 header?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -5291,6 +5291,19 @@
             "in": "query",
             "name": "season",
             "required": true
+          },
+          {
+            "schema": {
+              "default": "Standard",
+              "type": "string",
+              "enum": [
+                "Standard",
+                "Pairs"
+              ]
+            },
+            "in": "query",
+            "name": "gameType",
+            "required": false
           }
         ],
         "responses": {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -4875,6 +4875,15 @@
                                 "not_out": {
                                   "type": "boolean"
                                 },
+                                "times_out": {
+                                  "type": "number"
+                                },
+                                "dismissal_penalty": {
+                                  "type": "number"
+                                },
+                                "game_type": {
+                                  "type": "string"
+                                },
                                 "created_at": {
                                   "type": "string"
                                 }
@@ -4894,6 +4903,9 @@
                                 "sixes",
                                 "how_out",
                                 "not_out",
+                                "times_out",
+                                "dismissal_penalty",
+                                "game_type",
                                 "created_at"
                               ],
                               "additionalProperties": false
@@ -4946,6 +4958,9 @@
                                 "no_balls": {
                                   "type": "number"
                                 },
+                                "game_type": {
+                                  "type": "string"
+                                },
                                 "created_at": {
                                   "type": "string"
                                 }
@@ -4965,6 +4980,7 @@
                                 "wickets",
                                 "wides",
                                 "no_balls",
+                                "game_type",
                                 "created_at"
                               ],
                               "additionalProperties": false
@@ -5020,199 +5036,223 @@
                     "playCricketId": {
                       "type": "string"
                     },
-                    "seasons": {
-                      "type": "array",
-                      "items": {
-                        "type": "number"
-                      }
-                    },
-                    "battingSeasons": {
+                    "formats": {
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
-                          "season": {
-                            "type": "number"
+                          "gameType": {
+                            "type": "string",
+                            "enum": [
+                              "Standard",
+                              "Pairs"
+                            ]
                           },
-                          "innings": {
-                            "type": "number"
-                          },
-                          "notOuts": {
-                            "type": "number"
-                          },
-                          "runs": {
-                            "type": "number"
-                          },
-                          "highScore": {
-                            "type": "number"
-                          },
-                          "average": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "strikeRate": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "fours": {
-                            "type": "number"
-                          },
-                          "sixes": {
-                            "type": "number"
-                          },
-                          "fifties": {
-                            "type": "number"
-                          },
-                          "hundreds": {
-                            "type": "number"
-                          }
-                        },
-                        "required": [
-                          "season",
-                          "innings",
-                          "notOuts",
-                          "runs",
-                          "highScore",
-                          "average",
-                          "strikeRate",
-                          "fours",
-                          "sixes",
-                          "fifties",
-                          "hundreds"
-                        ],
-                        "additionalProperties": false
-                      }
-                    },
-                    "bowlingSeasons": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "season": {
-                            "type": "number"
-                          },
-                          "innings": {
-                            "type": "number"
-                          },
-                          "overs": {
+                          "label": {
                             "type": "string"
                           },
-                          "maidens": {
-                            "type": "number"
-                          },
-                          "runs": {
-                            "type": "number"
-                          },
-                          "wickets": {
-                            "type": "number"
-                          },
-                          "average": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "economy": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "strikeRate": {
-                            "nullable": true,
-                            "type": "number"
-                          },
-                          "bestBowling": {
-                            "nullable": true,
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "season",
-                          "innings",
-                          "overs",
-                          "maidens",
-                          "runs",
-                          "wickets",
-                          "average",
-                          "economy",
-                          "strikeRate",
-                          "bestBowling"
-                        ],
-                        "additionalProperties": false
-                      }
-                    },
-                    "career": {
-                      "type": "object",
-                      "properties": {
-                        "batting": {
-                          "type": "object",
-                          "properties": {
-                            "matches": {
-                              "type": "number"
-                            },
-                            "runs": {
-                              "type": "number"
-                            },
-                            "highScore": {
-                              "type": "number"
-                            },
-                            "notOuts": {
+                          "seasons": {
+                            "type": "array",
+                            "items": {
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "matches",
-                            "runs",
-                            "highScore",
-                            "notOuts"
-                          ],
-                          "additionalProperties": false
-                        },
-                        "bowling": {
-                          "type": "object",
-                          "properties": {
-                            "innings": {
-                              "type": "number"
-                            },
-                            "wickets": {
-                              "type": "number"
-                            },
-                            "bestBowling": {
-                              "nullable": true,
+                          "battingSeasons": {
+                            "type": "array",
+                            "items": {
                               "type": "object",
                               "properties": {
-                                "wickets": {
+                                "season": {
+                                  "type": "number"
+                                },
+                                "innings": {
+                                  "type": "number"
+                                },
+                                "notOuts": {
                                   "type": "number"
                                 },
                                 "runs": {
                                   "type": "number"
+                                },
+                                "highScore": {
+                                  "type": "number"
+                                },
+                                "average": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "strikeRate": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "fours": {
+                                  "type": "number"
+                                },
+                                "sixes": {
+                                  "type": "number"
+                                },
+                                "fifties": {
+                                  "type": "number"
+                                },
+                                "hundreds": {
+                                  "type": "number"
                                 }
                               },
                               "required": [
-                                "wickets",
-                                "runs"
+                                "season",
+                                "innings",
+                                "notOuts",
+                                "runs",
+                                "highScore",
+                                "average",
+                                "strikeRate",
+                                "fours",
+                                "sixes",
+                                "fifties",
+                                "hundreds"
                               ],
                               "additionalProperties": false
                             }
                           },
-                          "required": [
-                            "innings",
-                            "wickets",
-                            "bestBowling"
-                          ],
-                          "additionalProperties": false
-                        }
-                      },
-                      "required": [
-                        "batting",
-                        "bowling"
-                      ],
-                      "additionalProperties": false
+                          "bowlingSeasons": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "season": {
+                                  "type": "number"
+                                },
+                                "innings": {
+                                  "type": "number"
+                                },
+                                "overs": {
+                                  "type": "string"
+                                },
+                                "maidens": {
+                                  "type": "number"
+                                },
+                                "runs": {
+                                  "type": "number"
+                                },
+                                "wickets": {
+                                  "type": "number"
+                                },
+                                "average": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "economy": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "strikeRate": {
+                                  "nullable": true,
+                                  "type": "number"
+                                },
+                                "bestBowling": {
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "season",
+                                "innings",
+                                "overs",
+                                "maidens",
+                                "runs",
+                                "wickets",
+                                "average",
+                                "economy",
+                                "strikeRate",
+                                "bestBowling"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "career": {
+                            "type": "object",
+                            "properties": {
+                              "batting": {
+                                "type": "object",
+                                "properties": {
+                                  "matches": {
+                                    "type": "number"
+                                  },
+                                  "runs": {
+                                    "type": "number"
+                                  },
+                                  "highScore": {
+                                    "type": "number"
+                                  },
+                                  "notOuts": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "matches",
+                                  "runs",
+                                  "highScore",
+                                  "notOuts"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "bowling": {
+                                "type": "object",
+                                "properties": {
+                                  "innings": {
+                                    "type": "number"
+                                  },
+                                  "wickets": {
+                                    "type": "number"
+                                  },
+                                  "bestBowling": {
+                                    "nullable": true,
+                                    "type": "object",
+                                    "properties": {
+                                      "wickets": {
+                                        "type": "number"
+                                      },
+                                      "runs": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "wickets",
+                                      "runs"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "innings",
+                                  "wickets",
+                                  "bestBowling"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "batting",
+                              "bowling"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "gameType",
+                          "label",
+                          "seasons",
+                          "battingSeasons",
+                          "bowlingSeasons",
+                          "career"
+                        ],
+                        "additionalProperties": false
+                      }
                     }
                   },
                   "required": [
                     "playCricketId",
-                    "seasons",
-                    "battingSeasons",
-                    "bowlingSeasons",
-                    "career"
+                    "formats"
                   ],
                   "additionalProperties": false
                 }
@@ -16200,6 +16240,19 @@
           },
           {
             "schema": {
+              "default": "Standard",
+              "type": "string",
+              "enum": [
+                "Standard",
+                "Pairs"
+              ]
+            },
+            "in": "query",
+            "name": "gameType",
+            "required": false
+          },
+          {
+            "schema": {
               "default": 50,
               "type": "integer",
               "minimum": 1,
@@ -16337,6 +16390,19 @@
             },
             "in": "query",
             "name": "competitionTypes",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": "Standard",
+              "type": "string",
+              "enum": [
+                "Standard",
+                "Pairs"
+              ]
+            },
+            "in": "query",
+            "name": "gameType",
             "required": false
           },
           {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -4398,6 +4398,9 @@
                         "toss": {
                           "type": "string"
                         },
+                        "gameType": {
+                          "type": "string"
+                        },
                         "innings": {
                           "type": "array",
                           "items": {
@@ -4423,6 +4426,10 @@
                               },
                               "allOut": {
                                 "type": "boolean"
+                              },
+                              "netScore": {
+                                "nullable": true,
+                                "type": "number"
                               }
                             },
                             "required": [
@@ -4432,7 +4439,8 @@
                               "wickets",
                               "overs",
                               "declared",
-                              "allOut"
+                              "allOut",
+                              "netScore"
                             ],
                             "additionalProperties": false
                           }
@@ -4442,6 +4450,7 @@
                         "outcome",
                         "description",
                         "toss",
+                        "gameType",
                         "innings"
                       ],
                       "additionalProperties": false

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -111,11 +111,17 @@ function ResultSummary({
 }: {
   result: NonNullable<GameData["result"]>;
 }) {
+  const isPairs = result.gameType === "Pairs";
   return (
     <Card>
       <CardContent className="flex flex-col gap-3 p-4">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {result.outcome && <OutcomeBadge outcome={result.outcome} />}
+          {isPairs && (
+            <span className="rounded-full bg-stone-700 px-2 py-0.5 text-xs font-semibold text-white">
+              Women&apos;s Softball
+            </span>
+          )}
           {result.toss && (
             <span className="text-sm text-stone-600">{result.toss}</span>
           )}
@@ -127,8 +133,13 @@ function ResultSummary({
               className="flex items-baseline justify-between gap-4"
             >
               <span className="text-sm font-medium">{inn.teamName}</span>
-              <span className="font-mono text-sm font-semibold tabular-nums">
-                {formatInningsScore(inn)}
+              <span className="flex items-baseline gap-2 font-mono text-sm font-semibold tabular-nums">
+                <span>{formatInningsScore(inn)}</span>
+                {inn.netScore !== null && (
+                  <span className="rounded bg-green-50 px-1.5 py-0.5 text-xs font-bold text-green-800">
+                    Net {inn.netScore}
+                  </span>
+                )}
               </span>
             </div>
           ))}

--- a/apps/web/src/pages/person/player-stats.tsx
+++ b/apps/web/src/pages/person/player-stats.tsx
@@ -7,8 +7,14 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
+import type { paths } from "@/lib/api.gen";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
+
+type CareerStats = NonNullable<
+  paths["/api/play-cricket/player-career-stats"]["get"]["responses"]["200"]["content"]["application/json"]
+>;
+type FormatStats = CareerStats["formats"][number];
 
 function StatCard({ label, value }: { label: string; value: string }) {
   return (
@@ -19,53 +25,26 @@ function StatCard({ label, value }: { label: string; value: string }) {
   );
 }
 
-export function PlayerStats({ slug }: { slug: string }) {
-  const careerQuery = useQuery({
-    queryKey: ["player-career-stats", slug],
-    queryFn: () =>
-      callApi(
-        api.GET("/api/play-cricket/player-career-stats", {
-          params: { query: { slug } },
-        }),
-      ),
-    staleTime: 5 * 60 * 1000,
-  });
-
-  if (careerQuery.isPending) {
-    return (
-      <div className="mt-6 space-y-3">
-        <div className="h-6 w-32 animate-pulse rounded bg-stone-200" />
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
-          {["s1", "s2", "s3", "s4", "s5"].map((k) => (
-            <div
-              key={k}
-              className="h-16 animate-pulse rounded-lg bg-stone-100"
-            />
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (!careerQuery.data) {
-    return null;
-  }
-
-  const { career, battingSeasons, bowlingSeasons } = careerQuery.data;
-
-  if (battingSeasons.length === 0 && bowlingSeasons.length === 0) {
-    return null;
-  }
-
+function FormatSection({
+  format,
+  showHeading,
+}: {
+  format: FormatStats;
+  showHeading: boolean;
+}) {
+  const { career, battingSeasons, bowlingSeasons } = format;
   const bestBowling = career.bowling.bestBowling
     ? `${career.bowling.bestBowling.wickets}/${career.bowling.bestBowling.runs}`
     : null;
 
   return (
-    <div className="mt-6">
-      <h2 className="mb-4 text-lg font-semibold">Statistics</h2>
+    <section className="mb-8 last:mb-0">
+      {showHeading && (
+        <h3 className="mb-3 text-base font-semibold text-stone-700">
+          {format.label}
+        </h3>
+      )}
 
-      {/* Career headline stats */}
       <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
         <StatCard label="Matches" value={String(career.batting.matches)} />
         <StatCard label="Total Runs" value={String(career.batting.runs)} />
@@ -84,7 +63,6 @@ export function PlayerStats({ slug }: { slug: string }) {
         )}
       </div>
 
-      {/* Batting by season */}
       {battingSeasons.length > 0 && (
         <div>
           <p className="mb-1 text-xs font-medium text-stone-500">Batting</p>
@@ -151,7 +129,6 @@ export function PlayerStats({ slug }: { slug: string }) {
         </div>
       )}
 
-      {/* Bowling by season */}
       {bowlingSeasons.length > 0 && (
         <div className="mt-4">
           <p className="mb-1 text-xs font-medium text-stone-500">Bowling</p>
@@ -209,16 +186,69 @@ export function PlayerStats({ slug }: { slug: string }) {
           </div>
         </div>
       )}
+    </section>
+  );
+}
 
-      {/* Leaderboard link */}
-      {battingSeasons.length > 0 && (
+export function PlayerStats({ slug }: { slug: string }) {
+  const careerQuery = useQuery({
+    queryKey: ["player-career-stats", slug],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/play-cricket/player-career-stats", {
+          params: { query: { slug } },
+        }),
+      ),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (careerQuery.isPending) {
+    return (
+      <div className="mt-6 space-y-3">
+        <div className="h-6 w-32 animate-pulse rounded bg-stone-200" />
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
+          {["s1", "s2", "s3", "s4", "s5"].map((k) => (
+            <div
+              key={k}
+              className="h-16 animate-pulse rounded-lg bg-stone-100"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!careerQuery.data || careerQuery.data.formats.length === 0) {
+    return null;
+  }
+
+  const { formats } = careerQuery.data;
+  // Only label sections when there is more than one — players with a single
+  // format see the same headline-stats-and-tables view they always have.
+  const showHeadings = formats.length > 1;
+  const hardballSeasons =
+    formats.find((f) => f.gameType === "Standard")?.battingSeasons ?? [];
+
+  return (
+    <div className="mt-6">
+      <h2 className="mb-4 text-lg font-semibold">Statistics</h2>
+
+      {formats.map((format) => (
+        <FormatSection
+          key={format.gameType}
+          format={format}
+          showHeading={showHeadings}
+        />
+      ))}
+
+      {hardballSeasons.length > 0 && (
         <p className="mt-4 text-xs text-stone-400">
           View the full{" "}
           <Link
-            to={`/cricket/records/leaderboards?season=${battingSeasons[0].season}`}
+            to={`/cricket/records/leaderboards?season=${hardballSeasons[0].season}`}
             className="text-green-800 underline decoration-green-800/30 underline-offset-2 hover:decoration-green-800"
           >
-            {battingSeasons[0].season} season leaderboard
+            {hardballSeasons[0].season} season leaderboard
           </Link>
         </p>
       )}

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -548,7 +548,9 @@ export interface MatchPerformanceBatting {
   balls: Generated<number>;
   competition_type: Generated<string>;
   created_at: Generated<string>;
+  dismissal_penalty: Generated<number>;
   fours: Generated<number>;
+  game_type: Generated<string>;
   how_out: Generated<string>;
   id: string;
   match_date: string;
@@ -560,11 +562,13 @@ export interface MatchPerformanceBatting {
   season: number;
   sixes: Generated<number>;
   team_id: string;
+  times_out: Generated<number>;
 }
 
 export interface MatchPerformanceBowling {
   competition_type: Generated<string>;
   created_at: Generated<string>;
+  game_type: Generated<string>;
   id: string;
   maidens: Generated<number>;
   match_date: string;
@@ -584,6 +588,7 @@ export interface MatchPerformanceFielding {
   catches: Generated<number>;
   competition_type: Generated<string>;
   created_at: Generated<string>;
+  game_type: Generated<string>;
   id: string;
   is_wicketkeeper: Generated<boolean>;
   match_date: string;
@@ -603,6 +608,8 @@ export interface MatchResult {
   away_team_name: string;
   competition_type: Generated<string>;
   created_at: Generated<string>;
+  dismissal_penalty: number | null;
+  game_type: Generated<string>;
   home_club_id: string | null;
   home_club_name: string | null;
   home_team_id: string;
@@ -614,6 +621,7 @@ export interface MatchResult {
   result_applied_to: Generated<string>;
   result_description: Generated<string>;
   season: number;
+  starting_runs: number | null;
 }
 
 export interface MatchStream {

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -459,10 +459,13 @@ export interface MatchBall {
   ball_spot_x: number | null;
   ball_spot_y: number | null;
   ball_time_utc: Timestamp | null;
+  batter_inst_num: number | null;
+  batter_ns_inst_num: number | null;
   batter_ns_rv_id: number | null;
   batter_rv_id: number | null;
   bowler_rv_id: number | null;
   created_at: Generated<Timestamp>;
+  dismissed_batter_inst_num: number | null;
   dismissed_batter_rv_id: number | null;
   extras_type: string | null;
   highlight_events: Generated<Json>;

--- a/packages/db/src/migrations/2026-05-22T10:15:34.589Z.ts
+++ b/packages/db/src/migrations/2026-05-22T10:15:34.589Z.ts
@@ -1,0 +1,96 @@
+import { type Kysely, sql } from "kysely";
+
+// Adds Women's Softball (Play Cricket "Pairs" game_type) support to the
+// performance tables and match_result. Pairs games differ from hardball in two
+// ways the data model previously couldn't represent:
+//   1. A single batter can be dismissed more than once per innings (times_out),
+//      and innings.wickets = sum of per-batter times_out.
+//   2. Net runs are computed against a starting score with a per-dismissal
+//      penalty: net_score = starting_runs + runs - wickets * dismissal_penalty.
+// Storing the format + scoring constants on every performance row lets the
+// unified average formula
+//   (SUM(runs) - SUM(times_out * dismissal_penalty)) / NULLIF(SUM(times_out),0)
+// collapse to the standard hardball average when dismissal_penalty = 0.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("match_performance_batting")
+    .addColumn("times_out", "integer", (col) => col.notNull().defaultTo(0))
+    .addColumn("dismissal_penalty", "integer", (col) =>
+      col.notNull().defaultTo(0),
+    )
+    .addColumn("game_type", "text", (col) =>
+      col.notNull().defaultTo("Standard"),
+    )
+    .execute();
+
+  // Backfill: existing rows are all hardball. Each dismissed batter counts as
+  // exactly one wicket; not-outs as zero.
+  await sql`
+    UPDATE match_performance_batting
+    SET times_out = CASE WHEN not_out THEN 0 ELSE 1 END
+    WHERE times_out = 0 AND not_out = false
+  `.execute(db);
+
+  await db.schema
+    .alterTable("match_performance_bowling")
+    .addColumn("game_type", "text", (col) =>
+      col.notNull().defaultTo("Standard"),
+    )
+    .execute();
+
+  await db.schema
+    .alterTable("match_performance_fielding")
+    .addColumn("game_type", "text", (col) =>
+      col.notNull().defaultTo("Standard"),
+    )
+    .execute();
+
+  await db.schema
+    .alterTable("match_result")
+    .addColumn("game_type", "text", (col) =>
+      col.notNull().defaultTo("Standard"),
+    )
+    .addColumn("starting_runs", "integer")
+    .addColumn("dismissal_penalty", "integer")
+    .execute();
+
+  // Index supports "career stats partitioned by format" queries on the
+  // player profile and records pages.
+  await db.schema
+    .createIndex("idx_batting_player_game_type")
+    .on("match_performance_batting")
+    .columns(["player_id", "game_type"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .dropIndex("idx_batting_player_game_type")
+    .ifExists()
+    .execute();
+
+  await db.schema
+    .alterTable("match_result")
+    .dropColumn("game_type")
+    .dropColumn("starting_runs")
+    .dropColumn("dismissal_penalty")
+    .execute();
+
+  await db.schema
+    .alterTable("match_performance_fielding")
+    .dropColumn("game_type")
+    .execute();
+
+  await db.schema
+    .alterTable("match_performance_bowling")
+    .dropColumn("game_type")
+    .execute();
+
+  await db.schema
+    .alterTable("match_performance_batting")
+    .dropColumn("times_out")
+    .dropColumn("dismissal_penalty")
+    .dropColumn("game_type")
+    .execute();
+}

--- a/packages/db/src/migrations/2026-05-22T12:00:33.695Z.ts
+++ b/packages/db/src/migrations/2026-05-22T12:00:33.695Z.ts
@@ -1,0 +1,29 @@
+import type { Kysely } from "kysely";
+
+// Per-batter instance numbers from RV ball-by-ball. Always 1 in hardball but
+// significant in Pairs / Women's Softball where a batter can be dismissed,
+// retire, and return later in the same innings: their second trip carries
+// inst_num = 2. Required to split a single batter's wagon wheel between
+// instances and to attribute dismissals to the correct one.
+//
+// Nullable - older rows pre-date this column and existing hardball ingests
+// don't lose anything if these stay null (wagon-wheel queries fall back to
+// "all instances" when absent).
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("match_ball")
+    .addColumn("batter_inst_num", "integer")
+    .addColumn("batter_ns_inst_num", "integer")
+    .addColumn("dismissed_batter_inst_num", "integer")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("match_ball")
+    .dropColumn("batter_inst_num")
+    .dropColumn("batter_ns_inst_num")
+    .dropColumn("dismissed_batter_inst_num")
+    .execute();
+}


### PR DESCRIPTION
## Summary

- Play Cricket's `Pairs` game_type (Women's Softball) breaks hardball assumptions. Our sync silently dropped every softball batting row (`didBat()` returned false when `how_out` is null), and our averages logic had no way to express Play Cricket's net-average formula. Fixes both.
- Adds `times_out`, `dismissal_penalty`, `game_type` to performance rows + `match_result`, and switches every average query to the unified formula `(Σ runs − Σ times_out × dismissal_penalty) / NULLIF(Σ times_out, 0)` — collapses to standard `runs / dismissals` for hardball (`dismissal_penalty = 0`), matches Play Cricket's net average for Pairs.
- Scorecard renders Net Score, a "Women's Softball" badge, a "Times Out" column, and "retired not out" labels for Pairs matches.
- Player profile career stats are partitioned by game type — formats with no data are omitted, so hardball-only players see one section and no empty "Softball" card.

## Test plan

- [x] `pnpm --filter api test` — 509 unit tests pass, including new `didBat()` truth-table cases
- [x] `pnpm --filter api test:integration` — 378 tests pass, including:
  - New softball sync test ingesting a synthetic Pairs match (modeled on the real response for match 7660052)
  - Career-stats partition tests: hardball-only, softball-only-with-net-average, no-data
- [x] `pnpm --filter web test` — 477 tests pass
- [x] Lint + typecheck clean across api/web/matchday/shared/db
- [x] `pnpm format:check` passes
- [x] Web bundle builds cleanly
- [ ] UI smoke test — not yet performed. The scorecard hasn't been visually inspected in a browser; please confirm rendering on https://www.percymain.org/calendar/game/7660052 once deployed (or pull the branch locally if you want to verify before merge)

## Verified data

- Real Play Cricket response for match 7660052 confirms `game_type: "Pairs"`, `starting_runs: "200"`, `dismissal_penalty: "5"`, per-batter `times_out`, and the formula `200 + 77 − 5×5 = 252` matches the screenshot's "Net Score 252".

🤖 Generated with [Claude Code](https://claude.com/claude-code)