### PR TITLE
fix(matchday): make web push actually deliver (sync SW listeners + survive endpoint rotation)

### DIFF
--- a/apps/matchday/public/push-handler.js
+++ b/apps/matchday/public/push-handler.js
@@ -135,10 +135,12 @@ self.addEventListener("pushsubscriptionchange", (event) => {
       if (!json.endpoint || !keys.p256dh || !keys.auth) return;
 
       try {
-        // Cross-origin to the API subdomain; credentials carry the
+        // apiBase already includes the `/api` prefix (it's VITE_API_URL,
+        // e.g. https://api.v2.percymain.org/api), so this resolves to
+        // /api/me/push-subscriptions - the same route the typed client
+        // hits. Cross-origin to the API subdomain; credentials carry the
         // cross-subdomain session cookie (CORS-allowlisted for matchday).
-        // A 401 here (expired session) is fine - re-enable on next visit.
-        await fetch(`${apiBase}/me/push-subscriptions`, {
+        const res = await fetch(`${apiBase}/me/push-subscriptions`, {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
@@ -151,8 +153,13 @@ self.addEventListener("pushsubscriptionchange", (event) => {
             ).slice(0, 500),
           }),
         });
+        // A 401 (expired session) or other non-2xx is best-effort: the new
+        // endpoint stays unregistered until the user next opens the app,
+        // where the enable flow / backfill re-syncs it. Don't pretend a
+        // failed POST succeeded - just nothing more we can do from the SW.
+        if (!res.ok) return;
       } catch {
-        // best-effort; nothing more we can do from the SW
+        // network error - same best-effort fallback as a non-2xx response
       }
     })(),
   );

--- a/apps/matchday/public/push-handler.js
+++ b/apps/matchday/public/push-handler.js
@@ -1,4 +1,4 @@
-/* global self, clients */
+/* global self, clients, caches, fetch */
 // Web Push handler for matchday. Imported by the generateSW-produced
 // service worker via vite-plugin-pwa's workbox.importScripts. Lives as
 // a plain script (not bundled by Vite) because it's loaded with
@@ -6,6 +6,28 @@
 //
 // Payload contract: the API sends JSON.stringify({ title, body, url, tag }).
 // Anything else is treated as a bare title-only push.
+//
+// Config (the cross-origin API base + current VAPID key) is stashed into
+// the Cache below by the enable flow (use-push.ts) - the SW can't read
+// import.meta.env and a pushsubscriptionchange can fire with no client
+// open, so a window→SW shared Cache entry is the durable handoff.
+
+// Keep in sync with use-push.ts.
+const PUSH_CONFIG_CACHE = "push-config-v1";
+const PUSH_CONFIG_KEY = "/__push-config__";
+
+// base64url → Uint8Array for PushManager.subscribe()'s applicationServerKey.
+// Mirror of the helper in use-push.ts (can't import across the SW boundary).
+function urlBase64ToUint8Array(base64String) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = self.atob(base64);
+  const output = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    output[i] = rawData.charCodeAt(i);
+  }
+  return output;
+}
 
 self.addEventListener("push", (event) => {
   let payload = { title: "Percy Main", body: "" };
@@ -69,6 +91,68 @@ self.addEventListener("notificationclick", (event) => {
       }
       if (clients.openWindow) {
         await clients.openWindow(targetUrl);
+      }
+    })(),
+  );
+});
+
+// The push service periodically rotates or expires a subscription's
+// endpoint and fires `pushsubscriptionchange` in the SW. Without this
+// handler the subscription silently dies: the next server send hits the
+// dead endpoint, gets a 410, and the row is pruned - leaving the user
+// "enabled" in the browser but with nothing registered server-side, and
+// no notifications. Re-subscribe with the stored VAPID key and re-register
+// the fresh endpoint so delivery survives a rotation transparently.
+self.addEventListener("pushsubscriptionchange", (event) => {
+  event.waitUntil(
+    (async () => {
+      let config;
+      try {
+        const cache = await caches.open(PUSH_CONFIG_CACHE);
+        const res = await cache.match(PUSH_CONFIG_KEY);
+        if (!res) return; // never enabled on this device - nothing to do
+        config = await res.json();
+      } catch {
+        return;
+      }
+      const { apiBase, vapidPublicKey } = config ?? {};
+      if (!apiBase || !vapidPublicKey) return;
+
+      let subscription;
+      try {
+        subscription = await self.registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+        });
+      } catch {
+        // Permission revoked or push otherwise unavailable - the server
+        // prunes the dead endpoint on its next 410. Re-enable is manual.
+        return;
+      }
+
+      const json = subscription.toJSON();
+      const keys = json.keys || {};
+      if (!json.endpoint || !keys.p256dh || !keys.auth) return;
+
+      try {
+        // Cross-origin to the API subdomain; credentials carry the
+        // cross-subdomain session cookie (CORS-allowlisted for matchday).
+        // A 401 here (expired session) is fine - re-enable on next visit.
+        await fetch(`${apiBase}/me/push-subscriptions`, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            endpoint: json.endpoint,
+            keys: { p256dh: keys.p256dh, auth: keys.auth },
+            userAgent: (self.navigator && self.navigator.userAgent
+              ? self.navigator.userAgent
+              : ""
+            ).slice(0, 500),
+          }),
+        });
+      } catch {
+        // best-effort; nothing more we can do from the SW
       }
     })(),
   );

