### PR TITLE
feat(matchday): celebrate recent milestone performances on home screen

### DIFF
--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -1,3 +1,4 @@
+import { format, subDays } from "date-fns";
 import { sql } from "kysely";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { SendPush } from "../../lib/push-sender.ts";
@@ -16,6 +17,7 @@ import {
   deleteExpense,
   finishMatch,
   getMatch,
+  getMyRecentMilestones,
   getMyUpcomingMatches,
   getPastUnfinishedMatchdays,
   listMatches,
@@ -2277,6 +2279,253 @@ describe("matchday service (integration)", () => {
 
       expect(recipients).toContain(mdAdmin.email.toLowerCase());
       expect(recipients).not.toContain(genAdmin.email.toLowerCase());
+    });
+  });
+
+  describe("getMyRecentMilestones", () => {
+    function daysAgoIso(days: number) {
+      return format(subDays(new Date(), days), "yyyy-MM-dd");
+    }
+
+    /** Seed a member linked to a Play-Cricket player id; returns the email. */
+    async function seedLinkedMember(playCricketId: string) {
+      const email = `ms-${crypto.randomUUID()}@test.com`;
+      const memberId = await seedMember("Milestone Player", email);
+      await ctx.db
+        .updateTable("member")
+        .set({ play_cricket_id: playCricketId })
+        .where("id", "=", memberId)
+        .execute();
+      return email;
+    }
+
+    async function seedBatting(values: {
+      playerId: string;
+      matchId: string;
+      matchDate: string;
+      runs: number;
+      notOut?: boolean;
+      teamId?: string;
+    }) {
+      await ctx.db
+        .insertInto("match_performance_batting")
+        .values({
+          id: crypto.randomUUID(),
+          match_id: values.matchId,
+          match_date: values.matchDate,
+          player_id: values.playerId,
+          player_name: "Milestone Player",
+          season: new Date().getFullYear(),
+          team_id: values.teamId ?? "pm-team",
+          runs: values.runs,
+          not_out: values.notOut ?? false,
+        })
+        .execute();
+    }
+
+    async function seedBowling(values: {
+      playerId: string;
+      matchId: string;
+      matchDate: string;
+      wickets: number;
+      runsConceded: number;
+      teamId?: string;
+    }) {
+      await ctx.db
+        .insertInto("match_performance_bowling")
+        .values({
+          id: crypto.randomUUID(),
+          match_id: values.matchId,
+          match_date: values.matchDate,
+          player_id: values.playerId,
+          player_name: "Milestone Player",
+          season: new Date().getFullYear(),
+          team_id: values.teamId ?? "pm-team",
+          wickets: values.wickets,
+          runs: values.runsConceded,
+        })
+        .execute();
+    }
+
+    async function seedResult(values: {
+      matchId: string;
+      matchDate: string;
+      homeTeamId: string;
+      homeTeamName: string;
+      homeClubName?: string;
+      awayTeamId: string;
+      awayTeamName: string;
+      awayClubName?: string;
+    }) {
+      await ctx.db
+        .insertInto("match_result")
+        .values({
+          id: crypto.randomUUID(),
+          match_id: values.matchId,
+          match_date: values.matchDate,
+          season: new Date().getFullYear(),
+          home_team_id: values.homeTeamId,
+          home_team_name: values.homeTeamName,
+          home_club_name: values.homeClubName ?? null,
+          away_team_id: values.awayTeamId,
+          away_team_name: values.awayTeamName,
+          away_club_name: values.awayClubName ?? null,
+        })
+        .execute();
+    }
+
+    it("returns empty for members without a linked play_cricket_id", async () => {
+      const email = `ms-nolink-${crypto.randomUUID()}@test.com`;
+      await seedMember("Unlinked Player", email);
+
+      const result = await getMyRecentMilestones(ctx.db)(email);
+
+      expect(result).toEqual({ windowDays: 7, milestones: [] });
+    });
+
+    it("returns a fifty with opposition derived from a home result", async () => {
+      const playerId = `pc-${crypto.randomUUID()}`;
+      const email = await seedLinkedMember(playerId);
+      const matchId = `m-${crypto.randomUUID()}`;
+      const matchDate = daysAgoIso(2);
+
+      await seedBatting({
+        playerId,
+        matchId,
+        matchDate,
+        runs: 57,
+        notOut: true,
+        teamId: "pm-1",
+      });
+      await seedResult({
+        matchId,
+        matchDate,
+        homeTeamId: "pm-1",
+        homeTeamName: "1st XI",
+        homeClubName: "Percy Main CC",
+        awayTeamId: "opp-1",
+        awayTeamName: "2nd XI",
+        awayClubName: "Tynemouth CC",
+      });
+
+      const { milestones } = await getMyRecentMilestones(ctx.db)(email);
+
+      expect(milestones).toEqual([
+        {
+          type: "batting",
+          matchId,
+          matchDate,
+          opposition: "Tynemouth CC 2nd XI",
+          runs: 57,
+          notOut: true,
+        },
+      ]);
+    });
+
+    it("returns a five-for with opposition from an away result", async () => {
+      const playerId = `pc-${crypto.randomUUID()}`;
+      const email = await seedLinkedMember(playerId);
+      const matchId = `m-${crypto.randomUUID()}`;
+      const matchDate = daysAgoIso(4);
+
+      await seedBowling({
+        playerId,
+        matchId,
+        matchDate,
+        wickets: 5,
+        runsConceded: 23,
+        teamId: "pm-1",
+      });
+      // Club and team name identical — opposition collapses to the club.
+      await seedResult({
+        matchId,
+        matchDate,
+        homeTeamId: "opp-2",
+        homeTeamName: "Benwell Hill CC",
+        homeClubName: "Benwell Hill CC",
+        awayTeamId: "pm-1",
+        awayTeamName: "1st XI",
+        awayClubName: "Percy Main CC",
+      });
+
+      const { milestones } = await getMyRecentMilestones(ctx.db)(email);
+
+      expect(milestones).toEqual([
+        {
+          type: "bowling",
+          matchId,
+          matchDate,
+          opposition: "Benwell Hill CC",
+          wickets: 5,
+          runsConceded: 23,
+        },
+      ]);
+    });
+
+    it("excludes sub-threshold and out-of-window performances", async () => {
+      const playerId = `pc-${crypto.randomUUID()}`;
+      const email = await seedLinkedMember(playerId);
+
+      await seedBatting({
+        playerId,
+        matchId: `m-${crypto.randomUUID()}`,
+        matchDate: daysAgoIso(0),
+        runs: 49,
+      });
+      await seedBatting({
+        playerId,
+        matchId: `m-${crypto.randomUUID()}`,
+        matchDate: daysAgoIso(10),
+        runs: 80,
+      });
+      await seedBowling({
+        playerId,
+        matchId: `m-${crypto.randomUUID()}`,
+        matchDate: daysAgoIso(0),
+        wickets: 4,
+        runsConceded: 12,
+      });
+
+      const { milestones } = await getMyRecentMilestones(ctx.db)(email);
+
+      expect(milestones).toEqual([]);
+    });
+
+    it("sorts newest first; opposition is null without a result row", async () => {
+      const playerId = `pc-${crypto.randomUUID()}`;
+      const email = await seedLinkedMember(playerId);
+      const centuryMatchId = `m-${crypto.randomUUID()}`;
+      const fiveForMatchId = `m-${crypto.randomUUID()}`;
+
+      await seedBatting({
+        playerId,
+        matchId: centuryMatchId,
+        matchDate: daysAgoIso(6),
+        runs: 102,
+      });
+      await seedBowling({
+        playerId,
+        matchId: fiveForMatchId,
+        matchDate: daysAgoIso(1),
+        wickets: 6,
+        runsConceded: 40,
+      });
+
+      const { milestones } = await getMyRecentMilestones(ctx.db)(email);
+
+      expect(milestones).toHaveLength(2);
+      expect(milestones[0]).toMatchObject({
+        type: "bowling",
+        matchId: fiveForMatchId,
+        opposition: null,
+      });
+      expect(milestones[1]).toMatchObject({
+        type: "batting",
+        matchId: centuryMatchId,
+        runs: 102,
+        notOut: false,
+        opposition: null,
+      });
     });
   });
 });

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -24,6 +24,7 @@ import {
   markPaidSchema,
   matchIdParamSchema,
   matchdayPlayerIdParamSchema,
+  myRecentMilestonesResponseSchema,
   myRecentPerformanceResponseSchema,
   myUpcomingMatchesResponseSchema,
   notifyChargesResponseSchema,
@@ -54,6 +55,7 @@ import {
   getAllPastUnfinishedMatchdays,
   getMatch,
   getMatchPublic,
+  getMyRecentMilestones,
   getMyRecentPerformance,
   getMyUpcomingMatches,
   getPastUnfinishedMatchdays,
@@ -106,6 +108,7 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
   const remove = deleteExpense(app.db);
   const myUpcoming = getMyUpcomingMatches(app.db);
   const myPerformance = getMyRecentPerformance(app.db);
+  const myMilestones = getMyRecentMilestones(app.db);
   const withdraw = withdrawFromMatch(
     app.db,
     app.send,
@@ -141,6 +144,20 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       const { user } = getAuthSession(request);
       return await myPerformance(user.email);
+    },
+  );
+
+  app.get(
+    "/matchday/mine/recent-milestones",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        response: { 200: myRecentMilestonesResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await myMilestones(user.email);
     },
   );
 

--- a/apps/api/src/features/matchday/schemas.ts
+++ b/apps/api/src/features/matchday/schemas.ts
@@ -438,6 +438,33 @@ export const myRecentPerformanceResponseSchema = z.object({
   catches: z.number().int().nonnegative(),
 });
 
+// Celebration-worthy single-game performances. `opposition` is derived
+// from the synced match_result row and is null until that row lands.
+const battingMilestoneSchema = z.object({
+  type: z.literal("batting"),
+  matchId: z.string(),
+  matchDate: z.string(),
+  opposition: z.string().nullable(),
+  runs: z.number().int().nonnegative(),
+  notOut: z.boolean(),
+});
+
+const bowlingMilestoneSchema = z.object({
+  type: z.literal("bowling"),
+  matchId: z.string(),
+  matchDate: z.string(),
+  opposition: z.string().nullable(),
+  wickets: z.number().int().nonnegative(),
+  runsConceded: z.number().int().nonnegative(),
+});
+
+export const myRecentMilestonesResponseSchema = z.object({
+  windowDays: z.number().int().positive(),
+  milestones: z.array(
+    z.union([battingMilestoneSchema, bowlingMilestoneSchema]),
+  ),
+});
+
 // ── Types ──
 
 export type ListMatches = z.infer<typeof listMatchesSchema>;

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -553,6 +553,130 @@ export function getMyRecentPerformance(db: Kysely<DB>) {
   };
 }
 
