### PR TITLE
feat(matchday): availability review screen + team news image download

### DIFF
--- a/apps/matchday/src/features/team-news-image.ts
+++ b/apps/matchday/src/features/team-news-image.ts
@@ -3,11 +3,15 @@ import { API_BASE } from "@/lib/api-client.js";
 /**
  * Fetch the server-generated team news PNG and hand it to the user.
  *
+ * Uses raw fetch (not the openapi-fetch typed client) because the
+ * endpoint returns binary PNG bytes - the typed client only handles
+ * application/json responses. Same pattern as the fantasy share button.
+ *
  * The backend route is officials-only; this helper assumes the caller
  * has already gated the affordance behind `canViewMatchdayAdmin`. On
- * mobile we try Web Share first (so it lands in the user's photo roll
- * / a chat) and fall back to a download anchor if share is unavailable
- * or the user cancels.
+ * mobile we try Web Share first; if the user cancels the share sheet
+ * we treat that as "done" (no download fallback). Only unsupported
+ * share or a real share failure falls through to a download anchor.
  */
 export async function shareOrDownloadTeamNewsImage(opts: {
   matchId: string;
@@ -21,14 +25,7 @@ export async function shareOrDownloadTeamNewsImage(opts: {
 
   const res = await fetch(url, { credentials: "include" });
   if (!res.ok) {
-    let detail = res.statusText;
-    try {
-      const body = (await res.json()) as { error?: string; message?: string };
-      detail = body.error ?? body.message ?? detail;
-    } catch {
-      // not JSON, keep the status text
-    }
-    throw new Error(detail || `HTTP ${res.status}`);
+    throw new Error(res.statusText || `HTTP ${res.status}`);
   }
   const blob = await res.blob();
   const filename = `team-news-${opts.matchId}.png`;
@@ -38,11 +35,20 @@ export async function shareOrDownloadTeamNewsImage(opts: {
     try {
       await navigator.share({ files: [file], title: "Team news" });
       return;
-    } catch {
-      // user cancelled or share failed - fall through to download
+    } catch (err) {
+      // User cancelled the share sheet: that's a deliberate "no" -
+      // not a signal to silently dump the file into Downloads. Only
+      // a non-abort failure should fall through to the download path.
+      if (err instanceof DOMException && err.name === "AbortError") {
+        return;
+      }
     }
   }
 
+  triggerDownload(blob, filename);
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
   const blobUrl = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = blobUrl;

--- a/apps/matchday/src/features/team-news-image.ts
+++ b/apps/matchday/src/features/team-news-image.ts
@@ -1,0 +1,54 @@
+import { API_BASE } from "@/lib/api-client.js";
+
+/**
+ * Fetch the server-generated team news PNG and hand it to the user.
+ *
+ * The backend route is officials-only; this helper assumes the caller
+ * has already gated the affordance behind `canViewMatchdayAdmin`. On
+ * mobile we try Web Share first (so it lands in the user's photo roll
+ * / a chat) and fall back to a download anchor if share is unavailable
+ * or the user cancels.
+ */
+export async function shareOrDownloadTeamNewsImage(opts: {
+  matchId: string;
+  isHome: boolean;
+  matchTime: string | null;
+}): Promise<void> {
+  const base = API_BASE.replace(/\/$/, "");
+  const params = new URLSearchParams({ isHome: String(opts.isHome) });
+  if (opts.matchTime) params.set("matchTime", opts.matchTime);
+  const url = `${base}/matchday/${encodeURIComponent(opts.matchId)}/team-news-image?${params.toString()}`;
+
+  const res = await fetch(url, { credentials: "include" });
+  if (!res.ok) {
+    let detail = res.statusText;
+    try {
+      const body = (await res.json()) as { error?: string; message?: string };
+      detail = body.error ?? body.message ?? detail;
+    } catch {
+      // not JSON, keep the status text
+    }
+    throw new Error(detail || `HTTP ${res.status}`);
+  }
+  const blob = await res.blob();
+  const filename = `team-news-${opts.matchId}.png`;
+  const file = new File([blob], filename, { type: "image/png" });
+
+  if (navigator.share && navigator.canShare?.({ files: [file] })) {
+    try {
+      await navigator.share({ files: [file], title: "Team news" });
+      return;
+    } catch {
+      // user cancelled or share failed - fall through to download
+    }
+  }
+
+  const blobUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = blobUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(blobUrl);
+}

--- a/apps/matchday/src/pages/availability-mine.tsx
+++ b/apps/matchday/src/pages/availability-mine.tsx
@@ -1,0 +1,274 @@
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardEyebrow,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { fmtDate } from "@/features/format.js";
+import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
+import { cn } from "@/lib/utils.js";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowRightIcon,
+  CheckIcon,
+  CircleAlertIcon,
+  CircleCheckIcon,
+  XIcon,
+} from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router";
+
+/**
+ * Review/edit your availability. Lists every open request and every date
+ * (answered or not) with the current vote and an inline change affordance.
+ * The step-by-step wizard at /availability/respond stays for fast-path
+ * first-time answering; this page is the persistent surface a player
+ * lands on when they want to remember or change what they said.
+ */
+
+type ActiveResponse = ApiResponse<"/api/availability/active">;
+type ActiveItem = ActiveResponse["items"][number];
+type Fixture = ActiveItem["fixtures"][number];
+type MyResponse = ActiveItem["myResponses"][number];
+
+export default function AvailabilityMine() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["availability", "active"],
+    queryFn: () => callApi(api.GET("/api/availability/active")),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto w-full max-w-2xl space-y-3 px-4 py-6">
+        <div className="bg-border h-6 w-1/3 rounded-md" />
+        <div className="bg-border h-32 rounded-2xl" />
+      </div>
+    );
+  }
+  if (isError) {
+    return (
+      <div className="mx-auto max-w-md px-6 py-12 text-center">
+        <h1 className="text-lg font-semibold">Couldn't load availability</h1>
+        <p className="text-text-secondary mt-2 text-sm">
+          Try again in a moment.
+        </p>
+        <Button asChild tone="outline" className="mt-4 inline-flex">
+          <Link to="/">Back to home</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const items = (data?.items ?? []).filter((i) => i.status === "open");
+  const unansweredCount = countUnanswered(items);
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-3 px-4 py-6">
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-xl font-semibold tracking-[-0.015em]">
+          Your availability
+        </h1>
+        {unansweredCount > 0 && (
+          <Button asChild tone="primary" size="sm">
+            <Link to="/availability/respond">
+              Answer {unansweredCount}
+              <ArrowRightIcon className="size-4" />
+            </Link>
+          </Button>
+        )}
+      </header>
+
+      {items.length === 0 && (
+        <Card>
+          <CardContent className="text-text-secondary py-8 text-center text-sm">
+            No open availability requests right now. We'll let you know.
+          </CardContent>
+        </Card>
+      )}
+
+      {items.map((req) => (
+        <RequestCard key={req.id} request={req} />
+      ))}
+    </div>
+  );
+}
+
+function countUnanswered(items: ActiveItem[]): number {
+  let n = 0;
+  for (const item of items) {
+    const answered = new Set(item.myResponses.map((r) => r.match_date));
+    const dates = new Set(item.fixtures.map((f) => f.match_date));
+    for (const d of dates) if (!answered.has(d)) n++;
+  }
+  return n;
+}
+
+function RequestCard({ request }: { request: ActiveItem }) {
+  const byDate = new Map<string, Fixture[]>();
+  for (const f of request.fixtures) {
+    const list = byDate.get(f.match_date) ?? [];
+    list.push(f);
+    byDate.set(f.match_date, list);
+  }
+  const dates = Array.from(byDate.keys()).sort();
+  const responseByDate = new Map<string, MyResponse>();
+  for (const r of request.myResponses) responseByDate.set(r.match_date, r);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardEyebrow icon={CircleCheckIcon}>
+          {fmtDate(request.date_from, "d MMM")}
+          {request.date_from !== request.date_to &&
+            ` - ${fmtDate(request.date_to, "d MMM")}`}
+        </CardEyebrow>
+        <CardTitle>
+          {dates.length} {dates.length === 1 ? "date" : "dates"}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {dates.map((date) => (
+          <DateRow
+            key={date}
+            requestId={request.id}
+            date={date}
+            fixtures={byDate.get(date) ?? []}
+            existing={responseByDate.get(date)}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DateRow({
+  requestId,
+  date,
+  fixtures,
+  existing,
+}: {
+  requestId: string;
+  date: string;
+  fixtures: Fixture[];
+  existing: MyResponse | undefined;
+}) {
+  const qc = useQueryClient();
+  const [pendingStatus, setPendingStatus] = useState<
+    "available" | "unavailable" | null
+  >(null);
+
+  const mutation = useMutation({
+    mutationFn: (status: "available" | "unavailable") =>
+      callApi(
+        api.POST("/api/availability/requests/{requestId}/respond", {
+          params: { path: { requestId } },
+          body: {
+            responses: [
+              {
+                matchDate: date,
+                status,
+                ...(existing?.note && { note: existing.note }),
+              },
+            ],
+          },
+        }),
+      ),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["availability"] });
+      setPendingStatus(null);
+    },
+    onError: () => {
+      setPendingStatus(null);
+    },
+  });
+
+  const current = existing?.status ?? null;
+
+  function choose(next: "available" | "unavailable") {
+    if (current === next || mutation.isPending) return;
+    setPendingStatus(next);
+    mutation.mutate(next);
+  }
+
+  return (
+    <div className="border-border bg-surface rounded-xl border p-3">
+      <div className="flex items-baseline justify-between">
+        <p className="text-sm font-semibold">{fmtDate(date, "EEEE d MMMM")}</p>
+        {current ? (
+          <span
+            className={cn(
+              "text-[11px] font-semibold tracking-[0.06em] uppercase",
+              current === "available" ? "text-success" : "text-danger",
+            )}
+          >
+            {current === "available" ? "Available" : "Unavailable"}
+          </span>
+        ) : (
+          <span className="text-warning text-[11px] font-semibold tracking-[0.06em] uppercase">
+            Not answered
+          </span>
+        )}
+      </div>
+      <div className="text-text-secondary mt-1 space-y-0.5">
+        {fixtures.map((f) => (
+          <p key={f.id} className="text-xs">
+            {[f.team_name, f.is_home ? "vs" : "@", f.opposition]
+              .filter(Boolean)
+              .join(" ")}
+            {f.competition_name && (
+              <span className="text-text-muted"> · {f.competition_name}</span>
+            )}
+            {f.match_time && (
+              <span className="text-text-muted"> · {f.match_time}</span>
+            )}
+          </p>
+        ))}
+      </div>
+      {existing?.note && (
+        <p className="text-text-secondary mt-1 text-xs italic">
+          "{existing.note}"
+        </p>
+      )}
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          disabled={mutation.isPending}
+          onClick={() => choose("available")}
+          className={cn(
+            "flex items-center justify-center gap-1.5 rounded-md border-2 px-3 py-2 text-sm font-semibold disabled:opacity-60",
+            current === "available"
+              ? "border-success/40 bg-success-bg text-success"
+              : "border-border bg-surface text-text-secondary hover:bg-surface-raised",
+          )}
+          aria-pressed={current === "available"}
+        >
+          <CheckIcon className="size-4" strokeWidth={2.4} />
+          {pendingStatus === "available" ? "Saving…" : "Available"}
+        </button>
+        <button
+          type="button"
+          disabled={mutation.isPending}
+          onClick={() => choose("unavailable")}
+          className={cn(
+            "flex items-center justify-center gap-1.5 rounded-md border-2 px-3 py-2 text-sm font-semibold disabled:opacity-60",
+            current === "unavailable"
+              ? "border-danger/40 bg-danger-bg text-danger"
+              : "border-border bg-surface text-text-secondary hover:bg-surface-raised",
+          )}
+          aria-pressed={current === "unavailable"}
+        >
+          <XIcon className="size-4" strokeWidth={2.4} />
+          {pendingStatus === "unavailable" ? "Saving…" : "Unavailable"}
+        </button>
+      </div>
+      {mutation.isError && (
+        <p className="text-danger mt-2 flex items-center gap-1.5 text-xs">
+          <CircleAlertIcon className="size-3.5" />
+          Couldn't save, try again.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/matchday/src/pages/home.tsx
+++ b/apps/matchday/src/pages/home.tsx
@@ -139,20 +139,57 @@ function AvailabilityAwaitingCard() {
   if (isLoading) return <CardSkeleton />;
   if (isError) return <CardError label="Couldn't load availability" />;
 
-  const count = countUnansweredDates(data);
-  // Quiet — don't take up real estate when there's nothing to do.
-  if (count === 0) return null;
+  const openItems = (data?.items ?? []).filter((i) => i.status === "open");
+  if (openItems.length === 0) return null;
+
+  const unanswered = countUnansweredDates(data);
+  // All answered: a quiet "review" card so players can find and change
+  // what they said. The "X to answer" prompt below handles the unanswered
+  // case with a primary CTA.
+  if (unanswered === 0) {
+    const answered = openItems.reduce(
+      (acc, i) => acc + i.myResponses.length,
+      0,
+    );
+    return (
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardEyebrow icon={CircleCheckIcon}>Availability</CardEyebrow>
+            <StatusPill tone="success" dot>
+              All answered
+            </StatusPill>
+          </div>
+          <CardTitle>
+            You've answered {answered} {answered === 1 ? "date" : "dates"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-text-secondary mb-3 text-sm">
+            Need to change one? Review or update your responses.
+          </p>
+          <Button asChild tone="outline" className="w-full">
+            <Link to="/availability">
+              Review your availability
+              <ArrowRightIcon className="size-4" />
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardEyebrow icon={CircleCheckIcon}>Availability</CardEyebrow>
           <StatusPill tone="warning" dot>
-            {count} to answer
+            {unanswered} to answer
           </StatusPill>
         </div>
         <CardTitle>
-          You've {count} {count === 1 ? "date" : "dates"} to confirm
+          You've {unanswered} {unanswered === 1 ? "date" : "dates"} to confirm
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -165,6 +202,12 @@ function AvailabilityAwaitingCard() {
             <ArrowRightIcon className="size-4" />
           </Link>
         </Button>
+        <Link
+          to="/availability"
+          className="text-text-secondary mt-2 block text-center text-xs underline"
+        >
+          Review what you've said
+        </Link>
       </CardContent>
     </Card>
   );

--- a/apps/matchday/src/pages/matchday-edit.tsx
+++ b/apps/matchday/src/pages/matchday-edit.tsx
@@ -4,6 +4,7 @@ import { CrownIcon, GloveIcon } from "@/features/icons/cricket-icons.js";
 import { shareOrDownloadTeamNewsImage } from "@/features/team-news-image.js";
 import { useDebouncedValue } from "@/hooks/use-debounced-value.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
+import { canViewMatchdayAdmin, useSession } from "@/lib/auth-client.js";
 import { cn } from "@/lib/utils.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -28,6 +29,8 @@ export default function MatchdayEdit() {
   const navigate = useNavigate();
   const qc = useQueryClient();
   const { matchdayId } = useParams();
+  const { data: session } = useSession();
+  const isOfficial = canViewMatchdayAdmin(session?.user);
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, 250);
   const [guestName, setGuestName] = useState("");
@@ -60,10 +63,17 @@ export default function MatchdayEdit() {
   const downloadImage = useMutation({
     mutationFn: () => {
       if (!matchdayId) throw new Error("Match id missing");
+      // `away` is nullable on the public projection (TBC fixtures), so
+      // a missing publicDetail.data here would silently flip the image
+      // to "away" - guard the mutation and let the disabled state
+      // below keep the user from triggering it before data lands.
+      if (!publicDetail.data) {
+        throw new Error("Match details not loaded yet");
+      }
       return shareOrDownloadTeamNewsImage({
         matchId: matchdayId,
-        isHome: publicDetail.data?.away === false,
-        matchTime: publicDetail.data?.startTime ?? null,
+        isHome: publicDetail.data.away === false,
+        matchTime: publicDetail.data.startTime,
       });
     },
   });
@@ -174,20 +184,22 @@ export default function MatchdayEdit() {
             {fmtDate(md.matchday.match_date, "EEE d MMM")} · pick squad
           </span>
         </div>
-        <button
-          type="button"
-          onClick={() => downloadImage.mutate()}
-          disabled={
-            downloadImage.isPending ||
-            players.length === 0 ||
-            publicDetail.isLoading
-          }
-          className="text-text-secondary hover:bg-surface-raised inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium disabled:opacity-50"
-          aria-label="Download team news image"
-        >
-          <ImageIcon className="size-4" />
-          {downloadImage.isPending ? "Preparing…" : "Team image"}
-        </button>
+        {isOfficial && (
+          <button
+            type="button"
+            onClick={() => downloadImage.mutate()}
+            disabled={
+              downloadImage.isPending ||
+              players.length === 0 ||
+              !publicDetail.data
+            }
+            className="text-text-secondary hover:bg-surface-raised inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium disabled:opacity-50"
+            aria-label="Download team news image"
+          >
+            <ImageIcon className="size-4" />
+            {downloadImage.isPending ? "Preparing…" : "Team image"}
+          </button>
+        )}
       </header>
       {downloadImage.isError && (
         <p className="text-danger px-4 pt-2 text-xs">

--- a/apps/matchday/src/pages/matchday-edit.tsx
+++ b/apps/matchday/src/pages/matchday-edit.tsx
@@ -1,11 +1,18 @@
 import { Button } from "@/components/ui/button.js";
 import { fmtDate } from "@/features/format.js";
 import { CrownIcon, GloveIcon } from "@/features/icons/cricket-icons.js";
+import { shareOrDownloadTeamNewsImage } from "@/features/team-news-image.js";
 import { useDebouncedValue } from "@/hooks/use-debounced-value.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
 import { cn } from "@/lib/utils.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeftIcon, SearchIcon, UserPlusIcon, XIcon } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  ImageIcon,
+  SearchIcon,
+  UserPlusIcon,
+  XIcon,
+} from "lucide-react";
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 
@@ -34,6 +41,31 @@ export default function MatchdayEdit() {
         }),
       ),
     enabled: !!matchdayId,
+  });
+
+  // Home/away + start time live on the public projection (sourced from
+  // play-cricket), not the official detail endpoint. Fetch it alongside
+  // so the team-news-image download has accurate query params.
+  const publicDetail = useQuery({
+    queryKey: ["matchday", matchdayId, "public"],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/matchday/{matchId}/public", {
+          params: { path: { matchId: matchdayId ?? "" } },
+        }),
+      ),
+    enabled: !!matchdayId,
+  });
+
+  const downloadImage = useMutation({
+    mutationFn: () => {
+      if (!matchdayId) throw new Error("Match id missing");
+      return shareOrDownloadTeamNewsImage({
+        matchId: matchdayId,
+        isHome: publicDetail.data?.away === false,
+        matchTime: publicDetail.data?.startTime ?? null,
+      });
+    },
   });
 
   const searchResults = useQuery({
@@ -134,15 +166,34 @@ export default function MatchdayEdit() {
         >
           <ArrowLeftIcon className="size-5" />
         </Link>
-        <div>
-          <strong className="block text-sm">
+        <div className="min-w-0 flex-1">
+          <strong className="block truncate text-sm">
             {md.team?.name ?? "Team"} vs {md.matchday.opposition}
           </strong>
           <span className="text-text-secondary text-[11px]">
             {fmtDate(md.matchday.match_date, "EEE d MMM")} · pick squad
           </span>
         </div>
+        <button
+          type="button"
+          onClick={() => downloadImage.mutate()}
+          disabled={
+            downloadImage.isPending ||
+            players.length === 0 ||
+            publicDetail.isLoading
+          }
+          className="text-text-secondary hover:bg-surface-raised inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium disabled:opacity-50"
+          aria-label="Download team news image"
+        >
+          <ImageIcon className="size-4" />
+          {downloadImage.isPending ? "Preparing…" : "Team image"}
+        </button>
       </header>
+      {downloadImage.isError && (
+        <p className="text-danger px-4 pt-2 text-xs">
+          Couldn't generate team image. Try again.
+        </p>
+      )}
 
       <section className="border-border bg-surface border-b p-3">
         <div className="bg-surface-raised flex items-center gap-2 rounded-xl px-3 py-2">

--- a/apps/matchday/src/pages/team-sheet.tsx
+++ b/apps/matchday/src/pages/team-sheet.tsx
@@ -2,11 +2,12 @@ import { StatusPill } from "@/components/primitives/status-pill.js";
 import { Button } from "@/components/ui/button.js";
 import { fmtDate } from "@/features/format.js";
 import { CrownIcon, GloveIcon } from "@/features/icons/cricket-icons.js";
+import { shareOrDownloadTeamNewsImage } from "@/features/team-news-image.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
-import { useSession } from "@/lib/auth-client.js";
+import { canViewMatchdayAdmin, useSession } from "@/lib/auth-client.js";
 import { cn } from "@/lib/utils.js";
-import { useQuery } from "@tanstack/react-query";
-import { ArrowLeftIcon, ShareIcon } from "lucide-react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { ArrowLeftIcon, ImageIcon, ShareIcon } from "lucide-react";
 import { useState } from "react";
 import { Link, useParams } from "react-router";
 
@@ -29,6 +30,7 @@ export default function TeamSheet() {
   const { matchdayId } = useParams();
   const { data: session } = useSession();
   const myUserId = session?.user.id;
+  const isOfficial = canViewMatchdayAdmin(session?.user);
   const {
     data: md,
     isLoading,
@@ -46,11 +48,29 @@ export default function TeamSheet() {
   const [showDropouts, setShowDropouts] = useState(false);
   const [copied, setCopied] = useState(false);
 
+  const downloadImage = useMutation({
+    mutationFn: () => {
+      if (!matchdayId || !md) {
+        throw new Error("Match details not loaded");
+      }
+      return shareOrDownloadTeamNewsImage({
+        matchId: matchdayId,
+        isHome: md.away === false,
+        matchTime: md.startTime,
+      });
+    },
+  });
+
   if (isLoading) return <Skel />;
   if (isError || !md) return <ErrState />;
 
   return (
     <div className="mx-auto w-full max-w-2xl pb-12">
+      {downloadImage.isError && (
+        <p className="text-danger px-4 pt-3 text-xs">
+          Couldn't generate team image. Try again.
+        </p>
+      )}
       <div className="flex items-center justify-between p-3">
         <Link
           to="/fixtures"
@@ -58,21 +78,35 @@ export default function TeamSheet() {
         >
           <ArrowLeftIcon className="size-4" /> Back
         </Link>
-        <button
-          type="button"
-          onClick={() => {
-            void navigator.clipboard.writeText(window.location.href);
-            setCopied(true);
-            setTimeout(() => {
-              setCopied(false);
-            }, 2200);
-          }}
-          className="text-text-secondary hover:bg-surface-raised inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium"
-          aria-label="Copy team-sheet link"
-        >
-          <ShareIcon className="size-4" />
-          {copied ? "Copied" : "Share"}
-        </button>
+        <div className="flex items-center gap-1">
+          {isOfficial && (
+            <button
+              type="button"
+              onClick={() => downloadImage.mutate()}
+              disabled={downloadImage.isPending}
+              className="text-text-secondary hover:bg-surface-raised inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium disabled:opacity-60"
+              aria-label="Download team news image"
+            >
+              <ImageIcon className="size-4" />
+              {downloadImage.isPending ? "Preparing…" : "Team image"}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              void navigator.clipboard.writeText(window.location.href);
+              setCopied(true);
+              setTimeout(() => {
+                setCopied(false);
+              }, 2200);
+            }}
+            className="text-text-secondary hover:bg-surface-raised inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium"
+            aria-label="Copy team-sheet link"
+          >
+            <ShareIcon className="size-4" />
+            {copied ? "Copied" : "Share"}
+          </button>
+        </div>
       </div>
       <header className="px-4 pb-3">
         <p className="text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase">

--- a/apps/matchday/src/router.tsx
+++ b/apps/matchday/src/router.tsx
@@ -21,6 +21,12 @@ const routes: RouteObject[] = [
             Component: lazyWithReload(() => import("./pages/me.js")),
           },
           {
+            path: "availability",
+            Component: lazyWithReload(
+              () => import("./pages/availability-mine.js"),
+            ),
+          },
+          {
             path: "availability/respond",
             Component: lazyWithReload(
               () => import("./pages/availability-respond.js"),


### PR DESCRIPTION
## Summary

Two minor matchday UX fixes.

**1. Players can now see and modify their previous availability response.** Previously, once you voted on every open date, the home card disappeared and `/availability/respond` told you you were "all caught up" - with no way to remember or change what you'd said.

- New `/availability` page lists every open availability request and every date with the current vote (Available / Unavailable / Not answered) and inline change buttons.
- The wizard at `/availability/respond` stays unchanged for fast-path first-time answering.
- Home dashboard's `AvailabilityAwaitingCard` now also surfaces an "All answered" state with a "Review your availability" link, so the affordance never vanishes while there are still open requests. The unanswered-state card also gets a quieter "Review what you've said" link.

**2. The Team news image download from v1 is back.** The API endpoint (`GET /api/matchday/:matchId/team-news-image`) already existed; just no UI surfaced it.

- New shared helper `shareOrDownloadTeamNewsImage` does Web Share on mobile with a download fallback.
- Officials get a Team image button on `team-sheet.tsx` (next to Share) and on `matchday-edit.tsx` (in the header). Matchday-edit was already officials-gated; team-sheet uses `canViewMatchdayAdmin` to hide the button from regular players.
- The button is disabled until the squad has at least one player and the public matchday detail (home/away + start time) has loaded.

## Test plan

- [ ] As a member: visit `/availability` before voting -> see "Not answered" pills and answer buttons.
- [ ] As a member: vote on a date via the wizard, then visit `/availability` -> see the vote reflected with the matching pill and pre-selected button.
- [ ] As a member: change a vote inline on `/availability` -> server-side response updates and the home card reflects the new state on refresh.
- [ ] As a member who has answered everything: home page shows "All answered" card with a Review link instead of disappearing.
- [ ] As an official on a confirmed matchday: click Team image on `team-sheet` -> PNG downloads / share sheet opens.
- [ ] As an official editing a squad: click Team image in header on `matchday-edit` -> PNG downloads / share sheet opens. Confirm disabled state when squad is empty.
- [ ] As a non-official member: confirm Team image button is NOT visible on `team-sheet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)