### PR TITLE
fix(matchday): replace native confirm() with an in-app modal (#464)

### DIFF
--- a/apps/matchday/src/components/ui/confirm-dialog.tsx
+++ b/apps/matchday/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,73 @@
+import { Button, type ButtonProps } from "@/components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
+import type * as React from "react";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Tone of the confirm button — use "destructive" for irreversible actions. */
+  confirmTone?: ButtonProps["tone"];
+  /** Disables both buttons (and blocks dismissal) while the action is in flight. */
+  pending?: boolean;
+  onConfirm: () => void;
+}
+
+/**
+ * Accessible replacement for the browser's blocking `confirm()`. Renders a
+ * modal with a cancel/confirm pair so destructive matchday actions (closing
+ * an availability request, locking in a team) get a proper in-app prompt
+ * instead of a native dialog the PWA can't style or theme.
+ */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  confirmTone = "primary",
+  pending = false,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (pending) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="w-[calc(100%-1.5rem)] max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description != null && (
+            <DialogDescription>{description}</DialogDescription>
+          )}
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            tone="ghost"
+            disabled={pending}
+            onClick={() => onOpenChange(false)}
+          >
+            {cancelLabel}
+          </Button>
+          <Button tone={confirmTone} disabled={pending} onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/matchday/src/pages/official-availability-date.tsx
+++ b/apps/matchday/src/pages/official-availability-date.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button.js";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog.js";
 import { fmtDate } from "@/features/format.js";
 import { useDebouncedValue } from "@/hooks/use-debounced-value.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
@@ -836,6 +837,7 @@ function ConfirmTeamControl({
   onConfirm: (fixtureId: string) => void;
   confirming: boolean;
 }) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
   if (fixture.matchdayId) {
     return (
       <div className="border-border-light mt-3 flex items-center justify-between border-t pt-3">
@@ -854,23 +856,31 @@ function ConfirmTeamControl({
   }
   if (fixture.assignments.length === 0) return null;
   return (
-    <Button
-      tone="primary"
-      size="sm"
-      className="mt-3 w-full"
-      disabled={confirming}
-      onClick={() => {
-        if (
-          confirm(
-            `Confirm this team and create the matchday for ${fixture.team_name ?? "this team"} vs ${fixture.opposition}? Players can still update availability for other games in this request.`,
-          )
-        ) {
+    <>
+      <Button
+        tone="primary"
+        size="sm"
+        className="mt-3 w-full"
+        disabled={confirming}
+        onClick={() => {
+          setConfirmOpen(true);
+        }}
+      >
+        {confirming ? "Confirming…" : "Confirm team →"}
+      </Button>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Confirm this team?"
+        description={`This creates the matchday for ${fixture.team_name ?? "this team"} vs ${fixture.opposition}. Players can still update availability for other games in this request.`}
+        confirmLabel="Confirm team"
+        pending={confirming}
+        onConfirm={() => {
           onConfirm(fixture.id);
-        }
-      }}
-    >
-      {confirming ? "Confirming…" : "Confirm team →"}
-    </Button>
+          setConfirmOpen(false);
+        }}
+      />
+    </>
   );
 }
 

--- a/apps/matchday/src/pages/official-availability-detail.tsx
+++ b/apps/matchday/src/pages/official-availability-detail.tsx
@@ -1,10 +1,12 @@
 import { StatusPill } from "@/components/primitives/status-pill.js";
 import { StickyActionBar } from "@/components/shell/sticky-action-bar.js";
 import { Button } from "@/components/ui/button.js";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog.js";
 import { fmtDate } from "@/features/format.js";
 import { api, callApi } from "@/lib/api-client.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeftIcon } from "lucide-react";
+import { useState } from "react";
 import { Link, useParams } from "react-router";
 
 /**
@@ -18,6 +20,7 @@ import { Link, useParams } from "react-router";
 export default function OfficialAvailabilityDetail() {
   const { requestId } = useParams();
   const qc = useQueryClient();
+  const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
   const { data, isLoading, isError } = useQuery({
     queryKey: ["availability", "request", requestId],
     queryFn: () =>
@@ -144,19 +147,30 @@ export default function OfficialAvailabilityDetail() {
             className="flex-1"
             disabled={close.isPending}
             onClick={() => {
-              if (
-                confirm(
-                  "Close this request? Players won't be able to respond after this, and any picked-but-unconfirmed teams will be turned into matchdays.",
-                )
-              ) {
-                close.mutate();
-              }
+              setConfirmCloseOpen(true);
             }}
           >
             Close request
           </Button>
         </StickyActionBar>
       )}
+
+      <ConfirmDialog
+        open={confirmCloseOpen}
+        onOpenChange={setConfirmCloseOpen}
+        title="Close this request?"
+        description="Players won't be able to respond after this, and any picked-but-unconfirmed teams will be turned into matchdays."
+        confirmLabel="Close request"
+        confirmTone="destructive"
+        pending={close.isPending}
+        onConfirm={() => {
+          close.mutate(undefined, {
+            onSuccess: () => {
+              setConfirmCloseOpen(false);
+            },
+          });
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #464.

## What

Audited the matchday PWA for native JS dialogs. The only real uses were two `confirm()` calls on the official availability screens, both guarding consequential actions:

- **Close an availability request** (`official-availability-detail.tsx`) - irreversible; stops player responses and turns picked teams into matchdays.
- **Confirm a team / create a matchday** (`official-availability-date.tsx`).

(The `prompt()` in `install-prompt.tsx` is the PWA `BeforeInstallPromptEvent.prompt()` browser API, not a JS dialog, so it was left untouched.)

## How

- Added a reusable `ConfirmDialog` (`components/ui/confirm-dialog.tsx`) built on the existing `Dialog` primitive - title, description, configurable confirm tone/label, and a `pending` flag that disables both buttons (and blocks dismissal) while a mutation is in flight.
- Wired it into both call sites. The "close request" action uses the `destructive` tone and closes the modal on mutation success.

Native `confirm()` can't be themed, doesn't match the PWA shell, and reads as out of place on mobile; this brings both prompts in-app.

## Testing

- `pnpm typecheck`, `pnpm lint` (matchday) - clean
- `pnpm format` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)