+export const BATTING_MILESTONE_RUNS = 50;
+export const BOWLING_MILESTONE_WICKETS = 5;
+
+/**
+ * Single-game milestone performances (50+ runs batting, 5+ wickets
+ * bowling) for the signed-in user in the trailing `windowDays` window
+ * (default 7). Powers the home-screen celebration card.
+ *
+ * Same email → member.play_cricket_id resolution as
+ * getMyRecentPerformance: members without a linked Play-Cricket ID get
+ * an empty list. A genuine all-round day (fifty AND a five-for in one
+ * match) produces two milestones, deliberately — both deserve a shout.
+ */
+export function getMyRecentMilestones(db: Kysely<DB>) {
+  return async (email: string, windowDays = 7) => {
+    const member = await db
+      .selectFrom("member")
+      .where("email", "=", email)
+      .select(["play_cricket_id"])
+      .executeTakeFirst();
+    if (!member?.play_cricket_id) return { windowDays, milestones: [] };
+
+    const sinceIso = formatDate(subDays(new Date(), windowDays), "yyyy-MM-dd");
+    const playerId = member.play_cricket_id;
+
+    const batting = await db
+      .selectFrom("match_performance_batting")
+      .leftJoin(
+        "match_result",
+        "match_result.match_id",
+        "match_performance_batting.match_id",
+      )
+      .where("match_performance_batting.player_id", "=", playerId)
+      .where("match_performance_batting.match_date", ">=", sinceIso)
+      .where("match_performance_batting.runs", ">=", BATTING_MILESTONE_RUNS)
+      .select([
+        "match_performance_batting.match_id as matchId",
+        "match_performance_batting.match_date as matchDate",
+        "match_performance_batting.team_id as teamId",
+        "match_performance_batting.runs",
+        "match_performance_batting.not_out as notOut",
+        "match_result.home_team_id as homeTeamId",
+        "match_result.home_team_name as homeTeamName",
+        "match_result.home_club_name as homeClubName",
+        "match_result.away_team_name as awayTeamName",
+        "match_result.away_club_name as awayClubName",
+      ])
+      .execute();
+
+    const bowling = await db
+      .selectFrom("match_performance_bowling")
+      .leftJoin(
+        "match_result",
+        "match_result.match_id",
+        "match_performance_bowling.match_id",
+      )
+      .where("match_performance_bowling.player_id", "=", playerId)
+      .where("match_performance_bowling.match_date", ">=", sinceIso)
+      .where(
+        "match_performance_bowling.wickets",
+        ">=",
+        BOWLING_MILESTONE_WICKETS,
+      )
+      .select([
+        "match_performance_bowling.match_id as matchId",
+        "match_performance_bowling.match_date as matchDate",
+        "match_performance_bowling.team_id as teamId",
+        "match_performance_bowling.wickets",
+        "match_performance_bowling.runs as runsConceded",
+        "match_result.home_team_id as homeTeamId",
+        "match_result.home_team_name as homeTeamName",
+        "match_result.home_club_name as homeClubName",
+        "match_result.away_team_name as awayTeamName",
+        "match_result.away_club_name as awayClubName",
+      ])
+      .execute();
+
+    const milestones = [
+      ...batting.map((row) => ({
+        type: "batting" as const,
+        matchId: row.matchId,
+        matchDate: row.matchDate,
+        opposition: oppositionFromResult(row),
+        runs: row.runs,
+        notOut: row.notOut,
+      })),
+      ...bowling.map((row) => ({
+        type: "bowling" as const,
+        matchId: row.matchId,
+        matchDate: row.matchDate,
+        opposition: oppositionFromResult(row),
+        wickets: row.wickets,
+        runsConceded: row.runsConceded,
+      })),
+    ].sort((a, b) => b.matchDate.localeCompare(a.matchDate));
+
+    return { windowDays, milestones };
+  };
+}
+
+/**
+ * Opponent display name ("Club 2nd XI") from a joined match_result row,
+ * mirroring oppositionName() in the matchday app. The perf row's
+ * team_id is always the Percy Main side, so the opponent is whichever
+ * of home/away it isn't. Null when the result row hasn't synced yet
+ * (left join missed).
+ */
+function oppositionFromResult(row: {
+  teamId: string;
+  homeTeamId: string | null;
+  homeTeamName: string | null;
+  homeClubName: string | null;
+  awayTeamName: string | null;
+  awayClubName: string | null;
+}): string | null {
+  if (row.homeTeamId === null) return null;
+  const home = row.homeTeamId === row.teamId;
+  const club = home ? row.awayClubName : row.homeClubName;
+  const team = home ? row.awayTeamName : row.homeTeamName;
+  if (!club) return team;
+  if (!team || team === club) return club;
+  return `${club} ${team}`;
+}
+
 export function recordExpense(db: Kysely<DB>, s3: S3Uploader) {
   return async (
     userId: string,

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -4131,6 +4131,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/matchday/mine/recent-milestones": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            windowDays: number;
+                            milestones: ({
+                                /** @enum {string} */
+                                type: "batting";
+                                matchId: string;
+                                matchDate: string;
+                                opposition: string | null;
+                                runs: number;
+                                notOut: boolean;
+                            } | {
+                                /** @enum {string} */
+                                type: "bowling";
+                                matchId: string;
+                                matchDate: string;
+                                opposition: string | null;
+                                wickets: number;
+                                runsConceded: number;
+                            })[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/matchday/mine/{matchdayPlayerId}/withdraw": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -7178,6 +7178,120 @@
         }
       }
     },
