### PR TITLE
fix(games): ball-by-ball viewer fixes and enhancements

### DIFF
--- a/apps/api/src/features/games/integration.test.ts
+++ b/apps/api/src/features/games/integration.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import { getWagonWheel } from "./service.ts";
+
+let ctx: TestContext;
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+}, 30_000);
+
+afterAll(async () => {
+  await stopTestContainer(ctx);
+});
+
+async function seedMatchResult(matchId: string) {
+  await ctx.db
+    .insertInto("match_result")
+    .values({
+      id: crypto.randomUUID(),
+      match_id: matchId,
+      home_team_id: "home",
+      away_team_id: "away",
+      home_team_name: "1st XI",
+      away_team_name: "1st XI",
+      match_date: "2026-06-06",
+      season: 2026,
+    })
+    .onConflict((oc) => oc.column("match_id").doNothing())
+    .execute();
+}
+
+async function seedBall(args: {
+  matchId: string;
+  rvResultId: string;
+  over: number;
+  ball: number;
+  lDesc: string;
+  ballTimeUtc: string | null;
+}) {
+  await ctx.db
+    .insertInto("match_ball")
+    .values({
+      match_id: args.matchId,
+      rv_match_id: "rv-match",
+      rv_result_id: args.rvResultId,
+      innings_number: 1, // RV serves both batting innings as innings_number=1
+      over_no: args.over,
+      ball_no: args.ball,
+      ball_no_disp: args.ball,
+      runs_bat: 1,
+      runs_extra: 0,
+      l_desc: args.lDesc,
+      s_desc: args.lDesc,
+      ball_time_utc: args.ballTimeUtc,
+    })
+    .execute();
+}
+
+describe("getWagonWheel innings ordering", () => {
+  it("orders innings by batting chronology, not rv_result_id", async () => {
+    // The team batting FIRST (earlier ball times) is given the HIGHER
+    // rv_result_id, and the team batting SECOND the LOWER id. Sorting by
+    // rv_result_id would reverse the innings and mislabel the tabs.
+    const matchId = "match-ww-chrono";
+    await seedMatchResult(matchId);
+    await seedBall({
+      matchId,
+      rvResultId: "200",
+      over: 0,
+      ball: 1,
+      lDesc: "FIRST-INN",
+      ballTimeUtc: "2026-06-06T10:00:00Z",
+    });
+    await seedBall({
+      matchId,
+      rvResultId: "100",
+      over: 0,
+      ball: 1,
+      lDesc: "SECOND-INN",
+      ballTimeUtc: "2026-06-06T14:00:00Z",
+    });
+
+    const result = await getWagonWheel(ctx.db)(matchId);
+
+    expect(result.innings).toHaveLength(2);
+    expect(result.innings[0]?.inningsNumber).toBe(1);
+    expect(result.innings[0]?.balls[0]?.lDesc).toBe("FIRST-INN");
+    expect(result.innings[1]?.inningsNumber).toBe(2);
+    expect(result.innings[1]?.balls[0]?.lDesc).toBe("SECOND-INN");
+  });
+
+  it("falls back to rv_result_id order when ball times are absent", async () => {
+    const matchId = "match-ww-notime";
+    await seedMatchResult(matchId);
+    await seedBall({
+      matchId,
+      rvResultId: "b",
+      over: 0,
+      ball: 1,
+      lDesc: "RESULT-B",
+      ballTimeUtc: null,
+    });
+    await seedBall({
+      matchId,
+      rvResultId: "a",
+      over: 0,
+      ball: 1,
+      lDesc: "RESULT-A",
+      ballTimeUtc: null,
+    });
+
+    const result = await getWagonWheel(ctx.db)(matchId);
+
+    expect(result.innings).toHaveLength(2);
+    expect(result.innings[0]?.balls[0]?.lDesc).toBe("RESULT-A");
+    expect(result.innings[1]?.balls[0]?.lDesc).toBe("RESULT-B");
+  });
+});

