### PR TITLE
feat(infra): add clickjacking protection (CSP frame-ancestors) (#436)

### DIFF
--- a/infra/modules/cdn/main.tf
+++ b/infra/modules/cdn/main.tf
@@ -284,9 +284,10 @@ resource "aws_cloudfront_function" "spa_rewrite" {
 # -----------------------------------------------------------------------------
 # CloudFront Response Headers Policy - Security Headers
 #
-# Attached to every cache behavior. For now it only sets
-# X-Content-Type-Options: nosniff. Later issues will extend this same
-# policy with frame-ancestors (CSP) and HSTS.
+# Attached to every cache behavior. Sets X-Content-Type-Options: nosniff
+# and clickjacking protection (CSP frame-ancestors 'self' + the legacy
+# X-Frame-Options: SAMEORIGIN fallback, which matches 'self'). A later
+# issue will extend this same policy with HSTS.
 # -----------------------------------------------------------------------------
 
 resource "aws_cloudfront_response_headers_policy" "security" {
@@ -295,6 +296,16 @@ resource "aws_cloudfront_response_headers_policy" "security" {
   security_headers_config {
     content_type_options {
       override = true
+    }
+
+    frame_options {
+      frame_option = "SAMEORIGIN"
+      override     = true
+    }
+
+    content_security_policy {
+      content_security_policy = "frame-ancestors 'self'"
+      override                = true
     }
   }
 }

--- a/infra/modules/spa-cdn/main.tf
+++ b/infra/modules/spa-cdn/main.tf
@@ -252,9 +252,10 @@ resource "aws_cloudfront_function" "spa_rewrite" {
 # -----------------------------------------------------------------------------
 # CloudFront Response Headers Policy - Security Headers
 #
-# Attached to every cache behavior. For now it only sets
-# X-Content-Type-Options: nosniff. Later issues will extend this same
-# policy with frame-ancestors (CSP) and HSTS.
+# Attached to every cache behavior. Sets X-Content-Type-Options: nosniff
+# and clickjacking protection (CSP frame-ancestors 'self' + the legacy
+# X-Frame-Options: SAMEORIGIN fallback, which matches 'self'). A later
+# issue will extend this same policy with HSTS.
 # -----------------------------------------------------------------------------
 
 resource "aws_cloudfront_response_headers_policy" "security" {
@@ -263,6 +264,16 @@ resource "aws_cloudfront_response_headers_policy" "security" {
   security_headers_config {
     content_type_options {
       override = true
+    }
+
+    frame_options {
+      frame_option = "SAMEORIGIN"
+      override     = true
+    }
+
+    content_security_policy {
+      content_security_policy = "frame-ancestors 'self'"
+      override                = true
     }
   }
 }


### PR DESCRIPTION
Closes #436

## Problem
No clickjacking protection - neither `Content-Security-Policy: frame-ancestors` nor `X-Frame-Options` was present, so the site could be embedded in an iframe by any origin.

## Fix
Extend the shared `aws_cloudfront_response_headers_policy "security"` (added in #435) in both the `cdn` and `spa-cdn` modules with:
- `Content-Security-Policy: frame-ancestors 'self'`
- `X-Frame-Options: SAMEORIGIN` (legacy fallback)

### Note on SAMEORIGIN vs DENY
The issue suggested `X-Frame-Options: DENY` as the legacy fallback, but `DENY` is inconsistent with `frame-ancestors 'self'` (DENY blocks all framing including same-origin). I used `SAMEORIGIN`, which is the exact legacy equivalent of `'self'`: same-origin framing allowed (not a clickjacking vector), cross-origin framing blocked. If the club truly never frames itself, this can be tightened to `frame-ancestors 'none'` + `DENY` later.

## Validation
- `terraform fmt -check -recursive infra/` clean
- `terraform validate` passes on both modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)