### PR TITLE
feat(matchday): restore cancel-match action in the matchday PWA

### DIFF
--- a/apps/matchday/src/lib/auth-client.ts
+++ b/apps/matchday/src/lib/auth-client.ts
@@ -53,6 +53,21 @@ export function canViewMatchdayAdmin(
 }
 
 /**
+ * True iff the user has the `matchday:manage` permission — i.e. can
+ * mutate matchdays (create one via Pick team, manage the squad, wrap up
+ * the result, cancel). Mirrors the server-side
+ * `requirePermission("matchday", "manage")` preHandler (`adminRole` in
+ * the matchday routes), so action affordances are gated on exactly the
+ * permission the API enforces — never the broader `view` permission,
+ * which a `matchday_viewer` holds without `manage` and would 403 on.
+ */
+export function canManageMatchday(
+  user: { role?: string | null } | null | undefined,
+): boolean {
+  return checkPermission(user?.role ?? null, "matchday", "manage");
+}
+
+/**
  * Names of every runtime cache populated by vite-plugin-pwa for
  * /api/* responses. Kept in lockstep with vite.config.ts. Used to
  * wipe per-user data on sign-out / sign-in-as-someone-else so a

--- a/apps/matchday/src/pages/fixture-detail.tsx
+++ b/apps/matchday/src/pages/fixture-detail.tsx
@@ -80,7 +80,11 @@ export default function FixtureDetail() {
   // set after cancellation (the games query has no status filter), so a
   // cancelled match keeps showing here rather than reverting to Pick team.
   const matchdayId = game?.lineup?.matchdayId ?? null;
-  const { data: matchdayDetail } = useQuery({
+  const {
+    data: matchdayDetail,
+    isLoading: matchdayLoading,
+    isError: matchdayError,
+  } = useQuery({
     queryKey: ["matchday", matchdayId],
     enabled: !!matchdayId && showOfficialActions,
     queryFn: () =>
@@ -183,7 +187,20 @@ export default function FixtureDetail() {
               Manage this match
             </p>
             {matchdayId ? (
-              matchdayCancelled ? (
+              matchdayLoading ? (
+                // Status drives whether we show manage links or a cancelled
+                // banner, so hold the section until it resolves - otherwise a
+                // cancelled match flashes "Manage squad/game" on first paint.
+                <div className="bg-surface-raised h-10 animate-pulse rounded-md" />
+              ) : matchdayError ? (
+                // Unknown status: never assume "not cancelled" and expose
+                // stale management links. The mutations are API-protected, but
+                // surfacing them here would be misleading.
+                <p className="text-text-secondary text-xs">
+                  Couldn&apos;t load this match&apos;s status. Reload to manage
+                  it.
+                </p>
+              ) : matchdayCancelled ? (
                 <div className="border-border bg-danger-bg rounded-xl border p-3">
                   <p className="text-danger text-sm font-medium">
                     Match cancelled

--- a/apps/matchday/src/pages/fixture-detail.tsx
+++ b/apps/matchday/src/pages/fixture-detail.tsx
@@ -1,15 +1,24 @@
 import { StatusPill } from "@/components/primitives/status-pill.js";
 import { Button } from "@/components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
 import { fmtDate, toIsoDate } from "@/features/format.js";
 import { oppositionName, played, type GameDetail } from "@/features/games.js";
 import { api, callApi } from "@/lib/api-client.js";
 import {
-  canViewMatchdayAdmin,
+  canManageMatchday,
   useSession,
   type SessionUser,
 } from "@/lib/auth-client.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeftIcon } from "lucide-react";
+import { ArrowLeftIcon, BanIcon } from "lucide-react";
+import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 
 export default function FixtureDetail() {
@@ -32,7 +41,11 @@ export default function FixtureDetail() {
   const qc = useQueryClient();
   const { data: session } = useSession();
   const user = session?.user as SessionUser | undefined;
-  const showOfficialActions = canViewMatchdayAdmin(user);
+  // Every affordance in the "Manage this match" section mutates the
+  // matchday (Pick team / Manage squad / Manage game / Cancel), so gate
+  // on `matchday:manage` — the same permission the API's `adminRole`
+  // preHandler enforces — not the broader `matchday:view`.
+  const showOfficialActions = canManageMatchday(user);
   const create = useMutation({
     mutationFn: (vars: {
       teamId: string;
@@ -59,10 +72,51 @@ export default function FixtureDetail() {
       void navigate(`/matchday/${data.id}/edit`);
     },
   });
+
+  // A matchday only exists once selection has started (see Pick team /
+  // Go to selection below). Fetch its detail so the official actions can
+  // offer "Cancel match" and reflect an already-cancelled match - the
+  // game payload itself carries no matchday status. `matchdayId` stays
+  // set after cancellation (the games query has no status filter), so a
+  // cancelled match keeps showing here rather than reverting to Pick team.
+  const matchdayId = game?.lineup?.matchdayId ?? null;
+  const { data: matchdayDetail } = useQuery({
+    queryKey: ["matchday", matchdayId],
+    enabled: !!matchdayId && showOfficialActions,
+    queryFn: () =>
+      callApi(
+        api.GET("/api/matchday/{matchId}", {
+          params: { path: { matchId: matchdayId ?? "" } },
+        }),
+      ),
+  });
+  const [cancelOpen, setCancelOpen] = useState(false);
+  const [cancelReason, setCancelReason] = useState("");
+  const cancelMatch = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/matchday/{matchId}/cancel", {
+          params: { path: { matchId: matchdayId ?? "" } },
+          body: cancelReason.trim() ? { reason: cancelReason.trim() } : {},
+        }),
+      ),
+    onSuccess: () => {
+      setCancelOpen(false);
+      setCancelReason("");
+      void qc.invalidateQueries({ queryKey: ["games"] });
+      void qc.invalidateQueries({ queryKey: ["matchday", matchdayId] });
+    },
+  });
+
   if (isLoading) return <Skel />;
   if (isError || !game) return <ErrState />;
   const directionsQuery = directionsTarget(game);
-  const matchdayId = game.lineup?.matchdayId ?? null;
+  const matchdayStatus = matchdayDetail?.matchday.status ?? null;
+  const matchdayCancelled = matchdayStatus === "cancelled";
+  // Cancel is a close-off-without-charging action: the API only allows it
+  // on a live (pending/confirmed) matchday, not a finished one.
+  const canCancelMatchday =
+    matchdayStatus === "pending" || matchdayStatus === "confirmed";
   // Surfacing only the open case: once this fixture's team is confirmed
   // (on the selection screen, or when the request closes) a matchday
   // exists and matchdayId is set above, so the squad-management buttons
@@ -129,21 +183,54 @@ export default function FixtureDetail() {
               Manage this match
             </p>
             {matchdayId ? (
-              <>
-                <Button asChild tone="outline" className="w-full">
-                  <Link to={`/matchday/${matchdayId}/edit`}>
-                    Manage squad →
-                  </Link>
-                </Button>
-                {/* Same screen pre- and post-match: pre-match it's the
-                    captain's live view (squad statuses, expenses), post-
-                    match it's the wrap-up (result picker, mark-paid).
-                    No gate on match date - captains wrap up the same
-                    evening, before the date-based isPast check flips. */}
-                <Button asChild tone="primary" className="w-full">
-                  <Link to={`/matchday/${matchdayId}/wrap`}>Manage game →</Link>
-                </Button>
-              </>
+              matchdayCancelled ? (
+                <div className="border-border bg-danger-bg rounded-xl border p-3">
+                  <p className="text-danger text-sm font-medium">
+                    Match cancelled
+                  </p>
+                  {matchdayDetail?.matchday.cancelled_reason && (
+                    <p className="text-text-secondary mt-1 text-xs">
+                      {matchdayDetail.matchday.cancelled_reason}
+                    </p>
+                  )}
+                  {matchdayDetail?.matchday.cancelled_at && (
+                    <p className="text-text-secondary mt-1 text-[11px]">
+                      Cancelled{" "}
+                      {fmtDate(
+                        matchdayDetail.matchday.cancelled_at,
+                        "EEE d MMM",
+                      )}
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <>
+                  <Button asChild tone="outline" className="w-full">
+                    <Link to={`/matchday/${matchdayId}/edit`}>
+                      Manage squad →
+                    </Link>
+                  </Button>
+                  {/* Same screen pre- and post-match: pre-match it's the
+                      captain's live view (squad statuses, expenses), post-
+                      match it's the wrap-up (result picker, mark-paid).
+                      No gate on match date - captains wrap up the same
+                      evening, before the date-based isPast check flips. */}
+                  <Button asChild tone="primary" className="w-full">
+                    <Link to={`/matchday/${matchdayId}/wrap`}>
+                      Manage game →
+                    </Link>
+                  </Button>
+                  {canCancelMatchday && (
+                    <button
+                      type="button"
+                      onClick={() => setCancelOpen(true)}
+                      className="text-danger hover:bg-danger-bg flex w-full items-center justify-center gap-1.5 rounded-md py-2 text-sm font-medium"
+                    >
+                      <BanIcon className="size-4" /> Cancel match
+                    </button>
+                  )}
+                </>
+              )
             ) : openAvailabilityRequest ? (
               <>
                 <p className="text-text-secondary text-xs leading-snug">
@@ -221,6 +308,64 @@ export default function FixtureDetail() {
           </section>
         )}
       </div>
+
+      {showOfficialActions && (
+        <Dialog
+          open={cancelOpen}
+          onOpenChange={(open) => {
+            if (!cancelMatch.isPending) setCancelOpen(open);
+          }}
+        >
+          <DialogContent className="w-[calc(100%-1.5rem)] max-w-md sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Cancel this match?</DialogTitle>
+              <DialogDescription>
+                Marks {game.team.name} vs {oppositionName(game)} as cancelled.
+                Players won&apos;t be charged a match donation. This can&apos;t
+                be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-2">
+              <label
+                htmlFor="cancel-reason"
+                className="text-text-secondary text-xs font-medium"
+              >
+                Reason (optional)
+              </label>
+              <textarea
+                id="cancel-reason"
+                value={cancelReason}
+                onChange={(e) => setCancelReason(e.currentTarget.value)}
+                maxLength={500}
+                rows={3}
+                placeholder="e.g. Rained off, opposition withdrew"
+                className="border-border bg-surface mt-1 w-full rounded-lg border px-3 py-2 text-sm"
+              />
+            </div>
+            {cancelMatch.isError && (
+              <p className="text-danger mt-2 text-xs">
+                {cancelMatch.error.message}
+              </p>
+            )}
+            <DialogFooter>
+              <Button
+                tone="outline"
+                onClick={() => setCancelOpen(false)}
+                disabled={cancelMatch.isPending}
+              >
+                Keep match
+              </Button>
+              <Button
+                tone="destructive"
+                onClick={() => cancelMatch.mutate()}
+                disabled={cancelMatch.isPending}
+              >
+                {cancelMatch.isPending ? "Cancelling…" : "Cancel match"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

Restores the ability for officials to cancel a match from the matchday PWA, and tightens permission gating on the per-fixture management actions.

### Background
The cancel-matchday API (`POST /api/matchday/:matchId/cancel`) is fully intact and tested - it sets `status = "cancelled"`, records who/when/why, blocks if match-donation charges already exist, and only allows cancelling `pending`/`confirmed` matchdays. But its **UI** was deleted along with the old `apps/web` official panel in PR #352 when the matchday flow moved into the dedicated PWA, and the PWA never got a cancel button. So the endpoint worked but nothing called it.

### Changes
- **Cancel action** added to `fixture-detail`'s "Manage this match" section:
  - "Cancel match" opens a confirm dialog with an optional reason (<=500 chars, matching the API schema) and surfaces server-side block messages (e.g. "Cannot cancel: match donation charges already exist…") verbatim.
  - Shown only for `pending`/`confirmed` matchdays. A cancelled matchday swaps the manage buttons for a cancelled banner (reason + date).
  - Fetches matchday detail (the game payload carries no matchday status). `matchdayId` stays set after cancellation (the games query has no status filter), so the fixture keeps showing here instead of reverting to "Pick team".

- **Permission gating fix:** every affordance in "Manage this match" (Pick team / Manage squad / Manage game / Cancel) hits the API's `adminRole` = `matchday:manage`, but the UI gated the whole section on `matchday:view`. A `matchday_viewer` would have seen buttons that 403. Added `canManageMatchday()` and gated the section on it. View-only surfaces (team-image download, needs-attention card, official nav) stay on `matchday:view`, matching their genuinely view-gated endpoints.

## Testing
- `pnpm --filter matchday typecheck` ✅
- `pnpm --filter matchday lint` ✅ (no warnings)
- `prettier --check` ✅

No backend or schema changes, so no OpenAPI regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)