### PR TITLE
fix(matchday): decouple donation requests from match wrap-up

### DIFF
--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -21,6 +21,7 @@ import {
   listTeams,
   markExpenseReimbursed,
   markFeePaid,
+  notifyMatchCharges,
   recordExpense,
   rejectExpense,
   removePlayer,
@@ -45,18 +46,34 @@ async function finishAsTest(
     resultType?: "W" | "L" | "D" | "T" | "A" | "C" | "N";
   } = {},
 ) {
+  return finishMatch(ctx.db)(userId, "admin", matchdayId, {
+    resultType: data.resultType ?? "W",
+    playerStatuses: data.playerStatuses ?? [],
+    feeOverrides: data.feeOverrides ?? [],
+  });
+}
+
+// Fire the donation-request batch the way the route does, after the
+// match has been wrapped up.
+async function notifyAsTest(
+  matchdayId: string,
+  userId: string,
+  deps: {
+    sendEmail?: (e: {
+      to: string;
+      subject: string;
+      html: string;
+    }) => Promise<void>;
+    sendPush?: SendPush;
+  } = {},
+) {
   const { createNoopLogger } = await import("../../lib/worker-logger.ts");
-  return finishMatch(ctx.db, noopSendEmail, noopSendPush, testConfig)(
-    userId,
-    "admin",
-    matchdayId,
-    {
-      resultType: data.resultType ?? "W",
-      playerStatuses: data.playerStatuses ?? [],
-      feeOverrides: data.feeOverrides ?? [],
-    },
-    createNoopLogger(),
-  );
+  return notifyMatchCharges(
+    ctx.db,
+    deps.sendEmail ?? noopSendEmail,
+    deps.sendPush ?? noopSendPush,
+    testConfig,
+  )(userId, "admin", matchdayId, createNoopLogger());
 }
 
 const s3 = noopS3Uploader;
