### PR TITLE
feat(infra): add HSTS header (reversible config) (#434)

### DIFF
--- a/infra/modules/cdn/main.tf
+++ b/infra/modules/cdn/main.tf
@@ -284,10 +284,17 @@ resource "aws_cloudfront_function" "spa_rewrite" {
 # -----------------------------------------------------------------------------
 # CloudFront Response Headers Policy - Security Headers
 #
-# Attached to every cache behavior. Sets X-Content-Type-Options: nosniff
-# and clickjacking protection (CSP frame-ancestors 'self' + the legacy
-# X-Frame-Options: SAMEORIGIN fallback, which matches 'self'). A later
-# issue will extend this same policy with HSTS.
+# Attached to every cache behavior. Sets X-Content-Type-Options: nosniff,
+# clickjacking protection (CSP frame-ancestors 'self' + the legacy
+# X-Frame-Options: SAMEORIGIN fallback, which matches 'self'), and HSTS.
+#
+# HSTS is intentionally conservative: a 1-year max-age WITHOUT
+# include_subdomains and WITHOUT preload. Those two flags are the
+# effectively-irreversible part of HSTS (preload removal takes months,
+# and include_subdomains would break any subdomain that is ever served
+# over plain HTTP). Without them this is reversible: setting max-age to 0
+# clears it on a client's next visit. Ramp to include_subdomains/preload
+# only after confirming every subdomain is HTTPS-only.
 # -----------------------------------------------------------------------------
 
 resource "aws_cloudfront_response_headers_policy" "security" {
@@ -306,6 +313,13 @@ resource "aws_cloudfront_response_headers_policy" "security" {
     content_security_policy {
       content_security_policy = "frame-ancestors 'self'"
       override                = true
+    }
+
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = false
+      preload                    = false
+      override                   = true
     }
   }
 }

--- a/infra/modules/spa-cdn/main.tf
+++ b/infra/modules/spa-cdn/main.tf
@@ -252,10 +252,17 @@ resource "aws_cloudfront_function" "spa_rewrite" {
 # -----------------------------------------------------------------------------
 # CloudFront Response Headers Policy - Security Headers
 #
-# Attached to every cache behavior. Sets X-Content-Type-Options: nosniff
-# and clickjacking protection (CSP frame-ancestors 'self' + the legacy
-# X-Frame-Options: SAMEORIGIN fallback, which matches 'self'). A later
-# issue will extend this same policy with HSTS.
+# Attached to every cache behavior. Sets X-Content-Type-Options: nosniff,
+# clickjacking protection (CSP frame-ancestors 'self' + the legacy
+# X-Frame-Options: SAMEORIGIN fallback, which matches 'self'), and HSTS.
+#
+# HSTS is intentionally conservative: a 1-year max-age WITHOUT
+# include_subdomains and WITHOUT preload. Those two flags are the
+# effectively-irreversible part of HSTS (preload removal takes months,
+# and include_subdomains would break any subdomain that is ever served
+# over plain HTTP). Without them this is reversible: setting max-age to 0
+# clears it on a client's next visit. Ramp to include_subdomains/preload
+# only after confirming every subdomain is HTTPS-only.
 # -----------------------------------------------------------------------------
 
 resource "aws_cloudfront_response_headers_policy" "security" {
@@ -274,6 +281,13 @@ resource "aws_cloudfront_response_headers_policy" "security" {
     content_security_policy {
       content_security_policy = "frame-ancestors 'self'"
       override                = true
+    }
+
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = false
+      preload                    = false
+      override                   = true
     }
   }
 }


### PR DESCRIPTION
Closes #434

## Problem
No `Strict-Transport-Security` header on any response, so browsers will attempt plain HTTP on first visit and after cache expiry.

## Fix
Extend the shared `aws_cloudfront_response_headers_policy "security"` (cdn + spa-cdn modules) with:

```
Strict-Transport-Security: max-age=31536000
```

### Deliberately reversible (important)
The issue flags HSTS as a near-irreversible commitment and recommends ramping. Since this is being applied autonomously while the maintainer is unavailable, it ships the **reversible** subset only:
- `max-age = 31536000` (1 year) - the standard value, satisfies "long max-age"
- **no** `include_subdomains` - would break any subdomain ever served over plain HTTP (api, kit, staging, matchday, etc. not all confirmed)
- **no** `preload` - the genuinely irreversible part (preload-list removal takes months)

Without `preload`/`include_subdomains`, this is fully reversible: setting `max-age` to 0 clears it on a client's next visit.

**Follow-up (needs maintainer decision):** once every subdomain is confirmed HTTPS-only, ramp to `include_subdomains` + `preload` and submit to the preload list.

## Validation
- `terraform fmt -check -recursive infra/` clean
- `terraform validate` passes on both modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)