### PR TITLE
feat(matchday): confirm a team per fixture without closing the request

### DIFF
--- a/apps/api/src/features/availability/integration.test.ts
+++ b/apps/api/src/features/availability/integration.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   assignPlayer,
   confirmDate,
+  confirmFixture,
   getActiveRequests,
   getDateDetail,
   getRequest,
@@ -633,6 +634,149 @@ describe("availability service (integration)", () => {
       await expect(
         confirmDate(ctx.db)(userId, reqId, "2027-08-01"),
       ).rejects.toThrow("already exists");
+    });
+  });
+
+  describe("confirmFixture", () => {
+    it("creates a matchday for one fixture and leaves the request open", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cf-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam("Confirm Fixture XI");
+      const reqId = await seedRequest(userId, "2027-05-01", "2027-05-14");
+      // Two dates in the same request: confirming the earlier one must not
+      // touch the later one, and must leave the request open.
+      const earlyFix = await seedFixture(
+        reqId,
+        teamId,
+        "2027-05-01",
+        "Early Opp CC",
+      );
+      const lateFix = await seedFixture(
+        reqId,
+        teamId,
+        "2027-05-08",
+        "Late Opp CC",
+      );
+      await assignPlayer(ctx.db)(reqId, "2027-05-01", {
+        fixtureId: earlyFix,
+        playerName: "Early Player",
+      });
+
+      const result = await confirmFixture(ctx.db)(
+        userId,
+        reqId,
+        "2027-05-01",
+        earlyFix,
+      );
+
+      const matchday = await ctx.db
+        .selectFrom("matchday")
+        .where("id", "=", result.matchdayId)
+        .selectAll()
+        .executeTakeFirst();
+      expect(matchday?.opposition).toBe("Early Opp CC");
+      expect(matchday?.status).toBe("pending");
+
+      // Request stays open.
+      const request = await ctx.db
+        .selectFrom("availability_request")
+        .where("id", "=", reqId)
+        .select("status")
+        .executeTakeFirst();
+      expect(request?.status).toBe("open");
+
+      // The later fixture has no matchday yet.
+      const lateMatchday = await ctx.db
+        .selectFrom("matchday")
+        .where("play_cricket_match_id", "=", (eb) =>
+          eb
+            .selectFrom("availability_fixture")
+            .where("id", "=", lateFix)
+            .select("play_cricket_match_id"),
+        )
+        .executeTakeFirst();
+      expect(lateMatchday).toBeUndefined();
+    });
+
+    it("rejects confirming a fixture with no assignments", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cf-empty-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam("Empty Confirm XI");
+      const reqId = await seedRequest(userId, "2027-06-01", "2027-06-07");
+      const fixId = await seedFixture(
+        reqId,
+        teamId,
+        "2027-06-01",
+        "Empty Opp CC",
+      );
+
+      await expect(
+        confirmFixture(ctx.db)(userId, reqId, "2027-06-01", fixId),
+      ).rejects.toThrow("No players");
+    });
+
+    it("throws 409 when re-confirming an already-confirmed fixture", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cf-conflict-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam("Reconfirm XI");
+      const reqId = await seedRequest(userId, "2027-07-01", "2027-07-07");
+      const fixId = await seedFixture(
+        reqId,
+        teamId,
+        "2027-07-01",
+        "Reconfirm Opp CC",
+      );
+      await assignPlayer(ctx.db)(reqId, "2027-07-01", {
+        fixtureId: fixId,
+        playerName: "Guest",
+      });
+
+      await confirmFixture(ctx.db)(userId, reqId, "2027-07-01", fixId);
+      await expect(
+        confirmFixture(ctx.db)(userId, reqId, "2027-07-01", fixId),
+      ).rejects.toThrow("already exists");
+    });
+
+    it("surfaces the confirmed matchday on the date detail", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `cf-detail-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam("Detail Confirm XI");
+      const reqId = await seedRequest(userId, "2027-09-01", "2027-09-07");
+      const fixId = await seedFixture(
+        reqId,
+        teamId,
+        "2027-09-01",
+        "Detail Opp CC",
+      );
+      await assignPlayer(ctx.db)(reqId, "2027-09-01", {
+        fixtureId: fixId,
+        playerName: "Guest",
+      });
+
+      const before = await getDateDetail(ctx.db)(reqId, "2027-09-01");
+      expect(before.fixtures[0].matchdayId).toBeNull();
+
+      const { matchdayId } = await confirmFixture(ctx.db)(
+        userId,
+        reqId,
+        "2027-09-01",
+        fixId,
+      );
+
+      const after = await getDateDetail(ctx.db)(reqId, "2027-09-01");
+      expect(after.fixtures[0].matchdayId).toBe(matchdayId);
+
+      const detail = await getRequest(ctx.db)(reqId);
+      const dateEntry = detail.dates.find((d) => d.date === "2027-09-01");
+      expect(dateEntry?.confirmedCount).toBe(1);
     });
   });
 

--- a/apps/api/src/features/availability/routes.ts
+++ b/apps/api/src/features/availability/routes.ts
@@ -10,6 +10,7 @@ import {
   assignPlayerSchema,
   assignmentIdParamSchema,
   confirmDateResponseSchema,
+  confirmFixtureResponseSchema,
   createRequestResponseSchema,
   createRequestSchema,
   getActiveRequestsResponseSchema,
@@ -22,6 +23,7 @@ import {
   notifySendSchema,
   previewFixturesResponseSchema,
   previewRangeSchema,
+  requestDateFixtureParamSchema,
   requestDateMemberParamSchema,
   requestDateParamSchema,
   requestIdParamSchema,
@@ -34,6 +36,7 @@ import {
 import {
   assignPlayer,
   confirmDate,
+  confirmFixture,
   createRequest,
   getActiveRequests,
   getDateDetail,
@@ -217,6 +220,27 @@ export const availabilityRoutes: FastifyPluginAsyncZod = async (app) => {
         user.id,
         request.params.requestId,
         request.params.date,
+      );
+    },
+  );
+
+  const confirmOneFixture = confirmFixture(app.db);
+  app.post(
+    "/availability/requests/:requestId/dates/:date/fixtures/:fixtureId/confirm",
+    {
+      preHandler: [matchdayManage],
+      schema: {
+        params: requestDateFixtureParamSchema,
+        response: { 200: confirmFixtureResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await confirmOneFixture(
+        user.id,
+        request.params.requestId,
+        request.params.date,
+        request.params.fixtureId,
       );
     },
   );

--- a/apps/api/src/features/availability/schemas.ts
+++ b/apps/api/src/features/availability/schemas.ts
@@ -17,6 +17,12 @@ export const assignmentIdParamSchema = z.object({
   assignmentId: z.string(),
 });
 
+export const requestDateFixtureParamSchema = z.object({
+  requestId: z.string(),
+  date: z.string().regex(isoDateRegex, "Must be YYYY-MM-DD format"),
+  fixtureId: z.string(),
+});
+
 export const requestDateMemberParamSchema = z.object({
   requestId: z.string(),
   date: z.string().regex(isoDateRegex, "Must be YYYY-MM-DD format"),
@@ -125,6 +131,10 @@ const dateEntrySchema = z.object({
   fixtures: z.array(fixtureSchema),
   responseCount: z.number(),
   assignmentCount: z.number(),
+  // Number of this date's fixtures that already have a (non-cancelled)
+  // matchday - i.e. teams confirmed individually without closing the
+  // whole request. Drives the per-date "confirmed" indicator.
+  confirmedCount: z.number(),
 });
 
 export const getRequestResponseSchema = z.object({
@@ -175,6 +185,10 @@ const dateDetailFixtureSchema = z.object({
   match_time: z.string().nullable(),
   team_name: z.string().nullable(),
   assignments: z.array(assignmentSchema),
+  // Set once this fixture's team has been confirmed into a matchday
+  // (per-fixture confirm, or on request close). Null while the picks are
+  // still provisional. Drives the "Confirm team" vs "Manage squad" CTA.
+  matchdayId: z.string().nullable(),
 });
 
 export const getDateDetailResponseSchema = z.object({
@@ -204,6 +218,10 @@ export const confirmDateResponseSchema = z.object({
       matchdayId: z.string(),
     }),
   ),
+});
+
+export const confirmFixtureResponseSchema = z.object({
+  matchdayId: z.string(),
 });
 
 export const updateRequestStatusResponseSchema = z.object({

--- a/apps/api/src/features/availability/service.ts
+++ b/apps/api/src/features/availability/service.ts
@@ -403,6 +403,7 @@ export function getRequest(db: Kysely<DB>) {
         fixtures: typeof fixtures;
         responseCount: number;
         assignmentCount: number;
+        confirmedCount: number;
       }
     >();
 
@@ -413,10 +414,32 @@ export function getRequest(db: Kysely<DB>) {
           fixtures: [],
           responseCount: 0,
           assignmentCount: 0,
+          confirmedCount: 0,
         });
       }
       const entry = dates.get(fixture.match_date);
       if (entry) entry.fixtures.push(fixture);
+    }
+
+    // Count fixtures already confirmed into a (non-cancelled) matchday,
+    // per date, so the detail cards can show which dates are locked in.
+    const pcMatchIds = fixtures.map((f) => f.play_cricket_match_id);
+    const confirmedMatchdays =
+      pcMatchIds.length > 0
+        ? await db
+            .selectFrom("matchday")
+            .where("play_cricket_match_id", "in", pcMatchIds)
+            .where("status", "!=", "cancelled")
+            .select(["play_cricket_match_id"])
+            .execute()
+        : [];
+    const confirmedPcMatchIds = new Set(
+      confirmedMatchdays.map((m) => m.play_cricket_match_id),
+    );
+    for (const entry of dates.values()) {
+      entry.confirmedCount = entry.fixtures.filter((f) =>
+        confirmedPcMatchIds.has(f.play_cricket_match_id),
+      ).length;
     }
 
     // Get response counts per date
@@ -527,6 +550,24 @@ export function getDateDetail(db: Kysely<DB>) {
       assignmentsByFixture.set(a.availability_fixture_id, list);
     }
 
+    // A fixture is "confirmed" once a non-cancelled matchday exists for
+    // its Play Cricket match. Keyed by play_cricket_match_id (1:1 with the
+    // fixture) so the picker can show "Manage squad" instead of "Confirm
+    // team" for teams already locked in.
+    const pcMatchIds = fixtures.map((f) => f.play_cricket_match_id);
+    const matchdays =
+      pcMatchIds.length > 0
+        ? await db
+            .selectFrom("matchday")
+            .where("play_cricket_match_id", "in", pcMatchIds)
+            .where("status", "!=", "cancelled")
+            .select(["id", "play_cricket_match_id"])
+            .execute()
+        : [];
+    const matchdayByPcMatchId = new Map(
+      matchdays.map((m) => [m.play_cricket_match_id, m.id]),
+    );
+
     // Per amendments §2: all responses surface to officials, regardless
     // of whether the responder is in one of the request's user groups.
     // (The pre-amendment behaviour filtered non-group respondents out.)
@@ -587,6 +628,7 @@ export function getDateDetail(db: Kysely<DB>) {
       fixtures: fixtures.map((f) => ({
         ...f,
         assignments: assignmentsByFixture.get(f.id) ?? [],
+        matchdayId: matchdayByPcMatchId.get(f.play_cricket_match_id) ?? null,
       })),
       pools: {
         available,
@@ -859,6 +901,56 @@ export function confirmDate(db: Kysely<DB>) {
     });
 
     return { matchdays: matchdayIds };
+  };
+}
+
+/**
+ * Confirm a single fixture's team into a matchday, leaving the rest of
+ * the availability request open. This is the path that lets officials
+ * lock in an earlier game while later games in the same multi-day
+ * request keep collecting responses. Re-confirming an already-confirmed
+ * fixture throws 409 (per `materialiseFixtureMatchday`'s "conflict"
+ * mode) so picks added after the matchday exists aren't silently
+ * dropped - manage those on the matchday squad screen instead.
+ */
+export function confirmFixture(db: Kysely<DB>) {
+  return async (
+    userId: string,
+    requestId: string,
+    date: string,
+    fixtureId: string,
+  ) => {
+    const request = await db
+      .selectFrom("availability_request")
+      .where("id", "=", requestId)
+      .select(["id"])
+      .executeTakeFirst();
+
+    if (!request) throwHttpError(404, "Availability request not found");
+
+    const fixture = await db
+      .selectFrom("availability_fixture")
+      .where("id", "=", fixtureId)
+      .where("availability_request_id", "=", requestId)
+      .where("match_date", "=", date)
+      .selectAll()
+      .executeTakeFirst();
+
+    if (!fixture) {
+      throwHttpError(404, "Fixture not found for this request and date");
+    }
+
+    const result = await db
+      .transaction()
+      .execute((trx) =>
+        materialiseFixtureMatchday(trx, userId, fixture, "conflict"),
+      );
+
+    if (!result) {
+      throwHttpError(400, "No players are assigned to this fixture yet");
+    }
+
+    return { matchdayId: result.matchdayId };
   };
 }
 

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -79,8 +79,10 @@ export interface GameDetail extends GameListItem {
   } | null;
   // Non-null while an availability_request covers this fixture. When
   // status is "open" the FE swaps the "Pick team" CTA for a link into
-  // the selection picker - matchdays are auto-created when the request
-  // closes (see updateRequestStatus), so creating one early here would
+  // the selection picker, where an official confirms this fixture's team
+  // to create its matchday (see confirmFixture) without closing the
+  // whole request. Closing the request also materialises any still-open
+  // fixtures (see updateRequestStatus). Creating one directly here would
   // race the selection and is forbidden by createMatchday.
   availabilityRequest: {
     id: string;

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -5471,6 +5471,7 @@ export interface paths {
                                 }[];
                                 responseCount: number;
                                 assignmentCount: number;
+                                confirmedCount: number;
                             }[];
                         };
                     };
@@ -5561,6 +5562,7 @@ export interface paths {
                                     position: number;
                                     created_at: string;
                                 }[];
+                                matchdayId: string | null;
                             }[];
                             pools: {
                                 available: {
@@ -5767,6 +5769,47 @@ export interface paths {
                                 fixtureId: string;
                                 matchdayId: string;
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/availability/requests/{requestId}/dates/{date}/fixtures/{fixtureId}/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                    date: string;
+                    fixtureId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            matchdayId: string;
                         };
                     };
                 };

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -9560,13 +9560,17 @@
                           },
                           "assignmentCount": {
                             "type": "number"
+                          },
+                          "confirmedCount": {
+                            "type": "number"
                           }
                         },
                         "required": [
                           "date",
                           "fixtures",
                           "responseCount",
-                          "assignmentCount"
+                          "assignmentCount",
+                          "confirmedCount"
                         ],
                         "additionalProperties": false
                       }
@@ -9745,6 +9749,10 @@
                               ],
                               "additionalProperties": false
                             }
+                          },
+                          "matchdayId": {
+                            "nullable": true,
+                            "type": "string"
                           }
                         },
                         "required": [
@@ -9757,7 +9765,8 @@
                           "competition_name",
                           "match_time",
                           "team_name",
-                          "assignments"
+                          "assignments",
+                          "matchdayId"
                         ],
                         "additionalProperties": false
                       }
@@ -10129,6 +10138,58 @@
                   },
                   "required": [
                     "matchdays"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/availability/requests/{requestId}/dates/{date}/fixtures/{fixtureId}/confirm": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "in": "path",
+            "name": "date",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "fixtureId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "matchdayId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "matchdayId"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/matchday/src/pages/fixture-detail.tsx
+++ b/apps/matchday/src/pages/fixture-detail.tsx
@@ -63,9 +63,10 @@ export default function FixtureDetail() {
   if (isError || !game) return <ErrState />;
   const directionsQuery = directionsTarget(game);
   const matchdayId = game.lineup?.matchdayId ?? null;
-  // Surfacing only the open case: a closed request already auto-created
-  // the matchday (matchdayId is set above), so the squad-management
-  // buttons take over and this never renders.
+  // Surfacing only the open case: once this fixture's team is confirmed
+  // (on the selection screen, or when the request closes) a matchday
+  // exists and matchdayId is set above, so the squad-management buttons
+  // take over and this never renders.
   const openAvailabilityRequest =
     game.availabilityRequest?.status === "open"
       ? game.availabilityRequest
@@ -146,8 +147,9 @@ export default function FixtureDetail() {
             ) : openAvailabilityRequest ? (
               <>
                 <p className="text-text-secondary text-xs leading-snug">
-                  Team selection is underway. The matchday will be created when
-                  the availability request is closed.
+                  Team selection is underway. Confirm this team on the selection
+                  screen to create the matchday - the rest of the availability
+                  request stays open.
                 </p>
                 <Button asChild tone="primary" className="w-full">
                   <Link

--- a/apps/matchday/src/pages/official-availability-date.tsx
+++ b/apps/matchday/src/pages/official-availability-date.tsx
@@ -154,8 +154,12 @@ export default function OfficialAvailabilityDate() {
       ),
     onSuccess: () => {
       invalidate();
-      // The fixture now has a matchday - the fixtures list (Pick team CTA)
-      // and any open request views should reflect the confirmed team.
+      // The fixture now has a matchday - refresh the request detail (its
+      // confirmed count badge), the fixtures list (Pick team CTA), and any
+      // open request views so they all reflect the confirmed team.
+      void qc.invalidateQueries({
+        queryKey: ["availability", "request", requestId],
+      });
       void qc.invalidateQueries({ queryKey: ["games"] });
     },
   });
@@ -198,6 +202,12 @@ export default function OfficialAvailabilityDate() {
   const available = pd.pools.available.filter(matchPool);
   const unavailable = pd.pools.unavailable.filter(matchPool);
   const noResponse = pd.pools.noResponse.filter(matchNoResp);
+
+  // Once a fixture is confirmed its squad is snapshotted into the
+  // matchday, so assignment edits here would no longer reach it. Confined
+  // assign/move/guest targets to still-open fixtures; the Teams rail still
+  // lists every fixture (confirmed ones get a "Manage squad" link).
+  const openFixtures = pd.fixtures.filter((f) => !f.matchdayId);
 
   // Index of each member's current assignment (if any) so each list can
   // surface a "currently in <team>" pill and "Move" action without a
@@ -297,7 +307,7 @@ export default function OfficialAvailabilityDate() {
           {tab === "available" && (
             <AvailableList
               players={available}
-              fixtures={pd.fixtures}
+              fixtures={openFixtures}
               assignmentByMember={assignmentByMember}
               actions={actions}
               actionPending={actionPending}
@@ -330,7 +340,7 @@ export default function OfficialAvailabilityDate() {
         </div>
 
         <div className="border-border-light mt-2 border-t px-4 pt-4">
-          <GuestEntry fixtures={pd.fixtures} onAdd={actions.assign} />
+          <GuestEntry fixtures={openFixtures} onAdd={actions.assign} />
         </div>
       </div>
 
@@ -345,7 +355,7 @@ export default function OfficialAvailabilityDate() {
             >
               <AvailableList
                 players={available}
-                fixtures={pd.fixtures}
+                fixtures={openFixtures}
                 assignmentByMember={assignmentByMember}
                 actions={actions}
                 actionPending={actionPending}
@@ -385,7 +395,7 @@ export default function OfficialAvailabilityDate() {
             confirming={confirmFixture.isPending}
           />
           <div className="border-border bg-surface-raised border-t p-4">
-            <GuestEntry fixtures={pd.fixtures} onAdd={actions.assign} />
+            <GuestEntry fixtures={openFixtures} onAdd={actions.assign} />
           </div>
         </div>
       </div>
@@ -393,7 +403,7 @@ export default function OfficialAvailabilityDate() {
       {assignTarget && (
         <AssignSheet
           target={assignTarget}
-          fixtures={pd.fixtures}
+          fixtures={openFixtures}
           currentAssignment={
             assignmentByMember.get(assignTarget.member_id)?.assignment ?? null
           }
@@ -522,6 +532,10 @@ function AvailableList({
       )}
       {players.map((p) => {
         const current = assignmentByMember.get(p.member_id);
+        // A player snapshotted into a confirmed matchday can't be moved
+        // from here - the team is owned by the matchday screen now - so we
+        // show their team as a static label rather than a move button.
+        const lockedIn = current?.fixture.matchdayId != null;
         return (
           <div
             key={p.id}
@@ -541,15 +555,21 @@ function AvailableList({
               )}
             </div>
             {current ? (
-              <button
-                type="button"
-                onClick={() => actions.openAssignSheet(p)}
-                disabled={actionPending}
-                className="bg-info-bg text-navy rounded-full px-2.5 py-1 text-[11px] font-semibold disabled:opacity-60 dark:text-white"
-              >
-                {current.fixture.team_name ?? current.fixture.opposition}
-              </button>
-            ) : fixtures.length === 1 ? (
+              lockedIn ? (
+                <span className="bg-success-bg text-success rounded-full px-2.5 py-1 text-[11px] font-semibold">
+                  {current.fixture.team_name ?? current.fixture.opposition} ✓
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => actions.openAssignSheet(p)}
+                  disabled={actionPending}
+                  className="bg-info-bg text-navy rounded-full px-2.5 py-1 text-[11px] font-semibold disabled:opacity-60 dark:text-white"
+                >
+                  {current.fixture.team_name ?? current.fixture.opposition}
+                </button>
+              )
+            ) : fixtures.length === 0 ? null : fixtures.length === 1 ? (
               <Button
                 size="sm"
                 tone="ghost"
@@ -875,6 +895,8 @@ function GuestEntry({
     [fixtures, fixtureId],
   );
   const canAdd = name.trim().length > 0 && !!fixtureValue;
+  // No open fixtures left to add to (all confirmed) - nothing to do here.
+  if (fixtures.length === 0) return null;
   return (
     <div>
       <p className="text-text-secondary mb-2 text-[11px] font-semibold tracking-[0.06em] uppercase">

--- a/apps/matchday/src/pages/official-availability-date.tsx
+++ b/apps/matchday/src/pages/official-availability-date.tsx
@@ -4,7 +4,13 @@ import { useDebouncedValue } from "@/hooks/use-debounced-value.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
 import { cn } from "@/lib/utils.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeftIcon, SearchIcon, UserPlusIcon, XIcon } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  CheckCircle2Icon,
+  SearchIcon,
+  UserPlusIcon,
+  XIcon,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link, useParams } from "react-router";
 
@@ -130,6 +136,30 @@ export default function OfficialAvailabilityDate() {
     },
   });
 
+  const confirmFixture = useMutation({
+    mutationFn: (fixtureId: string) =>
+      callApi(
+        api.POST(
+          "/api/availability/requests/{requestId}/dates/{date}/fixtures/{fixtureId}/confirm",
+          {
+            params: {
+              path: {
+                requestId: requestId ?? "",
+                date: date ?? "",
+                fixtureId,
+              },
+            },
+          },
+        ),
+      ),
+    onSuccess: () => {
+      invalidate();
+      // The fixture now has a matchday - the fixtures list (Pick team CTA)
+      // and any open request views should reflect the confirmed team.
+      void qc.invalidateQueries({ queryKey: ["games"] });
+    },
+  });
+
   const override = useMutation({
     mutationFn: (vars: { memberId: string; status: OverrideStatus }) =>
       callApi(
@@ -233,6 +263,13 @@ export default function OfficialAvailabilityDate() {
         <SearchInput value={searchTerm} onChange={setSearchTerm} />
       </div>
 
+      {confirmFixture.isError && (
+        <p className="text-danger mx-4 mt-3 text-sm">
+          Couldn't confirm that team. It may already have a matchday - reload
+          and check.
+        </p>
+      )}
+
       {/* Mobile (<md): tabbed view. */}
       <div className="md:hidden">
         <div className="bg-surface-raised mx-4 mt-3 grid grid-cols-3 gap-1 rounded-xl p-1">
@@ -282,7 +319,17 @@ export default function OfficialAvailabilityDate() {
           )}
         </section>
 
-        <div className="border-border-light mt-6 border-t px-4 pt-4">
+        <div className="mt-6">
+          <AssignmentRail
+            fixtures={pd.fixtures}
+            onRemove={actions.unassign}
+            removing={unassign.isPending}
+            onConfirm={(fixtureId) => confirmFixture.mutate(fixtureId)}
+            confirming={confirmFixture.isPending}
+          />
+        </div>
+
+        <div className="border-border-light mt-2 border-t px-4 pt-4">
           <GuestEntry fixtures={pd.fixtures} onAdd={actions.assign} />
         </div>
       </div>
@@ -334,6 +381,8 @@ export default function OfficialAvailabilityDate() {
             fixtures={pd.fixtures}
             onRemove={actions.unassign}
             removing={unassign.isPending}
+            onConfirm={(fixtureId) => confirmFixture.mutate(fixtureId)}
+            confirming={confirmFixture.isPending}
           />
           <div className="border-border bg-surface-raised border-t p-4">
             <GuestEntry fixtures={pd.fixtures} onAdd={actions.assign} />
@@ -673,15 +722,19 @@ function AssignmentRail({
   fixtures,
   onRemove,
   removing,
+  onConfirm,
+  confirming,
 }: {
   fixtures: Fixture[];
   onRemove: (assignmentId: string) => void;
   removing: boolean;
+  onConfirm: (fixtureId: string) => void;
+  confirming: boolean;
 }) {
   return (
     <div className="border-border bg-surface-raised border-t p-4">
       <p className="text-text-secondary mb-2 text-[11px] font-semibold tracking-[0.06em] uppercase">
-        Current assignments
+        Teams
       </p>
       <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
         {fixtures.map((f) => (
@@ -719,22 +772,85 @@ function AssignmentRail({
                         </span>
                       )}
                     </span>
-                    <button
-                      type="button"
-                      onClick={() => onRemove(a.id)}
-                      disabled={removing}
-                      className="text-text-secondary hover:text-danger ml-2 text-[11px] disabled:opacity-60"
-                    >
-                      Remove
-                    </button>
+                    {/* Once confirmed the squad is owned by the matchday
+                        screen, so removing a pick here would no longer
+                        reach it - hide the action to avoid that trap. */}
+                    {!f.matchdayId && (
+                      <button
+                        type="button"
+                        onClick={() => onRemove(a.id)}
+                        disabled={removing}
+                        className="text-text-secondary hover:text-danger ml-2 text-[11px] disabled:opacity-60"
+                      >
+                        Remove
+                      </button>
+                    )}
                   </li>
                 ))}
               </ol>
             )}
+            <ConfirmTeamControl
+              fixture={f}
+              onConfirm={onConfirm}
+              confirming={confirming}
+            />
           </div>
         ))}
       </div>
     </div>
+  );
+}
+
+/**
+ * Per-fixture confirm control. Turning a provisional team into a matchday
+ * is what lets an official lock in one game while the request stays open
+ * for the others. Once confirmed, the squad is managed on the matchday
+ * screen, so we swap the button for a link there.
+ */
+function ConfirmTeamControl({
+  fixture,
+  onConfirm,
+  confirming,
+}: {
+  fixture: Fixture;
+  onConfirm: (fixtureId: string) => void;
+  confirming: boolean;
+}) {
+  if (fixture.matchdayId) {
+    return (
+      <div className="border-border-light mt-3 flex items-center justify-between border-t pt-3">
+        <span className="text-success inline-flex items-center gap-1.5 text-xs font-semibold">
+          <CheckCircle2Icon className="size-4" />
+          Team confirmed
+        </span>
+        <Link
+          to={`/matchday/${fixture.matchdayId}/edit`}
+          className="text-navy text-xs font-semibold underline dark:text-white"
+        >
+          Manage squad →
+        </Link>
+      </div>
+    );
+  }
+  if (fixture.assignments.length === 0) return null;
+  return (
+    <Button
+      tone="primary"
+      size="sm"
+      className="mt-3 w-full"
+      disabled={confirming}
+      onClick={() => {
+        if (
+          confirm(
+            `Confirm this team and create the matchday for ${fixture.team_name ?? "this team"} vs ${fixture.opposition}? Players can still update availability for other games in this request.`,
+          )
+        ) {
+          onConfirm(fixture.id);
+        }
+      }}
+    >
+      {confirming ? "Confirming…" : "Confirm team →"}
+    </Button>
   );
 }
 

--- a/apps/matchday/src/pages/official-availability-detail.tsx
+++ b/apps/matchday/src/pages/official-availability-detail.tsx
@@ -127,6 +127,11 @@ export default function OfficialAvailabilityDetail() {
               <span className="bg-success-bg text-success rounded px-2 py-0.5">
                 {d.assignmentCount} assigned
               </span>
+              {d.confirmedCount > 0 && (
+                <span className="bg-success text-surface rounded px-2 py-0.5 font-semibold">
+                  {d.confirmedCount} of {d.fixtures.length} confirmed
+                </span>
+              )}
             </div>
           </Link>
         ))}
@@ -141,7 +146,7 @@ export default function OfficialAvailabilityDetail() {
             onClick={() => {
               if (
                 confirm(
-                  "Close this request? Players won't be able to respond after this.",
+                  "Close this request? Players won't be able to respond after this, and any picked-but-unconfirmed teams will be turned into matchdays.",
                 )
               ) {
                 close.mutate();

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -5471,6 +5471,7 @@ export interface paths {
                                 }[];
                                 responseCount: number;
                                 assignmentCount: number;
+                                confirmedCount: number;
                             }[];
                         };
                     };
@@ -5561,6 +5562,7 @@ export interface paths {
                                     position: number;
                                     created_at: string;
                                 }[];
+                                matchdayId: string | null;
                             }[];
                             pools: {
                                 available: {
@@ -5767,6 +5769,47 @@ export interface paths {
                                 fixtureId: string;
                                 matchdayId: string;
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/availability/requests/{requestId}/dates/{date}/fixtures/{fixtureId}/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    requestId: string;
+                    date: string;
+                    fixtureId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            matchdayId: string;
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -9560,13 +9560,17 @@
                           },
                           "assignmentCount": {
                             "type": "number"
+                          },
+                          "confirmedCount": {
+                            "type": "number"
                           }
                         },
                         "required": [
                           "date",
                           "fixtures",
                           "responseCount",
-                          "assignmentCount"
+                          "assignmentCount",
+                          "confirmedCount"
                         ],
                         "additionalProperties": false
                       }
@@ -9745,6 +9749,10 @@
                               ],
                               "additionalProperties": false
                             }
+                          },
+                          "matchdayId": {
+                            "nullable": true,
+                            "type": "string"
                           }
                         },
                         "required": [
@@ -9757,7 +9765,8 @@
                           "competition_name",
                           "match_time",
                           "team_name",
-                          "assignments"
+                          "assignments",
+                          "matchdayId"
                         ],
                         "additionalProperties": false
                       }
@@ -10129,6 +10138,58 @@
                   },
                   "required": [
                     "matchdays"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/availability/requests/{requestId}/dates/{date}/fixtures/{fixtureId}/confirm": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "requestId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "in": "path",
+            "name": "date",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "fixtureId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "matchdayId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "matchdayId"
                   ],
                   "additionalProperties": false
                 }


### PR DESCRIPTION
## Problem

An availability request spans a date range with fixtures across multiple days. Previously the **only** way to turn picks into matchdays was *Close request*, which materialised every fixture at once and stopped all responses. So you could not lock in a team for an earlier game while later games in the same request kept collecting availability - the fixture page even said *"The matchday will be created when the availability request is closed."*

## Change

The backend already had per-date confirm logic (`confirmDate`) but it was never wired into the UI. This adds a **per-fixture** confirm path so an official can lock in one game and create its matchday while the rest of the request stays open.

### API
- New `POST /availability/requests/:requestId/dates/:date/fixtures/:fixtureId/confirm` + `confirmFixture` service. Reuses `materialiseFixtureMatchday` with `conflict` semantics (re-confirming an already-confirmed fixture 409s, so picks added after the matchday exists are never silently dropped) and does **not** touch the request status.
- `getDateDetail` returns `matchdayId` per fixture; `getRequest` returns `confirmedCount` per date.

### Matchday app
- Date picker shows a per-fixture **Confirm team** control (mobile + desktop) that swaps to **Manage squad →** once confirmed. Remove is hidden after confirm (the squad is then owned by the matchday screen).
- Detail cards show *N of M confirmed*; fixture-detail and the close-request prompt copy updated to match.

### Decisions
- **Granularity: per fixture** (a date can have a 1st XI + 2nd XI confirmed at different times).
- **Responses stay open** for a confirmed fixture; changes after confirm don't flow into the created matchday (managed on the matchday screen). No response-locking added.

## Tests
- 4 new integration tests for `confirmFixture` (creates matchday + leaves request open, rejects empty team, 409 on re-confirm, surfaces on date detail + `confirmedCount`). Full availability integration suite: 26 passing.
- Typecheck + lint clean across the workspace; OpenAPI spec/types regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)