+    "/api/matchday/mine/recent-milestones": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "windowDays": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991
+                    },
+                    "milestones": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "batting"
+                                ]
+                              },
+                              "matchId": {
+                                "type": "string"
+                              },
+                              "matchDate": {
+                                "type": "string"
+                              },
+                              "opposition": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "runs": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 9007199254740991
+                              },
+                              "notOut": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "matchId",
+                              "matchDate",
+                              "opposition",
+                              "runs",
+                              "notOut"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "bowling"
+                                ]
+                              },
+                              "matchId": {
+                                "type": "string"
+                              },
+                              "matchDate": {
+                                "type": "string"
+                              },
+                              "opposition": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "wickets": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 9007199254740991
+                              },
+                              "runsConceded": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 9007199254740991
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "matchId",
+                              "matchDate",
+                              "opposition",
+                              "wickets",
+                              "runsConceded"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "windowDays",
+                    "milestones"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/matchday/mine/{matchdayPlayerId}/withdraw": {
       "post": {
         "parameters": [

--- a/apps/matchday/src/pages/home.tsx
+++ b/apps/matchday/src/pages/home.tsx
@@ -35,6 +35,7 @@ import {
   CircleAlertIcon,
   CircleCheckIcon,
   HistoryIcon,
+  PartyPopperIcon,
   TrophyIcon,
   UsersIcon,
   WalletIcon,
@@ -79,6 +80,7 @@ export default function Home() {
         </span>
       </div>
       <div className="space-y-3">
+        <CelebrationCard />
         <NeedsAttentionCard />
         <AvailabilityAwaitingCard />
         <YourUpcomingGamesCard />
@@ -89,6 +91,81 @@ export default function Home() {
         <InstallPrompt />
       </div>
     </div>
+  );
+}
+
+type Milestone =
+  ApiResponse<"/api/matchday/mine/recent-milestones">["milestones"][number];
+
+/**
+ * Congratulations card for milestone performances (50+ runs or 5+
+ * wickets in a single game) in the last 7 days. Sits at the very top
+ * of the feed — a player who's just had a big day should see it before
+ * any admin chores. Quiet by default: no skeleton or error state, since
+ * most weeks there's nothing to celebrate and the feed shouldn't flash
+ * a placeholder for an absent card.
+ */
+function CelebrationCard() {
+  const { data } = useQuery({
+    queryKey: ["matchday", "mine", "recent-milestones"],
+    queryFn: () => callApi(api.GET("/api/matchday/mine/recent-milestones")),
+  });
+  const milestones = data?.milestones ?? [];
+  if (milestones.length === 0) return null;
+  const first = milestones[0];
+  const title =
+    milestones.length > 1
+      ? "What a week you're having!"
+      : first.type === "bowling"
+        ? "You took a five-for!"
+        : first.runs >= 100
+          ? "You scored a century!"
+          : "You hit a fifty!";
+  return (
+    <Card className="border-warning/40 from-warning-bg/70 to-surface dark:to-surface-raised bg-gradient-to-br">
+      <CardHeader>
+        <CardEyebrow icon={PartyPopperIcon}>Congratulations</CardEyebrow>
+        <CardTitle>{title} 🎉</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-0">
+        {milestones.map((m) => (
+          <MilestoneRow key={`${m.type}-${m.matchId}`} milestone={m} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MilestoneRow({ milestone: m }: { milestone: Milestone }) {
+  // Cricket scorebook shorthand: 57* (not out) for batting,
+  // wickets-runs (5-23) for bowling.
+  const stat =
+    m.type === "batting"
+      ? `${m.runs}${m.notOut ? "*" : ""}`
+      : `${m.wickets}-${m.runsConceded}`;
+  const label =
+    m.type === "batting"
+      ? m.runs >= 100
+        ? "Century"
+        : "Fifty"
+      : `${m.wickets} wickets`;
+  return (
+    <Link
+      to={`/fixture/${m.matchId}`}
+      className="border-border-light flex items-center gap-3 border-t py-2.5 first:border-t-0"
+    >
+      <div className="bg-surface text-navy grid h-11 min-w-11 place-items-center rounded-md px-1.5 text-lg font-bold tracking-[-0.02em] dark:bg-white/10 dark:text-white">
+        {stat}
+      </div>
+      <div className="min-w-0">
+        <div className="truncate text-sm leading-tight font-medium">
+          {m.opposition ? `${label} vs ${m.opposition}` : label}
+        </div>
+        <div className="text-text-secondary mt-0.5 text-xs">
+          {fmtDate(m.matchDate, "EEEE d MMM")}
+        </div>
+      </div>
+    </Link>
   );
 }
 

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -4131,6 +4131,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/matchday/mine/recent-milestones": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            windowDays: number;
+                            milestones: ({
+                                /** @enum {string} */
+                                type: "batting";
+                                matchId: string;
+                                matchDate: string;
+                                opposition: string | null;
+                                runs: number;
+                                notOut: boolean;
+                            } | {
+                                /** @enum {string} */
+                                type: "bowling";
+                                matchId: string;
+                                matchDate: string;
+                                opposition: string | null;
+                                wickets: number;
+                                runsConceded: number;
+                            })[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/matchday/mine/{matchdayPlayerId}/withdraw": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -7178,6 +7178,120 @@
         }
       }
     },
+    "/api/matchday/mine/recent-milestones": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "windowDays": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "exclusiveMinimum": true,
+                      "maximum": 9007199254740991
+                    },
+                    "milestones": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "batting"
+                                ]
+                              },
+                              "matchId": {
+                                "type": "string"
+                              },
+                              "matchDate": {
+                                "type": "string"
+                              },
+                              "opposition": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "runs": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 9007199254740991
+                              },
+                              "notOut": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "matchId",
+                              "matchDate",
+                              "opposition",
+                              "runs",
+                              "notOut"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "bowling"
+                                ]
+                              },
+                              "matchId": {
+                                "type": "string"
+                              },
+                              "matchDate": {
+                                "type": "string"
+                              },
+                              "opposition": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "wickets": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 9007199254740991
+                              },
+                              "runsConceded": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 9007199254740991
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "matchId",
+                              "matchDate",
+                              "opposition",
+                              "wickets",
+                              "runsConceded"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "windowDays",
+                    "milestones"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/matchday/mine/{matchdayPlayerId}/withdraw": {
       "post": {
         "parameters": [


### PR DESCRIPTION
## Summary

Players who score 50+ runs or take 5+ wickets in a single game within the previous 7 days now get a congratulations card at the top of the matchday home feed.

### API

- New `GET /api/matchday/mine/recent-milestones` endpoint (auth required), following the existing `mine/*` pattern
- `getMyRecentMilestones` resolves email to `member.play_cricket_id` and scans `match_performance_batting` (runs >= 50) and `match_performance_bowling` (wickets >= 5) over the trailing window
- Opposition name is derived from the left-joined `match_result` row, mirroring the matchday app's `oppositionName()` (club + team, collapsed when identical); null until the result row syncs
- A genuine all-round day (fifty and a five-for in one match) deliberately yields two milestones
- Thresholds exported as constants (`BATTING_MILESTONE_RUNS`, `BOWLING_MILESTONE_WICKETS`)

### Matchday app

- `CelebrationCard` at the very top of the home feed - a player who has just had a big day sees it before any admin chores
- Scorebook shorthand stat block (`110*`, `5-23`), century vs fifty labelling, each row links to its fixture page
- Quiet by default: renders nothing while loading, on error, or when there is nothing to celebrate
- Amber-gradient treatment using existing warning tokens

### Tests

- 5 new integration tests (testcontainers): unlinked member, home/away opposition derivation, threshold + window exclusions, newest-first sorting, missing result row
- Full suite green: 55/55 matchday integration, 507/507 unit, typecheck, lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)