### PR TITLE
fix(calendar): trim long outcome desc + preserve bbb param on direct game URL

### DIFF
--- a/apps/api/src/features/og-image/routes.ts
+++ b/apps/api/src/features/og-image/routes.ts
@@ -46,6 +46,16 @@ export const ogImageRoutes: FastifyPluginAsync = async (app) => {
   app.get("/og/game/:matchId/page", async (request, reply) => {
     const { matchId } = parseParams(request, ogImageParamsSchema);
 
+    // Capture any forwarded query params (e.g. ?bbb=1) so we can reflect
+    // them back in the bypass redirect URL. The CloudFront SPA rewrite
+    // strips the `og` param itself when forwarding; we drop it defensively.
+    const rawQuery = request.query as Record<string, unknown>;
+    const extraParams: Record<string, string> = {};
+    for (const [k, v] of Object.entries(rawQuery)) {
+      if (k === "og") continue;
+      if (typeof v === "string") extraParams[k] = v;
+    }
+
     const hasResult = await app.db
       .selectFrom("match_result")
       .where("match_id", "=", matchId)
@@ -53,13 +63,14 @@ export const ogImageRoutes: FastifyPluginAsync = async (app) => {
       .executeTakeFirst();
 
     const label = hasResult ? "Match Result" : "Fixture Details";
-    const title = `${label} — Percy Main Cricket & Sports Club`;
+    const title = `${label} - Percy Main Cricket & Sports Club`;
 
     const html = buildOgHtmlPage(
       config.BASE_URL,
       config.API_BASE_URL,
       matchId,
       title,
+      extraParams,
     );
 
     return await reply.header("Content-Type", "text/html").send(html);

--- a/apps/api/src/features/og-image/routes.ts
+++ b/apps/api/src/features/og-image/routes.ts
@@ -1,7 +1,7 @@
 import type { FastifyPluginAsync } from "fastify";
-import { parseParams } from "../../lib/validation.ts";
+import { parseParams, parseQuery } from "../../lib/validation.ts";
 import { createApiClient } from "../play-cricket/api-client.ts";
-import { ogImageParamsSchema } from "./schemas.ts";
+import { ogImageParamsSchema, ogPageQuerySchema } from "./schemas.ts";
 import { buildOgHtmlPage, generateOgImage } from "./service.ts";
 
 // eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
@@ -49,11 +49,11 @@ export const ogImageRoutes: FastifyPluginAsync = async (app) => {
     // Capture any forwarded query params (e.g. ?bbb=1) so we can reflect
     // them back in the bypass redirect URL. The CloudFront SPA rewrite
     // strips the `og` param itself when forwarding; we drop it defensively.
-    const rawQuery = request.query as Record<string, unknown>;
+    const query = parseQuery(request, ogPageQuerySchema);
     const extraParams: Record<string, string> = {};
-    for (const [k, v] of Object.entries(rawQuery)) {
+    for (const [k, v] of Object.entries(query)) {
       if (k === "og") continue;
-      if (typeof v === "string") extraParams[k] = v;
+      extraParams[k] = v;
     }
 
     const hasResult = await app.db

--- a/apps/api/src/features/og-image/schemas.ts
+++ b/apps/api/src/features/og-image/schemas.ts
@@ -3,3 +3,20 @@ import { z } from "zod";
 export const ogImageParamsSchema = z.object({
   matchId: z.string().regex(/^\d+$/).max(20),
 });
+
+// Permissive passthrough — the OG page reflects any non-`og` query params
+// back to the SPA via the bypass redirect. Values are coerced to strings;
+// non-string entries (e.g. arrays from repeated keys) are dropped rather
+// than rejected so a weird URL never breaks the OG meta-tag page.
+export const ogPageQuerySchema = z
+  .record(z.string(), z.unknown())
+  .default({})
+  .transform((q) => {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(q)) {
+      if (typeof v !== "string") continue;
+      if (k.length > 64 || v.length > 256) continue;
+      out[k] = v;
+    }
+    return out;
+  });

--- a/apps/api/src/features/og-image/service.test.ts
+++ b/apps/api/src/features/og-image/service.test.ts
@@ -265,4 +265,36 @@ describe("buildOgHtmlPage", () => {
 
     expect(html).toContain("Percy Main &amp; Friends &lt;test&gt;");
   });
+
+  it("appends extra query params to the bypass redirect URL", () => {
+    const html = buildOgHtmlPage(
+      "https://percymain.org",
+      "https://api.percymain.org",
+      "12345",
+      "Match",
+      { bbb: "1" },
+    );
+
+    expect(html).toContain(
+      'http-equiv="refresh" content="0;url=https://percymain.org/calendar/game/12345?og=1&amp;bbb=1"',
+    );
+    // canonical og:url should still not include the bypass or extras
+    expect(html).toContain(
+      'og:url" content="https://percymain.org/calendar/game/12345"',
+    );
+  });
+
+  it("drops the og key from extra params", () => {
+    const html = buildOgHtmlPage(
+      "https://percymain.org",
+      "https://api.percymain.org",
+      "12345",
+      "Match",
+      { og: "should-not-double-up", bbb: "1" },
+    );
+
+    expect(html).toContain(
+      'http-equiv="refresh" content="0;url=https://percymain.org/calendar/game/12345?og=1&amp;bbb=1"',
+    );
+  });
 });

--- a/apps/api/src/features/og-image/service.ts
+++ b/apps/api/src/features/og-image/service.ts
@@ -464,10 +464,17 @@ export function buildOgHtmlPage(
   apiBaseUrl: string,
   matchId: string,
   title: string,
+  extraParams?: Record<string, string>,
 ): string {
   const imageUrl = `${apiBaseUrl}/api/og/game/${encodeURIComponent(matchId)}`;
   const canonicalUrl = `${baseUrl}/calendar/game/${encodeURIComponent(matchId)}`;
-  const redirectUrl = `${canonicalUrl}?og=1`;
+  const extraQs = extraParams
+    ? Object.entries(extraParams)
+        .filter(([k]) => k !== "og")
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join("&")
+    : "";
+  const redirectUrl = `${canonicalUrl}?og=1${extraQs ? `&${extraQs}` : ""}`;
 
   return `<!DOCTYPE html>
 <html>

--- a/apps/web/src/components/outcome-badge.tsx
+++ b/apps/web/src/components/outcome-badge.tsx
@@ -20,6 +20,23 @@ const config: Record<
   N: { label: "N/R", bg: "bg-stone-100", text: "text-stone-500", icon: null },
 };
 
+// Play Cricket returns score descriptions like
+// "Tynemouth CC - Tynemouth Willows - Women's Softball - Won" for matches
+// without an innings-level score. The outcome word is already in the badge
+// above, so a description that ends in a bare outcome word is noise we
+// drop. Substantive descriptions ("Won by 50 runs") survive.
+function tidyScoreDescription(desc: string): string | null {
+  const trimmed = desc.trim();
+  if (!trimmed) return null;
+  const outcomeWord = /^(won|lost|drew|tied|abandoned|cancelled|no result)$/i;
+  if (outcomeWord.test(trimmed)) return null;
+  const lastSegment = trimmed.split(/\s+-\s+/).pop();
+  if (lastSegment && outcomeWord.test(lastSegment) && lastSegment !== trimmed) {
+    return null;
+  }
+  return trimmed;
+}
+
 export function OutcomeBadge({
   outcome,
   scoreDescription,
@@ -28,6 +45,7 @@ export function OutcomeBadge({
   scoreDescription?: string;
 }) {
   const c = config[outcome];
+  const tidy = scoreDescription ? tidyScoreDescription(scoreDescription) : null;
 
   return (
     <div className="flex shrink-0 flex-col items-end gap-1">
@@ -58,10 +76,8 @@ export function OutcomeBadge({
         )}
         {c.label}
       </span>
-      {scoreDescription && (
-        <span className="text-[11px] font-semibold text-stone-400">
-          {scoreDescription}
-        </span>
+      {tidy && (
+        <span className="text-[11px] font-semibold text-stone-400">{tidy}</span>
       )}
     </div>
   );

--- a/infra/modules/cdn/spa-rewrite.handler.js
+++ b/infra/modules/cdn/spa-rewrite.handler.js
@@ -44,12 +44,34 @@ export function createHandler(apiBaseUrl) {
       var gameMatch = uri.match(/^\/calendar\/game\/(\d+)$/);
       var bypass = qs && qs.og && qs.og.value === "1";
       if (gameMatch && !bypass) {
+        // Forward any non-`og` query params so the OG page can reflect them
+        // back in the bypass redirect. Without this, deep links like
+        // ?bbb=1 (open ball-by-ball modal) get dropped on the round-trip.
+        var forwarded = "";
+        if (qs) {
+          var parts = [];
+          for (var k in qs) {
+            if (k === "og") continue;
+            var entry = qs[k];
+            if (entry && typeof entry.value === "string") {
+              parts.push(
+                encodeURIComponent(k) + "=" + encodeURIComponent(entry.value),
+              );
+            }
+          }
+          if (parts.length) forwarded = "?" + parts.join("&");
+        }
         return {
           statusCode: 302,
           statusDescription: "Found",
           headers: {
             location: {
-              value: apiBaseUrl + "/api/og/game/" + gameMatch[1] + "/page",
+              value:
+                apiBaseUrl +
+                "/api/og/game/" +
+                gameMatch[1] +
+                "/page" +
+                forwarded,
             },
           },
         };

--- a/infra/modules/cdn/spa-rewrite.js
+++ b/infra/modules/cdn/spa-rewrite.js
@@ -40,12 +40,34 @@ function handler(event) {
     var gameMatch = uri.match(/^\/calendar\/game\/(\d+)$/);
     var bypass = qs && qs.og && qs.og.value === "1";
     if (gameMatch && !bypass) {
+      // Forward any non-`og` query params so the OG page can reflect them
+      // back in the bypass redirect. Without this, deep links like
+      // ?bbb=1 (open ball-by-ball modal) get dropped on the round-trip.
+      var forwarded = "";
+      if (qs) {
+        var parts = [];
+        for (var k in qs) {
+          if (k === "og") continue;
+          var entry = qs[k];
+          if (entry && typeof entry.value === "string") {
+            parts.push(
+              encodeURIComponent(k) + "=" + encodeURIComponent(entry.value),
+            );
+          }
+        }
+        if (parts.length) forwarded = "?" + parts.join("&");
+      }
       return {
         statusCode: 302,
         statusDescription: "Found",
         headers: {
           location: {
-            value: API_BASE_URL + "/api/og/game/" + gameMatch[1] + "/page",
+            value:
+              API_BASE_URL +
+              "/api/og/game/" +
+              gameMatch[1] +
+              "/page" +
+              forwarded,
           },
         },
       };

--- a/infra/modules/cdn/spa-rewrite.test.js
+++ b/infra/modules/cdn/spa-rewrite.test.js
@@ -65,13 +65,17 @@ describe("spa-rewrite CloudFront function", () => {
       );
     });
 
-    it("strips the og param when forwarding (defensive — only set on bypass)", () => {
+    it("strips the og param from forwarded query (only og=1 should round-trip via bypass)", () => {
       const result = handler(
         makeEvent("/calendar/game/12345", "www.percymain.org", {
+          og: { value: "0" },
           foo: { value: "bar" },
         }),
       );
       expect(result.statusCode).toBe(302);
+      // og must not appear in the forwarded URL — the OG page sets og=1
+      // itself on the bypass redirect, so re-forwarding would let a caller
+      // sneak a non-bypass og value into the SPA's URL bar.
       expect(result.headers.location.value).toBe(
         "https://api.v2.percymain.org/api/og/game/12345/page?foo=bar",
       );

--- a/infra/modules/cdn/spa-rewrite.test.js
+++ b/infra/modules/cdn/spa-rewrite.test.js
@@ -53,6 +53,41 @@ describe("spa-rewrite CloudFront function", () => {
       expect(result.statusCode).toBeUndefined();
     });
 
+    it("forwards non-og query params to the OG page", () => {
+      const result = handler(
+        makeEvent("/calendar/game/12345", "www.percymain.org", {
+          bbb: { value: "1" },
+        }),
+      );
+      expect(result.statusCode).toBe(302);
+      expect(result.headers.location.value).toBe(
+        "https://api.v2.percymain.org/api/og/game/12345/page?bbb=1",
+      );
+    });
+
+    it("strips the og param when forwarding (defensive — only set on bypass)", () => {
+      const result = handler(
+        makeEvent("/calendar/game/12345", "www.percymain.org", {
+          foo: { value: "bar" },
+        }),
+      );
+      expect(result.statusCode).toBe(302);
+      expect(result.headers.location.value).toBe(
+        "https://api.v2.percymain.org/api/og/game/12345/page?foo=bar",
+      );
+    });
+
+    it("URL-encodes forwarded query values", () => {
+      const result = handler(
+        makeEvent("/calendar/game/12345", "www.percymain.org", {
+          q: { value: "hello world & friends" },
+        }),
+      );
+      expect(result.headers.location.value).toBe(
+        "https://api.v2.percymain.org/api/og/game/12345/page?q=hello%20world%20%26%20friends",
+      );
+    });
+
     it("does not redirect non-game pages", () => {
       const result = handler(makeEvent("/about", "www.percymain.org"));
       expect(result.uri).toBe("/index.html");


### PR DESCRIPTION
## Summary

Two small calendar/game-detail fixes spotted in dogfooding.

- **Long opposition team name in WON/LOST area** — Play Cricket returns score descriptions like `"Tynemouth CC - Tynemouth Willows - Women's Softball - Won"` for matches without an innings-level score (women's softball, some midweek games). The outcome word is already shown by the badge above, so the noisy text wrapped onto / overlapped the badge. `OutcomeBadge` now drops descriptions whose last ` - ` segment is a bare outcome word ("Won" / "Lost" / "Drew" / "Tied" / "Abandoned" / "Cancelled" / "No result"). Substantive descriptions like `"Won by 50 runs"` are kept.

- **`?bbb=1` stripped on direct game URL** — going straight to `/calendar/game/:id?bbb=1` (deep link that opens the ball-by-ball modal) was losing the query string. Root cause: the OG redirect round-trip dropped query params at each hop.
  1. CF Function 302s `/calendar/game/:id` to `/api/og/game/:id/page` (location header had no query string)
  2. OG page meta-refreshes to `/calendar/game/:id?og=1` (no original params)
  3. SPA strips `og=1`, leaving nothing
  
  Now the CF function appends non-`og` query params to the redirect URL, the OG route reflects them back into the bypass URL, and the SPA's existing strip-`og` logic leaves the rest in place.

## Test plan

- [x] Unit tests added for CF function query-string forwarding (`infra/modules/cdn/spa-rewrite.test.js`)
- [x] Unit tests added for `buildOgHtmlPage` extraParams handling (`apps/api/.../service.test.ts`)
- [x] `pnpm typecheck` (api + web) and `pnpm lint` clean
- [ ] After deploy: hit `https://www.percymain.org/calendar/game/<id>?bbb=1` and confirm the ball-by-ball modal opens directly
- [ ] After deploy: spot-check a women's softball game tile and confirm the badge area no longer overflows

CF function update ships via Terraform on merge to main per usual CI flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)