### PR TITLE
fix(matchday): guard dropout claim against a concurrently closed matchday

### DIFF
--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -1,3 +1,4 @@
+import { sql } from "kysely";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { SendPush } from "../../lib/push-sender.ts";
 import { noopS3Uploader } from "../../lib/s3-upload.ts";
@@ -53,6 +54,55 @@ async function finishAsTest(
     playerStatuses: data.playerStatuses ?? [],
     feeOverrides: data.feeOverrides ?? [],
   });
+}
+
+// Open a transaction that locks the matchday row and cancels it, then
+// holds the lock (uncommitted) until release() runs. `locked` resolves
+// once the row is locked and mutated, so a test can line up a second
+// operation whose initial read still sees the open matchday but whose
+// claim blocks on the lock. Used to drive the cancel-vs-{withdraw,finish}
+// races deterministically instead of with fixed sleeps.
+function holdCancelLock(matchdayId: string) {
+  let release!: () => void;
+  let signalLocked!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const locked = new Promise<void>((resolve) => {
+    signalLocked = resolve;
+  });
+  const txn = ctx.db.transaction().execute(async (trx) => {
+    await trx
+      .selectFrom("matchday")
+      .where("id", "=", matchdayId)
+      .select("id")
+      .forUpdate()
+      .executeTakeFirst();
+    await trx
+      .updateTable("matchday")
+      .set({ status: "cancelled" })
+      .where("id", "=", matchdayId)
+      .execute();
+    signalLocked();
+    await held;
+  });
+  return { locked, release, txn };
+}
+
+// Poll until a backend is parked waiting on a lock - i.e. an operation's
+// FOR UPDATE has blocked behind a held row lock. The per-file
+// testcontainer means the only such waiter is the operation under test,
+// so this replaces a flaky fixed sleep with a deterministic signal.
+async function waitForLockWaiter() {
+  for (let i = 0; i < 400; i++) {
+    const res = await sql<{ n: number }>`
+      select count(*)::int as n from pg_stat_activity
+      where wait_event_type = 'Lock' and state = 'active'
+    `.execute(ctx.db);
+    if ((res.rows[0]?.n ?? 0) > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("expected a backend to block on a row lock");
 }
 
 // Fire the donation-request batch the way the route does, after the
@@ -1870,44 +1920,24 @@ describe("matchday service (integration)", () => {
         { memberId, playerName: "Race Player" },
       );
 
-      // An in-flight cancel: a transaction that has locked + cancelled the
-      // matchday row but has not committed yet. While it's held, the
-      // dropout's initial read still sees the pre-cancel snapshot (open),
-      // then blocks on the row lock when it reaches the claim. Releasing the
-      // gate commits the cancel so the dropout re-reads it under the lock.
-      let releaseCancel: (() => void) | undefined;
-      const cancelHeld = new Promise<void>((resolve) => {
-        releaseCancel = resolve;
-      });
-      const cancelTxn = ctx.db.transaction().execute(async (trx) => {
-        await trx
-          .selectFrom("matchday")
-          .where("id", "=", matchdayId)
-          .select("id")
-          .forUpdate()
-          .executeTakeFirst();
-        await trx
-          .updateTable("matchday")
-          .set({ status: "cancelled" })
-          .where("id", "=", matchdayId)
-          .execute();
-        await cancelHeld;
-      });
-
+      const cancel = holdCancelLock(matchdayId);
       try {
-        // Let the cancel txn take the lock, start the dropout (it reads
-        // "open" then blocks on the lock), then commit the cancel.
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        // Cancel now holds the matchday lock (uncommitted), so the dropout's
+        // initial read still sees an open matchday. It clears the read-side
+        // check, then parks on FOR UPDATE at the claim.
+        await cancel.locked;
         const withdrawPromise = withdrawAsTest(email, playerId);
-        await new Promise((resolve) => setTimeout(resolve, 250));
-        releaseCancel?.();
-        await cancelTxn;
+        await waitForLockWaiter();
+        // Commit the cancel, freeing the lock so the dropout re-reads the
+        // now-cancelled status under it.
+        cancel.release();
+        await cancel.txn;
         await expect(withdrawPromise).rejects.toThrow(
           "no longer open for changes",
         );
       } finally {
-        releaseCancel?.();
-        await cancelTxn.catch(() => undefined);
+        cancel.release();
+        await cancel.txn.catch(() => undefined);
       }
 
       // The losing dropout left the selection untouched.
@@ -1917,6 +1947,53 @@ describe("matchday service (integration)", () => {
         .select("status")
         .executeTakeFirst();
       expect(row?.status).toBe("selected");
+    });
+
+    it("rejects a finish that races a cancel it could not see at read time", async () => {
+      // Finish takes the same matchday lock as withdraw/cancel (one order,
+      // no AB-BA deadlock) and re-reads status under it. Like the dropout
+      // case: finish's pre-lock reads see an open matchday, but a cancel
+      // commits before it claims, so only the locked re-read can reject it.
+      const { userId: adminId } = await seedTestUser(ctx.db, {
+        email: `fin-admin-race-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+        withMember: false,
+      });
+      const email = `fin-race-${crypto.randomUUID()}@test.com`;
+      const { memberId } = await seedTestUser(ctx.db, { email });
+      if (!memberId) throw new Error("expected memberId");
+
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: adminId });
+      await addPlayer(ctx.db)(adminId, "admin", matchdayId, {
+        memberId,
+        playerName: "Finish Race Player",
+      });
+
+      const cancel = holdCancelLock(matchdayId);
+      try {
+        await cancel.locked;
+        const finishPromise = finishAsTest(matchdayId, adminId, {
+          resultType: "W",
+        });
+        await waitForLockWaiter();
+        cancel.release();
+        await cancel.txn;
+        await expect(finishPromise).rejects.toThrow(
+          "Cannot finish a cancelled matchday",
+        );
+      } finally {
+        cancel.release();
+        await cancel.txn.catch(() => undefined);
+      }
+
+      // The losing finish left the matchday cancelled, not finished.
+      const md = await ctx.db
+        .selectFrom("matchday")
+        .where("id", "=", matchdayId)
+        .select("status")
+        .executeTakeFirst();
+      expect(md?.status).toBe("cancelled");
     });
 
     it("rejects a second dropout on an already-withdrawn selection", async () => {

--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -1846,6 +1846,79 @@ describe("matchday service (integration)", () => {
       expect(row?.is_captain).toBe(true);
     });
 
+    it("rejects a dropout that races a cancel it could not see at read time", async () => {
+      // The hard case the row lock exists for: the dropout's initial read
+      // runs while the matchday still looks open, so its read-side check
+      // passes, but a cancel commits before the dropout claims the slot.
+      // Only re-reading under FOR UPDATE catches this - a plain subquery
+      // would read the pre-cancel snapshot and let the withdrawal commit.
+      const { userId: adminId } = await seedTestUser(ctx.db, {
+        email: `wd-admin-race-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+        withMember: false,
+      });
+      const email = `wd-race-${crypto.randomUUID()}@test.com`;
+      const { memberId } = await seedTestUser(ctx.db, { email });
+      if (!memberId) throw new Error("expected memberId");
+
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: adminId });
+      const { id: playerId } = await addPlayer(ctx.db)(
+        adminId,
+        "admin",
+        matchdayId,
+        { memberId, playerName: "Race Player" },
+      );
+
+      // An in-flight cancel: a transaction that has locked + cancelled the
+      // matchday row but has not committed yet. While it's held, the
+      // dropout's initial read still sees the pre-cancel snapshot (open),
+      // then blocks on the row lock when it reaches the claim. Releasing the
+      // gate commits the cancel so the dropout re-reads it under the lock.
+      let releaseCancel: (() => void) | undefined;
+      const cancelHeld = new Promise<void>((resolve) => {
+        releaseCancel = resolve;
+      });
+      const cancelTxn = ctx.db.transaction().execute(async (trx) => {
+        await trx
+          .selectFrom("matchday")
+          .where("id", "=", matchdayId)
+          .select("id")
+          .forUpdate()
+          .executeTakeFirst();
+        await trx
+          .updateTable("matchday")
+          .set({ status: "cancelled" })
+          .where("id", "=", matchdayId)
+          .execute();
+        await cancelHeld;
+      });
+
+      try {
+        // Let the cancel txn take the lock, start the dropout (it reads
+        // "open" then blocks on the lock), then commit the cancel.
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        const withdrawPromise = withdrawAsTest(email, playerId);
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        releaseCancel?.();
+        await cancelTxn;
+        await expect(withdrawPromise).rejects.toThrow(
+          "no longer open for changes",
+        );
+      } finally {
+        releaseCancel?.();
+        await cancelTxn.catch(() => undefined);
+      }
+
+      // The losing dropout left the selection untouched.
+      const row = await ctx.db
+        .selectFrom("matchday_player")
+        .where("id", "=", playerId)
+        .select("status")
+        .executeTakeFirst();
+      expect(row?.status).toBe("selected");
+    });
+
     it("rejects a second dropout on an already-withdrawn selection", async () => {
       const { userId: adminId } = await seedTestUser(ctx.db, {
         email: `wd-admin5-${crypto.randomUUID()}@test.com`,

--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -1797,6 +1797,55 @@ describe("matchday service (integration)", () => {
       );
     });
 
+    it("rejects dropout once the matchday is cancelled, leaving the selection intact", async () => {
+      const { userId: adminId } = await seedTestUser(ctx.db, {
+        email: `wd-admin-cxl-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+        withMember: false,
+      });
+      const email = `wd-cxl-${crypto.randomUUID()}@test.com`;
+      const { memberId } = await seedTestUser(ctx.db, { email });
+      if (!memberId) throw new Error("expected memberId");
+
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: adminId });
+      const { id: playerId } = await addPlayer(ctx.db)(
+        adminId,
+        "admin",
+        matchdayId,
+        { memberId, playerName: "Cancelled Player" },
+      );
+      // Make the player a captain so we can assert the role flag survives a
+      // rejected dropout (the atomic claim clears flags, so a leak here would
+      // strip the captaincy off a still-selected player).
+      await ctx.db
+        .updateTable("matchday_player")
+        .set({ is_captain: true })
+        .where("id", "=", playerId)
+        .execute();
+
+      // An official cancels the matchday. The dropout must now be rejected -
+      // and must not flip the selection to withdrawn or clear its flags -
+      // even though the player row itself is still "selected". This is the
+      // guard the conditional claim enforces against a concurrent cancel.
+      await ctx.db
+        .updateTable("matchday")
+        .set({ status: "cancelled" })
+        .where("id", "=", matchdayId)
+        .execute();
+
+      await expect(withdrawAsTest(email, playerId)).rejects.toThrow(
+        "no longer open for changes",
+      );
+      const row = await ctx.db
+        .selectFrom("matchday_player")
+        .where("id", "=", playerId)
+        .select(["status", "is_captain"])
+        .executeTakeFirst();
+      expect(row?.status).toBe("selected");
+      expect(row?.is_captain).toBe(true);
+    });
+
     it("rejects a second dropout on an already-withdrawn selection", async () => {
       const { userId: adminId } = await seedTestUser(ctx.db, {
         email: `wd-admin5-${crypto.randomUUID()}@test.com`,

--- a/apps/api/src/features/matchday/service.test.ts
+++ b/apps/api/src/features/matchday/service.test.ts
@@ -17,6 +17,7 @@ const { mockExecute, mockExecuteTakeFirst, mockQueryBuilder } = vi.hoisted(
       where: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       selectAll: vi.fn().mockReturnThis(),
+      forUpdate: vi.fn().mockReturnThis(),
       set: vi.fn().mockReturnThis(),
       values: vi.fn().mockReturnThis(),
       orderBy: vi.fn().mockReturnThis(),
@@ -461,6 +462,8 @@ describe("expense approval workflow", () => {
         finished_at: null,
         finished_by: null,
       });
+      // status re-read under the FOR UPDATE lock inside the transaction
+      mockExecuteTakeFirst.mockResolvedValueOnce({ status: "confirmed" });
       // getAccessibleTeamIds - admin gets all teams
       mockExecute.mockResolvedValueOnce([{ id: "team-1" }]);
       // upfront fee-validation: players + fee rates
@@ -503,6 +506,8 @@ describe("expense approval workflow", () => {
         finished_at: "2026-03-20T18:00:00.000Z",
         finished_by: "user-1",
       });
+      // status re-read under the FOR UPDATE lock inside the transaction
+      mockExecuteTakeFirst.mockResolvedValueOnce({ status: "finished" });
       // getAccessibleTeamIds
       mockExecute.mockResolvedValueOnce([{ id: "team-1" }]);
       // update matchday

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -2059,18 +2059,45 @@ export function withdrawFromMatch(
     }
 
     // Claim the withdrawal atomically: flip the status only while it's
-    // still live. Two concurrent requests both pass the read check above,
-    // so this conditional UPDATE is what serialises them - the loser
-    // updates zero rows and bails before notifying the captain a second
-    // time. Captain/keeper flags are cleared so a withdrawn player can't
-    // leave an orphaned role on the team sheet.
+    // still live AND the matchday is still open. The status/date checks
+    // above are a read-side fast-path, but they're TOCTOU - an official
+    // can cancel or finish the matchday between that read and this write.
+    // Guarding on the matchday here (not just the player status) is what
+    // closes the race: a concurrent cancel/finish makes the subquery match
+    // no rows, so the claim updates nothing rather than withdrawing a
+    // player and stripping captain/keeper flags from a closed game. Two
+    // concurrent dropouts serialise the same way - the loser updates zero
+    // rows and bails before notifying the captain a second time.
     const claim = await db
       .updateTable("matchday_player")
       .set({ status: "withdrawn", is_captain: false, is_wicketkeeper: false })
       .where("id", "=", matchdayPlayerId)
       .where("status", "in", ["selected", "playing"])
+      .where("matchday_id", "in", (eb) =>
+        eb
+          .selectFrom("matchday")
+          .select("matchday.id")
+          .where("matchday.id", "=", player.matchdayId)
+          .where("matchday.status", "in", ["pending", "confirmed"])
+          .where("matchday.match_date", ">=", todayIso),
+      )
       .executeTakeFirst();
     if (claim.numUpdatedRows === 0n) {
+      // Zero rows means the selection was withdrawn under us, or the
+      // matchday closed under us. Re-read the matchday so the message
+      // matches the actual cause rather than always blaming the selection.
+      const current = await db
+        .selectFrom("matchday")
+        .where("id", "=", player.matchdayId)
+        .select(["status", "match_date"])
+        .executeTakeFirst();
+      if (
+        current &&
+        (current.match_date < todayIso ||
+          (current.status !== "pending" && current.status !== "confirmed"))
+      ) {
+        throwHttpError(400, "This game is no longer open for changes");
+      }
       throwHttpError(400, "You are not currently selected for this game");
     }
 

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -1484,6 +1484,26 @@ export function finishMatch(db: Kysely<DB>) {
     // forever on retry.
     let chargesCreated = 0;
     await db.transaction().execute(async (trx) => {
+      // Lock the matchday row before touching any matchday_player rows.
+      // Withdraw (and cancel) take the matchday lock first too, so finishing
+      // now uses the same order - they serialise instead of deadlocking
+      // AB-BA (finish used to lock player rows first, then the matchday).
+      // Re-read status under the lock so it's authoritative: a cancel that
+      // committed after the access check above is caught here, and the
+      // first-finish charge branch keys off the locked status so two
+      // concurrent finishes can't both create charges.
+      const locked = await trx
+        .selectFrom("matchday")
+        .where("id", "=", matchdayId)
+        .select("status")
+        .forUpdate()
+        .executeTakeFirst();
+      if (!locked) throwHttpError(404, "Matchday not found");
+      if (locked.status === "cancelled") {
+        throwHttpError(400, "Cannot finish a cancelled matchday");
+      }
+      const firstFinish = locked.status !== "finished";
+
       for (const { matchdayPlayerId, status } of playerStatuses) {
         await trx
           .updateTable("matchday_player")
@@ -1509,7 +1529,7 @@ export function finishMatch(db: Kysely<DB>) {
         .where("id", "=", matchdayId)
         .execute();
 
-      if (!isFirstFinish) return;
+      if (!firstFinish) return;
 
       // Any player still "selected" at finish time played - the captain
       // just didn't send an explicit per-player status. Normalise them

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -2058,46 +2058,53 @@ export function withdrawFromMatch(
       throwHttpError(400, "You are not currently selected for this game");
     }
 
-    // Claim the withdrawal atomically: flip the status only while it's
-    // still live AND the matchday is still open. The status/date checks
-    // above are a read-side fast-path, but they're TOCTOU - an official
-    // can cancel or finish the matchday between that read and this write.
-    // Guarding on the matchday here (not just the player status) is what
-    // closes the race: a concurrent cancel/finish makes the subquery match
-    // no rows, so the claim updates nothing rather than withdrawing a
-    // player and stripping captain/keeper flags from a closed game. Two
-    // concurrent dropouts serialise the same way - the loser updates zero
-    // rows and bails before notifying the captain a second time.
-    const claim = await db
-      .updateTable("matchday_player")
-      .set({ status: "withdrawn", is_captain: false, is_wicketkeeper: false })
-      .where("id", "=", matchdayPlayerId)
-      .where("status", "in", ["selected", "playing"])
-      .where("matchday_id", "in", (eb) =>
-        eb
-          .selectFrom("matchday")
-          .select("matchday.id")
-          .where("matchday.id", "=", player.matchdayId)
-          .where("matchday.status", "in", ["pending", "confirmed"])
-          .where("matchday.match_date", ">=", todayIso),
-      )
-      .executeTakeFirst();
-    if (claim.numUpdatedRows === 0n) {
-      // Zero rows means the selection was withdrawn under us, or the
-      // matchday closed under us. Re-read the matchday so the message
-      // matches the actual cause rather than always blaming the selection.
-      const current = await db
+    // Claim the withdrawal under a matchday row lock so it serialises
+    // against a concurrent cancel/finish. The status/date checks above are
+    // a read-side fast-path, but they're TOCTOU: an official can close the
+    // matchday between that read and this write. Locking the matchday row
+    // (SELECT ... FOR UPDATE) and re-reading its status under the lock is
+    // what closes the race - cancel/finish also touch this row, so whoever
+    // takes the lock first wins and the loser sees the committed result. A
+    // plain WHERE subquery would NOT do this: under READ COMMITTED it reads
+    // the pre-close snapshot, so the withdraw and the cancel both commit
+    // and a player ends up withdrawn (with captain/keeper flags stripped)
+    // from a closed game.
+    const outcome = await db.transaction().execute(async (trx) => {
+      const current = await trx
         .selectFrom("matchday")
         .where("id", "=", player.matchdayId)
         .select(["status", "match_date"])
+        .forUpdate()
         .executeTakeFirst();
       if (
-        current &&
-        (current.match_date < todayIso ||
-          (current.status !== "pending" && current.status !== "confirmed"))
+        !current ||
+        current.match_date < todayIso ||
+        (current.status !== "pending" && current.status !== "confirmed")
       ) {
-        throwHttpError(400, "This game is no longer open for changes");
+        return "closed" as const;
       }
+
+      // Flip the status only while the selection is still live. Two
+      // concurrent dropouts both queue on the matchday lock above, so the
+      // loser sees the row already withdrawn here, updates zero rows, and
+      // bails before notifying the captain a second time. Captain/keeper
+      // flags are cleared so a withdrawn player leaves no orphaned role on
+      // the team sheet.
+      const claim = await trx
+        .updateTable("matchday_player")
+        .set({ status: "withdrawn", is_captain: false, is_wicketkeeper: false })
+        .where("id", "=", matchdayPlayerId)
+        .where("status", "in", ["selected", "playing"])
+        .executeTakeFirst();
+      return claim.numUpdatedRows === 0n
+        ? ("not_selected" as const)
+        : ("withdrawn" as const);
+    });
+
+    if (outcome === "closed") {
+      throwHttpError(400, "This game is no longer open for changes");
+    }
+    if (outcome === "not_selected") {
       throwHttpError(400, "You are not currently selected for this game");
     }
 


### PR DESCRIPTION
## What

Closes a TOCTOU race in player dropout (`withdrawFromMatch`) and the matching lock-ordering hazard in `finishMatch`. Found by codex review on #465 and hardened across two further review passes.

### The bug
`withdrawFromMatch` checked the matchday's status/date on the read side, then claimed the withdrawal with a conditional `UPDATE` guarded only on `matchday_player.status`. If an official **cancels or finishes the matchday between the read and the write**, the claim still fired - the player got marked `withdrawn` and their captain/keeper flags stripped from an already-closed game. `finishMatch` had the inverse problem: it locked `matchday_player` rows *before* the `matchday` row, the opposite order to withdraw, so the two could deadlock AB-BA and finish wasn't serialised against a concurrent cancel.

### The fix
- **withdraw:** wrap the claim in a transaction that `SELECT ... FOR UPDATE` locks the matchday row and re-reads its status under the lock before flipping the player. A plain `WHERE` subquery does **not** serialise under READ COMMITTED (it reads the pre-close snapshot, so both writes commit).
- **finish:** take the same matchday `FOR UPDATE` lock first, before any `matchday_player` writes - one consistent lock order (matchday → player) everywhere, so withdraw/finish/cancel contend on one row instead of deadlocking. The first-finish charge branch now keys off the lock-authoritative status, so two concurrent finishes can't both create charges.
- On a lost claim, the message names the real cause ("no longer open for changes" vs "not currently selected").

## Testing
- Deterministic concurrency tests: a helper holds the matchday row locked (uncommitted) and signals once locked; the test starts the competing op (which reads the matchday as still open, clearing the read-side check), waits on `pg_stat_activity` until that op is genuinely parked on `FOR UPDATE`, then commits the cancel - so the test exercises the lock guard, not just the read-side check. Covers both withdraw-vs-cancel and finish-vs-cancel. Verified stable across repeated runs.
- Behavioural test: a cancelled matchday rejects dropout and leaves the selection + captain flag intact.
- `pnpm --filter api typecheck` / `lint` ✅; full API integration suite ✅ (431 tests).

Codex review: both prior findings confirmed resolved, no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)