### PR TITLE
fix(a11y): announce and associate auth form errors (#438)

### DIFF
--- a/apps/web/src/components/form/simple-input.tsx
+++ b/apps/web/src/components/form/simple-input.tsx
@@ -7,16 +7,33 @@ type Props = React.DetailedHTMLProps<
   HTMLInputElement
 > & {
   label: string;
+  /**
+   * When true, marks the field as invalid (`aria-invalid`) and links it to
+   * the error element identified by `errorId` (`aria-describedby`). When
+   * false/omitted, no ARIA association is added and behaviour/appearance is
+   * unchanged.
+   */
+  invalid?: boolean;
+  /** id of the error element this field is described by, when `invalid`. */
+  errorId?: string;
 };
 
-export const SimpleInput: FC<Props> = ({ label, ...inputProps }) => {
+export const SimpleInput: FC<Props> = ({
+  label,
+  invalid,
+  errorId,
+  ...inputProps
+}) => {
+  const ariaProps = invalid
+    ? { "aria-invalid": true, "aria-describedby": errorId }
+    : {};
   if (inputProps.hidden) {
-    return <input {...inputProps} name={inputProps.id} />;
+    return <input {...inputProps} {...ariaProps} name={inputProps.id} />;
   }
   return (
     <div className="mb-4 w-full space-y-2">
       <Label htmlFor={inputProps.id}>{label}</Label>
-      <Input {...inputProps} name={inputProps.id} />
+      <Input {...inputProps} {...ariaProps} name={inputProps.id} />
     </div>
   );
 };

--- a/apps/web/src/pages/auth/login/email-password.tsx
+++ b/apps/web/src/pages/auth/login/email-password.tsx
@@ -224,6 +224,8 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
             onChange={(e) => setEmail(e.currentTarget.value)}
             required
             autoComplete="email webauthn"
+            invalid={Boolean(error)}
+            errorId="login-error"
           />
           <SimpleInput
             id="password"
@@ -233,6 +235,8 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
             onChange={(e) => setPassword(e.currentTarget.value)}
             required
             autoComplete="current-password webauthn"
+            invalid={Boolean(error)}
+            errorId="login-error"
           />
           <div className="flex items-center justify-end">
             <Button
@@ -247,7 +251,13 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
             Sign in
           </Button>
           {error && (
-            <p className="text-sm font-light text-red-800">{error.message}</p>
+            <p
+              id="login-error"
+              role="alert"
+              className="text-sm font-light text-red-800"
+            >
+              {error.message}
+            </p>
           )}
           <p className="text-sm font-light text-stone-500">
             Don&apos;t have an account yet?{" "}

--- a/apps/web/src/pages/auth/login/email-password.tsx
+++ b/apps/web/src/pages/auth/login/email-password.tsx
@@ -216,6 +216,8 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
           <div className="h-px flex-1 bg-stone-300" />
         </div>
         <form className="space-y-4 md:space-y-6" onSubmit={handleSubmit}>
+          {/* Only credential (signin) failures mark these fields invalid -
+              a Google sign-in error is form-level, not about these inputs. */}
           <SimpleInput
             id="email"
             type="email"
@@ -224,7 +226,7 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
             onChange={(e) => setEmail(e.currentTarget.value)}
             required
             autoComplete="email webauthn"
-            invalid={Boolean(error)}
+            invalid={Boolean(signin.error)}
             errorId="login-error"
           />
           <SimpleInput
@@ -235,7 +237,7 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
             onChange={(e) => setPassword(e.currentTarget.value)}
             required
             autoComplete="current-password webauthn"
-            invalid={Boolean(error)}
+            invalid={Boolean(signin.error)}
             errorId="login-error"
           />
           <div className="flex items-center justify-end">

--- a/apps/web/src/pages/auth/login/forgot-password.tsx
+++ b/apps/web/src/pages/auth/login/forgot-password.tsx
@@ -56,7 +56,9 @@ export const ForgotPassword: FC = () => {
               Send reset link
             </Button>
             {error && (
-              <p className="text-sm font-light text-red-800">{error.message}</p>
+              <p role="alert" className="text-sm font-light text-red-800">
+                {error.message}
+              </p>
             )}
           </form>
         ))}

