### PR TITLE
feat(infra): add X-Content-Type-Options nosniff header (#435)

### DIFF
--- a/infra/modules/cdn/main.tf
+++ b/infra/modules/cdn/main.tf
@@ -282,6 +282,24 @@ resource "aws_cloudfront_function" "spa_rewrite" {
 }
 
 # -----------------------------------------------------------------------------
+# CloudFront Response Headers Policy - Security Headers
+#
+# Attached to every cache behavior. For now it only sets
+# X-Content-Type-Options: nosniff. Later issues will extend this same
+# policy with frame-ancestors (CSP) and HSTS.
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudfront_response_headers_policy" "security" {
+  name = "${var.environment}-security-headers"
+
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
 # CloudFront Distribution
 # -----------------------------------------------------------------------------
 
@@ -316,10 +334,11 @@ resource "aws_cloudfront_distribution" "main" {
 
   # /uploads/* -> Uploads S3 bucket (standard caching)
   ordered_cache_behavior {
-    path_pattern           = "/uploads/*"
-    target_origin_id       = local.uploads_origin_id
-    viewer_protocol_policy = "redirect-to-https"
-    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized.id
+    path_pattern               = "/uploads/*"
+    target_origin_id           = local.uploads_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
 
     allowed_methods = ["GET", "HEAD"]
     cached_methods  = ["GET", "HEAD"]
@@ -329,9 +348,10 @@ resource "aws_cloudfront_distribution" "main" {
   # --- Default Cache Behavior (frontend) ---
 
   default_cache_behavior {
-    target_origin_id       = local.frontend_origin_id
-    viewer_protocol_policy = "redirect-to-https"
-    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized.id
+    target_origin_id           = local.frontend_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
 
     allowed_methods = ["GET", "HEAD"]
     cached_methods  = ["GET", "HEAD"]

--- a/infra/modules/spa-cdn/main.tf
+++ b/infra/modules/spa-cdn/main.tf
@@ -250,6 +250,24 @@ resource "aws_cloudfront_function" "spa_rewrite" {
 }
 
 # -----------------------------------------------------------------------------
+# CloudFront Response Headers Policy - Security Headers
+#
+# Attached to every cache behavior. For now it only sets
+# X-Content-Type-Options: nosniff. Later issues will extend this same
+# policy with frame-ancestors (CSP) and HSTS.
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudfront_response_headers_policy" "security" {
+  name = "${var.environment}-${var.name}-security-headers"
+
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
 # CloudFront Distribution
 # -----------------------------------------------------------------------------
 
@@ -288,10 +306,11 @@ resource "aws_cloudfront_distribution" "main" {
   # rewrites bare-path navigations to /index.html, which then matches
   # this behaviour at the cache lookup).
   ordered_cache_behavior {
-    path_pattern           = "/index.html"
-    target_origin_id       = local.frontend_origin_id
-    viewer_protocol_policy = "redirect-to-https"
-    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_disabled.id
+    path_pattern               = "/index.html"
+    target_origin_id           = local.frontend_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
 
     allowed_methods = ["GET", "HEAD"]
     cached_methods  = ["GET", "HEAD"]
@@ -299,9 +318,10 @@ resource "aws_cloudfront_distribution" "main" {
   }
 
   default_cache_behavior {
-    target_origin_id       = local.frontend_origin_id
-    viewer_protocol_policy = "redirect-to-https"
-    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized.id
+    target_origin_id           = local.frontend_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_optimized.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security.id
 
     allowed_methods = ["GET", "HEAD"]
     cached_methods  = ["GET", "HEAD"]


### PR DESCRIPTION
Closes #435

## Problem
Responses carried no `X-Content-Type-Options: nosniff`, so browsers may MIME-sniff responses.

## Fix
Added a new `aws_cloudfront_response_headers_policy "security"` to both the `cdn` module (percymain.org) and the `spa-cdn` module (matchday.percymain.org), currently setting only `content_type_options` (nosniff), and attached it via `response_headers_policy_id` to **every** cache behavior on each distribution (default + ordered).

The policy is deliberately structured so the related issues can extend the same policy:
- #436 will add `frame_options` / CSP `frame-ancestors`
- #434 will add `strict_transport_security` (HSTS)

## Validation
- `terraform fmt -check -recursive infra/` clean
- `terraform validate` passes on both `infra/modules/cdn` and `infra/modules/spa-cdn`

Merging applies via the Terraform CI pipeline. Low risk / reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)