--- a/apps/matchday/src/features/notifications/use-push.ts
+++ b/apps/matchday/src/features/notifications/use-push.ts
@@ -80,6 +80,40 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
   return output;
 }
 
+// base64url-encode raw key bytes - inverse of urlBase64ToUint8Array. Used
+// to recover the stored VAPID key from an existing subscription's
+// applicationServerKey when backfilling config for devices that
+// subscribed before the pushsubscriptionchange recovery path shipped.
+function urlBase64FromBytes(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return window
+    .btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+// Devices that enabled push before the SW recovery path shipped have a
+// live subscription but no stashed config, so a pushsubscriptionchange
+// would no-op for them. Backfill from the subscription's own
+// applicationServerKey (no network round-trip) the first time we see it.
+async function backfillPushConfig(sub: PushSubscription): Promise<void> {
+  if (typeof caches === "undefined") return;
+  const key = sub.options.applicationServerKey;
+  if (!key) return;
+  try {
+    const cache = await caches.open(PUSH_CONFIG_CACHE);
+    if (await cache.match(PUSH_CONFIG_KEY)) return; // already stored
+  } catch {
+    return;
+  }
+  await storePushConfig(urlBase64FromBytes(key));
+}
+
 export interface PushState {
   support: Support;
   // null while react-query is still resolving the SW registration check.
@@ -92,6 +126,7 @@ async function readPushState(): Promise<PushState> {
   try {
     const reg = await navigator.serviceWorker.ready;
     const sub = await reg.pushManager.getSubscription();
+    if (sub) await backfillPushConfig(sub);
     return { support, subscribed: Boolean(sub) };
   } catch {
     return { support, subscribed: false };
@@ -190,6 +225,11 @@ export async function enablePushOnThisDevice(): Promise<{
 
 export async function disablePushOnThisDevice(): Promise<void> {
   if (!("serviceWorker" in navigator)) return;
+  // Drop the stashed config first - unconditionally, even if the local
+  // subscription has already expired/disappeared - so a later
+  // pushsubscriptionchange can't resurrect a subscription the user just
+  // turned off.
+  await clearPushConfig();
   const reg = await navigator.serviceWorker.ready;
   const sub = await reg.pushManager.getSubscription();
   if (!sub) return;
@@ -207,7 +247,4 @@ export async function disablePushOnThisDevice(): Promise<void> {
     // ignore - local unsubscribe still proceeds
   }
   await sub.unsubscribe();
-  // Drop the stashed config so a later pushsubscriptionchange doesn't
-  // silently resurrect a subscription the user just turned off.
-  await clearPushConfig();
 }

--- a/apps/matchday/src/features/notifications/use-push.ts
+++ b/apps/matchday/src/features/notifications/use-push.ts
@@ -1,5 +1,38 @@
-import { api, callApi } from "@/lib/api-client.js";
+import { api, API_BASE, callApi } from "@/lib/api-client.js";
 import { useQuery } from "@tanstack/react-query";
+
+// Shared with public/push-handler.js: the SW reads this Cache entry on
+// `pushsubscriptionchange` to re-subscribe + re-register after the push
+// service rotates an endpoint. Window and SW share Cache storage per
+// origin, so this is the durable handoff for config the SW can't read
+// from import.meta.env. Keep the names in sync with push-handler.js.
+const PUSH_CONFIG_CACHE = "push-config-v1";
+const PUSH_CONFIG_KEY = "/__push-config__";
+
+async function storePushConfig(vapidPublicKey: string): Promise<void> {
+  if (typeof caches === "undefined") return;
+  try {
+    const cache = await caches.open(PUSH_CONFIG_CACHE);
+    await cache.put(
+      PUSH_CONFIG_KEY,
+      new Response(JSON.stringify({ apiBase: API_BASE, vapidPublicKey }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  } catch {
+    // Best-effort: without it, a post-rotation re-subscribe just falls
+    // back to the user re-enabling manually (the pre-existing behaviour).
+  }
+}
+
+async function clearPushConfig(): Promise<void> {
+  if (typeof caches === "undefined") return;
+  try {
+    await caches.delete(PUSH_CONFIG_CACHE);
+  } catch {
+    // ignore
+  }
+}
 
 type Support =
   | { supported: true; permission: NotificationPermission }
@@ -148,6 +181,10 @@ export async function enablePushOnThisDevice(): Promise<{
     }),
   );
 
+  // Hand the SW what it needs to re-subscribe + re-register itself after
+  // the push service rotates this endpoint (pushsubscriptionchange).
+  await storePushConfig(publicKey);
+
   return { endpoint: json.endpoint };
 }
 
@@ -170,4 +207,7 @@ export async function disablePushOnThisDevice(): Promise<void> {
     // ignore - local unsubscribe still proceeds
   }
   await sub.unsubscribe();
+  // Drop the stashed config so a later pushsubscriptionchange doesn't
+  // silently resurrect a subscription the user just turned off.
+  await clearPushConfig();
 }

--- a/apps/matchday/vite.config.ts
+++ b/apps/matchday/vite.config.ts
@@ -64,6 +64,17 @@ export default defineConfig({
         ],
       },
       workbox: {
+        // Inline the workbox runtime into sw.js instead of emitting it as
+        // a separate module. Under Vite 8 (rolldown) an external runtime
+        // makes the bundler wrap the whole SW in an async AMD `define()`
+        // loader, so the worker body - including the importScripts() that
+        // registers the push/notificationclick listeners - runs inside a
+        // promise `.then()`. Service Worker functional-event listeners must
+        // be added synchronously during initial script evaluation; deferred
+        // registration means the browser never delivers push events to the
+        // handler (push service returns 201, but nothing is shown). Inlining
+        // removes the external dependency so the SW emits flat + synchronous.
+        inlineWorkboxRuntime: true,
         // Prompt-to-reload, NOT auto-takeover. The old SW keeps serving
         // the old precache (and therefore the old route chunks) until
         // the user taps Reload on the toast — at which point we send


### PR DESCRIPTION
## Summary

Investigated a report that push notifications "don't work, even though they're enabled." Push delivery was confirmed working server-side (a fresh subscription returned HTTP `201` from both Apple Web Push and FCM), but **nothing displayed on any device**. Two distinct service-worker bugs were responsible. Both are fixed here.

## Bug 1 — push listeners registered asynchronously (nothing ever shows)

Under Vite 8 (rolldown), emitting the workbox runtime as an external module made the bundler wrap the entire generated service worker in an async AMD `define(["./workbox-…"], fn)` loader. The worker body — including the `importScripts("/push-handler.js")` that registers the `push`/`notificationclick` listeners — ran inside a `Promise.all(...).then(...)` callback.

The Service Worker spec requires functional-event listeners to be added **synchronously during initial script evaluation**. Deferred a microtask, the browser never routes `push` events to the handler, so the notification is silently dropped despite successful delivery (the `201`s).

**Fix:** `inlineWorkboxRuntime: true` — with no external runtime module to defer behind, the SW emits as a flat, synchronous script. Verified the rebuilt `dist/sw.js` no longer contains the `self.define` wrapper and calls `importScripts("/push-handler.js")` at top level.

## Bug 2 — no `pushsubscriptionchange` handler (push dies after a rotation)

The push service periodically rotates/expires endpoints and fires `pushsubscriptionchange` in the SW. There was no handler, so the subscription silently died: the next send hit the dead endpoint → 410 → the row was pruned, leaving the user "enabled" in the browser but unregistered server-side. This already cost a production user their subscription.

**Fix:** add a `pushsubscriptionchange` handler that re-subscribes with the stored VAPID key and re-registers the fresh endpoint. Since the SW can't read `import.meta.env` and the event can fire with no client open, the enable flow stashes the cross-origin API base + VAPID key into a per-origin Cache entry the SW reads; disable clears it.

## Testing

- Rebuilt `dist/sw.js`: confirmed flat/synchronous (no `self.define`), `importScripts("/push-handler.js")` at top level, `pushsubscriptionchange` present in the emitted handler.
- `tsc --noEmit`, `eslint`, and `prettier --check` all clean.
- Server path independently verified during the investigation: VAPID keypair valid (derived public from private, matched SSM), and a test send to a live subscription returned `201`.

## Note
Requires a deploy + the prompt-to-reload SW swap to take effect on devices (registerType is `prompt`). After merge/deploy, re-test by tapping Reload on the update toast, then triggering a push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)