--- a/apps/web/src/pages/auth/login/recovery.tsx
+++ b/apps/web/src/pages/auth/login/recovery.tsx
@@ -62,7 +62,9 @@ export const Recovery: FC<Props> = ({ setPhase }) => {
           Use recovery code
         </Button>
         {error && (
-          <p className="text-sm font-light text-red-800">{error.message}</p>
+          <p role="alert" className="text-sm font-light text-red-800">
+            {error.message}
+          </p>
         )}
         <Button type="button" variant="link" onClick={() => setPhase("2fa")}>
           Back to 2FA

--- a/apps/web/src/pages/auth/login/reset-password.tsx
+++ b/apps/web/src/pages/auth/login/reset-password.tsx
@@ -97,7 +97,9 @@ export const ResetPassword: FC<Props> = ({ setPhase }) => {
           Set new password
         </Button>
         {error && (
-          <p className="text-sm font-light text-red-800">{error.message}</p>
+          <p role="alert" className="text-sm font-light text-red-800">
+            {error.message}
+          </p>
         )}
       </form>
     </section>

--- a/apps/web/src/pages/auth/login/two-fa.tsx
+++ b/apps/web/src/pages/auth/login/two-fa.tsx
@@ -75,7 +75,9 @@ export const TwoFA: FC<Props> = ({ setPhase }) => {
           Verify code
         </Button>
         {error && (
-          <p className="text-sm font-light text-red-800">{error.message}</p>
+          <p role="alert" className="text-sm font-light text-red-800">
+            {error.message}
+          </p>
         )}
         <Button
           type="button"

--- a/apps/web/src/pages/auth/register.tsx
+++ b/apps/web/src/pages/auth/register.tsx
@@ -152,6 +152,8 @@ export function Component() {
             value={email}
             onChange={(e) => update({ email: e.currentTarget.value })}
             required
+            invalid={isUserExists}
+            errorId="register-email-error"
           />
           <SimpleInput
             id="password"
@@ -163,7 +165,11 @@ export function Component() {
           />
 
           {isUserExists && (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+            <div
+              id="register-email-error"
+              role="alert"
+              className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800"
+            >
               <p className="font-medium">
                 An account with this email already exists.
               </p>
@@ -185,7 +191,10 @@ export function Component() {
           )}
 
           {hasGenericError && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+            <div
+              role="alert"
+              className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+            >
               <p>Something went wrong. Please try again.</p>
             </div>
           )}
@@ -203,6 +212,8 @@ export function Component() {
               }}
               className="mt-1 size-4 rounded border-stone-300 text-blue-600 focus:ring-blue-500"
               required
+              aria-invalid={ageError}
+              aria-describedby={ageError ? "age-error" : undefined}
             />
             <label htmlFor="age-confirmed" className="text-sm text-stone-700">
               I confirm I am aged 13 or over
@@ -210,7 +221,11 @@ export function Component() {
           </div>
 
           {ageError && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+            <div
+              id="age-error"
+              role="alert"
+              className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+            >
               <p>
                 You must confirm you are aged 13 or over to create an account.
               </p>


### PR DESCRIPTION
Closes #438

## Problem
Auth form errors were not exposed to assistive technology: submission errors rendered with no `role="alert"`/`aria-live` (a screen reader never hears them appear), and inputs had no `aria-invalid` / `aria-describedby` linking the message to a field.

## Fix
This repo has no shadcn Form primitives / react-hook-form, so the attributes are added manually.

- **`SimpleInput`** extended with optional `invalid` + `errorId` props -> adds `aria-invalid` + `aria-describedby` only when provided. Existing callers that pass neither are unchanged in DOM and appearance.
- **Login**: error `<p>` gets `id="login-error"` + `role="alert"`; the email and password inputs are marked invalid and described-by the error when a sign-in failure is present.
- **Register**: the user-exists, generic, and age-confirmation errors get `role="alert"`; the email input (user-exists) and age checkbox are wired to their error via `aria-invalid`/`aria-describedby`.
- **forgot-password, reset-password, two-fa, recovery**: submission error gets `role="alert"` so it announces.

ARIA-only: no copy, color, layout, or styling change (visually identical). `aria-describedby` is only set when the matching error element is rendered, so it never dangles.

## Validation
`pnpm --filter web typecheck` and `pnpm --filter web lint` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)