### PR TITLE
fix(a11y): respect prefers-reduced-motion (#441)

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -502,3 +502,18 @@
 .mdx-content tr:last-child td {
   @apply border-b-0;
 }
+
+/* Respect the OS "reduce motion" preference: Tailwind v4 does not add this
+   automatically, so transitions/animations would otherwise run regardless.
+   Near-instant (not 0s) durations keep transitionend / animationend handlers
+   firing so JS that waits on them does not hang. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
Closes #441

## Problem
The site did not respect `prefers-reduced-motion`. Tailwind v4 does not add this automatically, so all transitions/animations ran even when the OS "reduce motion" setting is on.

## Fix
Added a global guard to `apps/web/src/app.css`:

```css
@media (prefers-reduced-motion: reduce) {
  *, ::before, ::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

Durations collapse to 0.01ms (not 0) so `transitionend`/`animationend` handlers still fire and JS that waits on them does not hang.

## Acceptance
With OS "reduce motion" enabled, animations and transitions are effectively disabled. No visible change when reduce-motion is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)