### PR TITLE
ci: pin all third-party GitHub Actions to commit SHAs (#354)

### DIFF
--- a/.claude/skills/work-on-ci/SKILL.md
+++ b/.claude/skills/work-on-ci/SKILL.md
@@ -148,6 +148,8 @@ The code snippets elsewhere in this skill abbreviate refs to `@v6` etc. for read
 
 Exceptions, which stay as bare `./` refs (they are first-party and resolved from the repo's own tree, not downloaded): internal composite actions under `./.github/actions/*` and the reusable `./.github/workflows/_lint-test-build.yml`.
 
+One action carries a SHA with **no** `# vX.Y.Z` comment: `millionco/react-doctor` in `ci.yml`. It is deliberately pinned to an untagged commit on the maintainer's `main` (a recovery point from the PR #353 incident, sitting between releases), so there is no release tag to name. Dependabot can't auto-bump it while it's off a tag - the inline comment above the `uses:` line explains the situation. Re-pin it to a tagged release (with the `# vX.Y.Z` comment) once the upstream `--pr-comment` gap closes.
+
 GitHub also deprecates Node 20 actions on a rolling schedule (forced to Node 24 from June 2026, Node 20 removed September 2026). When a deprecation annotation appears, bump to the SHA of the latest major.
 
 ## Hooks and gotchas

--- a/.claude/skills/work-on-ci/SKILL.md
+++ b/.claude/skills/work-on-ci/SKILL.md
@@ -128,21 +128,27 @@ Tasks that have `outputs` defined in `turbo.json` are cached. The CI `.turbo` ca
 
 ## Action version policy
 
-GitHub deprecates Node 20 actions on a rolling schedule (forced to Node 24 from June 2026, Node 20 removed September 2026). When adding a new action **or** seeing a deprecation annotation, pin to the latest major:
+**Every third-party action is pinned to a full 40-char commit SHA**, with a trailing `# vX.Y.Z` comment naming the release that SHA belongs to:
 
-- `actions/checkout@v6`
-- `actions/setup-node@v6`
-- `actions/cache@v5`
-- `actions/upload-artifact@v7` / `actions/download-artifact@v8`
-- `pnpm/action-setup@v6`
-- `aws-actions/configure-aws-credentials@v6`
-- `hashicorp/setup-terraform@v4`
-- `dorny/paths-filter@v4`
-- `docker/setup-buildx-action@v3`, `docker/build-push-action@v6`
-- `EnricoMi/publish-unit-test-result-action@v2`
-- `actions/dependency-review-action@v5`
+```yaml
+- uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+```
 
-Third-party security actions are SHA-pinned (see `aquasecurity/trivy-action` in `ci.yml`). Keep them SHA-pinned and bump deliberately.
+A version-tag ref (`@v6`, `@main`) is mutable: the maintainer can retarget the tag at any commit, including a malicious one (the [tj-actions/changed-files compromise, March 2025](https://github.com/marketplace/actions/tj-actions/changed-files) exfiltrated secrets from thousands of repos this way), and a moving `@main` can ship a breaking change mid-flight (which is what broke `react-doctor` in PR #353). A SHA is immutable, so neither can happen. Auth, payments, and infra-deploy secrets (`AWS_*`, `STRIPE_*`, `BETTER_AUTH_*`, `NEW_RELIC_*`) flow through these workflows, so this is the policy for **all** external actions, including first-party `actions/*` from GitHub.
+
+The trailing `# vX.Y.Z` comment is not decoration: Dependabot reads it to know which release the SHA maps to, and opens a PR (bumping both SHA and comment) when upstream tags move. The `github-actions` ecosystem is enabled in `.github/dependabot.yml`, so this stays maintained without manual effort.
+
+To pin (or bump) an action, resolve the tag to a commit SHA and find the matching release tag:
+
+```sh
+gh api repos/<owner>/<repo>/commits/<tag> --jq .sha   # -> the 40-char SHA
+```
+
+The code snippets elsewhere in this skill abbreviate refs to `@v6` etc. for readability - the real workflow files are SHA-pinned, and any new ref you add must be too.
+
+Exceptions, which stay as bare `./` refs (they are first-party and resolved from the repo's own tree, not downloaded): internal composite actions under `./.github/actions/*` and the reusable `./.github/workflows/_lint-test-build.yml`.
+
+GitHub also deprecates Node 20 actions on a rolling schedule (forced to Node 24 from June 2026, Node 20 removed September 2026). When a deprecation annotation appears, bump to the SHA of the latest major.
 
 ## Hooks and gotchas
 

--- a/.github/actions/notify-deploy-failure/action.yml
+++ b/.github/actions/notify-deploy-failure/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Open issue + post Slack
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         JOB_NAME: ${{ inputs.job }}
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -9,11 +9,11 @@ description: >
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v6
+    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       with:
         version: 11.1.2
 
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
         cache: pnpm

--- a/.github/workflows/_lint-test-build.yml
+++ b/.github/workflows/_lint-test-build.yml
@@ -37,7 +37,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
@@ -48,11 +48,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-lint-${{ github.sha }}
@@ -65,11 +65,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-typecheck-${{ github.sha }}
@@ -82,11 +82,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-test-${{ github.sha }}
@@ -98,7 +98,7 @@ jobs:
           CI: "true"
       - name: Upload JUnit XML artefact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-unit
           path: "**/test-results/*.xml"
@@ -130,11 +130,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-test-integration-${{ github.sha }}
@@ -150,7 +150,7 @@ jobs:
           CI: "true"
       - name: Upload JUnit XML artefact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-integration
           path: "**/test-results/*.xml"
@@ -162,11 +162,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-build-${{ github.sha }}
@@ -191,11 +191,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-deps
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-openapi-${{ github.sha }}
@@ -228,14 +228,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Download unit JUnit XML
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: junit-unit
           path: junit-xml/unit
         continue-on-error: true
 
       - name: Download integration JUnit XML
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: junit-integration
           path: junit-xml/integration
@@ -243,7 +243,7 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           files: "junit-xml/**/*.xml"
           check_name: "Vitest results"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     # Opt-out via a `safe-ddl-ack: <reason>` token in any commit message.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       # setup-deps installs the workspace and gives the script access to
@@ -57,7 +57,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       # Pinned to a SHA: their @main shipped a `--pr-comment` flag on
@@ -89,13 +89,13 @@ jobs:
     env:
       IMAGE: percy-main-api:pr-${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build API image (local, no push)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: apps/api/Dockerfile
@@ -127,8 +127,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/dependency-review-action@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           # Block GPL/AGPL/etc copyleft licences in production deps —

--- a/.github/workflows/deploy-api-manual.yml
+++ b/.github/workflows/deploy-api-manual.yml
@@ -41,7 +41,7 @@ jobs:
       ECS_CLUSTER: percy-main-production-cluster
       ECS_SERVICE: production-api
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
 
@@ -57,14 +57,14 @@ jobs:
           echo "Deployed SHA: ${DEPLOYED_SHA}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to ECR
         id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
 
       - name: Build and push Docker image
         id: build
@@ -95,7 +95,7 @@ jobs:
 
       - name: Generate SBOM (SPDX JSON)
         id: sbom
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ steps.build.outputs.image }}
           format: spdx-json

--- a/.github/workflows/deploy-terraform-manual.yml
+++ b/.github/workflows/deploy-terraform-manual.yml
@@ -54,7 +54,7 @@ jobs:
     # against an arbitrary ref still requires reviewer approval.
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
 
@@ -69,12 +69,12 @@ jobs:
           echo "Deployed SHA: ${DEPLOYED_SHA}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.TERRAFORM_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -181,7 +181,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
 
@@ -196,12 +196,12 @@ jobs:
           echo "Deployed SHA: ${DEPLOYED_SHA}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.TERRAFORM_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TF_VERSION }}
 

--- a/.github/workflows/deploy-web-manual.yml
+++ b/.github/workflows/deploy-web-manual.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
 
@@ -51,11 +51,11 @@ jobs:
           echo "sha=${DEPLOYED_SHA}" >> "$GITHUB_OUTPUT"
           echo "Deployed SHA: ${DEPLOYED_SHA}"
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.1.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -76,7 +76,7 @@ jobs:
           VITE_GA4_MEASUREMENT_ID: ${{ vars.GA4_MEASUREMENT_ID }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,8 +43,8 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
       matchday: ${{ steps.filter.outputs.matchday }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -83,15 +83,15 @@ jobs:
       NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
       TF_VAR_newrelic_account_id: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.TERRAFORM_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -215,15 +215,15 @@ jobs:
     env:
       TF_VERSION: "1.7"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.TERRAFORM_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -331,17 +331,17 @@ jobs:
       ECS_CLUSTER: percy-main-production-cluster
       ECS_SERVICE: production-api
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to ECR
         id: ecr-login
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
 
       - name: Build and push Docker image
         id: build
@@ -379,7 +379,7 @@ jobs:
         # for forensics when a future CVE drops ("did the version we
         # shipped on $SHA include vulnerable lib X?") without needing
         # to re-pull the image months later.
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ steps.build.outputs.image }}
           format: spdx-json
@@ -686,13 +686,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.1.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -718,7 +718,7 @@ jobs:
           VITE_GA4_MEASUREMENT_ID: ${{ vars.GA4_MEASUREMENT_ID }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -852,7 +852,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Verify required GitHub repo variables are set
         # First-run protection. The matchday bucket + distribution are
@@ -877,11 +877,11 @@ jobs:
             exit 1
           fi
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.1.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -896,7 +896,7 @@ jobs:
           VITE_STRIPE_PUBLIC_KEY: ${{ vars.STRIPE_PUBLIC_KEY }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -29,7 +29,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/rotate-secrets-reminder.yml
+++ b/.github/workflows/rotate-secrets-reminder.yml
@@ -17,7 +17,7 @@ jobs:
   open-reminder:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Open or update reminder issue
         env:

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -41,10 +41,10 @@ jobs:
       matrix:
         environment: [shared, production]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           # The plan role is read-only (ReadOnlyAccess + extras). Drift
           # runs are scheduled / workflow_dispatch, so the OIDC subject
@@ -54,7 +54,7 @@ jobs:
           role-to-assume: ${{ vars.TERRAFORM_PLAN_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Open drift issue
         if: steps.plan.outputs.exitcode == '2'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ENV: ${{ matrix.environment }}
         with:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,15 +40,15 @@ jobs:
       matrix:
         environment: [shared, production]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ vars.TERRAFORM_PLAN_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Post plan to PR
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Closes #354.

## What

Pins every third-party GitHub Action to a full 40-char commit SHA with a trailing `# vX.Y.Z` comment, following the pattern already used for `aquasecurity/trivy-action`.

17 distinct actions across 12 files (workflows + composite actions):

| Action | Pinned to |
| --- | --- |
| `actions/checkout` | `df4cb1c` # v6.0.3 |
| `actions/cache` | `27d5ce7` # v5.0.5 |
| `actions/upload-artifact` | `043fb46` # v7.0.1 |
| `actions/download-artifact` | `3e5f45b` # v8.0.1 |
| `actions/setup-node` | `48b55a0` # v6.4.0 |
| `actions/dependency-review-action` | `a1d282b` # v5.0.0 |
| `actions/labeler` | `f27b608` # v6.1.0 |
| `actions/github-script` | `3a2844b` # v9.0.0 |
| `pnpm/action-setup` | `0e279bb` # v6.0.8 |
| `aws-actions/configure-aws-credentials` | `e7f100c` # v6.2.0 |
| `aws-actions/amazon-ecr-login` | `fa648b4` # v2.1.5 |
| `hashicorp/setup-terraform` | `dfe3c3f` # v4.0.1 |
| `EnricoMi/publish-unit-test-result-action` | `c950f6f` # v2.23.0 |
| `docker/setup-buildx-action` | `d7f5e7f` # v4.1.0 |
| `docker/build-push-action` | `f9f3042` # v7.2.0 |
| `anchore/sbom-action` | `e22c389` # v0.24.0 |
| `dorny/paths-filter` | `fbd0ab8` # v4.0.1 |

SHAs were resolved from the tags live (`gh api repos/<owner>/<repo>/commits/<tag>`); the version comment is the most specific semver tag pointing at that commit.

## Why

Version-tag refs (`@v6`, `@main`) are mutable. A maintainer can retarget a tag at any commit, including a malicious one (the [tj-actions/changed-files compromise, March 2025](https://github.com/marketplace/actions/tj-actions/changed-files)), and a moving `@main` can ship a breaking change mid-flight (which broke `react-doctor` in PR #353). Auth, payments, and infra-deploy secrets flow through these workflows. A SHA is immutable, so neither failure mode applies.

## Issue steps

1. ✅ Replace every third-party `@vX` with `@<sha> # vX.Y.Z`, including first-party `actions/*` (per the issue's "out of scope" note that they're worth pinning in the same pass).
2. ✅ Dependabot `github-actions` ecosystem - **already enabled** in `.github/dependabot.yml`, no change needed. The trailing comments give it the version anchor to bump from.
3. ✅ Documented the policy in `.claude/skills/work-on-ci/SKILL.md`.

## Out of scope (unchanged)

- Internal `./.github/actions/*` composite actions and `_lint-test-build.yml` stay as `./` refs (first-party, resolved from the repo tree).
- `aquasecurity/trivy-action` and `millionco/react-doctor` were already SHA-pinned. react-doctor sits on an untagged recovery commit, so it has no `# vX.Y.Z` comment (the existing inline comment explains why).

## Runtime impact

None. CI workflow YAML only - no runtime application code touched. The pinned SHAs resolve to the same action releases the version tags currently point at, so behaviour is unchanged.

## Validation

- `pnpm format:check` passes (workflow YAML is prettier-formatted).
- All workflow + action YAML files parse.
- Every changed line is a `uses:` ref; no other edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)