### PR TITLE
fix(matchday): availability flow tweaks + per-date available counts

### DIFF
--- a/apps/api/src/features/availability/schemas.ts
+++ b/apps/api/src/features/availability/schemas.ts
@@ -234,6 +234,11 @@ const myResponseSchema = z.object({
   note: z.string().nullable(),
 });
 
+const availableCountSchema = z.object({
+  match_date: z.string(),
+  count: z.number(),
+});
+
 export const getActiveRequestsResponseSchema = z.object({
   memberId: z.string().nullable(),
   items: z.array(
@@ -246,6 +251,7 @@ export const getActiveRequestsResponseSchema = z.object({
       created_at: z.string(),
       fixtures: z.array(activeFixtureSchema),
       myResponses: z.array(myResponseSchema),
+      availableCounts: z.array(availableCountSchema),
     }),
   ),
 });

--- a/apps/api/src/features/availability/service.ts
+++ b/apps/api/src/features/availability/service.ts
@@ -1006,12 +1006,18 @@ export function getActiveRequests(db: Kysely<DB>) {
         .execute();
     }
 
+    const today = new Date().toISOString().split("T")[0];
+    const activeFixtures = fixtures.filter((f) => f.match_date >= today);
+
     // Count "available" responses per (request, date) so the response
     // and review screens can show "N players are available so far".
+    // Scoped to today+ so we match the active-fixtures filter and don't
+    // ship counts for past dates the UI can't display.
     const availableRows = await db
       .selectFrom("availability_response")
       .where("availability_request_id", "in", requestIds)
       .where("status", "=", "available")
+      .where("match_date", ">=", today)
       .groupBy(["availability_request_id", "match_date"])
       .select([
         "availability_request_id",
@@ -1019,9 +1025,6 @@ export function getActiveRequests(db: Kysely<DB>) {
         db.fn.countAll<string>().as("count"),
       ])
       .execute();
-
-    const today = new Date().toISOString().split("T")[0];
-    const activeFixtures = fixtures.filter((f) => f.match_date >= today);
 
     const fixturesByRequest = new Map<string, typeof fixtures>();
     for (const f of activeFixtures) {

--- a/apps/api/src/features/availability/service.ts
+++ b/apps/api/src/features/availability/service.ts
@@ -1006,6 +1006,20 @@ export function getActiveRequests(db: Kysely<DB>) {
         .execute();
     }
 
+    // Count "available" responses per (request, date) so the response
+    // and review screens can show "N players are available so far".
+    const availableRows = await db
+      .selectFrom("availability_response")
+      .where("availability_request_id", "in", requestIds)
+      .where("status", "=", "available")
+      .groupBy(["availability_request_id", "match_date"])
+      .select([
+        "availability_request_id",
+        "match_date",
+        db.fn.countAll<string>().as("count"),
+      ])
+      .execute();
+
     const today = new Date().toISOString().split("T")[0];
     const activeFixtures = fixtures.filter((f) => f.match_date >= today);
 
@@ -1023,12 +1037,24 @@ export function getActiveRequests(db: Kysely<DB>) {
       responsesByRequest.set(r.availability_request_id, list);
     }
 
+    const availableCountsByRequest = new Map<
+      string,
+      Array<{ match_date: string; count: number }>
+    >();
+    for (const r of availableRows) {
+      const list =
+        availableCountsByRequest.get(r.availability_request_id) ?? [];
+      list.push({ match_date: r.match_date, count: Number(r.count) });
+      availableCountsByRequest.set(r.availability_request_id, list);
+    }
+
     return {
       memberId: member?.id ?? null,
       items: requests.map((r) => ({
         ...r,
         fixtures: fixturesByRequest.get(r.id) ?? [],
         myResponses: responsesByRequest.get(r.id) ?? [],
+        availableCounts: availableCountsByRequest.get(r.id) ?? [],
       })),
     };
   };

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -5942,6 +5942,10 @@ export interface paths {
                                     status: string;
                                     note: string | null;
                                 }[];
+                                availableCounts: {
+                                    match_date: string;
+                                    count: number;
+                                }[];
                             }[];
                         };
                     };

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -10490,6 +10490,25 @@
                               ],
                               "additionalProperties": false
                             }
