### PR TITLE
fix(matchday): stop sticky bottom nav leaving a gap under it on iOS Chrome

### DIFF
--- a/apps/matchday/src/components/shell/app-shell.tsx
+++ b/apps/matchday/src/components/shell/app-shell.tsx
@@ -30,17 +30,25 @@ export function AppShell() {
     ? "official"
     : "player";
   const tabs = tabsForRole(role);
+  // Fixed-height app shell: the outer box is exactly one dynamic
+  // viewport tall (`h-dvh`) and clips overflow, so the page body never
+  // scrolls - only <main> does (`overflow-y-auto`). This keeps the
+  // browser's address/toolbar chrome from auto-hiding on scroll, which
+  // is what let iOS Chrome leave a gap under a `position: fixed` bottom
+  // nav (Safari re-anchored it to the visual viewport, Chrome didn't).
+  // With the bar now a normal flex child at the foot of the column, it
+  // is structurally pinned to the bottom on every browser.
   return (
-    <div className="bg-surface-raised text-text flex min-h-dvh">
+    <div className="bg-surface-raised text-text flex h-dvh overflow-hidden">
       <DesktopSideNav tabs={tabs} />
       <div className="flex min-w-0 flex-1 flex-col">
         <TopBar />
         <OfflineIndicator />
-        <main className="flex-1 pb-[calc(env(safe-area-inset-bottom)+72px)] md:pb-0">
+        <main className="flex-1 overflow-y-auto">
           <Outlet />
         </main>
+        <BottomTabBar tabs={tabs} />
       </div>
-      <BottomTabBar tabs={tabs} />
       <ServiceWorkerUpdate />
     </div>
   );

--- a/apps/matchday/src/components/shell/app-shell.tsx
+++ b/apps/matchday/src/components/shell/app-shell.tsx
@@ -7,7 +7,8 @@ import { OfflineIndicator } from "@/components/shell/offline-indicator.js";
 import { ServiceWorkerUpdate } from "@/components/shell/sw-update.js";
 import { TopBar } from "@/components/shell/top-bar.js";
 import { canViewMatchdayAdmin, useSession } from "@/lib/auth-client.js";
-import { Outlet } from "react-router";
+import { useLayoutEffect, useRef } from "react";
+import { Outlet, useLocation } from "react-router";
 
 /**
  * Top-level shell wrapping every authenticated route. Renders the top
@@ -30,6 +31,19 @@ export function AppShell() {
     ? "official"
     : "player";
   const tabs = tabsForRole(role);
+
+  // <main> is now the scroll container instead of the window, and the
+  // shell stays mounted across route changes, so its scroll offset would
+  // otherwise carry over when you switch tabs (land partway down the next
+  // page). Reset it to the top on every navigation - the expected
+  // behaviour for tab nav. useLayoutEffect runs before paint so there's
+  // no visible jump from the previous page's scroll position.
+  const { pathname } = useLocation();
+  const mainRef = useRef<HTMLElement>(null);
+  useLayoutEffect(() => {
+    mainRef.current?.scrollTo({ top: 0 });
+  }, [pathname]);
+
   // Fixed-height app shell: the outer box is exactly one dynamic
   // viewport tall (`h-dvh`) and clips overflow, so the page body never
   // scrolls - only <main> does (`overflow-y-auto`). This keeps the
@@ -44,7 +58,7 @@ export function AppShell() {
       <div className="flex min-w-0 flex-1 flex-col">
         <TopBar />
         <OfflineIndicator />
-        <main className="flex-1 overflow-y-auto">
+        <main ref={mainRef} className="flex-1 overflow-y-auto">
           <Outlet />
         </main>
         <BottomTabBar tabs={tabs} />

--- a/apps/matchday/src/components/shell/bottom-tab-bar.tsx
+++ b/apps/matchday/src/components/shell/bottom-tab-bar.tsx
@@ -74,7 +74,7 @@ export function BottomTabBar({ tabs }: { tabs: TabDef[] }) {
     activeIdx >= 0 ? `${((activeIdx + 0.5) * 100) / tabs.length}%` : "-100%";
   return (
     <nav
-      className="border-border bg-surface/95 fixed inset-x-0 bottom-0 z-30 grid auto-cols-fr grid-flow-col border-t pt-1 pb-[max(env(safe-area-inset-bottom),6px)] backdrop-blur md:hidden"
+      className="border-border bg-surface/95 relative z-30 grid auto-cols-fr grid-flow-col border-t pt-1 pb-[max(env(safe-area-inset-bottom),6px)] backdrop-blur md:hidden"
       aria-label="Matchday navigation"
     >
       {/* Single sliding accent bar shared across the row. CSS

--- a/apps/matchday/src/pages/availability-respond.tsx
+++ b/apps/matchday/src/pages/availability-respond.tsx
@@ -360,5 +360,5 @@ function EmptyDone({
 }
 
 function FlowFrame({ children }: { children: React.ReactNode }) {
-  return <div className="bg-surface flex min-h-dvh flex-col">{children}</div>;
+  return <div className="bg-surface flex min-h-full flex-col">{children}</div>;
 }

--- a/apps/matchday/src/pages/matchday-live.tsx
+++ b/apps/matchday/src/pages/matchday-live.tsx
@@ -177,7 +177,7 @@ export default function MatchdayLive() {
   const notified = md.matchday.charges_notified_at != null;
 
   return (
-    <div className="bg-surface flex min-h-dvh flex-col">
+    <div className="bg-surface flex min-h-full flex-col">
       <header className="bg-navy px-4 py-3 text-white">
         <p className="text-[11px] font-semibold tracking-[0.06em] uppercase opacity-70">
           Match day · captain


### PR DESCRIPTION
## Problem

On mobile web (iOS Chrome), scrolling the matchday app retracts the browser's bottom chrome and a gap opens up *under* the sticky bottom tab bar. It works fine in iOS Safari.

**Root cause:** the tab bar was `position: fixed; bottom-0`. With the page body scrolling, iOS Chrome retracts its toolbar but keeps `fixed` elements pinned to the *layout* viewport (Safari re-anchors them to the *visual* viewport), so the nav stayed put while the visible area grew - hence the gap. Combined with `viewport-fit=cover`, this is a long-standing iOS Chrome quirk, not a bug in our CSS.

## Fix (fixed-height shell, internal scroll)

Eliminate body scroll so the browser chrome never retracts and the gap can't form:

- **`app-shell.tsx`** - shell is now `h-dvh overflow-hidden`; `<main>` is the only scroller (`overflow-y-auto`); `BottomTabBar` moved *inside* the column as a normal flex child. Dropped the `pb-[…72px]` spacer (the in-flow nav reserves its own space).
- **`bottom-tab-bar.tsx`** - dropped `fixed inset-x-0 bottom-0`, added `relative` so the `absolute` sliding active-tab indicator still anchors to the nav. Structurally pinned to the bottom on every browser now.
- **`matchday-live.tsx` / `availability-respond.tsx`** - full-screen wrappers go `min-h-dvh` → `min-h-full` so they fill the bounded `<main>` instead of overflowing it by the topbar+nav height.

`StickyActionBar` and the SW-update toast stay `fixed` - they're correct now that the viewport is static, and their offsets still clear the in-flow nav.

## Tradeoff

The browser's address/toolbar chrome **no longer auto-hides on scroll** - we trade that bit of extra height for a deterministic layout (chosen over a `visualViewport` JS patch, which preserved chrome-hiding but is fiddly to keep pixel-accurate).

## Verification

- `typecheck` ✅ · `lint` ✅ · `prettier --check` ✅
- The gap itself is iOS-Chrome-specific and needs on-device confirmation in Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)