### PR TITLE
fix(a11y): add caption + th scope to data tables (#439)

### DIFF
--- a/apps/web/src/components/leaderboard-content.tsx
+++ b/apps/web/src/components/leaderboard-content.tsx
@@ -204,30 +204,41 @@ function BattingTable({
   return (
     <div>
       <Table>
+        <caption className="sr-only">Season batting leaderboard</caption>
         <TableHeader>
           <TableRow>
-            <TableHead className="w-10">#</TableHead>
-            <TableHead>Player</TableHead>
-            <TableHead className="text-right">Inn</TableHead>
-            <TableHead className="hidden text-right sm:table-cell">
+            <TableHead scope="col" className="w-10">
+              #
+            </TableHead>
+            <TableHead scope="col">Player</TableHead>
+            <TableHead scope="col" className="text-right">
+              Inn
+            </TableHead>
+            <TableHead scope="col" className="hidden text-right sm:table-cell">
               NO
             </TableHead>
-            <TableHead className="text-right">Runs</TableHead>
-            <TableHead className="text-right">HS</TableHead>
-            <TableHead className="text-right">Avg</TableHead>
-            <TableHead className="hidden text-right md:table-cell">
+            <TableHead scope="col" className="text-right">
+              Runs
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              HS
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Avg
+            </TableHead>
+            <TableHead scope="col" className="hidden text-right md:table-cell">
               SR
             </TableHead>
-            <TableHead className="hidden text-right md:table-cell">
+            <TableHead scope="col" className="hidden text-right md:table-cell">
               4s
             </TableHead>
-            <TableHead className="hidden text-right md:table-cell">
+            <TableHead scope="col" className="hidden text-right md:table-cell">
               6s
             </TableHead>
-            <TableHead className="hidden text-right lg:table-cell">
+            <TableHead scope="col" className="hidden text-right lg:table-cell">
               50s
             </TableHead>
-            <TableHead className="hidden text-right lg:table-cell">
+            <TableHead scope="col" className="hidden text-right lg:table-cell">
               100s
             </TableHead>
           </TableRow>
@@ -313,22 +324,35 @@ function BowlingTable({
   return (
     <div>
       <Table>
+        <caption className="sr-only">Season bowling leaderboard</caption>
         <TableHeader>
           <TableRow>
-            <TableHead className="w-10">#</TableHead>
-            <TableHead>Player</TableHead>
-            <TableHead className="text-right">O</TableHead>
-            <TableHead className="hidden text-right sm:table-cell">M</TableHead>
-            <TableHead className="text-right">R</TableHead>
-            <TableHead className="text-right">W</TableHead>
-            <TableHead className="text-right">Avg</TableHead>
-            <TableHead className="hidden text-right md:table-cell">
+            <TableHead scope="col" className="w-10">
+              #
+            </TableHead>
+            <TableHead scope="col">Player</TableHead>
+            <TableHead scope="col" className="text-right">
+              O
+            </TableHead>
+            <TableHead scope="col" className="hidden text-right sm:table-cell">
+              M
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              R
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              W
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Avg
+            </TableHead>
+            <TableHead scope="col" className="hidden text-right md:table-cell">
               Econ
             </TableHead>
-            <TableHead className="hidden text-right md:table-cell">
+            <TableHead scope="col" className="hidden text-right md:table-cell">
               SR
             </TableHead>
-            <TableHead className="hidden text-right lg:table-cell">
+            <TableHead scope="col" className="hidden text-right lg:table-cell">
               Best
             </TableHead>
           </TableRow>

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -121,13 +121,21 @@ function LeagueTable({
         <h2 className="mb-3 text-2xl leading-tight font-semibold">{name}</h2>
         <div className="overflow-x-auto">
           <table className="min-w-full text-xs">
+            <caption className="sr-only">
+              {name ? `${name} league table` : "League table"}
+            </caption>
             <thead className="rounded-t-lg dark:bg-stone-300">
               <tr className="text-right">
-                <th title="Position" className="p-3 text-left">
+                <th scope="col" title="Position" className="p-3 text-left">
                   Position
                 </th>
                 {columns.map((column) => (
-                  <th key={column} title={column} className="p-3 text-left">
+                  <th
+                    key={column}
+                    scope="col"
+                    title={column}
+                    className="p-3 text-left"
+                  >
                     {column}
                   </th>
                 ))}

--- a/apps/web/src/components/records-wall.tsx
+++ b/apps/web/src/components/records-wall.tsx
@@ -117,13 +117,18 @@ function HonoursTable({
 
   return (
     <Table>
+      <caption className="sr-only">
+        {type === "batting" ? "Centuries" : "Five-wicket hauls"}
+      </caption>
       <TableHeader>
         <TableRow>
-          <TableHead>Player</TableHead>
-          <TableHead className="text-right">
+          <TableHead scope="col">Player</TableHead>
+          <TableHead scope="col" className="text-right">
             {type === "batting" ? "Score" : "Figures"}
           </TableHead>
-          <TableHead className="text-right">Season</TableHead>
+          <TableHead scope="col" className="text-right">
+            Season
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>

--- a/apps/web/src/components/scorecard.tsx
+++ b/apps/web/src/components/scorecard.tsx
@@ -392,14 +392,25 @@ function BattingCard({
   return (
     <div>
       <Table>
+        <caption className="sr-only">Batting scorecard</caption>
         <TableHeader>
           <TableRow>
-            <TableHead className="w-full">Batter</TableHead>
-            <TableHead className="text-right">R</TableHead>
-            <TableHead className="text-right">B</TableHead>
-            <TableHead className="text-right">4s</TableHead>
-            <TableHead className="text-right">6s</TableHead>
-            <TableHead className="text-right">
+            <TableHead scope="col" className="w-full">
+              Batter
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              R
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              B
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              4s
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              6s
+            </TableHead>
+            <TableHead scope="col" className="text-right">
               {isPairs ? "TO" : "SR"}
             </TableHead>
           </TableRow>
@@ -480,14 +491,27 @@ function BattingCard({
 function BowlingCard({ bowling }: { bowling: BowlingEntry[] }) {
   return (
     <Table>
+      <caption className="sr-only">Bowling scorecard</caption>
       <TableHeader>
         <TableRow>
-          <TableHead className="w-full">Bowler</TableHead>
-          <TableHead className="text-right">O</TableHead>
-          <TableHead className="text-right">M</TableHead>
-          <TableHead className="text-right">R</TableHead>
-          <TableHead className="text-right">W</TableHead>
-          <TableHead className="text-right">Econ</TableHead>
+          <TableHead scope="col" className="w-full">
+            Bowler
+          </TableHead>
+          <TableHead scope="col" className="text-right">
+            O
+          </TableHead>
+          <TableHead scope="col" className="text-right">
+            M
+          </TableHead>
+          <TableHead scope="col" className="text-right">
+            R
+          </TableHead>
+          <TableHead scope="col" className="text-right">
+            W
+          </TableHead>
+          <TableHead scope="col" className="text-right">
+            Econ
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>

--- a/apps/web/src/components/season-leaders.tsx
+++ b/apps/web/src/components/season-leaders.tsx
@@ -54,10 +54,12 @@ function PlayerLink({
 
 function MiniTable({
   title,
+  caption,
   children,
   headers,
 }: {
   title: string;
+  caption: string;
   children: React.ReactNode;
   headers: React.ReactNode;
 }) {
@@ -67,6 +69,7 @@ function MiniTable({
         {title}
       </h4>
       <Table>
+        <caption className="sr-only">{caption}</caption>
         <TableHeader>
           <TableRow>{headers}</TableRow>
         </TableHeader>
@@ -147,15 +150,26 @@ export function SeasonLeaders() {
           {battingEntries.length > 0 && (
             <MiniTable
               title="Top Run Scorers"
+              caption="Top run scorers"
               headers={
                 <>
-                  <TableHead className="w-8">#</TableHead>
-                  <TableHead>Player</TableHead>
-                  <TableHead className="text-right">Runs</TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead scope="col" className="w-8">
+                    #
+                  </TableHead>
+                  <TableHead scope="col">Player</TableHead>
+                  <TableHead scope="col" className="text-right">
+                    Runs
+                  </TableHead>
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     HS
                   </TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     Avg
                   </TableHead>
                 </>
@@ -186,15 +200,26 @@ export function SeasonLeaders() {
           {bowlingEntries.length > 0 && (
             <MiniTable
               title="Top Wicket Takers"
+              caption="Top wicket takers"
               headers={
                 <>
-                  <TableHead className="w-8">#</TableHead>
-                  <TableHead>Player</TableHead>
-                  <TableHead className="text-right">Wkts</TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead scope="col" className="w-8">
+                    #
+                  </TableHead>
+                  <TableHead scope="col">Player</TableHead>
+                  <TableHead scope="col" className="text-right">
+                    Wkts
+                  </TableHead>
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     Overs
                   </TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     Avg
                   </TableHead>
                 </>

--- a/apps/web/src/pages/fantasy/fantasy-rules.tsx
+++ b/apps/web/src/pages/fantasy/fantasy-rules.tsx
@@ -64,10 +64,11 @@ function SandwichBudgetRules() {
             season performance. Top performers cost more sandwiches.
           </p>
           <Table>
+            <caption className="sr-only">Sandwich cost tiers</caption>
             <TableHeader>
               <TableRow>
-                <TableHead>Cost</TableHead>
-                <TableHead>Player Tier</TableHead>
+                <TableHead scope="col">Cost</TableHead>
+                <TableHead scope="col">Player Tier</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -117,11 +118,16 @@ function WicketkeeperRules() {
             Scoring is based on the actual match role, not just the fantasy tag:
           </p>
           <Table>
+            <caption className="sr-only">Wicketkeeper scoring</caption>
             <TableHeader>
               <TableRow>
-                <TableHead>Scenario</TableHead>
-                <TableHead className="text-right">Catches</TableHead>
-                <TableHead className="text-right">Stumpings</TableHead>
+                <TableHead scope="col">Scenario</TableHead>
+                <TableHead scope="col" className="text-right">
+                  Catches
+                </TableHead>
+                <TableHead scope="col" className="text-right">
+                  Stumpings
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -176,10 +182,13 @@ function BattingRules() {
       </CardHeader>
       <CardContent>
         <Table>
+          <caption className="sr-only">Batting scoring</caption>
           <TableHeader>
             <TableRow>
-              <TableHead>Action</TableHead>
-              <TableHead className="w-24 text-right">Points</TableHead>
+              <TableHead scope="col">Action</TableHead>
+              <TableHead scope="col" className="w-24 text-right">
+                Points
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -232,10 +241,13 @@ function BowlingRules() {
       </CardHeader>
       <CardContent>
         <Table>
+          <caption className="sr-only">Bowling scoring</caption>
           <TableHeader>
             <TableRow>
-              <TableHead>Action</TableHead>
-              <TableHead className="w-24 text-right">Points</TableHead>
+              <TableHead scope="col">Action</TableHead>
+              <TableHead scope="col" className="w-24 text-right">
+                Points
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -298,10 +310,13 @@ function FieldingRules() {
       </CardHeader>
       <CardContent>
         <Table>
+          <caption className="sr-only">Fielding scoring</caption>
           <TableHeader>
             <TableRow>
-              <TableHead>Action</TableHead>
-              <TableHead className="w-24 text-right">Points</TableHead>
+              <TableHead scope="col">Action</TableHead>
+              <TableHead scope="col" className="w-24 text-right">
+                Points
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -346,10 +361,13 @@ function GeneralRules() {
       </CardHeader>
       <CardContent>
         <Table>
+          <caption className="sr-only">Team and general scoring</caption>
           <TableHeader>
             <TableRow>
-              <TableHead>Rule</TableHead>
-              <TableHead className="w-24 text-right">Points</TableHead>
+              <TableHead scope="col">Rule</TableHead>
+              <TableHead scope="col" className="w-24 text-right">
+                Points
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/apps/web/src/pages/fantasy/fantasy.tsx
+++ b/apps/web/src/pages/fantasy/fantasy.tsx
@@ -395,10 +395,13 @@ function HomeTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
               </CardHeader>
               <CardContent>
                 <Table>
+                  <caption className="sr-only">Most owned players</caption>
                   <TableHeader>
                     <TableRow>
-                      <TableHead>Player</TableHead>
-                      <TableHead className="w-20 text-right">Owned</TableHead>
+                      <TableHead scope="col">Player</TableHead>
+                      <TableHead scope="col" className="w-20 text-right">
+                        Owned
+                      </TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -425,10 +428,13 @@ function HomeTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
               </CardHeader>
               <CardContent>
                 <Table>
+                  <caption className="sr-only">Most captained players</caption>
                   <TableHeader>
                     <TableRow>
-                      <TableHead>Player</TableHead>
-                      <TableHead className="w-20 text-right">Captain</TableHead>
+                      <TableHead scope="col">Player</TableHead>
+                      <TableHead scope="col" className="w-20 text-right">
+                        Captain
+                      </TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -466,11 +472,16 @@ function HomeTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
             </CardHeader>
             <CardContent>
               <Table>
+                <caption className="sr-only">Differential picks</caption>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Player</TableHead>
-                    <TableHead className="text-right">Pts</TableHead>
-                    <TableHead className="text-right">Owned</TableHead>
+                    <TableHead scope="col">Player</TableHead>
+                    <TableHead scope="col" className="text-right">
+                      Pts
+                    </TableHead>
+                    <TableHead scope="col" className="text-right">
+                      Owned
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -508,12 +519,17 @@ function HomeTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
             </CardHeader>
             <CardContent>
               <Table>
+                <caption className="sr-only">Sandwich efficiency</caption>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>#</TableHead>
-                    <TableHead>Player</TableHead>
-                    <TableHead className="text-right">Pts</TableHead>
-                    <TableHead className="text-right">PPS</TableHead>
+                    <TableHead scope="col">#</TableHead>
+                    <TableHead scope="col">Player</TableHead>
+                    <TableHead scope="col" className="text-right">
+                      Pts
+                    </TableHead>
+                    <TableHead scope="col" className="text-right">
+                      PPS
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -549,12 +565,17 @@ function HomeTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
           </CardHeader>
           <CardContent>
             <Table>
+              <caption className="sr-only">Season standings</caption>
               <TableHeader>
                 <TableRow>
-                  <TableHead>#</TableHead>
-                  <TableHead>Team</TableHead>
-                  <TableHead className="text-right">Points</TableHead>
-                  <TableHead className="text-right">Gameweeks</TableHead>
+                  <TableHead scope="col">#</TableHead>
+                  <TableHead scope="col">Team</TableHead>
+                  <TableHead scope="col" className="text-right">
+                    Points
+                  </TableHead>
+                  <TableHead scope="col" className="text-right">
+                    Gameweeks
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -677,12 +698,17 @@ function SeasonLeaderboard({
 
   return (
     <Table>
+      <caption className="sr-only">Season leaderboard</caption>
       <TableHeader>
         <TableRow>
-          <TableHead>#</TableHead>
-          <TableHead>Team</TableHead>
-          <TableHead className="text-right">Points</TableHead>
-          <TableHead className="text-right">Gameweeks</TableHead>
+          <TableHead scope="col">#</TableHead>
+          <TableHead scope="col">Team</TableHead>
+          <TableHead scope="col" className="text-right">
+            Points
+          </TableHead>
+          <TableHead scope="col" className="text-right">
+            Gameweeks
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -743,11 +769,14 @@ function WeeklyLeaderboard({
         <p className="text-muted-foreground text-center">No scores yet.</p>
       ) : (
         <Table>
+          <caption className="sr-only">Weekly leaderboard</caption>
           <TableHeader>
             <TableRow>
-              <TableHead>#</TableHead>
-              <TableHead>Team</TableHead>
-              <TableHead className="text-right">Points</TableHead>
+              <TableHead scope="col">#</TableHead>
+              <TableHead scope="col">Team</TableHead>
+              <TableHead scope="col" className="text-right">
+                Points
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -791,15 +820,26 @@ function PlayerLeaderboard({
   return (
     <div className="overflow-x-auto">
       <Table>
+        <caption className="sr-only">Player leaderboard</caption>
         <TableHeader>
           <TableRow>
-            <TableHead>#</TableHead>
-            <TableHead>Player</TableHead>
-            <TableHead className="text-right">Bat</TableHead>
-            <TableHead className="text-right">Bowl</TableHead>
-            <TableHead className="text-right">Field</TableHead>
-            <TableHead className="text-right">Total</TableHead>
-            <TableHead className="text-right">Matches</TableHead>
+            <TableHead scope="col">#</TableHead>
+            <TableHead scope="col">Player</TableHead>
+            <TableHead scope="col" className="text-right">
+              Bat
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Bowl
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Field
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Total
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Matches
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -847,10 +887,13 @@ function AllTeamsTab({ onViewTeam }: { onViewTeam: (teamId: number) => void }) {
 
   return (
     <Table>
+      <caption className="sr-only">All fantasy teams</caption>
       <TableHeader>
         <TableRow>
-          <TableHead>Team</TableHead>
-          <TableHead className="text-right">Joined</TableHead>
+          <TableHead scope="col">Team</TableHead>
+          <TableHead scope="col" className="text-right">
+            Joined
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -936,15 +979,24 @@ function TeamView({
       </div>
 
       <Table>
+        <caption className="sr-only">Team squad</caption>
         <TableHeader>
           <TableRow>
-            <TableHead>Player</TableHead>
-            <TableHead>Slot</TableHead>
-            <TableHead className="text-center">Cost</TableHead>
-            <TableHead className="text-right">Owned</TableHead>
-            <TableHead className="text-right">Season</TableHead>
+            <TableHead scope="col">Player</TableHead>
+            <TableHead scope="col">Slot</TableHead>
+            <TableHead scope="col" className="text-center">
+              Cost
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Owned
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Season
+            </TableHead>
             {latestGameweek !== null && (
-              <TableHead className="text-right">GW{latestGameweek}</TableHead>
+              <TableHead scope="col" className="text-right">
+                GW{latestGameweek}
+              </TableHead>
             )}
           </TableRow>
         </TableHeader>
@@ -1035,15 +1087,28 @@ function PlayerView({
       ) : (
         <div className="overflow-x-auto">
           <Table>
+            <caption className="sr-only">Player points by gameweek</caption>
             <TableHeader>
               <TableRow>
-                <TableHead>Gameweek</TableHead>
-                <TableHead className="text-right">Bat</TableHead>
-                <TableHead className="text-right">Bowl</TableHead>
-                <TableHead className="text-right">Field</TableHead>
-                <TableHead className="text-right">Team</TableHead>
-                <TableHead className="text-right">Total</TableHead>
-                <TableHead className="text-right">Matches</TableHead>
+                <TableHead scope="col">Gameweek</TableHead>
+                <TableHead scope="col" className="text-right">
+                  Bat
+                </TableHead>
+                <TableHead scope="col" className="text-right">
+                  Bowl
+                </TableHead>
+                <TableHead scope="col" className="text-right">
+                  Field
+                </TableHead>
+                <TableHead scope="col" className="text-right">
+                  Team
+                </TableHead>
+                <TableHead scope="col" className="text-right">
+                  Total
+                </TableHead>
+                <TableHead scope="col" className="text-right">
+                  Matches
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/apps/web/src/pages/game/be-the-keeper-leaderboard.tsx
+++ b/apps/web/src/pages/game/be-the-keeper-leaderboard.tsx
@@ -60,18 +60,34 @@ export function Component() {
       {entries && entries.length > 0 && (
         <div className="overflow-x-auto rounded-lg border border-stone-200">
           <table className="w-full text-left text-sm">
+            <caption className="sr-only">Be the Keeper leaderboard</caption>
             <thead>
               <tr className="bg-[#1B3D2F] text-white">
-                <th className="px-4 py-3 font-semibold">#</th>
-                <th className="px-4 py-3 font-semibold">Name</th>
-                <th className="px-4 py-3 text-right font-semibold">Score</th>
-                <th className="hidden px-4 py-3 text-right font-semibold sm:table-cell">
+                <th scope="col" className="px-4 py-3 font-semibold">
+                  #
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold">
+                  Name
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-semibold">
+                  Score
+                </th>
+                <th
+                  scope="col"
+                  className="hidden px-4 py-3 text-right font-semibold sm:table-cell"
+                >
                   Level
                 </th>
-                <th className="hidden px-4 py-3 text-right font-semibold sm:table-cell">
+                <th
+                  scope="col"
+                  className="hidden px-4 py-3 text-right font-semibold sm:table-cell"
+                >
                   Catches
                 </th>
-                <th className="hidden px-4 py-3 text-right font-semibold md:table-cell">
+                <th
+                  scope="col"
+                  className="hidden px-4 py-3 text-right font-semibold md:table-cell"
+                >
                   Best Streak
                 </th>
               </tr>

--- a/apps/web/src/pages/person/player-stats.tsx
+++ b/apps/web/src/pages/person/player-stats.tsx
@@ -68,27 +68,55 @@ function FormatSection({
           <p className="mb-1 text-xs font-medium text-stone-500">Batting</p>
           <div className="overflow-x-auto">
             <Table>
+              <caption className="sr-only">
+                Batting statistics by season
+              </caption>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Season</TableHead>
-                  <TableHead className="text-right">Inn</TableHead>
-                  <TableHead className="text-right">NO</TableHead>
-                  <TableHead className="text-right">Runs</TableHead>
-                  <TableHead className="text-right">HS</TableHead>
-                  <TableHead className="text-right">Avg</TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead scope="col">Season</TableHead>
+                  <TableHead scope="col" className="text-right">
+                    Inn
+                  </TableHead>
+                  <TableHead scope="col" className="text-right">
+                    NO
+                  </TableHead>
+                  <TableHead scope="col" className="text-right">
+                    Runs
+                  </TableHead>
+                  <TableHead scope="col" className="text-right">
+                    HS
+                  </TableHead>
+                  <TableHead scope="col" className="text-right">
+                    Avg
+                  </TableHead>
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     SR
                   </TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     4s
                   </TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     6s
                   </TableHead>
-                  <TableHead className="hidden text-right md:table-cell">
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right md:table-cell"
+                  >
                     50s
                   </TableHead>
-                  <TableHead className="hidden text-right md:table-cell">
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right md:table-cell"
+                  >
                     100s
                   </TableHead>
                 </TableRow>
@@ -134,23 +162,46 @@ function FormatSection({
           <p className="mb-1 text-xs font-medium text-stone-500">Bowling</p>
           <div className="overflow-x-auto">
             <Table>
+              <caption className="sr-only">
+                Bowling statistics by season
+              </caption>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Season</TableHead>
-                  <TableHead className="text-right">O</TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead scope="col">Season</TableHead>
+                  <TableHead scope="col" className="text-right">
+                    O
+                  </TableHead>
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     M
                   </TableHead>
-                  <TableHead className="text-right">R</TableHead>
-                  <TableHead className="text-right">W</TableHead>
-                  <TableHead className="text-right">Avg</TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead scope="col" className="text-right">
+                    R
+                  </TableHead>
+                  <TableHead scope="col" className="text-right">
+                    W
+                  </TableHead>
+                  <TableHead scope="col" className="text-right">
+                    Avg
+                  </TableHead>
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     Econ
                   </TableHead>
-                  <TableHead className="hidden text-right sm:table-cell">
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right sm:table-cell"
+                  >
                     SR
                   </TableHead>
-                  <TableHead className="hidden text-right md:table-cell">
+                  <TableHead
+                    scope="col"
+                    className="hidden text-right md:table-cell"
+                  >
                     Best
                   </TableHead>
                 </TableRow>


### PR DESCRIPTION
Closes #439

## Problem
Data tables lacked a `<caption>` and column-header `scope`, so screen readers could not reliably announce row/column relationships. Called out on the cricket leaderboards and the homepage Top Run Scorers / Top Wicket Takers tables.

## Fix
Added a visually-hidden `<caption className="sr-only">` (meaningful per table) and `scope="col"` on every column-header cell across all genuine data tables:
- Leaderboards, season-leaders (homepage), scorecards, records wall, player stats, fantasy + fantasy-rules tables (shadcn `Table`)
- League table (mdx-components) and Be-the-Keeper leaderboard (raw `<table>`)

Body cells are intentionally left as `<td>` (no `scope="row"` / no conversion to `<th>`), so there is **zero visual change** - the caption is `sr-only` and `scope` does not render. The layout-only membership summary table is excluded.

The reusable `MiniTable` (season-leaders) and `HonoursTable` (records-wall) take the caption per instance so semantically different tables get distinct captions.

## Validation
`pnpm --filter web typecheck` and `pnpm --filter web lint` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)