+                          },
+                          "availableCounts": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "match_date": {
+                                  "type": "string"
+                                },
+                                "count": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "match_date",
+                                "count"
+                              ],
+                              "additionalProperties": false
+                            }
                           }
                         },
                         "required": [
@@ -10500,7 +10519,8 @@
                           "status",
                           "created_at",
                           "fixtures",
-                          "myResponses"
+                          "myResponses",
+                          "availableCounts"
                         ],
                         "additionalProperties": false
                       }

--- a/apps/matchday/src/pages/availability-mine.tsx
+++ b/apps/matchday/src/pages/availability-mine.tsx
@@ -32,6 +32,7 @@ type ActiveResponse = ApiResponse<"/api/availability/active">;
 type ActiveItem = ActiveResponse["items"][number];
 type Fixture = ActiveItem["fixtures"][number];
 type MyResponse = ActiveItem["myResponses"][number];
+type AvailableCount = ActiveItem["availableCounts"][number];
 
 export default function AvailabilityMine() {
   const { data, isLoading, isError } = useQuery({
@@ -115,6 +116,10 @@ function RequestCard({ request }: { request: ActiveItem }) {
   const dates = Array.from(byDate.keys()).sort();
   const responseByDate = new Map<string, MyResponse>();
   for (const r of request.myResponses) responseByDate.set(r.match_date, r);
+  const availableCountByDate = new Map<string, AvailableCount>();
+  for (const c of request.availableCounts) {
+    availableCountByDate.set(c.match_date, c);
+  }
 
   return (
     <Card>
@@ -136,6 +141,7 @@ function RequestCard({ request }: { request: ActiveItem }) {
             date={date}
             fixtures={byDate.get(date) ?? []}
             existing={responseByDate.get(date)}
+            availableCount={availableCountByDate.get(date)?.count ?? 0}
           />
         ))}
       </CardContent>
@@ -148,11 +154,13 @@ function DateRow({
   date,
   fixtures,
   existing,
+  availableCount,
 }: {
   requestId: string;
   date: string;
   fixtures: Fixture[];
   existing: MyResponse | undefined;
+  availableCount: number;
 }) {
   const qc = useQueryClient();
   const [pendingStatus, setPendingStatus] = useState<
@@ -231,6 +239,10 @@ function DateRow({
           "{existing.note}"
         </p>
       )}
+      <p className="text-text-secondary mt-2 text-xs">
+        {availableCount} {availableCount === 1 ? "player is" : "players are"}{" "}
+        available so far
+      </p>
       <div className="mt-3 grid grid-cols-2 gap-2">
         <button
           type="button"

--- a/apps/matchday/src/pages/availability-respond.tsx
+++ b/apps/matchday/src/pages/availability-respond.tsx
@@ -39,7 +39,7 @@ export default function AvailabilityRespond() {
     queryFn: () => callApi(api.GET("/api/availability/active")),
   });
 
-  const steps = useMemo<Step[]>(() => {
+  const computedSteps = useMemo<Step[]>(() => {
     if (!data) return [];
     const out: Step[] = [];
     for (const item of data.items) {
@@ -62,9 +62,39 @@ export default function AvailabilityRespond() {
     return out;
   }, [data]);
 
+  // Snapshot the unanswered step set once data first loads with at least
+  // one entry. We invalidate the availability query after each save so
+  // the home card stays fresh, but the refetch removes the just-answered
+  // date from `computedSteps` - without this snapshot the list shrinks
+  // under us and bounces the user to the "all done" screen after the
+  // first answer. (Setting state from render is the documented React
+  // pattern for "store info from previous renders"; the conditional
+  // makes it idempotent.)
+  const [snapshot, setSnapshot] = useState<Step[] | null>(null);
+  if (snapshot === null && computedSteps.length > 0) {
+    setSnapshot(computedSteps);
+  }
+  const flowSteps = snapshot ?? computedSteps;
+
+  // Available-so-far counts come back fresh on every refetch (we want
+  // these to update as other players answer), so they're keyed off the
+  // live `data` rather than the snapshotted `flowSteps`.
+  const availableCountByKey = useMemo<Map<string, number>>(() => {
+    const m = new Map<string, number>();
+    for (const item of data?.items ?? []) {
+      for (const c of item.availableCounts) {
+        m.set(`${item.id}:${c.match_date}`, c.count);
+      }
+    }
+    return m;
+  }, [data]);
+
   const [stepIndex, setStepIndex] = useState(0);
   const [note, setNote] = useState("");
-  const current = steps[stepIndex];
+  const current = flowSteps[stepIndex];
+  const currentAvailableCount = current
+    ? (availableCountByKey.get(`${current.requestId}:${current.date}`) ?? 0)
+    : 0;
 
   // Player-side endpoint — gated on requireAuth, accepts a batch of
   // { matchDate, status, note? } per request. Per-date PUT is the
@@ -103,27 +133,7 @@ export default function AvailabilityRespond() {
       ],
     });
     setNote("");
-    setStepIndex((prev) => Math.min(prev + 1, steps.length));
-  }
-
-  async function applyToAllRemaining(answer: "available" | "unavailable") {
-    // Batch by request so we make one POST per active request.
-    const remaining = steps.slice(stepIndex);
-    const byRequest = new Map<
-      string,
-      Array<{ matchDate: string; status: "available" | "unavailable" }>
-    >();
-    for (const s of remaining) {
-      const list = byRequest.get(s.requestId) ?? [];
-      list.push({ matchDate: s.date, status: answer });
-      byRequest.set(s.requestId, list);
-    }
-    await Promise.all(
-      Array.from(byRequest.entries()).map(([requestId, responses]) =>
-        respond.mutateAsync({ requestId, responses }),
-      ),
-    );
-    setStepIndex(steps.length);
+    setStepIndex((prev) => Math.min(prev + 1, flowSteps.length));
   }
 
   if (isLoading) {
@@ -152,7 +162,7 @@ export default function AvailabilityRespond() {
       </FlowFrame>
     );
   }
-  if (steps.length === 0) {
+  if (flowSteps.length === 0) {
     return (
       <FlowFrame>
         <EmptyDone
@@ -165,7 +175,7 @@ export default function AvailabilityRespond() {
       </FlowFrame>
     );
   }
-  if (stepIndex >= steps.length || !current) {
+  if (stepIndex >= flowSteps.length || !current) {
     return (
       <FlowFrame>
         <EmptyDone
@@ -180,7 +190,7 @@ export default function AvailabilityRespond() {
     );
   }
 
-  const total = steps.length;
+  const total = flowSteps.length;
   return (
     <FlowFrame>
       <header className="border-border flex items-center gap-3 border-b p-3">
@@ -195,7 +205,7 @@ export default function AvailabilityRespond() {
           <ArrowLeftIcon className="size-5" />
         </button>
         <div className="flex flex-1 gap-1.5">
-          {steps.map((s, i) => (
+          {flowSteps.map((s, i) => (
             <span
               key={`${s.requestId}:${s.date}`}
               className={cn(
@@ -257,6 +267,12 @@ export default function AvailabilityRespond() {
           ))}
         </div>
 
+        <p className="text-text-secondary mt-3 text-xs">
+          {currentAvailableCount}{" "}
+          {currentAvailableCount === 1 ? "player is" : "players are"} available
+          so far
+        </p>
+
         <div className="mt-6 grid grid-cols-2 gap-3">
           <button
             type="button"
@@ -297,29 +313,6 @@ export default function AvailabilityRespond() {
             className="placeholder:text-text-muted mt-1 w-full bg-transparent text-sm outline-none"
           />
         </div>
-
-        {steps.length - stepIndex > 1 && (
-          <div className="mt-6 flex flex-col items-center gap-1 text-center">
-            <button
-              type="button"
-              onClick={() => {
-                void applyToAllRemaining("available");
-              }}
-              className="text-text-secondary text-xs font-medium underline"
-            >
-              Apply Available to all {steps.length - stepIndex} remaining
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                void applyToAllRemaining("unavailable");
-              }}
-              className="text-text-secondary text-xs font-medium underline"
-            >
-              Apply Unavailable to all {steps.length - stepIndex} remaining
-            </button>
-          </div>
-        )}
 
         {respond.isError && (
           <p className="text-danger mt-4 flex items-center gap-1.5 text-sm">

--- a/apps/matchday/src/pages/home.tsx
+++ b/apps/matchday/src/pages/home.tsx
@@ -189,25 +189,20 @@ function AvailabilityAwaitingCard() {
           </StatusPill>
         </div>
         <CardTitle>
-          You've {unanswered} {unanswered === 1 ? "date" : "dates"} to confirm
+          {countWord(unanswered)} upcoming{" "}
+          {unanswered === 1 ? "matchday" : "matchdays"}
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="text-text-secondary mb-3 text-sm">
-          Manager picks the squad mid-week. Takes a minute.
-        </p>
         <Button asChild tone="primary" className="w-full">
           <Link to="/availability/respond">
             Answer availability
             <ArrowRightIcon className="size-4" />
           </Link>
         </Button>
-        <Link
-          to="/availability"
-          className="text-text-secondary mt-2 block text-center text-xs underline"
-        >
-          Review what you've said
-        </Link>
+        <Button asChild tone="outline" className="mt-2 w-full">
+          <Link to="/availability">Review what you've said</Link>
+        </Button>
       </CardContent>
     </Card>
   );
@@ -325,6 +320,22 @@ function PerfStat({ label, value }: { label: string; value: number }) {
       </div>
     </div>
   );
+}
+
+function countWord(n: number): string {
+  const words = [
+    "Zero",
+    "One",
+    "Two",
+    "Three",
+    "Four",
+    "Five",
+    "Six",
+    "Seven",
+    "Eight",
+    "Nine",
+  ];
+  return words[n] ?? String(n);
 }
 
 function countUnansweredDates(data: ActiveAvailability | undefined): number {

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -5942,6 +5942,10 @@ export interface paths {
                                     status: string;
                                     note: string | null;
                                 }[];
+                                availableCounts: {
+                                    match_date: string;
+                                    count: number;
+                                }[];
                             }[];
                         };
                     };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -10490,6 +10490,25 @@
                               ],
                               "additionalProperties": false
                             }
+                          },
+                          "availableCounts": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "match_date": {
+                                  "type": "string"
+                                },
+                                "count": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "match_date",
+                                "count"
+                              ],
+                              "additionalProperties": false
+                            }
                           }
                         },
                         "required": [
@@ -10500,7 +10519,8 @@
                           "status",
                           "created_at",
                           "fixtures",
-                          "myResponses"
+                          "myResponses",
+                          "availableCounts"
                         ],
                         "additionalProperties": false
                       }


### PR DESCRIPTION
## Summary

- **/availability/respond bounce fix**: snapshot the unanswered step list on first data load so the post-save refetch doesn't shrink the array under us and skip the user to the All Done screen after the first answer.
- **Copy/layout tweaks**: drop the "Manager picks the squad mid-week" subtitle and the "Apply Available/Unavailable to all N remaining" shortcuts; promote the "Review what you've said" link to an outline button below the primary CTA; reword the card title to "N upcoming matchday(s)".
- **Per-date available counts**: new `availableCounts` field on `/api/availability/active` (`{ match_date, count }[]` per request, status=available only). Surfaces as "N players are available so far" on the response flow (current step) and the review page (each date row).

## Test plan

- [ ] Open /availability/respond with two unanswered dates, answer the first → second date is shown next, not "All done"
- [ ] Home card no longer shows "Manager picks the squad" copy and "Review what you've said" is a button
- [ ] Apply-to-all shortcuts no longer rendered
- [ ] /availability and /availability/respond both show a "N players are available so far" line that matches the actual response counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)