@@ -702,23 +719,18 @@ describe("matchday service (integration)", () => {
         return Promise.resolve();
       };
 
-      const { createNoopLogger } = await import("../../lib/worker-logger.ts");
-      const result = await finishMatch(
-        ctx.db,
-        recordingSendEmail,
-        recordingSendPush,
-        testConfig,
-      )(
-        adminId,
-        "admin",
-        matchdayId,
-        {
-          resultType: "W",
-          playerStatuses: [{ matchdayPlayerId: playerId, status: "playing" }],
-          feeOverrides: [],
-        },
-        createNoopLogger(),
-      );
+      // Wrapping up only creates the charge - no notifications yet.
+      await finishAsTest(matchdayId, adminId, {
+        playerStatuses: [{ matchdayPlayerId: playerId, status: "playing" }],
+      });
+      expect(pushCalls).toHaveLength(0);
+      expect(emailCalls).toHaveLength(0);
+
+      // The captain then sends the donation-request batch.
+      const result = await notifyAsTest(matchdayId, adminId, {
+        sendEmail: recordingSendEmail,
+        sendPush: recordingSendPush,
+      });
 
       expect(result.success).toBe(true);
       expect(result.emailsSent).toBe(1);
@@ -734,6 +746,83 @@ describe("matchday service (integration)", () => {
       expect(payload.title).toBeTruthy();
       expect(payload.body).toContain("£5.00");
       expect(payload.tag.startsWith("charge:")).toBe(true);
+
+      // One-shot: a second batch is refused.
+      await expect(notifyAsTest(matchdayId, adminId)).rejects.toThrow(
+        "Donation requests have already been sent",
+      );
+    });
+
+    it("skips players marked paid before the donation batch is sent", async () => {
+      const { userId: adminId } = await seedTestUser(ctx.db, {
+        email: `notify-admin-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+        withMember: false,
+      });
+      const paidEmail = `paid-${crypto.randomUUID()}@test.com`;
+      const unpaidEmail = `unpaid-${crypto.randomUUID()}@test.com`;
+      const paidMemberId = await seedMember("Paid Player", paidEmail, "senior");
+      const unpaidMemberId = await seedMember(
+        "Unpaid Player",
+        unpaidEmail,
+        "senior",
+      );
+
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: adminId });
+      await seedFeeRate({ teamId, memberCategory: "senior", amountPence: 500 });
+
+      const { id: paidPlayerId } = await addPlayer(ctx.db)(
+        adminId,
+        "admin",
+        matchdayId,
+        { memberId: paidMemberId, playerName: "Paid Player" },
+      );
+      const { id: unpaidPlayerId } = await addPlayer(ctx.db)(
+        adminId,
+        "admin",
+        matchdayId,
+        { memberId: unpaidMemberId, playerName: "Unpaid Player" },
+      );
+
+      await finishAsTest(matchdayId, adminId, {
+        playerStatuses: [
+          { matchdayPlayerId: paidPlayerId, status: "playing" },
+          { matchdayPlayerId: unpaidPlayerId, status: "playing" },
+        ],
+      });
+
+      // Captain collects cash from one player on the day, before notifying.
+      await markFeePaid(ctx.db)(adminId, "admin", matchdayId, paidPlayerId, {
+        paymentMethod: "cash",
+      });
+
+      const emailCalls: Array<{ to: string }> = [];
+      const result = await notifyAsTest(matchdayId, adminId, {
+        sendEmail: (e) => {
+          emailCalls.push({ to: e.to });
+          return Promise.resolve();
+        },
+      });
+
+      // Only the still-unpaid player is emailed.
+      expect(result.emailsSent).toBe(1);
+      expect(emailCalls).toHaveLength(1);
+      expect(emailCalls[0]?.to).toBe(unpaidEmail);
+    });
+
+    it("refuses to notify before the match is wrapped up", async () => {
+      const { userId: adminId } = await seedTestUser(ctx.db, {
+        email: `early-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+        withMember: false,
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: adminId });
+
+      await expect(notifyAsTest(matchdayId, adminId)).rejects.toThrow(
+        "Wrap up the match before sending donation requests",
+      );
     });
 
     it("raises a junior-rate charge against the parent when a dependent plays", async () => {

--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -825,6 +825,51 @@ describe("matchday service (integration)", () => {
       );
     });
 
+    it("only one of two concurrent notify calls delivers the batch", async () => {
+      const { userId: adminId } = await seedTestUser(ctx.db, {
+        email: `race-admin-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+        withMember: false,
+      });
+      const playerEmail = `race-player-${crypto.randomUUID()}@test.com`;
+      const memberId = await seedMember("Race Player", playerEmail, "senior");
+
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: adminId });
+      await seedFeeRate({ teamId, memberCategory: "senior", amountPence: 500 });
+
+      const { id: playerId } = await addPlayer(ctx.db)(
+        adminId,
+        "admin",
+        matchdayId,
+        { memberId, playerName: "Race Player" },
+      );
+      await finishAsTest(matchdayId, adminId, {
+        playerStatuses: [{ matchdayPlayerId: playerId, status: "playing" }],
+      });
+
+      const emailCalls: Array<{ to: string }> = [];
+      const recordingSendEmail = (e: { to: string }) => {
+        emailCalls.push({ to: e.to });
+        return Promise.resolve();
+      };
+
+      // Fire both at once. The up-front conditional claim serialises them:
+      // exactly one stamps the row and delivers, the other updates zero
+      // rows and rejects - so the player is emailed once, not twice.
+      const settled = await Promise.allSettled([
+        notifyAsTest(matchdayId, adminId, { sendEmail: recordingSendEmail }),
+        notifyAsTest(matchdayId, adminId, { sendEmail: recordingSendEmail }),
+      ]);
+
+      const fulfilled = settled.filter((s) => s.status === "fulfilled");
+      const rejected = settled.filter((s) => s.status === "rejected");
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect(emailCalls).toHaveLength(1);
+      expect(emailCalls[0]?.to).toBe(playerEmail);
+    });
+
     it("raises a junior-rate charge against the parent when a dependent plays", async () => {
       const { userId } = await seedTestUser(ctx.db, {
         email: `junior-fee-${crypto.randomUUID()}@test.com`,

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -25,6 +25,7 @@ import {
   matchIdParamSchema,
   myRecentPerformanceResponseSchema,
   myUpcomingMatchesResponseSchema,
+  notifyChargesResponseSchema,
   pastUnfinishedMatchdaysResponseSchema,
   playerIdParamSchema,
   publicMatchdayResponseSchema,
@@ -62,6 +63,7 @@ import {
   listTeams,
   markExpenseReimbursed,
   markFeePaid,
+  notifyMatchCharges,
   recordExpense,
   rejectExpense,
   removePlayer,
@@ -383,7 +385,8 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
   const removeP = removePlayer(app.db);
   const setRoles = setMatchRoles(app.db);
   const paid = markFeePaid(app.db);
-  const finish = finishMatch(app.db, app.send, app.sendPush, app.config);
+  const finish = finishMatch(app.db);
+  const notify = notifyMatchCharges(app.db, app.send, app.sendPush, app.config);
   const cancel = cancelMatchday(app.db);
 
   // Play-Cricket API client for upcoming matches — wired at registration time
@@ -589,13 +592,23 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       const { user } = getAuthSession(request);
       const role = (user as { role?: string | null }).role ?? "user";
-      return await finish(
-        user.id,
-        role,
-        request.params.matchId,
-        request.body,
-        request.log,
-      );
+      return await finish(user.id, role, request.params.matchId, request.body);
+    },
+  );
+
+  app.post(
+    "/matchday/:matchId/notify-charges",
+    {
+      preHandler: [adminRole],
+      schema: {
+        params: matchIdParamSchema,
+        response: { 200: notifyChargesResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      const role = (user as { role?: string | null }).role ?? "user";
+      return await notify(user.id, role, request.params.matchId, request.log);
     },
   );
 

--- a/apps/api/src/features/matchday/schemas.ts
+++ b/apps/api/src/features/matchday/schemas.ts
@@ -182,6 +182,11 @@ const matchdayItemSchema = z.object({
   cancelled_at: z.string().nullable(),
   cancelled_by: z.string().nullable(),
   cancelled_reason: z.string().nullable(),
+  // Null until the captain sends the donation-request batch. Lets the
+  // wrap-up UI show an unpaid count and a "Send donation requests" CTA
+  // before notifying, and switch to a "sent" state afterwards.
+  charges_notified_at: z.string().nullable(),
+  charges_notified_by: z.string().nullable(),
 });
 
 export const listMatchesResponseSchema = z.object({
@@ -382,7 +387,16 @@ export const addPlayerResponseSchema = z.object({
   id: z.string(),
 });
 
+// Wrapping up a match only creates the match-fee charges now - the
+// donation-request emails/pushes go out via a separate notify step. So
+// the response reports how many charges were raised, not how many
+// emails were sent.
 export const finishMatchResponseSchema = z.object({
+  success: z.boolean(),
+  chargesCreated: z.number(),
+});
+
+export const notifyChargesResponseSchema = z.object({
   success: z.boolean(),
   emailsSent: z.number(),
   emailErrors: z.array(z.string()),

--- a/apps/api/src/features/matchday/service.test.ts
+++ b/apps/api/src/features/matchday/service.test.ts
@@ -37,7 +37,6 @@ const { mockExecute, mockExecuteTakeFirst, mockQueryBuilder } = vi.hoisted(
 );
 
 import { noopS3Uploader } from "../../lib/s3-upload.ts";
-import { createNoopLogger } from "../../lib/worker-logger.ts";
 import {
   addPlayer,
   approveExpense,
@@ -53,8 +52,6 @@ import {
   searchMembers,
   submitExpenseClaim,
 } from "./service.ts";
-
-const log = createNoopLogger();
 
 const db = mockQueryBuilder as unknown as Kysely<DB>;
 const s3 = noopS3Uploader;
@@ -403,26 +400,17 @@ describe("expense approval workflow", () => {
   });
 
   describe("finishMatch", () => {
-    const mockSendEmail = vi.fn().mockResolvedValue(undefined);
-    const mockSendPush = vi
-      .fn()
-      .mockImplementation((sub: { endpoint: string }) =>
-        Promise.resolve({ ok: true, endpoint: sub.endpoint }),
-      );
-    const mockConfig = { BASE_URL: "https://example.com" };
-    const finish = finishMatch(db, mockSendEmail, mockSendPush, mockConfig);
+    const finish = finishMatch(db);
 
     it("rejects if matchday not found", async () => {
       mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
 
       await expect(
-        finish(
-          "user-1",
-          "admin",
-          "match-1",
-          { resultType: "W", playerStatuses: [], feeOverrides: [] },
-          log,
-        ),
+        finish("user-1", "admin", "match-1", {
+          resultType: "W",
+          playerStatuses: [],
+          feeOverrides: [],
+        }),
       ).rejects.toThrow("Matchday not found");
     });
 
@@ -436,13 +424,11 @@ describe("expense approval workflow", () => {
       mockExecute.mockResolvedValueOnce([{ id: "team-1" }]);
 
       await expect(
-        finish(
-          "user-1",
-          "admin",
-          "match-1",
-          { resultType: "W", playerStatuses: [], feeOverrides: [] },
-          log,
-        ),
+        finish("user-1", "admin", "match-1", {
+          resultType: "W",
+          playerStatuses: [],
+          feeOverrides: [],
+        }),
       ).rejects.toThrow("Cannot finish a cancelled matchday");
     });
 
@@ -456,13 +442,11 @@ describe("expense approval workflow", () => {
       mockExecute.mockResolvedValueOnce([]);
 
       await expect(
-        finish(
-          "user-1",
-          "admin",
-          "match-1",
-          { resultType: "W", playerStatuses: [], feeOverrides: [] },
-          log,
-        ),
+        finish("user-1", "admin", "match-1", {
+          resultType: "W",
+          playerStatuses: [],
+          feeOverrides: [],
+        }),
       ).rejects.toThrow("You do not have access to this matchday");
     });
 
@@ -490,22 +474,16 @@ describe("expense approval workflow", () => {
       mockExecute.mockResolvedValueOnce([]);
       // uncharged players query
       mockExecute.mockResolvedValueOnce([]);
-      // unpaid players query
-      mockExecute.mockResolvedValueOnce([]);
 
-      const result = await finish(
-        "user-1",
-        "admin",
-        "match-1",
-        {
-          resultType: "W",
-          playerStatuses: [],
-          feeOverrides: [],
-        },
-        log,
-      );
+      const result = await finish("user-1", "admin", "match-1", {
+        resultType: "W",
+        playerStatuses: [],
+        feeOverrides: [],
+      });
 
       expect(result.success).toBe(true);
+      // No uncharged players seeded, so no charges are raised.
+      expect(result.chargesCreated).toBe(0);
       expect(mockQueryBuilder.set).toHaveBeenCalledWith(
         expect.objectContaining({
           status: "finished",
@@ -530,20 +508,15 @@ describe("expense approval workflow", () => {
       // update matchday
       mockExecute.mockResolvedValueOnce([]);
 
-      const result = await finish(
-        "user-1",
-        "admin",
-        "match-1",
-        {
-          resultType: "L",
-          playerStatuses: [],
-          feeOverrides: [],
-        },
-        log,
-      );
+      const result = await finish("user-1", "admin", "match-1", {
+        resultType: "L",
+        playerStatuses: [],
+        feeOverrides: [],
+      });
 
       expect(result.success).toBe(true);
-      expect(result.emailsSent).toBe(0);
+      // Re-submission never re-creates charges.
+      expect(result.chargesCreated).toBe(0);
       // Should preserve original finished_at/finished_by
       expect(mockQueryBuilder.set).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -1708,8 +1708,32 @@ export function notifyMatchCharges(
     }
 
     // One-shot: a captain can only fire the batch once. Re-sends would
-    // re-nag players who've since paid, so we block them outright.
+    // re-nag players who've since paid. Cheap fast-path so the common
+    // re-tap returns a clear error without touching the DB again - but
+    // the authoritative guard is the conditional claim below.
     if (matchday.charges_notified_at) {
+      throwHttpError(400, "Donation requests have already been sent");
+    }
+
+    // Claim the batch atomically BEFORE sending anything: stamp the row
+    // only while charges_notified_at is still null. Two captains tapping
+    // "send" at once would both pass the read-side check above, so the
+    // conditional UPDATE is what actually serialises them - the loser
+    // updates zero rows and bails before delivering a duplicate blast.
+    // Claiming up-front (rather than after the send) means a crash
+    // mid-delivery leaves the match marked notified, which is the right
+    // call for a one-shot: better a few undelivered than a re-blast.
+    const claim = await db
+      .updateTable("matchday")
+      .set({
+        charges_notified_at: new Date().toISOString(),
+        charges_notified_by: userId,
+      })
+      .where("id", "=", matchdayId)
+      .where("status", "=", "finished")
+      .where("charges_notified_at", "is", null)
+      .executeTakeFirst();
+    if (claim.numUpdatedRows === 0n) {
       throwHttpError(400, "Donation requests have already been sent");
     }
 
@@ -1915,19 +1939,11 @@ export function notifyMatchCharges(
       }
     }
 
-    // Stamp the matchday as notified even if some deliveries failed - the
-    // batch is one-shot, and failed addresses are chased via the charges
-    // admin (emailErrors is surfaced to the captain so they know).
-    await db
-      .updateTable("matchday")
-      .set({
-        charges_notified_at: new Date().toISOString(),
-        charges_notified_by: userId,
-      })
-      .where("id", "=", matchdayId)
-      .where("charges_notified_at", "is", null)
-      .execute();
-
+    // The matchday was already stamped notified by the up-front claim, so
+    // there's nothing more to persist here. Partial delivery failures stay
+    // recorded as notified (the batch is one-shot) and are surfaced to the
+    // captain via emailErrors; failed addresses are chased via the charges
+    // admin rather than a re-send.
     return { success: true, emailsSent, emailErrors };
   };
 }

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -1338,25 +1338,12 @@ export function cancelMatchday(db: Kysely<DB>) {
   };
 }
 
-export function finishMatch(
-  db: Kysely<DB>,
-  sendEmail: (email: {
-    to: string;
-    subject: string;
-    html: string;
-  }) => Promise<void>,
-  sendPush: SendPush,
-  config: { BASE_URL: string; MATCHDAY_URL?: string },
-) {
-  const fetchPrefs = getNotificationPreferencesByUserIds(db);
-  const fetchPushSubs = listPushSubscriptionsForUsers(db);
-  const pruneSubscription = deletePushSubscriptionByEndpoint(db);
+export function finishMatch(db: Kysely<DB>) {
   return async (
     userId: string,
     role: string,
     matchdayId: string,
     data: FinishMatch,
-    log: FastifyBaseLogger,
   ) => {
     const matchday = await db
       .selectFrom("matchday")
@@ -1490,6 +1477,7 @@ export function finishMatch(
     // failure would leave the matchday flagged "finished" with the
     // first-finish branch (charges, draft expense submission) skipped
     // forever on retry.
+    let chargesCreated = 0;
     await db.transaction().execute(async (trx) => {
       for (const { matchdayPlayerId, status } of playerStatuses) {
         await trx
@@ -1655,218 +1643,292 @@ export function finishMatch(
           type: "match_fee",
           chargeDate: matchday.match_date,
         });
+        chargesCreated++;
       }
     });
 
-    if (isFirstFinish) {
-      // Send notifications AFTER the transaction commits so a delivery
-      // hiccup can't roll back the charges. Join `member` via
-      // `charge.member_id` (not `matchday_player.member_id`) so junior
-      // donations - which sit on the parent's member row - also get a
-      // notification.
-      const unpaidPlayers = await db
-        .selectFrom("matchday_player")
-        .innerJoin("charge", "charge.id", "matchday_player.charge_id")
-        .innerJoin("member", "member.id", "charge.member_id")
-        .where("matchday_player.matchday_id", "=", matchdayId)
-        .where("charge.paid_at", "is", null)
-        .where("charge.deleted_at", "is", null)
-        // Don't nag members about charges the club has waived.
-        .where("charge.relieved_at", "is", null)
-        .select([
-          "charge.id as charge_id",
-          "member.name as member_name",
-          "member.email as member_email",
-          "charge.description as charge_description",
-          "charge.amount_pence",
-          "charge.charge_date",
-        ])
-        .execute();
+    // Notifications are no longer sent here. Wrapping up only creates the
+    // charges; the captain sends the donation-request batch separately
+    // (notifyMatchCharges) once they've marked off anyone who paid cash /
+    // bank transfer at the ground. On a result re-submission isFirstFinish
+    // is false, so chargesCreated stays 0.
+    return { success: true, chargesCreated };
+  };
+}
 
-      const currencyFormatter = new Intl.NumberFormat("en-GB", {
-        style: "currency",
-        currency: "GBP",
-      });
+/**
+ * Send the match-fee donation-request batch for a finished matchday.
+ *
+ * Split out from finishMatch (amendments §5 follow-up): a captain wraps
+ * up the match, marks off whoever paid on the day, *then* notifies only
+ * the players still owing. One-shot - once `charges_notified_at` is set
+ * the endpoint refuses to re-send, so a player marked paid after the
+ * batch is never re-nagged and late squad additions are handled via the
+ * charges admin rather than a second blast.
+ *
+ * Join `member` via `charge.member_id` (not `matchday_player.member_id`)
+ * so junior donations - which sit on the parent's member row - also get
+ * a notification. Only unpaid, non-deleted, non-relieved charges are
+ * included.
+ */
+export function notifyMatchCharges(
+  db: Kysely<DB>,
+  sendEmail: (email: {
+    to: string;
+    subject: string;
+    html: string;
+  }) => Promise<void>,
+  sendPush: SendPush,
+  config: { BASE_URL: string; MATCHDAY_URL?: string },
+) {
+  const fetchPrefs = getNotificationPreferencesByUserIds(db);
+  const fetchPushSubs = listPushSubscriptionsForUsers(db);
+  const pruneSubscription = deletePushSubscriptionByEndpoint(db);
+  return async (
+    userId: string,
+    role: string,
+    matchdayId: string,
+    log: FastifyBaseLogger,
+  ) => {
+    const matchday = await db
+      .selectFrom("matchday")
+      .where("id", "=", matchdayId)
+      .select(["id", "status", "play_cricket_team_id", "charges_notified_at"])
+      .executeTakeFirst();
 
-      const { render } = await import("react-email");
-      const { ChargeNotification } = await import("@percy-main/email");
+    if (!matchday) throwHttpError(404, "Matchday not found");
 
-      // Resolve user ids so we can apply each recipient's matchday_channel
-      // preference. Member rows whose email doesn't match a user (legacy
-      // members who never registered) get email-only delivery, matching
-      // pre-push behavior.
-      const recipientEmails = unpaidPlayers
-        .map((p) => p.member_email?.toLowerCase())
-        .filter((e): e is string => Boolean(e));
-
-      const userRows =
-        recipientEmails.length > 0
-          ? await db
-              .selectFrom("user")
-              .where("email", "in", recipientEmails)
-              .select(["id", "email"])
-              .execute()
-          : [];
-      const userIdByEmail = new Map<string, string>();
-      for (const u of userRows) {
-        userIdByEmail.set(u.email.toLowerCase(), u.id);
-      }
-      const userIds = userRows.map((u) => u.id);
-
-      const [prefs, pushSubsByUser] = await Promise.all([
-        fetchPrefs(userIds),
-        fetchPushSubs(userIds),
-      ]);
-
-      let emailsSent = 0;
-      const emailErrors: string[] = [];
-
-      const sendOneEmail = async (
-        player: (typeof unpaidPlayers)[number],
-        amountFormatted: string,
-      ): Promise<{ ok: true } | { ok: false; reason: string }> => {
-        try {
-          const element = ChargeNotification.component({
-            imageBaseUrl: `${config.BASE_URL}/images`,
-            name: player.member_name ?? "Member",
-            description: player.charge_description,
-            amount: amountFormatted,
-            chargeDate: formatDate(new Date(player.charge_date), "dd/MM/yyyy"),
-            loginUrl: `${config.BASE_URL}/auth/login`,
-          });
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-          const html = await render(element as any);
-          await sendEmail({
-            to: player.member_email ?? "",
-            subject: ChargeNotification.subject,
-            html,
-          });
-          return { ok: true };
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          log.error(
-            {
-              err,
-              recipientEmail: player.member_email,
-              matchdayId,
-              channel: "email",
-            },
-            "matchday_charge_notification_failed",
-          );
-          return { ok: false, reason };
-        }
-      };
-
-      for (const player of unpaidPlayers) {
-        if (!player.member_email) continue;
-
-        const amountFormatted = currencyFormatter.format(
-          player.amount_pence / 100,
-        );
-
-        const userId = userIdByEmail.get(player.member_email.toLowerCase());
-        const channel: MatchdayChannel = userId
-          ? (prefs.get(userId) ?? DEFAULT_MATCHDAY_CHANNEL)
-          : "email";
-
-        const wantsEmail = channel === "email" || channel === "both";
-        const wantsPush = channel === "push" || channel === "both";
-
-        const subscriptions = userId ? (pushSubsByUser.get(userId) ?? []) : [];
-        const pushAvailable = wantsPush && subscriptions.length > 0;
-
-        let deliveredAny = false;
-        let recipientFailure: string | null = null;
-
-        // Push-only recipients with no live subscriptions fall back to
-        // email - opt-in subscriptions plus a payment ask is too easy to
-        // miss otherwise.
-        if (wantsEmail || (wantsPush && !pushAvailable)) {
-          const result = await sendOneEmail(player, amountFormatted);
-          if (result.ok) {
-            deliveredAny = true;
-          } else {
-            recipientFailure = result.reason;
-          }
-        }
-
-        if (pushAvailable) {
-          // The matchday PWA's service worker registered this subscription,
-          // so opening the URL on that origin keeps the user inside the app
-          // and at the new in-app pay-outstanding flow. Fall back to the
-          // main-site payments tab when MATCHDAY_URL is unset (dev/preview).
-          const payUrl = config.MATCHDAY_URL
-            ? `${config.MATCHDAY_URL}/donations`
-            : `${config.BASE_URL}/members?tab=payments`;
-          const payload = {
-            title: ChargeNotification.subject,
-            body: `${amountFormatted} - ${player.charge_description}`,
-            url: payUrl,
-            tag: `charge:${player.charge_id}`,
-          };
-          let pushDelivered = false;
-          let allGone = true;
-          for (const sub of subscriptions) {
-            const result = await sendPush(sub, payload);
-            if (result.ok) {
-              deliveredAny = true;
-              pushDelivered = true;
-              allGone = false;
-            } else if (result.gone) {
-              await pruneSubscription(result.endpoint);
-              log.info(
-                {
-                  matchdayId,
-                  chargeId: player.charge_id,
-                  endpoint: result.endpoint,
-                },
-                "push_subscription_gone_pruned",
-              );
-            } else {
-              allGone = false;
-              log.warn(
-                {
-                  matchdayId,
-                  chargeId: player.charge_id,
-                  recipientEmail: player.member_email,
-                  endpoint: result.endpoint,
-                  reason: result.reason,
-                  channel: "push",
-                },
-                "matchday_charge_notification_failed",
-              );
-              recipientFailure ??= result.reason;
-            }
-          }
-
-          // Push-only recipient whose every subscription was pruned this
-          // turn looks subscribed in our store but the push service
-          // disagrees - email them so they don't silently miss the charge.
-          if (!wantsEmail && !pushDelivered && allGone) {
-            const fallback = await sendOneEmail(player, amountFormatted);
-            if (fallback.ok) {
-              deliveredAny = true;
-              recipientFailure = null;
-            } else {
-              recipientFailure ??= fallback.reason;
-            }
-          }
-        }
-
-        if (deliveredAny) {
-          emailsSent++;
-        } else {
-          emailErrors.push(
-            `${player.member_email}: ${recipientFailure ?? "no delivery channel"}`,
-          );
-        }
-      }
-
-      return { success: true, emailsSent, emailErrors };
+    const accessibleIds = await getAccessibleTeamIds(db, userId, role);
+    if (!accessibleIds.includes(matchday.play_cricket_team_id)) {
+      throwHttpError(403, "You do not have access to this matchday");
     }
 
-    // Result resubmission — just update the result, no charges/emails
-    return { success: true, emailsSent: 0, emailErrors: [] };
+    if (matchday.status !== "finished") {
+      throwHttpError(400, "Wrap up the match before sending donation requests");
+    }
+
+    // One-shot: a captain can only fire the batch once. Re-sends would
+    // re-nag players who've since paid, so we block them outright.
+    if (matchday.charges_notified_at) {
+      throwHttpError(400, "Donation requests have already been sent");
+    }
+
+    const unpaidPlayers = await db
+      .selectFrom("matchday_player")
+      .innerJoin("charge", "charge.id", "matchday_player.charge_id")
+      .innerJoin("member", "member.id", "charge.member_id")
+      .where("matchday_player.matchday_id", "=", matchdayId)
+      .where("charge.paid_at", "is", null)
+      .where("charge.deleted_at", "is", null)
+      // Don't nag members about charges the club has waived.
+      .where("charge.relieved_at", "is", null)
+      .select([
+        "charge.id as charge_id",
+        "member.name as member_name",
+        "member.email as member_email",
+        "charge.description as charge_description",
+        "charge.amount_pence",
+        "charge.charge_date",
+      ])
+      .execute();
+
+    const currencyFormatter = new Intl.NumberFormat("en-GB", {
+      style: "currency",
+      currency: "GBP",
+    });
+
+    const { render } = await import("react-email");
+    const { ChargeNotification } = await import("@percy-main/email");
+
+    // Resolve user ids so we can apply each recipient's matchday_channel
+    // preference. Member rows whose email doesn't match a user (legacy
+    // members who never registered) get email-only delivery, matching
+    // pre-push behavior.
+    const recipientEmails = unpaidPlayers
+      .map((p) => p.member_email?.toLowerCase())
+      .filter((e): e is string => Boolean(e));
+
+    const userRows =
+      recipientEmails.length > 0
+        ? await db
+            .selectFrom("user")
+            .where("email", "in", recipientEmails)
+            .select(["id", "email"])
+            .execute()
+        : [];
+    const userIdByEmail = new Map<string, string>();
+    for (const u of userRows) {
+      userIdByEmail.set(u.email.toLowerCase(), u.id);
+    }
+    const userIds = userRows.map((u) => u.id);
+
+    const [prefs, pushSubsByUser] = await Promise.all([
+      fetchPrefs(userIds),
+      fetchPushSubs(userIds),
+    ]);
+
+    let emailsSent = 0;
+    const emailErrors: string[] = [];
+
+    const sendOneEmail = async (
+      player: (typeof unpaidPlayers)[number],
+      amountFormatted: string,
+    ): Promise<{ ok: true } | { ok: false; reason: string }> => {
+      try {
+        const element = ChargeNotification.component({
+          imageBaseUrl: `${config.BASE_URL}/images`,
+          name: player.member_name ?? "Member",
+          description: player.charge_description,
+          amount: amountFormatted,
+          chargeDate: formatDate(new Date(player.charge_date), "dd/MM/yyyy"),
+          loginUrl: `${config.BASE_URL}/auth/login`,
+        });
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+        const html = await render(element as any);
+        await sendEmail({
+          to: player.member_email ?? "",
+          subject: ChargeNotification.subject,
+          html,
+        });
+        return { ok: true };
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        log.error(
+          {
+            err,
+            recipientEmail: player.member_email,
+            matchdayId,
+            channel: "email",
+          },
+          "matchday_charge_notification_failed",
+        );
+        return { ok: false, reason };
+      }
+    };
+
+    for (const player of unpaidPlayers) {
+      if (!player.member_email) continue;
+
+      const amountFormatted = currencyFormatter.format(
+        player.amount_pence / 100,
+      );
+
+      const recipientUserId = userIdByEmail.get(
+        player.member_email.toLowerCase(),
+      );
+      const channel: MatchdayChannel = recipientUserId
+        ? (prefs.get(recipientUserId) ?? DEFAULT_MATCHDAY_CHANNEL)
+        : "email";
+
+      const wantsEmail = channel === "email" || channel === "both";
+      const wantsPush = channel === "push" || channel === "both";
+
+      const subscriptions = recipientUserId
+        ? (pushSubsByUser.get(recipientUserId) ?? [])
+        : [];
+      const pushAvailable = wantsPush && subscriptions.length > 0;
+
+      let deliveredAny = false;
+      let recipientFailure: string | null = null;
+
+      // Push-only recipients with no live subscriptions fall back to
+      // email - opt-in subscriptions plus a payment ask is too easy to
+      // miss otherwise.
+      if (wantsEmail || (wantsPush && !pushAvailable)) {
+        const result = await sendOneEmail(player, amountFormatted);
+        if (result.ok) {
+          deliveredAny = true;
+        } else {
+          recipientFailure = result.reason;
+        }
+      }
+
+      if (pushAvailable) {
+        // The matchday PWA's service worker registered this subscription,
+        // so opening the URL on that origin keeps the user inside the app
+        // and at the new in-app pay-outstanding flow. Fall back to the
+        // main-site payments tab when MATCHDAY_URL is unset (dev/preview).
+        const payUrl = config.MATCHDAY_URL
+          ? `${config.MATCHDAY_URL}/donations`
+          : `${config.BASE_URL}/members?tab=payments`;
+        const payload = {
+          title: ChargeNotification.subject,
+          body: `${amountFormatted} - ${player.charge_description}`,
+          url: payUrl,
+          tag: `charge:${player.charge_id}`,
+        };
+        let pushDelivered = false;
+        let allGone = true;
+        for (const sub of subscriptions) {
+          const result = await sendPush(sub, payload);
+          if (result.ok) {
+            deliveredAny = true;
+            pushDelivered = true;
+            allGone = false;
+          } else if (result.gone) {
+            await pruneSubscription(result.endpoint);
+            log.info(
+              {
+                matchdayId,
+                chargeId: player.charge_id,
+                endpoint: result.endpoint,
+              },
+              "push_subscription_gone_pruned",
+            );
+          } else {
+            allGone = false;
+            log.warn(
+              {
+                matchdayId,
+                chargeId: player.charge_id,
+                recipientEmail: player.member_email,
+                endpoint: result.endpoint,
+                reason: result.reason,
+                channel: "push",
+              },
+              "matchday_charge_notification_failed",
+            );
+            recipientFailure ??= result.reason;
+          }
+        }
+
+        // Push-only recipient whose every subscription was pruned this
+        // turn looks subscribed in our store but the push service
+        // disagrees - email them so they don't silently miss the charge.
+        if (!wantsEmail && !pushDelivered && allGone) {
+          const fallback = await sendOneEmail(player, amountFormatted);
+          if (fallback.ok) {
+            deliveredAny = true;
+            recipientFailure = null;
+          } else {
+            recipientFailure ??= fallback.reason;
+          }
+        }
+      }
+
+      if (deliveredAny) {
+        emailsSent++;
+      } else {
+        emailErrors.push(
+          `${player.member_email}: ${recipientFailure ?? "no delivery channel"}`,
+        );
+      }
+    }
+
+    // Stamp the matchday as notified even if some deliveries failed - the
+    // batch is one-shot, and failed addresses are chased via the charges
+    // admin (emailErrors is surfaced to the captain so they know).
+    await db
+      .updateTable("matchday")
+      .set({
+        charges_notified_at: new Date().toISOString(),
+        charges_notified_by: userId,
+      })
+      .where("id", "=", matchdayId)
+      .where("charges_notified_at", "is", null)
+      .execute();
+
+    return { success: true, emailsSent, emailErrors };
   };
 }
 

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -4176,6 +4176,8 @@ export interface paths {
                                 cancelled_at: string | null;
                                 cancelled_by: string | null;
                                 cancelled_reason: string | null;
+                                charges_notified_at: string | null;
+                                charges_notified_by: string | null;
                             }[];
                         };
                     };
@@ -4268,6 +4270,8 @@ export interface paths {
                                 cancelled_at: string | null;
                                 cancelled_by: string | null;
                                 cancelled_reason: string | null;
+                                charges_notified_at: string | null;
+                                charges_notified_by: string | null;
                             };
                             team: {
                                 id: string;
@@ -5215,6 +5219,46 @@ export interface paths {
                     };
                 };
             };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                            chargesCreated: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/matchday/{matchId}/notify-charges": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    matchId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
             responses: {
                 /** @description Default Response */
                 200: {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -7296,6 +7296,14 @@
                           "cancelled_reason": {
                             "nullable": true,
                             "type": "string"
+                          },
+                          "charges_notified_at": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "charges_notified_by": {
+                            "nullable": true,
+                            "type": "string"
                           }
                         },
                         "required": [
@@ -7318,7 +7326,9 @@
                           "result_source",
                           "cancelled_at",
                           "cancelled_by",
-                          "cancelled_reason"
+                          "cancelled_reason",
+                          "charges_notified_at",
+                          "charges_notified_by"
                         ],
                         "additionalProperties": false
                       }
@@ -7493,6 +7503,14 @@
                         "cancelled_reason": {
                           "nullable": true,
                           "type": "string"
+                        },
+                        "charges_notified_at": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "charges_notified_by": {
+                          "nullable": true,
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -7515,7 +7533,9 @@
                         "result_source",
                         "cancelled_at",
                         "cancelled_by",
-                        "cancelled_reason"
+                        "cancelled_reason",
+                        "charges_notified_at",
+                        "charges_notified_by"
                       ],
                       "additionalProperties": false
                     },
@@ -9056,6 +9076,45 @@
             }
           }
         },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "matchId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "chargesCreated": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "chargesCreated"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/matchday/{matchId}/notify-charges": {
+      "post": {
         "parameters": [
           {
             "schema": {

--- a/apps/matchday/src/pages/matchday-live.tsx
+++ b/apps/matchday/src/pages/matchday-live.tsx
@@ -16,11 +16,14 @@ import { useParams } from "react-router";
  *   1. Confirm who actually played - per-player playing / dropped-out
  *      / no-show selector.
  *   2. Result picker.
- *   3. Confirm - this is what creates the match-fee charges. If the
- *      API reports any player without a resolved fee, the captain
- *      enters the amount inline and re-submits.
- *   4. Mark each charge paid + payment method (post-finish only).
- *   5. Close match.
+ *   3. Confirm - this is what creates the match-fee charges. No emails
+ *      go out yet. If the API reports any player without a resolved
+ *      fee, the captain enters the amount inline and re-submits.
+ *   4. Mark each charge paid + payment method (post-finish only) - the
+ *      captain ticks off anyone who paid cash / bank transfer on the day.
+ *   5. Send donation requests - emails/pushes only the players still
+ *      unpaid. One-shot: once sent it can't be re-sent, so later cash is
+ *      just recorded via the mark-paid tick without re-nagging anyone.
  *
  * Pre-finish there are no charges yet, so the mark-paid UI is hidden.
  */
@@ -47,6 +50,9 @@ export default function MatchdayLive() {
   const [statusOverrides, setStatusOverrides] = useState<
     Record<string, PlayerStatus>
   >({});
+  // Two-step confirm on the one-shot donation-request batch - sending
+  // emails/pushes to members is outward-facing and can't be undone.
+  const [confirmNotify, setConfirmNotify] = useState(false);
 
   const { data } = useQuery({
     queryKey: ["matchday", matchdayId],
@@ -105,6 +111,19 @@ export default function MatchdayLive() {
     },
   });
 
+  const notify = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/matchday/{matchId}/notify-charges", {
+          params: { path: { matchId: matchdayId ?? "" } },
+        }),
+      ),
+    onSuccess: () => {
+      setConfirmNotify(false);
+      void qc.invalidateQueries({ queryKey: ["matchday", matchdayId] });
+    },
+  });
+
   if (!md) {
     return (
       <div className="space-y-2 p-4">
@@ -152,6 +171,10 @@ export default function MatchdayLive() {
   const hasCharge = (p: MatchdayPlayer) => p.chargeStatus !== null;
   const paid = playing.filter((p) => isSettled(p.chargeStatus)).length;
   const unpaid = playing.filter((p) => p.chargeStatus === "unpaid").length;
+  // Donation requests are a one-shot batch sent after wrap-up. Null until
+  // the captain fires it; once set, late cash is just recorded via the
+  // mark-paid tick and nobody is re-nagged.
+  const notified = md.matchday.charges_notified_at != null;
 
   return (
     <div className="bg-surface flex min-h-dvh flex-col">
@@ -196,6 +219,12 @@ export default function MatchdayLive() {
         <h2 className="text-text-secondary px-4 pt-3 pb-1 text-[11px] font-semibold tracking-[0.06em] uppercase">
           Squad · {md.players.length}
         </h2>
+        {finished && !notified && unpaid > 0 && (
+          <p className="text-text-secondary px-4 pb-1 text-[12px]">
+            Tick off anyone who paid on the day, then send donation requests to
+            the rest.
+          </p>
+        )}
         {md.players.map((p) => {
           const status = resolveStatus(p);
           const isPaid = isSettled(p.chargeStatus);
@@ -344,10 +373,57 @@ export default function MatchdayLive() {
             >
               Finish match
             </Button>
-          ) : (
+          ) : notified ? (
             <p className="text-text-secondary w-full text-center text-sm md:flex-1">
-              Match finished · result {md.matchday.result_type ?? "—"}
+              Donation requests sent · result {md.matchday.result_type ?? "—"}
             </p>
+          ) : unpaid === 0 ? (
+            <p className="text-text-secondary w-full text-center text-sm md:flex-1">
+              All donations settled · result {md.matchday.result_type ?? "—"}
+            </p>
+          ) : confirmNotify ? (
+            <div className="w-full md:flex-1">
+              <p className="text-text-secondary mb-2 text-center text-[13px]">
+                Email/push {unpaid} unpaid {unpaid === 1 ? "player" : "players"}
+                ? This can only be sent once.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  tone="outline"
+                  size="lg"
+                  className="flex-1"
+                  disabled={notify.isPending}
+                  onClick={() => setConfirmNotify(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  tone="primary"
+                  size="lg"
+                  className="flex-1"
+                  disabled={notify.isPending}
+                  onClick={() => notify.mutate()}
+                >
+                  {notify.isPending ? "Sending…" : "Send now"}
+                </Button>
+              </div>
+              {notify.isError && (
+                <p className="text-danger mt-2 text-center text-[12px]">
+                  {notify.error instanceof Error
+                    ? notify.error.message
+                    : "Could not send donation requests."}
+                </p>
+              )}
+            </div>
+          ) : (
+            <Button
+              tone="primary"
+              size="lg"
+              className="w-full md:flex-1"
+              onClick={() => setConfirmNotify(true)}
+            >
+              Send donation requests · {unpaid}
+            </Button>
           )}
         </div>
       </div>
@@ -687,7 +763,7 @@ function FinishSheet({
 
       <div className="bg-surface-raised mt-4 space-y-1 rounded-xl p-3 text-sm">
         <Row label={`${playingPlayers.length} playing`}>
-          will be charged · donation emails sent
+          will be charged · no emails yet
         </Row>
         <Row label={`${draftExpenseCount} draft expenses`}>
           will be submitted

--- a/apps/matchday/src/pages/matchday-live.tsx
+++ b/apps/matchday/src/pages/matchday-live.tsx
@@ -374,9 +374,17 @@ export default function MatchdayLive() {
               Finish match
             </Button>
           ) : notified ? (
-            <p className="text-text-secondary w-full text-center text-sm md:flex-1">
-              Donation requests sent · result {md.matchday.result_type ?? "—"}
-            </p>
+            <div className="w-full md:flex-1">
+              <p className="text-text-secondary text-center text-sm">
+                Donation requests sent · result {md.matchday.result_type ?? "—"}
+              </p>
+              {notify.data && notify.data.emailErrors.length > 0 && (
+                <p className="text-danger mt-1 text-center text-[12px]">
+                  {notify.data.emailErrors.length} could not be delivered -
+                  chase via the charges admin.
+                </p>
+              )}
+            </div>
           ) : unpaid === 0 ? (
             <p className="text-text-secondary w-full text-center text-sm md:flex-1">
               All donations settled · result {md.matchday.result_type ?? "—"}

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -4176,6 +4176,8 @@ export interface paths {
                                 cancelled_at: string | null;
                                 cancelled_by: string | null;
                                 cancelled_reason: string | null;
+                                charges_notified_at: string | null;
+                                charges_notified_by: string | null;
                             }[];
                         };
                     };
@@ -4268,6 +4270,8 @@ export interface paths {
                                 cancelled_at: string | null;
                                 cancelled_by: string | null;
                                 cancelled_reason: string | null;
+                                charges_notified_at: string | null;
+                                charges_notified_by: string | null;
                             };
                             team: {
                                 id: string;
@@ -5215,6 +5219,46 @@ export interface paths {
                     };
                 };
             };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                            chargesCreated: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/matchday/{matchId}/notify-charges": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    matchId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
             responses: {
                 /** @description Default Response */
                 200: {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -7296,6 +7296,14 @@
                           "cancelled_reason": {
                             "nullable": true,
                             "type": "string"
+                          },
+                          "charges_notified_at": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "charges_notified_by": {
+                            "nullable": true,
+                            "type": "string"
                           }
                         },
                         "required": [
@@ -7318,7 +7326,9 @@
                           "result_source",
                           "cancelled_at",
                           "cancelled_by",
-                          "cancelled_reason"
+                          "cancelled_reason",
+                          "charges_notified_at",
+                          "charges_notified_by"
                         ],
                         "additionalProperties": false
                       }
@@ -7493,6 +7503,14 @@
                         "cancelled_reason": {
                           "nullable": true,
                           "type": "string"
+                        },
+                        "charges_notified_at": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "charges_notified_by": {
+                          "nullable": true,
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -7515,7 +7533,9 @@
                         "result_source",
                         "cancelled_at",
                         "cancelled_by",
-                        "cancelled_reason"
+                        "cancelled_reason",
+                        "charges_notified_at",
+                        "charges_notified_by"
                       ],
                       "additionalProperties": false
                     },
@@ -9056,6 +9076,45 @@
             }
           }
         },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "matchId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "chargesCreated": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "chargesCreated"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/matchday/{matchId}/notify-charges": {
+      "post": {
         "parameters": [
           {
             "schema": {

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -487,6 +487,8 @@ export interface Matchday {
   cancelled_at: string | null;
   cancelled_by: string | null;
   cancelled_reason: string | null;
+  charges_notified_at: string | null;
+  charges_notified_by: string | null;
   competition_type: string | null;
   confirmed_at: string | null;
   confirmed_by: string | null;

--- a/packages/db/src/migrations/2026-05-31T20:02:48.632Z.ts
+++ b/packages/db/src/migrations/2026-05-31T20:02:48.632Z.ts
@@ -1,0 +1,30 @@
+import type { Kysely } from "kysely";
+
+// Decouple "create match-fee charges" from "notify players about them".
+// Wrapping up a match now only creates the charges; a separate captain
+// action sends the donation-request emails/pushes. These columns record
+// when (and by whom) that notification batch went out. Null = charges
+// exist but no donation requests have been sent yet. One-shot: once set,
+// the notify endpoint refuses to re-send (late additions are handled
+// manually via the charges admin).
+//
+// `charges_notified_by` references the user, mirroring the existing
+// finished_by / confirmed_by audit columns on this table.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("matchday")
+    .addColumn("charges_notified_at", "text")
+    .addColumn("charges_notified_by", "text", (col) =>
+      col.references("user.id"),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("matchday")
+    .dropColumn("charges_notified_at")
+    .dropColumn("charges_notified_by")
+    .execute();
+}

--- a/packages/db/src/migrations/2026-05-31T20:02:48.632Z.ts
+++ b/packages/db/src/migrations/2026-05-31T20:02:48.632Z.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 
 // Decouple "create match-fee charges" from "notify players about them".
 // Wrapping up a match now only creates the charges; a separate captain
@@ -19,6 +19,20 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       col.references("user.id"),
     )
     .execute();
+
+  // Backfill already-finished matchdays. Under the previous single-step
+  // flow, finishing a match sent the donation requests immediately, so
+  // every existing finished match has already notified its players.
+  // Stamp them as notified (using finished_at, falling back to created_at
+  // for legacy rows that never recorded a finish time) so the new
+  // one-shot guard doesn't offer a *second* batch for historical matches
+  // the moment this deploys.
+  await sql`
+    UPDATE matchday
+    SET charges_notified_at = COALESCE(finished_at, created_at::text),
+        charges_notified_by = finished_by
+    WHERE status = 'finished'
+  `.execute(db);
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  axios@<1.16.0: '>=1.16.0'
   fast-xml-parser@<5.7.0: '>=5.7.0'
   postcss@<8.5.10: '>=8.5.10'
   ws@<8.20.1: '>=8.20.1'
@@ -291,7 +292,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: ^1.6.11
-        version: 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)
+        version: 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)
       '@percy-main/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -4129,6 +4130,10 @@ packages:
     resolution: {integrity: sha512-2zVz1xm1AoaGKdZrRHIBNfB3fDL3xpfyRy8uUDJzzCp0b5zBJlmrv6zaJ7PO2XciJIaQvg3wvdWkiJ2LJ/P4gQ==}
     engines: {node: '>=18.17.0', npm: '>=9.6.7'}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -4271,8 +4276,8 @@ packages:
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -5531,6 +5536,10 @@ packages:
   http_ece@1.2.0:
     resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
     engines: {node: '>=16'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -9188,20 +9197,6 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
-    dependencies:
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.4.3)
-      jose: 6.2.3
-      kysely: 0.28.17
-      nanostores: 1.3.0
-      zod: 4.4.3
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-
   '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
@@ -9230,9 +9225,9 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
   '@better-auth/infra@0.2.8(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/sso@1.5.6(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3)))(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(zod@4.4.3)':
@@ -9246,34 +9241,22 @@ snapshots:
       libphonenumber-js: 1.13.2
       zod: 4.4.3
 
-  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
-
-  '@better-auth/passkey@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)':
-    dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
-      '@simplewebauthn/browser': 13.3.0
-      '@simplewebauthn/server': 13.3.0
-      better-auth: 1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
-      better-call: 1.3.2(zod@4.4.3)
-      nanostores: 1.3.0
-      zod: 4.4.3
 
   '@better-auth/passkey@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)':
     dependencies:
@@ -9287,9 +9270,9 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
   '@better-auth/sso@1.5.6(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6))(better-call@1.3.2(zod@4.4.3))':
@@ -9305,9 +9288,9 @@ snapshots:
       tldts: 6.1.86
       zod: 4.4.3
 
-  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
@@ -12080,6 +12063,12 @@ snapshots:
     dependencies:
       timezones-ical-library: 2.2.0
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ai@6.0.185(zod@4.4.3):
@@ -12262,13 +12251,15 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
-  axios@1.15.2:
+  axios@1.16.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   b4a@1.8.1: {}
 
@@ -12355,12 +12346,12 @@ snapshots:
   better-auth@1.6.11(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0
@@ -13540,7 +13531,7 @@ snapshots:
   google-ads-api@23.0.0:
     dependencies:
       '@isaacs/ttlcache': 1.4.1
-      axios: 1.15.2
+      axios: 1.16.1
       circ-json: 1.0.4
       google-ads-node: 23.0.0
       google-auth-library: 9.15.1
@@ -13749,6 +13740,13 @@ snapshots:
       - supports-color
 
   http_ece@1.2.0: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ allowBuilds:
 
 # Security overrides — force transitive deps off known-vulnerable versions.
 overrides:
+  axios@<1.16.0: ">=1.16.0"
   fast-xml-parser@<5.7.0: ">=5.7.0"
   postcss@<8.5.10: ">=8.5.10"
   ws@<8.20.1: ">=8.20.1"


### PR DESCRIPTION
## Problem

Wrapping up a match used to create the match-fee charges **and immediately** email/push every unpaid player. Because charges (the thing a captain marks paid) only exist post-finish, there was no way to record cash collected at the ground before the donation requests went out, so everyone got nagged even if half the squad had already paid.

## Approach (two-phase, one-shot)

Split "create charges" from "notify players":

- **`finishMatch`** now only flips status to `finished`, submits draft expenses, and creates the charges. No notifications. Returns `chargesCreated`.
- **New `notifyMatchCharges`** service + `POST /matchday/:matchId/notify-charges` sends the email/push batch to **unpaid, non-relieved** charges only. It requires the match to be finished, and is **one-shot** (guarded by the new `matchday.charges_notified_at` column): a player marked paid after the batch is never re-nagged, and late squad additions / failed deliveries are handled via the charges admin.

### Captain UX (matchday app)

1. Wrap up - creates charges, no emails (copy updated to "no emails yet").
2. The existing post-finish mark-paid checkboxes are now the collection step (tick off anyone who paid on the day).
3. "Send donation requests · N" with a one-shot confirm, then a "Donation requests sent" terminal state.

## Data model

Migration adds `charges_notified_at` + `charges_notified_by` to `matchday` (mirrors the existing `finished_by` audit columns). DB types + OpenAPI spec + typed clients regenerated.

## Tests

- All 497 API unit tests pass (finishMatch tests updated for the new shape).
- 35 matchday integration tests pass, including new coverage:
  - wrap-up sends no notifications
  - notify emails only the still-unpaid (a player marked paid pre-batch is skipped)
  - one-shot re-send is refused
  - notify-before-finish is rejected

## Trade-off (deliberate)

One-shot means no in-app re-send for players added after the batch or for failed deliveries - those go through the charges admin. `emailErrors` is surfaced to the captain so failures are visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)