--- a/apps/api/src/features/games/integration.test.ts
+++ b/apps/api/src/features/games/integration.test.ts
@@ -45,7 +45,7 @@ async function seedBall(args: {
     .insertInto("match_ball")
     .values({
       match_id: args.matchId,
-      rv_match_id: "rv-match",
+      rv_match_id: `rv-${args.matchId}`,
       rv_result_id: args.rvResultId,
       innings_number: 1, // RV serves both batting innings as innings_number=1
       over_no: args.over,
@@ -118,5 +118,35 @@ describe("getWagonWheel innings ordering", () => {
     expect(result.innings).toHaveLength(2);
     expect(result.innings[0]?.balls[0]?.lDesc).toBe("RESULT-A");
     expect(result.innings[1]?.balls[0]?.lDesc).toBe("RESULT-B");
+  });
+
+  it("falls back to rv_result_id order when only some innings are timed", async () => {
+    // Mixed timestamps give no reliable cross-innings order, so the timed
+    // innings must NOT float to the front — order by rv_result_id instead.
+    const matchId = "match-ww-mixed";
+    await seedMatchResult(matchId);
+    await seedBall({
+      matchId,
+      rvResultId: "200",
+      over: 0,
+      ball: 1,
+      lDesc: "UNTIMED-200",
+      ballTimeUtc: null,
+    });
+    await seedBall({
+      matchId,
+      rvResultId: "100",
+      over: 0,
+      ball: 1,
+      lDesc: "TIMED-100",
+      ballTimeUtc: "2026-06-06T14:00:00Z",
+    });
+
+    const result = await getWagonWheel(ctx.db)(matchId);
+
+    expect(result.innings).toHaveLength(2);
+    // rv_result_id "100" sorts before "200" despite "200" being untimed.
+    expect(result.innings[0]?.balls[0]?.lDesc).toBe("TIMED-100");
+    expect(result.innings[1]?.balls[0]?.lDesc).toBe("UNTIMED-200");
   });
 });

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -609,15 +609,17 @@ export function getWagonWheel(db: Kysely<DB>) {
     // tabs because the consumer aligns them positionally with the Play Cricket
     // batting-order team names. ball_time_utc is reliably populated for
     // live-scored matches (the only ones with wagon-wheel shot data), so order
-    // by earliest ball time, falling back to rv_result_id when a group has no
-    // timestamps at all.
-    const innings: WagonWheelInnings[] = Array.from(byResult.entries())
+    // by earliest ball time. Only trust timestamps when EVERY innings has one:
+    // a mix (one timed, one not) gives no reliable cross-innings order, so we
+    // fall back to deterministic rv_result_id ordering for the whole set rather
+    // than arbitrarily floating the timed innings to the front.
+    const groups = Array.from(byResult.entries());
+    const allTimed = groups.every(([, g]) => g.firstBallTime !== null);
+    const innings: WagonWheelInnings[] = groups
       .sort(([idA, a], [idB, b]) => {
-        if (a.firstBallTime !== null && b.firstBallTime !== null) {
+        if (allTimed && a.firstBallTime !== null && b.firstBallTime !== null) {
           return a.firstBallTime - b.firstBallTime;
         }
-        if (a.firstBallTime !== null) return -1;
-        if (b.firstBallTime !== null) return 1;
         return idA < idB ? -1 : idA > idB ? 1 : 0;
       })
       .map(([, group], idx) => ({

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -536,6 +536,7 @@ export function getWagonWheel(db: Kysely<DB>) {
         .select([
           "match_ball.rv_result_id",
           "match_ball.innings_number",
+          "match_ball.ball_time_utc",
           "match_ball.over_no",
           "match_ball.ball_no",
           "match_ball.ball_no_disp",
@@ -563,11 +564,13 @@ export function getWagonWheel(db: Kysely<DB>) {
     // Group by rv_result_id. RV serves both teams' batting innings as
     // innings_number=1 in their respective team feeds, so innings_number
     // alone collapses both innings into one. rv_result_id is the canonical
-    // per-innings discriminator. ball_time_utc is nullable and frequently
-    // null for non-live-scored matches, so we order by (rv_result_id,
-    // over_no, ball_no) for deterministic ordering without the risk of
-    // null timestamps shuffling balls around.
-    const byResult = new Map<string, WagonWheelBall[]>();
+    // per-innings discriminator. Within an innings we keep balls in
+    // (rv_result_id, over_no, ball_no) order from the query above, since
+    // ball_time_utc can be null mid-innings and would shuffle balls around.
+    const byResult = new Map<
+      string,
+      { balls: WagonWheelBall[]; firstBallTime: number | null }
+    >();
     for (const r of rows) {
       const ball: WagonWheelBall = {
         over: r.over_no,
@@ -586,14 +589,41 @@ export function getWagonWheel(db: Kysely<DB>) {
         shotAngle: r.shot_angle,
         shotLength: r.shot_length,
       };
-      const list = byResult.get(r.rv_result_id);
-      if (list) list.push(ball);
-      else byResult.set(r.rv_result_id, [ball]);
+      let group = byResult.get(r.rv_result_id);
+      if (!group) {
+        group = { balls: [], firstBallTime: null };
+        byResult.set(r.rv_result_id, group);
+      }
+      group.balls.push(ball);
+      if (r.ball_time_utc !== null) {
+        const t = new Date(r.ball_time_utc).getTime();
+        if (group.firstBallTime === null || t < group.firstBallTime) {
+          group.firstBallTime = t;
+        }
+      }
     }
 
-    const innings: WagonWheelInnings[] = Array.from(byResult.entries()).map(
-      ([, balls], idx) => ({ inningsNumber: idx + 1, balls }),
-    );
+    // Order innings by actual batting chronology, not rv_result_id.
+    // RapidViz assigns result ids arbitrarily, so the team batting second can
+    // have the lower id — sorting by rv_result_id then mislabels the innings
+    // tabs because the consumer aligns them positionally with the Play Cricket
+    // batting-order team names. ball_time_utc is reliably populated for
+    // live-scored matches (the only ones with wagon-wheel shot data), so order
+    // by earliest ball time, falling back to rv_result_id when a group has no
+    // timestamps at all.
+    const innings: WagonWheelInnings[] = Array.from(byResult.entries())
+      .sort(([idA, a], [idB, b]) => {
+        if (a.firstBallTime !== null && b.firstBallTime !== null) {
+          return a.firstBallTime - b.firstBallTime;
+        }
+        if (a.firstBallTime !== null) return -1;
+        if (b.firstBallTime !== null) return 1;
+        return idA < idB ? -1 : idA > idB ? 1 : 0;
+      })
+      .map(([, group], idx) => ({
+        inningsNumber: idx + 1,
+        balls: group.balls,
+      }));
 
     return { matchId, dismissalPenalty, innings };
   };

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -319,6 +319,46 @@
   border-color: #334155;
 }
 
+/* The ball-by-ball / wagon-wheel viewer is a deliberately dark slate UI in
+   BOTH app themes. The stone remap above (and the bg pins) would invert its
+   palette in dark mode — dark text on dark surfaces, bleached panels — so
+   re-pin the stone scale to its canonical Tailwind values within the viewer.
+   Custom-property cascade does the heavy lifting (closest ancestor wins), so
+   every text-/border-/bg-stone-* utility resolves to the intended dark look;
+   the handful of bg-stone-* pinned directly above are then neutralised back
+   to the same vars. color-scheme keeps native controls (the player <select>)
+   dark to match. */
+.wagon-wheel-surface {
+  color-scheme: dark;
+  --color-stone-50: #fafaf9;
+  --color-stone-100: #f5f5f4;
+  --color-stone-200: #e7e5e4;
+  --color-stone-300: #d6d3d1;
+  --color-stone-400: #a8a29e;
+  --color-stone-500: #78716c;
+  --color-stone-600: #57534e;
+  --color-stone-700: #44403c;
+  --color-stone-800: #292524;
+  --color-stone-900: #1c1917;
+  --color-stone-950: #0c0a09;
+}
+.dark .wagon-wheel-surface.bg-stone-950,
+.dark .wagon-wheel-surface .bg-stone-950 {
+  background-color: var(--color-stone-950);
+}
+.dark .wagon-wheel-surface .bg-stone-900 {
+  background-color: var(--color-stone-900);
+}
+.dark .wagon-wheel-surface .bg-stone-800 {
+  background-color: var(--color-stone-800);
+}
+.dark .wagon-wheel-surface .hover\:bg-stone-800:hover {
+  background-color: var(--color-stone-800);
+}
+.dark .wagon-wheel-surface .border-stone-700 {
+  border-color: var(--color-stone-700);
+}
+
 /* Primary is kept as dark green for bg-primary (header/footer with white text).
    Override text/border/outline uses to a brighter green so they're visible on dark surfaces. */
 .dark .text-primary {

--- a/apps/web/src/components/wagon-wheel-modal.tsx
+++ b/apps/web/src/components/wagon-wheel-modal.tsx
@@ -25,7 +25,7 @@ export function WagonWheelModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="h-screen max-h-screen w-screen max-w-none rounded-none border-0 bg-stone-950 p-0 text-stone-100">
+      <DialogContent className="wagon-wheel-surface h-screen max-h-screen w-screen max-w-none rounded-none border-0 bg-stone-950 p-0 text-stone-100">
         <div className="flex h-full flex-col">
           <div className="flex-1 overflow-y-auto p-4 sm:p-6">
             {isLoading && <LoadingState />}
@@ -104,6 +104,8 @@ function WagonWheelViewer({ data, inningsTeamNames }: ViewerProps) {
   const active = inningsWithBalls[inningsIndex];
   if (!active) return <EmptyState />;
 
+  const otherInnings = inningsWithBalls.find((_, i) => i !== inningsIndex);
+
   return (
     <div className="flex flex-col gap-4">
       {inningsWithBalls.length > 1 && (
@@ -138,11 +140,32 @@ function WagonWheelViewer({ data, inningsTeamNames }: ViewerProps) {
       <InningsView
         key={inningsIndex}
         balls={active.balls}
-        otherBalls={inningsWithBalls.find((_, i) => i !== inningsIndex)?.balls}
+        otherBalls={otherInnings?.balls}
         dismissalPenalty={data.dismissalPenalty}
       />
     </div>
   );
+}
+
+// Distinct players (by RV id) appearing in an innings, for the filter
+// dropdowns. Balls with a null RV id (placeholder players with no PC mapping)
+// can't be filtered individually, so they're omitted from the options.
+function playerOptions(
+  balls: Ball[],
+  pick: "bat" | "bowl",
+): Array<{ id: number; name: string }> {
+  const byId = new Map<number, string>();
+  for (const b of balls) {
+    const id = pick === "bat" ? b.batterRvId : b.bowlerRvId;
+    if (id == null) continue;
+    if (!byId.has(id)) {
+      const name = pick === "bat" ? b.batterName : b.bowlerName;
+      byId.set(id, name ?? `#${id}`);
+    }
+  }
+  return [...byId.entries()]
+    .map(([id, name]) => ({ id, name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function InningsView({
@@ -155,24 +178,46 @@ function InningsView({
   dismissalPenalty: number;
 }) {
   const [selectedOver, setSelectedOver] = useState<number | null>(null);
+  const [selectedBatter, setSelectedBatter] = useState<number | null>(null);
+  const [selectedBowler, setSelectedBowler] = useState<number | null>(null);
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
 
-  const filtered =
-    selectedOver === null
-      ? balls
-      : balls.filter((b) => b.over === selectedOver);
+  const batters = useMemo(() => playerOptions(balls, "bat"), [balls]);
+  const bowlers = useMemo(() => playerOptions(balls, "bowl"), [balls]);
+
+  const filtered = useMemo(
+    () =>
+      balls.filter(
+        (b) =>
+          (selectedOver === null || b.over === selectedOver) &&
+          (selectedBatter === null || b.batterRvId === selectedBatter) &&
+          (selectedBowler === null || b.bowlerRvId === selectedBowler),
+      ),
+    [balls, selectedOver, selectedBatter, selectedBowler],
+  );
 
   const stats = computeStats(filtered, dismissalPenalty);
 
   return (
     <>
-      <Timeline
+      <CumulativeChart
         balls={balls}
         otherBalls={otherBalls}
         dismissalPenalty={dismissalPenalty}
+      />
+      <OverFilter
+        balls={balls}
         selectedOver={selectedOver}
         onSelect={(o) => setSelectedOver((prev) => (prev === o ? null : o))}
         onClear={() => setSelectedOver(null)}
+      />
+      <PlayerFilter
+        batters={batters}
+        bowlers={bowlers}
+        selectedBatter={selectedBatter}
+        selectedBowler={selectedBowler}
+        onBatter={setSelectedBatter}
+        onBowler={setSelectedBowler}
       />
       <div className="grid gap-4 lg:grid-cols-[1fr_minmax(280px,_320px)]">
         <Wheel
@@ -192,6 +237,89 @@ function InningsView({
         </div>
       </div>
     </>
+  );
+}
+
+// --- Player filter (batter / bowler) ---
+
+function PlayerFilter({
+  batters,
+  bowlers,
+  selectedBatter,
+  selectedBowler,
+  onBatter,
+  onBowler,
+}: {
+  batters: Array<{ id: number; name: string }>;
+  bowlers: Array<{ id: number; name: string }>;
+  selectedBatter: number | null;
+  selectedBowler: number | null;
+  onBatter: (id: number | null) => void;
+  onBowler: (id: number | null) => void;
+}) {
+  if (batters.length === 0 && bowlers.length === 0) return null;
+  const hasFilter = selectedBatter !== null || selectedBowler !== null;
+  return (
+    <div className="flex flex-wrap items-end gap-3 rounded-md border border-stone-800 bg-stone-900 p-3">
+      <PlayerSelect
+        label="Batter"
+        options={batters}
+        value={selectedBatter}
+        onChange={onBatter}
+      />
+      <PlayerSelect
+        label="Bowler"
+        options={bowlers}
+        value={selectedBowler}
+        onChange={onBowler}
+      />
+      <button
+        type="button"
+        onClick={() => {
+          onBatter(null);
+          onBowler(null);
+        }}
+        disabled={!hasFilter}
+        className="rounded border border-stone-800 px-2 py-1.5 text-xs text-stone-300 transition-colors hover:border-stone-700 disabled:cursor-default disabled:opacity-40 disabled:hover:border-stone-800"
+      >
+        Clear players
+      </button>
+    </div>
+  );
+}
+
+function PlayerSelect({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: Array<{ id: number; name: string }>;
+  value: number | null;
+  onChange: (id: number | null) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[10px] font-semibold tracking-wider text-stone-500 uppercase">
+        {label}
+      </span>
+      <select
+        value={value ?? ""}
+        onChange={(e) =>
+          onChange(e.target.value === "" ? null : Number(e.target.value))
+        }
+        disabled={options.length === 0}
+        className="min-w-[10rem] rounded-md border border-stone-700 bg-stone-800 px-2 py-1.5 text-sm text-stone-100 transition-colors hover:border-stone-600 focus:border-stone-500 focus:outline-none disabled:opacity-40"
+      >
+        <option value="">All {label.toLowerCase()}s</option>
+        {options.map((o) => (
+          <option key={o.id} value={o.id}>
+            {o.name}
+          </option>
+        ))}
+      </select>
+    </label>
   );
 }
 
@@ -286,7 +414,7 @@ function LegendItem({ color, label }: { color: string; label: string }) {
   );
 }
 
-// --- Timeline ---
+// --- Over-by-over filter (collapsible) ---
 
 interface OverAgg {
   over: number;
@@ -310,21 +438,18 @@ function aggregateOvers(balls: Ball[]): OverAgg[] {
   return Array.from(byOver.values()).sort((a, b) => a.over - b.over);
 }
 
-function Timeline({
+function OverFilter({
   balls,
-  otherBalls,
-  dismissalPenalty,
   selectedOver,
   onSelect,
   onClear,
 }: {
   balls: Ball[];
-  otherBalls?: Ball[];
-  dismissalPenalty: number;
   selectedOver: number | null;
   onSelect: (over: number) => void;
   onClear: () => void;
 }) {
+  const [open, setOpen] = useState(false);
   const overs = useMemo(() => aggregateOvers(balls), [balls]);
   const maxBallRuns = useMemo(() => {
     let m = 1;
@@ -337,12 +462,40 @@ function Timeline({
     return m;
   }, [overs]);
 
+  if (overs.length === 0) return null;
+
   return (
-    <div className="rounded-md border border-stone-800 bg-stone-900 p-3">
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <h3 className="text-[10px] font-semibold tracking-wider text-stone-500 uppercase">
+    <div className="rounded-md border border-stone-800 bg-stone-900">
+      <div className="flex items-center justify-between gap-2 p-3">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="flex items-center gap-2 text-[10px] font-semibold tracking-wider text-stone-400 uppercase transition-colors hover:text-stone-200"
+        >
+          <svg
+            viewBox="0 0 12 12"
+            className={
+              "size-3 transition-transform " + (open ? "rotate-90" : "")
+            }
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path
+              d="M4 2l4 4-4 4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
           Over by over
-        </h3>
+          {selectedOver !== null && (
+            <span className="rounded bg-stone-800 px-1.5 py-0.5 text-stone-200 normal-case">
+              Over {selectedOver + 1}
+            </span>
+          )}
+        </button>
         <button
           type="button"
           onClick={onClear}
@@ -352,68 +505,71 @@ function Timeline({
           Clear filter
         </button>
       </div>
-      <p className="mb-2 text-xs text-stone-500">
-        Tap an over to filter the wheel.
-      </p>
-      <div className="flex items-stretch gap-1 overflow-x-auto pb-1">
-        {overs.map((o) => {
-          const isSelected = selectedOver === o.over;
-          return (
-            <button
-              key={o.over}
-              type="button"
-              onClick={() => onSelect(o.over)}
-              className={
-                "flex flex-1 shrink-0 grow basis-[60px] flex-col items-center rounded-md px-2 py-1 transition-colors " +
-                (isSelected
-                  ? "bg-stone-800 outline outline-stone-600"
-                  : "hover:bg-stone-800/60")
-              }
-              aria-pressed={isSelected}
-              aria-label={`Over ${o.over + 1}, ${o.runs} runs${o.wickets ? `, ${o.wickets} wicket${o.wickets === 1 ? "" : "s"}` : ""}`}
-            >
-              <div className="flex h-12 items-end gap-px">
-                {o.balls.map((b) => {
-                  const r = b.runsBat + b.runsExtra;
-                  const h = 4 + (r / Math.max(1, maxBallRuns)) * 44;
-                  return (
-                    <span
-                      key={`${b.over}-${b.ball}`}
-                      style={{
-                        height: `${h}px`,
-                        backgroundColor: runColor(b),
-                        outline: b.dismissed
-                          ? `1.5px solid ${COLORS.wkt}`
-                          : undefined,
-                      }}
-                      className="w-1.5 rounded-sm"
-                      title={b.lDesc || b.sDesc}
-                    />
-                  );
-                })}
-              </div>
-              <div className="mt-1 font-mono text-xs font-semibold tabular-nums">
-                {o.runs}
-                {o.wickets > 0 && (
-                  <span
-                    className="ml-0.5"
-                    style={{ color: COLORS.wkt }}
-                  >{`·${o.wickets}`}</span>
-                )}
-              </div>
-              <div className="font-mono text-[10px] text-stone-500 tabular-nums">
-                {o.over + 1}
-              </div>
-            </button>
-          );
-        })}
-      </div>
-
-      <CumulativeChart
-        balls={balls}
-        otherBalls={otherBalls}
-        dismissalPenalty={dismissalPenalty}
-      />
+      {open && (
+        <div className="px-3 pb-3">
+          <p className="mb-2 text-xs text-stone-500">
+            Tap an over to filter the wheel.
+          </p>
+          {/* Wrap into a responsive grid rather than a single horizontally
+              scrolling row. A long innings (40+ overs) overflowed an invisible
+              horizontal scrollbar inside the vertically scrolling modal, leaving
+              later overs unreachable on a laptop. auto-fill keeps cells uniform
+              and every over visible/tappable at any width. */}
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(60px,1fr))] gap-1">
+            {overs.map((o) => {
+              const isSelected = selectedOver === o.over;
+              return (
+                <button
+                  key={o.over}
+                  type="button"
+                  onClick={() => onSelect(o.over)}
+                  className={
+                    "flex flex-col items-center rounded-md px-2 py-1 transition-colors " +
+                    (isSelected
+                      ? "bg-stone-800 outline outline-stone-600"
+                      : "hover:bg-stone-800/60")
+                  }
+                  aria-pressed={isSelected}
+                  aria-label={`Over ${o.over + 1}, ${o.runs} runs${o.wickets ? `, ${o.wickets} wicket${o.wickets === 1 ? "" : "s"}` : ""}`}
+                >
+                  <div className="flex h-12 items-end gap-px">
+                    {o.balls.map((b) => {
+                      const r = b.runsBat + b.runsExtra;
+                      const h = 4 + (r / Math.max(1, maxBallRuns)) * 44;
+                      return (
+                        <span
+                          key={`${b.over}-${b.ball}`}
+                          style={{
+                            height: `${h}px`,
+                            backgroundColor: runColor(b),
+                            outline: b.dismissed
+                              ? `1.5px solid ${COLORS.wkt}`
+                              : undefined,
+                          }}
+                          className="w-1.5 rounded-sm"
+                          title={b.lDesc || b.sDesc}
+                        />
+                      );
+                    })}
+                  </div>
+                  <div className="mt-1 font-mono text-xs font-semibold tabular-nums">
+                    {o.runs}
+                    {o.wickets > 0 && (
+                      <span
+                        className="ml-0.5"
+                        style={{ color: COLORS.wkt }}
+                      >{`·${o.wickets}`}</span>
+                    )}
+                  </div>
+                  <div className="font-mono text-[10px] text-stone-500 tabular-nums">
+                    {o.over + 1}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -500,6 +656,25 @@ function CumulativeChart({
   const sx = (x: number) => (x / xMax) * W;
   const sy = (y: number) => H - padY - ((y - yMin) / yRange) * (H - padY * 2);
 
+  // Axis markers: every 5 overs on x, every 50 runs on y. The x-axis is
+  // ball-indexed, so map each over boundary to the index of its first ball in
+  // the current (primary) innings.
+  const firstIdxByOver = new Map<number, number>();
+  let maxOver = 0;
+  points.forEach((p, i) => {
+    if (!firstIdxByOver.has(p.ball.over)) firstIdxByOver.set(p.ball.over, i);
+    if (p.ball.over > maxOver) maxOver = p.ball.over;
+  });
+  const overMarks: Array<{ over: number; x: number }> = [];
+  for (let t = 5; t <= maxOver; t += 5) {
+    const idx = firstIdxByOver.get(t);
+    if (idx !== undefined) overMarks.push({ over: t, x: idx });
+  }
+  const runMarks: number[] = [];
+  for (let v = Math.ceil(yMin / 50) * 50; v <= yMax; v += 50) {
+    if (v !== 0) runMarks.push(v); // 0 already drawn as the baseline
+  }
+
   const toPath = (pts: ChartPoint[]): string =>
     pts.map((p, i) => `${i === 0 ? "M" : "L"} ${sx(p.x)} ${sy(p.y)}`).join(" ");
 
@@ -523,27 +698,9 @@ function CumulativeChart({
   }
 
   return (
-    <div className="relative mt-3 border-t border-stone-800 pt-3">
+    <div className="relative rounded-md border border-stone-800 bg-stone-900 p-3">
       <div className="mb-1 flex items-center justify-between gap-3 text-[10px] font-semibold tracking-wider text-stone-500 uppercase">
-        <div className="flex items-center gap-3">
-          <span>Cumulative runs</span>
-          <span className="flex items-center gap-1 normal-case">
-            <span
-              className="inline-block h-0.5 w-3 rounded"
-              style={{ backgroundColor: COLORS.r1 }}
-            />
-            this innings
-          </span>
-          {other && (
-            <span className="flex items-center gap-1 normal-case">
-              <span
-                className="inline-block h-0.5 w-3 rounded"
-                style={{ backgroundColor: "#5eb3ff", opacity: 0.35 }}
-              />
-              other innings
-            </span>
-          )}
-        </div>
+        <span>Cumulative runs</span>
         <span className="font-mono text-stone-400 normal-case tabular-nums">
           {totalRuns} • {wickets.length} wkt
           {wickets.length === 1 ? "" : "s"}
@@ -558,6 +715,33 @@ function CumulativeChart({
           role="img"
           aria-label={`Cumulative runs: ${totalRuns} runs, ${wickets.length} wickets`}
         >
+          {/* Run gridlines every 50 (y) */}
+          {runMarks.map((v) => (
+            <line
+              key={`run-${v}`}
+              x1={0}
+              x2={W}
+              y1={sy(v)}
+              y2={sy(v)}
+              stroke="#2a2f3d"
+              strokeWidth={1}
+              strokeDasharray="2 5"
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
+          {/* Over gridlines every 5 (x) */}
+          {overMarks.map((m) => (
+            <line
+              key={`over-${m.over}`}
+              x1={sx(m.x)}
+              x2={sx(m.x)}
+              y1={padY}
+              y2={H - padY}
+              stroke="#2a2f3d"
+              strokeWidth={1}
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
           {/* Baseline at y=0 (or yMin if negative) */}
           <line
             x1={0}
@@ -601,6 +785,26 @@ function CumulativeChart({
             />
           ))}
         </svg>
+        {/* Axis labels as HTML overlays — SVG text would distort under
+          preserveAspectRatio="none". Runs up the left, overs along the bottom. */}
+        {runMarks.map((v) => (
+          <span
+            key={`run-lbl-${v}`}
+            className="pointer-events-none absolute left-0 -translate-y-1/2 bg-stone-900/80 pr-1 font-mono text-[9px] text-stone-500 tabular-nums"
+            style={{ top: `${(sy(v) / H) * 100}%` }}
+          >
+            {v}
+          </span>
+        ))}
+        {overMarks.map((m) => (
+          <span
+            key={`over-lbl-${m.over}`}
+            className="pointer-events-none absolute bottom-0 -translate-x-1/2 font-mono text-[9px] text-stone-500 tabular-nums"
+            style={{ left: `${(sx(m.x) / W) * 100}%` }}
+          >
+            {m.over}
+          </span>
+        ))}
         {/* W markers as HTML overlays. The SVG uses preserveAspectRatio="none",
           so shapes drawn in viewBox units stretch non-uniformly (tall/skinny
           ovals on mobile). HTML divs anchored by % stay circular. */}


### PR DESCRIPTION
Fixes and improvements to the ball-by-ball / wagon-wheel viewer (`/calendar/game/:id?bbb=1`), driven by issues spotted on a live match (7262946).

## Bug fixes
- **Innings tabs were reversed.** `getWagonWheel` ordered innings by `rv_result_id`, but RapidViz assigns those ids arbitrarily, so when the side batting second had the lower id the tabs were swapped relative to the Play Cricket batting-order team names (clicking a team showed the other team's wheel). Now ordered by batting chronology via `ball_time_utc` (reliably populated for live-scored matches), falling back to `rv_result_id` when no timestamps exist.
- **Over-by-over strip wasn't scrollable.** A long innings (40+ overs) overflowed an invisible horizontal scrollbar nested inside the vertically scrolling modal, so later overs were unreachable on a laptop. It now wraps into a responsive `auto-fill` grid; every over is visible and tappable at any width.
- **Viewer looked broken in app dark mode.** The global dark-mode CSS remaps the stone palette (inverting it). The viewer is a deliberately dark slate UI in both themes, so it now re-pins the stone scale within a `.wagon-wheel-surface` scope and renders identically in light and dark.

## Enhancements
- **Reordered** the viewer: cumulative chart on top, then a collapsible over filter, then the player filter.
- **Filter by batter or bowler** — narrows the wheel, stats and ball list to one player so they can see how their innings/spell went. Composes with the over filter.
- **Axis markers** on the cumulative chart: over markers every 5 overs (x), run markers every 50 runs (y).

## Testing
- New integration test for the innings ordering (chronology + rv_result_id fallback).
- `pnpm test` (507) and `pnpm test:integration` (433) green; typecheck, lint, prettier clean.
- Verified live against this match's prod data loaded locally: tabs now match the wheels, all 40 overs reach, batter/bowler filter works, and the viewer is identical in light and dark mode.

## Notes
- The per-player **Wkts** stat counts wickets that fell while that batter was on strike (existing per-ball semantics), so a non-striker run-out is included. Making it the player's own dismissal would need the dismissed player's id added to the wagon-wheel response.
- Over/innings/player filter state is in-memory (consistent with the existing modal), not persisted in the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)