### PR TITLE
Editor spike: TipTap vs BlockNote prototypes + decision ADR (#484)

### DIFF
--- a/apps/proto/README.md
+++ b/apps/proto/README.md
@@ -11,12 +11,15 @@ Both apps demo the same scenario so they can be compared side by side:
   read-only person card (stand-in for the real `<Person />` MDX component)
 - Image insert via file picker / drag-drop with a local object-URL placeholder
   (stand-in for the future S3 upload pipeline)
-- Markdown round-trip: live serialised markdown panel, import from markdown,
-  and a one-click round-trip fidelity check
 
-The BlockNote app additionally demos the chosen architecture (ADR 047):
-editor JSON as the canonical format with markdown derived one-way - see the
-"JSON (canonical)" / "Markdown (derived)" tabs.
+The TipTap app demos the markdown-canonical architecture that was evaluated
+and rejected: a live serialised markdown panel, import from markdown, and a
+one-click round-trip fidelity check.
+
+The BlockNote app demos the chosen architecture (ADR 047): editor JSON as
+the canonical format, shown in a live panel. Markdown appears only as the
+one-time inbound migration path (the sample report loads from markdown with
+`::person` directives mapped to person blocks); nothing serialises back out.
 
 ## Run them
 

--- a/apps/proto/README.md
+++ b/apps/proto/README.md
@@ -1,0 +1,33 @@
+# Editor spike prototypes (issue #484)
+
+Throwaway standalone prototypes comparing **TipTap** and **BlockNote** as the
+WYSIWYG editor for live content editing (epic #479). Not wired into the main
+app and not intended to merge - see the issue and the resulting ADR.
+
+Both apps demo the same scenario so they can be compared side by side:
+
+- Basic rich text: bold, italic, headings, lists, links
+- One custom directive block: `::person{slug="..."}` rendered in-editor as a
+  read-only person card (stand-in for the real `<Person />` MDX component)
+- Image insert via file picker / drag-drop with a local object-URL placeholder
+  (stand-in for the future S3 upload pipeline)
+- Markdown round-trip: live serialised markdown panel, import from markdown,
+  and a one-click round-trip fidelity check
+
+The BlockNote app additionally demos the chosen architecture (ADR 047):
+editor JSON as the canonical format with markdown derived one-way - see the
+"JSON (canonical)" / "Markdown (derived)" tabs.
+
+## Run them
+
+```sh
+pnpm install            # from repo root
+pnpm --filter @percy-main/proto-tiptap dev      # http://localhost:5275
+pnpm --filter @percy-main/proto-blocknote dev   # http://localhost:5276
+```
+
+To try on a phone, expose the dev server on the LAN:
+
+```sh
+pnpm --filter @percy-main/proto-tiptap dev -- --host
+```

--- a/apps/proto/blocknote/index.html
+++ b/apps/proto/blocknote/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Editor spike: BlockNote</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/proto/blocknote/package.json
+++ b/apps/proto/blocknote/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@percy-main/proto-blocknote",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@blocknote/core": "^0.47.2",
+    "@blocknote/mantine": "^0.47.2",
+    "@blocknote/react": "^0.47.2",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.0.2",
+    "@vitejs/plugin-react": "^6.0.2",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/apps/proto/blocknote/src/App.tsx
+++ b/apps/proto/blocknote/src/App.tsx
@@ -1,0 +1,191 @@
+import {
+  filterSuggestionItems,
+  insertOrUpdateBlockForSlashMenu,
+} from "@blocknote/core";
+import "@blocknote/core/fonts/inter.css";
+import { BlockNoteView } from "@blocknote/mantine";
+import "@blocknote/mantine/style.css";
+import {
+  getDefaultReactSlashMenuItems,
+  SuggestionMenuController,
+  useCreateBlockNote,
+} from "@blocknote/react";
+import { useEffect, useState } from "react";
+import { markdownToBlocks, toMarkdown } from "./markdown";
+import { SAMPLE_MARKDOWN } from "./sample";
+import { type Editor, type PartialBlock, schema } from "./schema";
+
+function insertPersonItem(editor: Editor) {
+  return {
+    title: "Person card",
+    subtext: "Embed a club member profile card",
+    group: "Club content",
+    aliases: ["person", "player", "profile"],
+    icon: <span aria-hidden>👤</span>,
+    onItemClick: () => {
+      insertOrUpdateBlockForSlashMenu(editor, { type: "person" });
+    },
+  };
+}
+
+export function App() {
+  // Editor JSON is the canonical format; markdown is derived one-way for
+  // revision diffs / export. The markdown tab keeps the round-trip check
+  // from the spike for comparison, but storage round-trips JSON only.
+  const [view, setView] = useState<"json" | "markdown">("json");
+  const [json, setJson] = useState("");
+  const [markdown, setMarkdown] = useState(SAMPLE_MARKDOWN);
+  const [roundTrip, setRoundTrip] = useState<"pass" | "fail" | null>(null);
+
+  const editor = useCreateBlockNote({
+    schema,
+    // Object URL stands in for the future S3 upload pipeline.
+    uploadFile: async (file) => URL.createObjectURL(file),
+  });
+
+  const syncPanels = () => {
+    setJson(JSON.stringify(editor.document, null, 2));
+    void toMarkdown(editor, editor.document).then(setMarkdown);
+  };
+
+  useEffect(() => {
+    // One-time import: the legacy MDX reports arrive as markdown once,
+    // then JSON is canonical from the first save.
+    void markdownToBlocks(editor, SAMPLE_MARKDOWN).then((blocks) => {
+      editor.replaceBlocks(editor.document, blocks);
+      syncPanels();
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- initial load only
+  }, [editor]);
+
+  const applyMarkdown = async (md: string) => {
+    const blocks = await markdownToBlocks(editor, md);
+    editor.replaceBlocks(editor.document, blocks);
+    return await toMarkdown(editor, editor.document);
+  };
+
+  const applyJson = (text: string) => {
+    editor.replaceBlocks(editor.document, JSON.parse(text) as PartialBlock[]);
+    syncPanels();
+  };
+
+  const checkRoundTrip = async () => {
+    const before = await toMarkdown(editor, editor.document);
+    const after = await applyMarkdown(before);
+    setMarkdown(after);
+    setRoundTrip(before === after ? "pass" : "fail");
+    if (before !== after) {
+      console.log("ROUND TRIP BEFORE:\n" + before);
+      console.log("ROUND TRIP AFTER:\n" + after);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-stone-100 p-4">
+      <header className="mx-auto mb-4 max-w-6xl">
+        <h1 className="text-xl font-bold text-stone-900">
+          Editor spike: BlockNote
+        </h1>
+        <p className="text-sm text-stone-600">
+          Issue #484 - rich text, ::person directive, image placeholder, JSON
+          canonical + derived markdown. Type / for the block menu.
+        </p>
+      </header>
+
+      <main className="mx-auto grid max-w-6xl grid-cols-1 gap-4 lg:grid-cols-2">
+        <section className="rounded-lg bg-white py-4">
+          <BlockNoteView
+            editor={editor}
+            theme="light"
+            slashMenu={false}
+            onChange={() => {
+              setRoundTrip(null);
+              syncPanels();
+            }}
+          >
+            <SuggestionMenuController
+              triggerCharacter="/"
+              getItems={async (query) =>
+                filterSuggestionItems(
+                  [
+                    insertPersonItem(editor),
+                    ...getDefaultReactSlashMenuItems(editor),
+                  ],
+                  query,
+                )
+              }
+            />
+          </BlockNoteView>
+        </section>
+
+        <section className="flex flex-col">
+          <div className="flex flex-wrap items-center gap-2 rounded-t-lg border-b border-stone-200 bg-stone-50 p-2">
+            <button
+              type="button"
+              onClick={() => setView("json")}
+              className={`min-h-9 rounded border px-2 text-sm font-medium ${
+                view === "json"
+                  ? "border-stone-700 bg-stone-700 text-white"
+                  : "border-stone-300 bg-white text-stone-700"
+              }`}
+            >
+              JSON (canonical)
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("markdown")}
+              className={`min-h-9 rounded border px-2 text-sm font-medium ${
+                view === "markdown"
+                  ? "border-stone-700 bg-stone-700 text-white"
+                  : "border-stone-300 bg-white text-stone-700"
+              }`}
+            >
+              Markdown (derived)
+            </button>
+            <button
+              type="button"
+              className="min-h-9 rounded border border-stone-300 bg-white px-2 text-sm"
+              onClick={() =>
+                view === "json" ? applyJson(json) : void applyMarkdown(markdown)
+              }
+            >
+              Apply to editor
+            </button>
+            {view === "markdown" && (
+              <>
+                <button
+                  type="button"
+                  className="min-h-9 rounded border border-stone-300 bg-white px-2 text-sm"
+                  onClick={() => void checkRoundTrip()}
+                >
+                  Round-trip check
+                </button>
+                {roundTrip && (
+                  <span
+                    className={`text-sm font-bold ${
+                      roundTrip === "pass" ? "text-green-700" : "text-red-700"
+                    }`}
+                  >
+                    {roundTrip === "pass"
+                      ? "✓ lossless"
+                      : "✗ lossy (see console)"}
+                  </span>
+                )}
+              </>
+            )}
+          </div>
+          <textarea
+            value={view === "json" ? json : markdown}
+            onChange={(e) =>
+              view === "json"
+                ? setJson(e.target.value)
+                : setMarkdown(e.target.value)
+            }
+            spellCheck={false}
+            className="min-h-64 flex-1 rounded-b-lg bg-stone-900 p-4 font-mono text-sm text-stone-100"
+          />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/proto/blocknote/src/App.tsx
+++ b/apps/proto/blocknote/src/App.tsx
@@ -11,7 +11,7 @@ import {
   useCreateBlockNote,
 } from "@blocknote/react";
 import { useEffect, useState } from "react";
-import { markdownToBlocks, toMarkdown } from "./markdown";
+import { markdownToBlocks } from "./markdown";
 import { SAMPLE_MARKDOWN } from "./sample";
 import { type Editor, type PartialBlock, schema } from "./schema";
 
@@ -29,13 +29,10 @@ function insertPersonItem(editor: Editor) {
 }
 
 export function App() {
-  // Editor JSON is the canonical format; markdown is derived one-way for
-  // revision diffs / export. The markdown tab keeps the round-trip check
-  // from the spike for comparison, but storage round-trips JSON only.
-  const [view, setView] = useState<"json" | "markdown">("json");
+  // Editor JSON is the canonical format (ADR 047). No markdown is derived;
+  // the sample loads through the one-time migration path once, then the
+  // document round-trips as JSON only.
   const [json, setJson] = useState("");
-  const [markdown, setMarkdown] = useState(SAMPLE_MARKDOWN);
-  const [roundTrip, setRoundTrip] = useState<"pass" | "fail" | null>(null);
 
   const editor = useCreateBlockNote({
     schema,
@@ -43,42 +40,12 @@ export function App() {
     uploadFile: async (file) => URL.createObjectURL(file),
   });
 
-  const syncPanels = () => {
-    setJson(JSON.stringify(editor.document, null, 2));
-    void toMarkdown(editor, editor.document).then(setMarkdown);
-  };
-
   useEffect(() => {
-    // One-time import: the legacy MDX reports arrive as markdown once,
-    // then JSON is canonical from the first save.
     void markdownToBlocks(editor, SAMPLE_MARKDOWN).then((blocks) => {
       editor.replaceBlocks(editor.document, blocks);
-      syncPanels();
+      setJson(JSON.stringify(editor.document, null, 2));
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- initial load only
   }, [editor]);
-
-  const applyMarkdown = async (md: string) => {
-    const blocks = await markdownToBlocks(editor, md);
-    editor.replaceBlocks(editor.document, blocks);
-    return await toMarkdown(editor, editor.document);
-  };
-
-  const applyJson = (text: string) => {
-    editor.replaceBlocks(editor.document, JSON.parse(text) as PartialBlock[]);
-    syncPanels();
-  };
-
-  const checkRoundTrip = async () => {
-    const before = await toMarkdown(editor, editor.document);
-    const after = await applyMarkdown(before);
-    setMarkdown(after);
-    setRoundTrip(before === after ? "pass" : "fail");
-    if (before !== after) {
-      console.log("ROUND TRIP BEFORE:\n" + before);
-      console.log("ROUND TRIP AFTER:\n" + after);
-    }
-  };
 
   return (
     <div className="min-h-screen bg-stone-100 p-4">
@@ -87,8 +54,8 @@ export function App() {
           Editor spike: BlockNote
         </h1>
         <p className="text-sm text-stone-600">
-          Issue #484 - rich text, ::person directive, image placeholder, JSON
-          canonical + derived markdown. Type / for the block menu.
+          Issue #484 - rich text, person card block, image placeholder, JSON
+          canonical (ADR 047). Type / for the block menu.
         </p>
       </header>
 
@@ -99,8 +66,7 @@ export function App() {
             theme="light"
             slashMenu={false}
             onChange={() => {
-              setRoundTrip(null);
-              syncPanels();
+              setJson(JSON.stringify(editor.document, null, 2));
             }}
           >
             <SuggestionMenuController
@@ -120,67 +86,25 @@ export function App() {
 
         <section className="flex flex-col">
           <div className="flex flex-wrap items-center gap-2 rounded-t-lg border-b border-stone-200 bg-stone-50 p-2">
-            <button
-              type="button"
-              onClick={() => setView("json")}
-              className={`min-h-9 rounded border px-2 text-sm font-medium ${
-                view === "json"
-                  ? "border-stone-700 bg-stone-700 text-white"
-                  : "border-stone-300 bg-white text-stone-700"
-              }`}
-            >
+            <span className="text-sm font-semibold text-stone-700">
               JSON (canonical)
-            </button>
-            <button
-              type="button"
-              onClick={() => setView("markdown")}
-              className={`min-h-9 rounded border px-2 text-sm font-medium ${
-                view === "markdown"
-                  ? "border-stone-700 bg-stone-700 text-white"
-                  : "border-stone-300 bg-white text-stone-700"
-              }`}
-            >
-              Markdown (derived)
-            </button>
+            </span>
             <button
               type="button"
               className="min-h-9 rounded border border-stone-300 bg-white px-2 text-sm"
               onClick={() =>
-                view === "json" ? applyJson(json) : void applyMarkdown(markdown)
+                editor.replaceBlocks(
+                  editor.document,
+                  JSON.parse(json) as PartialBlock[],
+                )
               }
             >
               Apply to editor
             </button>
-            {view === "markdown" && (
-              <>
-                <button
-                  type="button"
-                  className="min-h-9 rounded border border-stone-300 bg-white px-2 text-sm"
-                  onClick={() => void checkRoundTrip()}
-                >
-                  Round-trip check
-                </button>
-                {roundTrip && (
-                  <span
-                    className={`text-sm font-bold ${
-                      roundTrip === "pass" ? "text-green-700" : "text-red-700"
-                    }`}
-                  >
-                    {roundTrip === "pass"
-                      ? "✓ lossless"
-                      : "✗ lossy (see console)"}
-                  </span>
-                )}
-              </>
-            )}
           </div>
           <textarea
-            value={view === "json" ? json : markdown}
-            onChange={(e) =>
-              view === "json"
-                ? setJson(e.target.value)
-                : setMarkdown(e.target.value)
-            }
+            value={json}
+            onChange={(e) => setJson(e.target.value)}
             spellCheck={false}
             className="min-h-64 flex-1 rounded-b-lg bg-stone-900 p-4 font-mono text-sm text-stone-100"
           />

--- a/apps/proto/blocknote/src/index.css
+++ b/apps/proto/blocknote/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/apps/proto/blocknote/src/main.tsx
+++ b/apps/proto/blocknote/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/proto/blocknote/src/markdown.ts
+++ b/apps/proto/blocknote/src/markdown.ts
@@ -1,41 +1,10 @@
-import type { Block, Editor, PartialBlock } from "./schema";
+import type { Editor, PartialBlock } from "./schema";
 
 const DIRECTIVE_RE = /^::person\{slug="([^"]+)"\}$/;
 
-// BlockNote's markdown exporter has no hook for custom blocks (custom blocks
-// fall back to their HTML rendering, not a markdown form), so the directive
-// mapping lives out here: person blocks are swapped for their shortcode text
-// and the surrounding runs of standard blocks go through blocksToMarkdownLossy.
-// Runs are kept together so ordered-list numbering survives.
-export async function toMarkdown(
-  editor: Editor,
-  blocks: Block[],
-): Promise<string> {
-  const chunks: (Block[] | string)[] = [];
-  for (const block of blocks) {
-    if (block.type === "person") {
-      chunks.push(`::person{slug="${block.props.slug}"}`);
-    } else {
-      const last = chunks[chunks.length - 1];
-      if (Array.isArray(last)) {
-        last.push(block);
-      } else {
-        chunks.push([block]);
-      }
-    }
-  }
-  const parts = await Promise.all(
-    chunks.map(async (chunk) =>
-      typeof chunk === "string"
-        ? chunk
-        : (await editor.blocksToMarkdownLossy(chunk)).trim(),
-    ),
-  );
-  return parts.join("\n\n") + "\n";
-}
-
-// Inverse mapping: markdown parses with the directive line as a plain text
-// paragraph, which is then swapped for a person block.
+// One-time inbound migration only (ADR 047): the legacy MDX corpus arrives
+// as markdown once, with directive lines mapped to person blocks. Editor
+// JSON is canonical from then on - nothing derives markdown back out.
 export async function markdownToBlocks(
   editor: Editor,
   markdown: string,

--- a/apps/proto/blocknote/src/markdown.ts
+++ b/apps/proto/blocknote/src/markdown.ts
@@ -1,0 +1,60 @@
+import type { Block, Editor, PartialBlock } from "./schema";
+
+const DIRECTIVE_RE = /^::person\{slug="([^"]+)"\}$/;
+
+// BlockNote's markdown exporter has no hook for custom blocks (custom blocks
+// fall back to their HTML rendering, not a markdown form), so the directive
+// mapping lives out here: person blocks are swapped for their shortcode text
+// and the surrounding runs of standard blocks go through blocksToMarkdownLossy.
+// Runs are kept together so ordered-list numbering survives.
+export async function toMarkdown(
+  editor: Editor,
+  blocks: Block[],
+): Promise<string> {
+  const chunks: (Block[] | string)[] = [];
+  for (const block of blocks) {
+    if (block.type === "person") {
+      chunks.push(`::person{slug="${block.props.slug}"}`);
+    } else {
+      const last = chunks[chunks.length - 1];
+      if (Array.isArray(last)) {
+        last.push(block);
+      } else {
+        chunks.push([block]);
+      }
+    }
+  }
+  const parts = await Promise.all(
+    chunks.map(async (chunk) =>
+      typeof chunk === "string"
+        ? chunk
+        : (await editor.blocksToMarkdownLossy(chunk)).trim(),
+    ),
+  );
+  return parts.join("\n\n") + "\n";
+}
+
+// Inverse mapping: markdown parses with the directive line as a plain text
+// paragraph, which is then swapped for a person block.
+export async function markdownToBlocks(
+  editor: Editor,
+  markdown: string,
+): Promise<PartialBlock[]> {
+  const blocks = await editor.tryParseMarkdownToBlocks(markdown);
+  return blocks.map((block): PartialBlock => {
+    if (
+      block.type === "paragraph" &&
+      Array.isArray(block.content) &&
+      block.content.length === 1
+    ) {
+      const inline = block.content[0];
+      if (inline.type === "text") {
+        const match = DIRECTIVE_RE.exec(inline.text.trim());
+        if (match) {
+          return { type: "person", props: { slug: match[1] } };
+        }
+      }
+    }
+    return block;
+  });
+}

--- a/apps/proto/blocknote/src/people.ts
+++ b/apps/proto/blocknote/src/people.ts
@@ -1,0 +1,13 @@
+// Stand-in for apps/web's people data. The real editor will resolve
+// ::person{slug="..."} against the people content type.
+export type Person = { slug: string; name: string; role?: string };
+
+export const PEOPLE: Person[] = [
+  { slug: "alex-slaven", name: "Alex Slaven", role: "1st XI Captain" },
+  { slug: "jane-robson", name: "Jane Robson", role: "Club Secretary" },
+  { slug: "sam-ahmed", name: "Sam Ahmed", role: "Junior Coach" },
+];
+
+export function getPersonBySlug(slug: string): Person | undefined {
+  return PEOPLE.find((p) => p.slug === slug);
+}

--- a/apps/proto/blocknote/src/person-card.tsx
+++ b/apps/proto/blocknote/src/person-card.tsx
@@ -1,0 +1,32 @@
+import { getPersonBySlug } from "./people";
+
+// Visual stand-in for apps/web/src/components/mdx-components.tsx Person.
+// Initials avatar instead of the photo pipeline; otherwise the same card.
+export function PersonCard({ slug }: { slug: string }) {
+  const person = getPersonBySlug(slug);
+  const name = person?.name ?? slug;
+  const initials = name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="w-48 rounded-lg bg-white pb-4 text-stone-900 shadow-md">
+      <div className="h-2 rounded-t-lg bg-gradient-to-r from-red-700 to-orange-400" />
+      <div className="mx-auto mt-4 flex size-24 items-center justify-center rounded-full border-4 border-stone-100 bg-stone-200 text-2xl font-bold text-stone-500">
+        {initials}
+      </div>
+      <div className="mt-3 text-center">
+        <h5 className="pb-1 font-semibold">{name}</h5>
+        {person?.role && (
+          <p className="text-sm text-stone-600">{person.role}</p>
+        )}
+        <span className="mt-2 inline-block px-2 text-sm font-medium text-red-700 underline">
+          Profile
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/proto/blocknote/src/sample.ts
+++ b/apps/proto/blocknote/src/sample.ts
@@ -1,0 +1,15 @@
+export const SAMPLE_MARKDOWN = `# Match report: 1st XI vs Tynemouth
+
+A *fine* afternoon at St John's Terrace ended with a win by **42 runs**.
+
+## Top performers
+
+- 78 not out from the skipper
+- 4-23 off 8 overs of left-arm spin
+
+Full scorecard on [Play-Cricket](https://percymain.play-cricket.com).
+
+::person{slug="alex-slaven"}
+
+Junior nets resume on Thursday.
+`;

--- a/apps/proto/blocknote/src/schema.tsx
+++ b/apps/proto/blocknote/src/schema.tsx
@@ -1,0 +1,51 @@
+import { BlockNoteSchema, defaultBlockSpecs } from "@blocknote/core";
+import { createReactBlockSpec } from "@blocknote/react";
+import { PEOPLE } from "./people";
+import { PersonCard } from "./person-card";
+
+// Custom block for the remark-directive shortcode ::person{slug="..."}.
+// Rendered read-only in the editor, same as the published page.
+const personBlock = createReactBlockSpec(
+  {
+    type: "person",
+    propSchema: {
+      slug: { default: PEOPLE[0].slug },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => (
+      <div className="my-2 flex flex-col items-start gap-2">
+        <PersonCard slug={block.props.slug} />
+        <select
+          aria-label="Person"
+          value={block.props.slug}
+          onChange={(e) =>
+            editor.updateBlock(block, {
+              type: "person",
+              props: { slug: e.target.value },
+            })
+          }
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        >
+          {PEOPLE.map((p) => (
+            <option key={p.slug} value={p.slug}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    ),
+  },
+);
+
+export const schema = BlockNoteSchema.create({
+  blockSpecs: {
+    ...defaultBlockSpecs,
+    person: personBlock(),
+  },
+});
+
+export type Editor = typeof schema.BlockNoteEditor;
+export type Block = typeof schema.Block;
+export type PartialBlock = typeof schema.PartialBlock;

--- a/apps/proto/blocknote/tsconfig.json
+++ b/apps/proto/blocknote/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/proto/blocknote/vite.config.ts
+++ b/apps/proto/blocknote/vite.config.ts
@@ -1,0 +1,8 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: { port: 5276 },
+});

--- a/apps/proto/tiptap/index.html
+++ b/apps/proto/tiptap/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Editor spike: TipTap</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/proto/tiptap/package.json
+++ b/apps/proto/tiptap/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@percy-main/proto-tiptap",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tiptap/core": "^3.0.0",
+    "@tiptap/extension-image": "^3.0.0",
+    "@tiptap/markdown": "^3.0.0",
+    "@tiptap/pm": "^3.0.0",
+    "@tiptap/react": "^3.0.0",
+    "@tiptap/starter-kit": "^3.0.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.0.2",
+    "@vitejs/plugin-react": "^6.0.2",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/apps/proto/tiptap/src/App.tsx
+++ b/apps/proto/tiptap/src/App.tsx
@@ -1,0 +1,246 @@
+import Image from "@tiptap/extension-image";
+import { Markdown } from "@tiptap/markdown";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { useRef, useState } from "react";
+import { Person } from "./extensions/person";
+import { SAMPLE_MARKDOWN } from "./sample";
+
+function ToolbarButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      // prevent the editor losing selection when tapping toolbar buttons
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className={`min-h-9 rounded border px-2 text-sm font-medium ${
+        active
+          ? "border-stone-700 bg-stone-700 text-white"
+          : "border-stone-300 bg-white text-stone-700"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function App() {
+  const [markdown, setMarkdown] = useState(SAMPLE_MARKDOWN);
+  const [roundTrip, setRoundTrip] = useState<"pass" | "fail" | null>(null);
+  const [linkUrl, setLinkUrl] = useState("");
+  const [showLinkInput, setShowLinkInput] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const editor = useEditor({
+    extensions: [StarterKit, Image, Person, Markdown],
+    content: SAMPLE_MARKDOWN,
+    contentType: "markdown",
+    onUpdate: ({ editor }) => {
+      setMarkdown(editor.getMarkdown());
+      setRoundTrip(null);
+    },
+    editorProps: {
+      attributes: {
+        class: "tiptap rounded-b-lg bg-white p-4",
+      },
+      // Drag-dropped image files become object-URL placeholder images.
+      // The real implementation will upload to S3 and use the final URL.
+      handleDrop: (view, event) => {
+        const file = event.dataTransfer?.files?.[0];
+        if (!file?.type.startsWith("image/")) {
+          return false;
+        }
+        event.preventDefault();
+        const pos =
+          view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos ??
+          view.state.selection.from;
+        const node = view.state.schema.nodes.image.create({
+          src: URL.createObjectURL(file),
+          alt: file.name,
+        });
+        view.dispatch(view.state.tr.insert(pos, node));
+        return true;
+      },
+    },
+  });
+
+  if (!editor) {
+    return null;
+  }
+
+  const insertImageFromPicker = (file: File) => {
+    editor
+      .chain()
+      .focus()
+      .setImage({ src: URL.createObjectURL(file), alt: file.name })
+      .run();
+  };
+
+  const applyLink = () => {
+    if (linkUrl) {
+      editor.chain().focus().setLink({ href: linkUrl }).run();
+    } else {
+      editor.chain().focus().unsetLink().run();
+    }
+    setShowLinkInput(false);
+    setLinkUrl("");
+  };
+
+  const checkRoundTrip = () => {
+    const before = editor.getMarkdown();
+    editor.commands.setContent(before, { contentType: "markdown" });
+    const after = editor.getMarkdown();
+    setMarkdown(after);
+    setRoundTrip(before === after ? "pass" : "fail");
+    if (before !== after) {
+      console.log("ROUND TRIP BEFORE:\n" + before);
+      console.log("ROUND TRIP AFTER:\n" + after);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-stone-100 p-4">
+      <header className="mx-auto mb-4 max-w-6xl">
+        <h1 className="text-xl font-bold text-stone-900">
+          Editor spike: TipTap
+        </h1>
+        <p className="text-sm text-stone-600">
+          Issue #484 - rich text, ::person directive, image placeholder,
+          markdown round-trip
+        </p>
+      </header>
+
+      <main className="mx-auto grid max-w-6xl grid-cols-1 gap-4 lg:grid-cols-2">
+        <section>
+          <div className="sticky top-0 z-10 flex flex-wrap gap-1 rounded-t-lg border-b border-stone-200 bg-stone-50 p-2">
+            <ToolbarButton
+              label="B"
+              active={editor.isActive("bold")}
+              onClick={() => editor.chain().focus().toggleBold().run()}
+            />
+            <ToolbarButton
+              label="I"
+              active={editor.isActive("italic")}
+              onClick={() => editor.chain().focus().toggleItalic().run()}
+            />
+            <ToolbarButton
+              label="H1"
+              active={editor.isActive("heading", { level: 1 })}
+              onClick={() =>
+                editor.chain().focus().toggleHeading({ level: 1 }).run()
+              }
+            />
+            <ToolbarButton
+              label="H2"
+              active={editor.isActive("heading", { level: 2 })}
+              onClick={() =>
+                editor.chain().focus().toggleHeading({ level: 2 }).run()
+              }
+            />
+            <ToolbarButton
+              label="• List"
+              active={editor.isActive("bulletList")}
+              onClick={() => editor.chain().focus().toggleBulletList().run()}
+            />
+            <ToolbarButton
+              label="1. List"
+              active={editor.isActive("orderedList")}
+              onClick={() => editor.chain().focus().toggleOrderedList().run()}
+            />
+            <ToolbarButton
+              label="Link"
+              active={editor.isActive("link")}
+              onClick={() => setShowLinkInput((v) => !v)}
+            />
+            <ToolbarButton
+              label="Person"
+              onClick={() =>
+                editor.chain().focus().insertContent({ type: "person" }).run()
+              }
+            />
+            <ToolbarButton
+              label="Image"
+              onClick={() => fileInputRef.current?.click()}
+            />
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) {
+                  insertImageFromPicker(file);
+                }
+                e.target.value = "";
+              }}
+            />
+            {showLinkInput && (
+              <div className="flex w-full gap-1 pt-1">
+                <input
+                  type="url"
+                  placeholder="https://…"
+                  value={linkUrl}
+                  onChange={(e) => setLinkUrl(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && applyLink()}
+                  className="min-h-9 flex-1 rounded border border-stone-300 bg-white px-2 text-sm"
+                />
+                <ToolbarButton label="Set" onClick={applyLink} />
+              </div>
+            )}
+          </div>
+          <EditorContent editor={editor} />
+        </section>
+
+        <section className="flex flex-col">
+          <div className="flex flex-wrap items-center gap-2 rounded-t-lg border-b border-stone-200 bg-stone-50 p-2">
+            <span className="text-sm font-semibold text-stone-700">
+              Markdown
+            </span>
+            <button
+              type="button"
+              className="min-h-9 rounded border border-stone-300 bg-white px-2 text-sm"
+              onClick={() =>
+                editor.commands.setContent(markdown, {
+                  contentType: "markdown",
+                })
+              }
+            >
+              Apply to editor
+            </button>
+            <button
+              type="button"
+              className="min-h-9 rounded border border-stone-300 bg-white px-2 text-sm"
+              onClick={checkRoundTrip}
+            >
+              Round-trip check
+            </button>
+            {roundTrip && (
+              <span
+                className={`text-sm font-bold ${
+                  roundTrip === "pass" ? "text-green-700" : "text-red-700"
+                }`}
+              >
+                {roundTrip === "pass" ? "✓ lossless" : "✗ lossy (see console)"}
+              </span>
+            )}
+          </div>
+          <textarea
+            value={markdown}
+            onChange={(e) => setMarkdown(e.target.value)}
+            spellCheck={false}
+            className="min-h-64 flex-1 rounded-b-lg bg-stone-900 p-4 font-mono text-sm text-stone-100"
+          />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/proto/tiptap/src/extensions/person.tsx
+++ b/apps/proto/tiptap/src/extensions/person.tsx
@@ -1,0 +1,86 @@
+import { Node } from "@tiptap/core";
+import {
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+  type NodeViewProps,
+} from "@tiptap/react";
+import { PEOPLE } from "../people";
+import { PersonCard } from "../person-card";
+
+// Matches the remark-directive shortcode the content pipeline uses:
+// ::person{slug="alex-slaven"}
+const DIRECTIVE_RE = /^::person\{slug="([^"]+)"\}(?:\n+|$)/;
+
+function PersonView({ node, updateAttributes, selected }: NodeViewProps) {
+  const slug = node.attrs.slug as string;
+  return (
+    <NodeViewWrapper
+      className={`my-4 rounded-lg ${selected ? "ring-2 ring-blue-400" : ""}`}
+      data-person-slug={slug}
+    >
+      <div contentEditable={false} className="flex flex-col items-start gap-2">
+        <PersonCard slug={slug} />
+        <select
+          aria-label="Person"
+          value={slug}
+          onChange={(e) => updateAttributes({ slug: e.target.value })}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        >
+          {PEOPLE.map((p) => (
+            <option key={p.slug} value={p.slug}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+export const Person = Node.create({
+  name: "person",
+  group: "block",
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return { slug: { default: PEOPLE[0].slug } };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "div[data-person-slug]",
+        getAttrs: (el) => ({ slug: (el as HTMLElement).dataset.personSlug }),
+      },
+    ];
+  },
+
+  renderHTML({ node }) {
+    return ["div", { "data-person-slug": node.attrs.slug }];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(PersonView);
+  },
+
+  markdownTokenizer: {
+    name: "person",
+    level: "block",
+    start: (src: string) => src.indexOf("::person"),
+    tokenize: (src: string) => {
+      const match = DIRECTIVE_RE.exec(src);
+      if (!match) {
+        return undefined;
+      }
+      return { type: "person", raw: match[0], slug: match[1] };
+    },
+  },
+
+  parseMarkdown: (token) => ({
+    type: "person",
+    attrs: { slug: (token as { slug?: string }).slug },
+  }),
+
+  renderMarkdown: (node) => `::person{slug="${node.attrs?.slug}"}`,
+});

--- a/apps/proto/tiptap/src/index.css
+++ b/apps/proto/tiptap/src/index.css
@@ -1,0 +1,40 @@
+@import "tailwindcss";
+
+/* Minimal typography for the editor body - the real app styles markdown
+   output with its own prose styles, this just makes the spike readable. */
+.tiptap {
+  outline: none;
+  min-height: 16rem;
+}
+.tiptap h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0.75rem 0 0.5rem;
+}
+.tiptap h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0.75rem 0 0.5rem;
+}
+.tiptap p {
+  margin: 0.5rem 0;
+}
+.tiptap ul {
+  list-style: disc;
+  padding-left: 1.5rem;
+}
+.tiptap ol {
+  list-style: decimal;
+  padding-left: 1.5rem;
+}
+.tiptap a {
+  color: var(--color-blue-700);
+  text-decoration: underline;
+}
+.tiptap img {
+  max-width: 24rem;
+  border-radius: 0.5rem;
+}
+.tiptap img.ProseMirror-selectednode {
+  outline: 2px solid var(--color-blue-500);
+}

--- a/apps/proto/tiptap/src/main.tsx
+++ b/apps/proto/tiptap/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/proto/tiptap/src/people.ts
+++ b/apps/proto/tiptap/src/people.ts
@@ -1,0 +1,13 @@
+// Stand-in for apps/web's people data. The real editor will resolve
+// ::person{slug="..."} against the people content type.
+export type Person = { slug: string; name: string; role?: string };
+
+export const PEOPLE: Person[] = [
+  { slug: "alex-slaven", name: "Alex Slaven", role: "1st XI Captain" },
+  { slug: "jane-robson", name: "Jane Robson", role: "Club Secretary" },
+  { slug: "sam-ahmed", name: "Sam Ahmed", role: "Junior Coach" },
+];
+
+export function getPersonBySlug(slug: string): Person | undefined {
+  return PEOPLE.find((p) => p.slug === slug);
+}

--- a/apps/proto/tiptap/src/person-card.tsx
+++ b/apps/proto/tiptap/src/person-card.tsx
@@ -1,0 +1,32 @@
+import { getPersonBySlug } from "./people";
+
+// Visual stand-in for apps/web/src/components/mdx-components.tsx Person.
+// Initials avatar instead of the photo pipeline; otherwise the same card.
+export function PersonCard({ slug }: { slug: string }) {
+  const person = getPersonBySlug(slug);
+  const name = person?.name ?? slug;
+  const initials = name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="w-48 rounded-lg bg-white pb-4 text-stone-900 shadow-md">
+      <div className="h-2 rounded-t-lg bg-gradient-to-r from-red-700 to-orange-400" />
+      <div className="mx-auto mt-4 flex size-24 items-center justify-center rounded-full border-4 border-stone-100 bg-stone-200 text-2xl font-bold text-stone-500">
+        {initials}
+      </div>
+      <div className="mt-3 text-center">
+        <h5 className="pb-1 font-semibold">{name}</h5>
+        {person?.role && (
+          <p className="text-sm text-stone-600">{person.role}</p>
+        )}
+        <span className="mt-2 inline-block px-2 text-sm font-medium text-red-700 underline">
+          Profile
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/proto/tiptap/src/sample.ts
+++ b/apps/proto/tiptap/src/sample.ts
@@ -1,0 +1,15 @@
+export const SAMPLE_MARKDOWN = `# Match report: 1st XI vs Tynemouth
+
+A *fine* afternoon at St John's Terrace ended with a win by **42 runs**.
+
+## Top performers
+
+- 78 not out from the skipper
+- 4-23 off 8 overs of left-arm spin
+
+Full scorecard on [Play-Cricket](https://percymain.play-cricket.com).
+
+::person{slug="alex-slaven"}
+
+Junior nets resume on Thursday.
+`;

--- a/apps/proto/tiptap/tsconfig.json
+++ b/apps/proto/tiptap/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/proto/tiptap/vite.config.ts
+++ b/apps/proto/tiptap/vite.config.ts
@@ -1,0 +1,8 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: { port: 5275 },
+});

--- a/docs/adrs/047-content-editor-blocknote.md
+++ b/docs/adrs/047-content-editor-blocknote.md
@@ -8,9 +8,11 @@
 The live content editing project (#479) will build its editor on **BlockNote**
 (`@blocknote/core` / `@blocknote/react`), and the canonical body format
 becomes the **BlockNote editor JSON document** stored as JSONB, not GFM
-markdown + directives as planned in the epic. Markdown becomes a derived,
-one-way export (human-readable revision diffs, any future export needs), and
-an inbound one-time import format for migrating the existing MDX corpus.
+markdown + directives as planned in the epic. Markdown's only remaining role
+is as the inbound format for the one-time migration of the existing MDX
+corpus; after that, nothing in the system stores, derives, or serves markdown.
+Revisions are compared by rendering the content before/after through the same
+component mapping, not by diffing text.
 
 This exercises the fallback the epic had already agreed ("if WYSIWYG
 round-trip proves lossy, store editor JSON canonically and derive markdown") -
@@ -50,10 +52,6 @@ Notion-style block editor on ProseMirror/TipTap. The spike prototype
   (`{ "type": "person", "props": { "slug": "alex-slaven" } }`); storing and
   reloading the document is lossless by construction, with no serialisation
   mapping at all.
-- **Markdown as derived output works.** `blocksToMarkdownLossy` plus a small
-  person-block-to-directive mapping produces readable markdown for revision
-  diffs; lossiness (list-marker normalisation, dropped alignment props) is
-  acceptable in a derived artifact.
 - **One-time inbound migration works.** `tryParseMarkdownToBlocks` plus a
   directive-paragraph-to-person-block mapping imported the sample report
   cleanly; the 10 legacy game reports migrate this way once.
@@ -96,12 +94,14 @@ as the fallback architecture, so the storage format bent rather than the UX:
   components). The BlockNote runtime is **not** loaded on public pages - the
   JSON is plain data. With no raw-HTML node type in the mapping, output stays
   sanitised by construction, preserving the epic's security property.
-- **Revisions**: `content_revision` stores the JSON; derived markdown can be
-  rendered alongside for human-readable diffs where normalisation noise is
-  irrelevant.
+- **Revisions**: `content_revision` stores the JSON. Revision comparison is
+  render-before/after through the renderer - textual diffs were considered
+  and dropped as not a real requirement, which removes the only reason to
+  derive markdown from the editor document. (The spike did prove derived
+  markdown is feasible via `blocksToMarkdownLossy` plus a person-block
+  mapping, should an export need ever appear.)
 - **Migration**: legacy MDX reports go through the spike's
-  markdown-to-blocks import once; markdown then ceases to be a storage
-  format.
+  markdown-to-blocks import once; markdown then ceases to be used at all.
 
 Costs accepted, explicitly:
 

--- a/docs/adrs/047-content-editor-blocknote.md
+++ b/docs/adrs/047-content-editor-blocknote.md
@@ -1,0 +1,141 @@
+# Decision 047: Content Editor - BlockNote with Editor JSON as the Canonical Format
+
+**Date:** 2026-06-10
+**Status:** Accepted
+
+## Decision
+
+The live content editing project (#479) will build its editor on **BlockNote**
+(`@blocknote/core` / `@blocknote/react`), and the canonical body format
+becomes the **BlockNote editor JSON document** stored as JSONB, not GFM
+markdown + directives as planned in the epic. Markdown becomes a derived,
+one-way export (human-readable revision diffs, any future export needs), and
+an inbound one-time import format for migrating the existing MDX corpus.
+
+This exercises the fallback the epic had already agreed ("if WYSIWYG
+round-trip proves lossy, store editor JSON canonically and derive markdown") -
+not because round-trip was impossible, but because the editor with the best
+authoring UX treats markdown as lossy interchange, and authoring UX is the
+project's defining requirement.
+
+## Problem
+
+Phase 1 needs an editor that a team captain on a phone or an ageing laptop can
+use without seeing syntax: bold/italic/headings/lists/links, image upload, and
+"insert a player card" as a visual block. Issue #484 timeboxed a spike
+prototyping the two shortlisted libraries. Both prototypes live in
+`apps/proto/` on the spike branch (`spike/editor-prototypes-484`, deliberately
+unmerged - see the README there for how to run them).
+
+The spike surfaced a direct conflict between the two top candidates: the
+editor with markedly better out-of-box UX for non-technical users (BlockNote)
+is also the one that cannot round-trip the planned canonical markdown format
+faithfully. One of the two had to give, and the tech lead chose to keep the
+UX and change the storage format.
+
+## Options considered
+
+### BlockNote + JSON canonical (chosen)
+
+Notion-style block editor on ProseMirror/TipTap. The spike prototype
+(`apps/proto/blocknote`) demonstrated:
+
+- **Best authoring UX with near-zero code.** Slash menu, drag handles, block
+  side menu, and an image block with an `uploadFile` hook all work out of the
+  box; the custom person block slotted into the slash menu cleanly and
+  renders the real card read-only in-editor. Mobile experience is polished
+  without any work. Judged substantially better than the TipTap prototype
+  for the captain-on-a-phone persona.
+- **JSON canonical is trivial.** The custom person block is first-class data
+  (`{ "type": "person", "props": { "slug": "alex-slaven" } }`); storing and
+  reloading the document is lossless by construction, with no serialisation
+  mapping at all.
+- **Markdown as derived output works.** `blocksToMarkdownLossy` plus a small
+  person-block-to-directive mapping produces readable markdown for revision
+  diffs; lossiness (list-marker normalisation, dropped alignment props) is
+  acceptable in a derived artifact.
+- **One-time inbound migration works.** `tryParseMarkdownToBlocks` plus a
+  directive-paragraph-to-person-block mapping imported the sample report
+  cleanly; the 10 legacy game reports migrate this way once.
+
+### TipTap v3 + markdown canonical (rejected)
+
+ProseMirror extension framework, prototyped in `apps/proto/tiptap`:
+
+- **Lossless markdown round-trip** via the official `@tiptap/markdown`
+  extension - per-node tokenizer/parse/render hooks made the `::person`
+  directive round-trip byte-identical. This would have kept the epic's
+  markdown-canonical architecture unchanged.
+- **All editing chrome is DIY.** The prototype's toolbar is hand-built;
+  slash menu, drag handles, link editing, and mobile affordances would all be
+  assembled from primitives and styled by us. The spike's hand-built toolbar
+  was judged a substantially worse authoring experience than BlockNote's
+  defaults, and closing that gap is exactly the UI engineering this project
+  wanted to avoid spending volunteer time on.
+- Smaller bundle (215 kB vs 576 kB gzip JS in the prototypes) and MIT
+  licence - real advantages, but they accrue mostly to the admin editor
+  route, which will be lazy-loaded either way.
+
+## Rationale
+
+The target user is the whole point of the project: a non-technical committee
+member or captain who currently cannot publish at all. The spike put both
+editors in front of the tech lead and the BlockNote authoring experience was
+judged substantially better - and that gap is BlockNote's core product,
+not something a few weeks of our UI work reliably replicates.
+
+What BlockNote gives up - faithful markdown round-trip - only matters if
+markdown is the storage format. The epic had already pre-agreed JSON-canonical
+as the fallback architecture, so the storage format bent rather than the UX:
+
+- **Storage**: `content_item` body becomes the Zod-validated BlockNote block
+  array in JSONB (the epic already planned JSONB metadata; this extends the
+  approach to the body).
+- **Rendering**: public pages render the JSON block tree through our own
+  React component mapping (reusing the existing `Person`, image, etc.
+  components). The BlockNote runtime is **not** loaded on public pages - the
+  JSON is plain data. With no raw-HTML node type in the mapping, output stays
+  sanitised by construction, preserving the epic's security property.
+- **Revisions**: `content_revision` stores the JSON; derived markdown can be
+  rendered alongside for human-readable diffs where normalisation noise is
+  irrelevant.
+- **Migration**: legacy MDX reports go through the spike's
+  markdown-to-blocks import once; markdown then ceases to be a storage
+  format.
+
+Costs accepted, explicitly:
+
+- **Bundle**: the editor chunk is ~2.7x TipTap's (576 kB gzip JS in the
+  prototype). Mitigation: the editor loads only on admin editing routes via a
+  lazy-loaded chunk. The public-site bundle is unaffected because rendering
+  does not use BlockNote.
+- **Licence**: core BlockNote packages are **MPL-2.0** (the planning note in
+  #484 saying "core MIT" was wrong). Fine for unmodified dependency use.
+  The `@blocknote/xl-*` packages are AGPL/commercial and **must not be
+  imported** - watch for this in review, since they live in the same npm
+  namespace.
+- **A custom renderer must be built** (#486): the JSON-to-React mapping for
+  public pages is new work that the markdown-canonical plan would have
+  avoided (it reused react-markdown). It is straightforward tree-walking
+  over a Zod-validated structure, and it removes the directive
+  parse/serialise layer entirely, so net effort is roughly a wash.
+- **Styling**: the prototype uses `@blocknote/mantine`, which ships Mantine
+  alongside our Tailwind/shadcn stack. `@blocknote/shadcn` exists and should
+  be evaluated first during build-out.
+
+## Rejected alternatives
+
+- **TipTap + markdown canonical** - rejected because its authoring UX must be
+  built by hand, and the UX is the requirement that matters most. Would
+  become attractive if BlockNote's abstraction proves too rigid during
+  build-out (BlockNote is built on TipTap, so it remains the escape hatch -
+  custom block code and the ProseMirror schema knowledge transfer).
+- **BlockNote + markdown canonical** - rejected: BlockNote's markdown export
+  is lossy by design (`blocksToMarkdownLossy`), has no extension hook for
+  custom-block markdown (the spike had to bolt regex pre/post-processing
+  around the editor), and normalises formatting on import, which would
+  rewrite migrated reports and pollute every revision diff.
+- **Markdown + directives as canonical format generally** (the epic's
+  original plan) - superseded for content bodies by this ADR. The directive
+  vocabulary survives conceptually: each directive becomes a custom block
+  type, and the renderer maps block types to the same component map.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -25,3 +25,4 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 | [044](044-matchday-notification-channel-modelling.md)    | Matchday notification channel modelling                     | 2026-05-21 | Accepted |
 | [045](045-matchday-service-worker-push-integration.md)   | Matchday service worker push integration via importScripts  | 2026-05-21 | Accepted |
 | [046](046-vapid-public-key-via-api.md)                   | VAPID public key delivered via API, not bundled             | 2026-05-21 | Accepted |
+| [047](047-content-editor-blocknote.md)                   | Content Editor - BlockNote with JSON canonical format       | 2026-06-10 | Accepted |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,6 +388,95 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  apps/proto/blocknote:
+    dependencies:
+      '@blocknote/core':
+        specifier: ^0.47.2
+        version: 0.47.3(@types/hast@3.0.4)
+      '@blocknote/mantine':
+        specifier: ^0.47.2
+        version: 0.47.3(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mantine/hooks@8.3.18(react@19.2.7))(@mantine/utils@6.0.22(react@19.2.7))(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@blocknote/react':
+        specifier: ^0.47.2
+        version: 0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  apps/proto/tiptap:
+    dependencies:
+      '@tiptap/core':
+        specifier: ^3.0.0
+        version: 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/extension-image':
+        specifier: ^3.0.0
+        version: 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/markdown':
+        specifier: ^3.0.0
+        version: 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/pm':
+        specifier: ^3.0.0
+        version: 3.26.0
+      '@tiptap/react':
+        specifier: ^3.0.0
+        version: 3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/starter-kit':
+        specifier: ^3.0.0
+        version: 3.26.0
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
   apps/web:
     dependencies:
       '@ai-sdk/react':
@@ -1495,6 +1584,24 @@ packages:
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
+  '@blocknote/core@0.47.3':
+    resolution: {integrity: sha512-+YIOEXmmRXzDULYlQaycaFDofwQ/W79CWsU3GwNuRzp62QC+WpRLFLkgkoU4Pb1Vo7RvmzU1+udESdNUGhO2KA==}
+
+  '@blocknote/mantine@0.47.3':
+    resolution: {integrity: sha512-tLt4pnpT6Q+z4b9d/E5lHBLgYxzhBWomQKvJ+3Psad2LBEq+JIfMOe8yx9nLizeP/ILtsXnkWP0peuc/2NO5Lg==}
+    peerDependencies:
+      '@mantine/core': ^8.3.11
+      '@mantine/hooks': ^8.3.11
+      '@mantine/utils': ^6.0.22
+      react: ^18.0 || ^19.0 || >= 19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || >= 19.0.0-rc
+
+  '@blocknote/react@0.47.3':
+    resolution: {integrity: sha512-aWDgfnf/ufgqYfXtIy8QepfrgdVaC5DfU/BAWbazb/O5ucEFfCr6lK0SUVvswK1CkxL/KBpHpdAd+uT+rfgkmg==}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || >= 19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || >= 19.0.0-rc
+
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
     peerDependencies:
@@ -1525,6 +1632,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emoji-mart/data@1.2.1':
+    resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -1777,6 +1887,12 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
@@ -1802,6 +1918,13 @@ packages:
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@handlewithcare/prosemirror-inputrules@0.1.4':
+    resolution: {integrity: sha512-GMqlBeG2MKM+tXEFd2N+wIv5z4VvJTg8JtfJUrdjvFq2W6v+AW8oTgiWyFw8L3iEQwvtQcVJxU873iB0LXUNNw==}
+    peerDependencies:
+      prosemirror-model: ^1.0.0
+      prosemirror-state: ^1.0.0
+      prosemirror-view: ^1.0.0
 
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
@@ -2082,6 +2205,23 @@ packages:
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
+
+  '@mantine/core@8.3.18':
+    resolution: {integrity: sha512-9tph1lTVogKPjTx02eUxDUOdXacPzK62UuSqb4TdGliI54/Xgxftq0Dfqu6XuhCxn9J5MDJaNiLDvL/1KRkYqA==}
+    peerDependencies:
+      '@mantine/hooks': 8.3.18
+      react: ^18.x || ^19.x
+      react-dom: ^18.x || ^19.x
+
+  '@mantine/hooks@8.3.18':
+    resolution: {integrity: sha512-QoWr9+S8gg5050TQ06aTSxtlpGjYOpIllRbjYYXlRvZeTsUqiTbVfvQROLexu4rEaK+yy9Wwriwl9PMRgbLqPw==}
+    peerDependencies:
+      react: ^18.x || ^19.x
+
+  '@mantine/utils@6.0.22':
+    resolution: {integrity: sha512-RSKlNZvxhMCkOFZ6slbYvZYbWjHUM+PxDQnupIOxIdsTZQQjx/BFfrfJ7kQFOP+g7MtpOds8weAetEs5obwMOQ==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -3660,6 +3800,12 @@ packages:
     peerDependencies:
       selderee: ~0.12.0
 
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@simplewebauthn/browser@13.3.0':
     resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
 
@@ -3828,8 +3974,177 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@tanstack/react-store@0.7.7':
+    resolution: {integrity: sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/store@0.7.7':
+    resolution: {integrity: sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==}
+
   '@testcontainers/postgresql@12.0.1':
     resolution: {integrity: sha512-6SyyduUM6lTAo4UwKG1aCochP6wTe0k7/W/m5uODZQMUrV3STk6/28Km3474JLGZdw/P793BUEF2IeU7rDyoEg==}
+
+  '@tiptap/core@3.26.0':
+    resolution: {integrity: sha512-7jTed/RirIVsp+lLdLvGzGqF3EBGpnGHGYKOwz6t28V2BIJLAFdUhfEVdWie7xPxQNWK0TP+fPlsqZS0vxfHBg==}
+    peerDependencies:
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-blockquote@3.26.0':
+    resolution: {integrity: sha512-57accpka9affjiJRjP2LMNCDJDTMjTvO23RJCxtP43sp9cTIZ7YZnyDfRxCINTRBNK0X4o4w2+emOLyRwsk3CA==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-bold@3.26.0':
+    resolution: {integrity: sha512-j6CzTMofcGJ5iMoUgDRQpM0FkG00jBID3aKqs+UBbgtzLgtG/CI/91tMFv0XPC30LeFA895qYgvGZtHdejZhiQ==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-bubble-menu@3.26.0':
+    resolution: {integrity: sha512-H2E3Hp0lV79jQV8YGtdDJkXkUalXZeYzKCx+vCZlDpb2ChS7/rNT9YY7poRA1NlJLUO0DH1wbAnFhx9KZMUx5g==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-bullet-list@3.26.0':
+    resolution: {integrity: sha512-Jv7BX+kBB2wUIvO/NhuUjv+T3kAed2Tjr664fgQ2zKT6X69jKIkYuCCedrIHuOyaOQ+SBDuH9h51wYv/E97QgQ==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.26.0
+
+  '@tiptap/extension-code-block@3.26.0':
+    resolution: {integrity: sha512-WPN9iZ3UjeDD2ckDzSs9tleibXv0cLj7j575NxuvjhwZTehYGNeYDSUTi+6DQUG6bKbhGg9Wcei5H0131vvJHg==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-code@3.26.0':
+    resolution: {integrity: sha512-VJYcV6rvjnENRTroOi9tDcHWW6G0pmCoRETwatlbgfDzuCmkTOwVwQjeJCXOVMMLNPzNiXZzibsRCUt+Azq/jw==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-document@3.26.0':
+    resolution: {integrity: sha512-Xhd6DCjaxCN4otQNvV6qra+XuoIjk6Vyjm87E5xn5Y/BMw7UGAG7LTkk3C2IEvxKrVZwJjalfxEqdHOgXQzVfw==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-dropcursor@3.26.0':
+    resolution: {integrity: sha512-rhAtp5J/YVDUCUIc5T7b0XY9dLeuI72JgOr53w0QQc0VA0uwbfTn7sx0LI9PDCE9uwmDH8H3snVRZRnAvlM8oA==}
+    peerDependencies:
+      '@tiptap/extensions': 3.26.0
+
+  '@tiptap/extension-floating-menu@3.26.0':
+    resolution: {integrity: sha512-reQ77NRYAOP7iPudsNbzLBuBTdL2aGxZzjccUFmE2lNdmwP23n9A/JhkuUhshVBs/6IozvahI+smG3Bnea0TCQ==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.26.0
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-gapcursor@3.26.0':
+    resolution: {integrity: sha512-SIe68SDwx2fozt/XKG0FhCwzz/yRN6Bvo4D5TqvfDg6NK3PQb1DS4GN9PilmJqbY+kXryuiWEEJOWi7HpO8SuQ==}
+    peerDependencies:
+      '@tiptap/extensions': 3.26.0
+
+  '@tiptap/extension-hard-break@3.26.0':
+    resolution: {integrity: sha512-baXvv/rtOTVd2Axjb7Zbb41Y9Qmy3U2fP7EHqLuhViqGxVX8LwQtP0PHUXEZkPokbBpRez10+dmOlvvsYFKAZQ==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-heading@3.26.0':
+    resolution: {integrity: sha512-qenEQEgzE5FjQay/H6iKOnwIt6DPO27cS+v0mGhXmrL1MjrNER4X0ZkATJbVd0WA6ffsAGaP44NKYDworGeidw==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-horizontal-rule@3.26.0':
+    resolution: {integrity: sha512-a+N/C4wkQV+/8x4ShdoiC2JdTW3Tw84C5cAloYLFMeaWmRa2me9ACSI+zo0SO9bbH9RJwsoRp7eaxBbk27eF1Q==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-image@3.26.0':
+    resolution: {integrity: sha512-vinrbKa9Awmlb/UPpnes1pezL+ZeUC2v7XczZyNbggvcHKhlVkuXZIKytFQDXEYOTaKYzYE8B/Gz098PiJ9NYQ==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-italic@3.26.0':
+    resolution: {integrity: sha512-s8oFpH+0xmhvY19f452/2dExO3p1tjxh761g6cg4irwEUNUEAJKF2VLcjiaeOhNJ+pmnQYxb+VSkwkXvO+7vHQ==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-link@3.26.0':
+    resolution: {integrity: sha512-FA/d157aBxyvZFvsdc5eSu46tmHWXebAsqOQSvivOMyw+deBb00VlMsf+iD2J8+sekjbMYwx/hvbsu+xUoX43Q==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-list-item@3.26.0':
+    resolution: {integrity: sha512-MccGyj9HY4fkl04eIiFoTCkr8067Jku/VVdJNtRWW104Spx43C/7V2zpbxPvpcDhq3dW384fDxYXfpnb186xLg==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.26.0
+
+  '@tiptap/extension-list-keymap@3.26.0':
+    resolution: {integrity: sha512-oBcj6qaNrRHQ+N0+pDuOVAQa4Nx9r8Cm5ANvyM2lTpoy60sOLOizuVvcvw1andVxbSrsZ1N/Sk+RZWyv1uoWyQ==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.26.0
+
+  '@tiptap/extension-list@3.26.0':
+    resolution: {integrity: sha512-EM8woyHDNKLEQ+lWUEoDtA4KrwP6fei/mYX1NxseMzKHHo7LFecx7wk6sovAXZrUvdML/yFBihgiMiO5VIsfkg==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-ordered-list@3.26.0':
+    resolution: {integrity: sha512-ItLdFlcMsJz2vhbs1PcUfcN7nzVqGBOwPeCrrWxjrgscp+K3JoOGD+HhVVpBACOMwivUrlh8Ry5Ohvues2nOeA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.26.0
+
+  '@tiptap/extension-paragraph@3.26.0':
+    resolution: {integrity: sha512-h8fYLikg4qN39IghQ1y9g+zzUsgxBpDi5YS3IZbWoxWYYx1YqLL8nAvOiPr7Us14aQ0TjA2/xY7zqmyf29rX1A==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-strike@3.26.0':
+    resolution: {integrity: sha512-jUll3Pqhq7u1JKvO0B6USW/bmVmUsO6sRcxo/d5tXqLhS0tWAobOGoGU2IgwXnQDSjf+vF73RYD5tRGDLkRC9Q==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-text@3.26.0':
+    resolution: {integrity: sha512-yZXdevp3/8omGbb40Z52VfvID+tsRNhPQ1GNUToD56XSr2BjdJyAzAb9rWGgDKgVMUPLgJ26yT0O278RFqOKhA==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extension-underline@3.26.0':
+    resolution: {integrity: sha512-LlVkivH5cBwov/EMD8BL7ZRcU6YcadiSVIffLW1hyalw9YfhaFzoLxjtWhL7jiU/n2Kg+9dXSZxmV2hTeTwyrQ==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+
+  '@tiptap/extensions@3.26.0':
+    resolution: {integrity: sha512-4wajuqnO2X0+LVvsBjW/xk3/tmdb16bNL939QhicAay4YYqXITeV2v3XJsryzmG4L5GkK1yLxvRGk4aLoxWrnA==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/markdown@3.26.0':
+    resolution: {integrity: sha512-jg5xrwl1gTXUl5JA3+g8YYfhOzplM9CVecwKZeFtlYtPLyxLCmIDvqV/vULoGu57HwtY4819nNpMZwY6jBNtrw==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/pm@3.26.0':
+    resolution: {integrity: sha512-q4RDeWwVrhOL0jJCGRgGxLSdjOYwzQ4h2InURZVhC66433ipcHd6f3bqSOhcXZ4r0sFmMNsuF7aZmUntjWLc7w==}
+
+  '@tiptap/react@3.26.0':
+    resolution: {integrity: sha512-NLPAG6tk4/AsfOsUNsbGqdgIHuGsD4A/hlYriozuo+LCAAduuluhzsL/MEHZXtFT4GXUOlCdaEqNCOrMuz/zaw==}
+    peerDependencies:
+      '@tiptap/core': 3.26.0
+      '@tiptap/pm': 3.26.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@3.26.0':
+    resolution: {integrity: sha512-o34EtMfqtBaljdmeElZsRG/067oGx9Zcq+j2GWo71KlZe22ga/ALexeTf1c+ETsjCxSTKR6eyQ4RZvz/2JpYfg==}
 
   '@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1':
     resolution: {integrity: sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==}
@@ -4028,6 +4343,9 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/use-sync-external-store@1.5.0':
+    resolution: {integrity: sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==}
 
   '@types/web-push@3.6.4':
     resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
@@ -5027,6 +5345,9 @@ packages:
   electron-to-chromium@1.5.353:
     resolution: {integrity: sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==}
 
+  emoji-mart@5.6.0:
+    resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
+
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
@@ -5053,6 +5374,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   entities@7.0.1:
@@ -5256,6 +5581,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -5557,14 +5886,59 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-embedded@3.0.0:
+    resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
+
+  hast-util-format@1.1.0:
+    resolution: {integrity: sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==}
+
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-has-property@3.0.0:
+    resolution: {integrity: sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==}
+
+  hast-util-is-body-ok-link@3.0.1:
+    resolution: {integrity: sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-minify-whitespace@1.0.1:
+    resolution: {integrity: sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-phrasing@3.0.1:
+    resolution: {integrity: sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==}
+
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-mdast@10.1.2:
+    resolution: {integrity: sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -5594,6 +5968,12 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html-whitespace-sensitive-tag-names@3.0.1:
+    resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
@@ -5842,6 +6222,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -6030,6 +6413,11 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   libphonenumber-js@1.13.5:
     resolution: {integrity: sha512-7/kRezHmQlMfO6pmvt34orO/g3j1C47k8FCBXFgj/mklTLwQdBca1LkhDK6RM8UyM6JqHFAIikMdkKkyfQy39A==}
 
@@ -6121,6 +6509,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -6130,6 +6521,9 @@ packages:
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
@@ -6189,6 +6583,11 @@ packages:
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@17.0.6:
+    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -6585,6 +6984,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -6631,6 +7033,9 @@ packages:
 
   parse-svg-path@0.1.2:
     resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -6886,6 +7291,80 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-highlight@0.13.1:
+    resolution: {integrity: sha512-41EwMJDUeFBxizPP1/msQBjDke1YyaTy40w3CGoc7fjXboDBgyhz2LWThwaygL9LkDvBqn4pwBJg1PNtrNilGg==}
+    peerDependencies:
+      '@shikijs/types': ^1.29.2 || ^2.0.0 || ^3.0.0
+      '@types/hast': ^3.0.0
+      highlight.js: ^11.9.0
+      lowlight: ^3.1.0
+      prosemirror-model: ^1.19.3
+      prosemirror-state: ^1.4.3
+      prosemirror-transform: ^1.8.0
+      prosemirror-view: ^1.32.4
+      refractor: ^5.0.0
+      sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0
+    peerDependenciesMeta:
+      '@shikijs/types':
+        optional: true
+      '@types/hast':
+        optional: true
+      highlight.js:
+        optional: true
+      lowlight:
+        optional: true
+      prosemirror-model:
+        optional: true
+      prosemirror-state:
+        optional: true
+      prosemirror-transform:
+        optional: true
+      prosemirror-view:
+        optional: true
+      refractor:
+        optional: true
+      sugar-high:
+        optional: true
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-model@1.25.7:
+    resolution: {integrity: sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.41.8:
+    resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
+
   proto3-json-serializer@3.0.4:
     resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
     engines: {node: '>=18'}
@@ -6958,6 +7437,12 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-number-format@5.4.5:
+    resolution: {integrity: sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==}
+    peerDependencies:
+      react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-qr-code@2.0.21:
     resolution: {integrity: sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==}
     peerDependencies:
@@ -7014,6 +7499,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-textarea-autosize@8.5.9:
+    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -7100,8 +7591,23 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
+  rehype-format@5.0.1:
+    resolution: {integrity: sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==}
+
+  rehype-minify-whitespace@6.0.2:
+    resolution: {integrity: sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==}
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
+
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-remark@10.0.1:
+    resolution: {integrity: sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
 
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
@@ -7188,6 +7694,9 @@ packages:
     resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
@@ -7526,6 +8035,9 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -7646,6 +8158,9 @@ packages:
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trim-trailing-lines@2.1.0:
+    resolution: {integrity: sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
@@ -7776,6 +8291,9 @@ packages:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
 
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -7827,6 +8345,33 @@ packages:
       '@types/react':
         optional: true
 
+  use-composed-ref@1.4.0:
+    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.3.0:
+    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
@@ -7845,6 +8390,11 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -7853,6 +8403,9 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -7968,6 +8521,12 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-push@3.6.7:
     resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
@@ -8128,6 +8687,22 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y-prosemirror@1.3.7:
+    resolution: {integrity: sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      prosemirror-model: ^1.7.1
+      prosemirror-state: ^1.2.3
+      prosemirror-view: ^1.9.10
+      y-protocols: ^1.0.1
+      yjs: ^13.5.38
+
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -8150,6 +8725,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -9328,6 +9907,105 @@ snapshots:
 
   '@better-fetch/fetch@1.1.21': {}
 
+  '@blocknote/core@0.47.3(@types/hast@3.0.4)':
+    dependencies:
+      '@emoji-mart/data': 1.2.1
+      '@handlewithcare/prosemirror-inputrules': 0.1.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
+      '@shikijs/types': 3.23.0
+      '@tanstack/store': 0.7.7
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/extension-bold': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-code': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-horizontal-rule': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/extension-italic': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-link': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/extension-paragraph': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-strike': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-text': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-underline': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extensions': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+      emoji-mart: 5.6.0
+      fast-deep-equal: 3.1.3
+      hast-util-from-dom: 5.0.1
+      prosemirror-highlight: 0.13.1(@shikijs/types@3.23.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+      rehype-format: 5.0.1
+      rehype-parse: 9.0.1
+      rehype-remark: 10.0.1
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      uuid: 8.3.2
+      y-prosemirror: 1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
+      y-protocols: 1.0.7(yjs@13.6.31)
+      yjs: 13.6.31
+    transitivePeerDependencies:
+      - '@types/hast'
+      - highlight.js
+      - lowlight
+      - refractor
+      - sugar-high
+      - supports-color
+
+  '@blocknote/mantine@0.47.3(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mantine/hooks@8.3.18(react@19.2.7))(@mantine/utils@6.0.22(react@19.2.7))(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@blocknote/core': 0.47.3(@types/hast@3.0.4)
+      '@blocknote/react': 0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mantine/core': 8.3.18(@mantine/hooks@8.3.18(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mantine/hooks': 8.3.18(react@19.2.7)
+      '@mantine/utils': 6.0.22(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-icons: 5.6.0(react@19.2.7)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+      - '@types/hast'
+      - '@types/react'
+      - '@types/react-dom'
+      - highlight.js
+      - lowlight
+      - refractor
+      - sugar-high
+      - supports-color
+
+  '@blocknote/react@0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@blocknote/core': 0.47.3(@types/hast@3.0.4)
+      '@emoji-mart/data': 1.2.1
+      '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.11
+      '@tanstack/react-store': 0.7.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+      '@tiptap/react': 3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/use-sync-external-store': 1.5.0
+      emoji-mart: 5.6.0
+      fast-deep-equal: 3.1.3
+      lodash.merge: 4.6.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-icons: 5.6.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+      - '@types/hast'
+      - '@types/react'
+      - '@types/react-dom'
+      - highlight.js
+      - lowlight
+      - refractor
+      - sugar-high
+      - supports-color
+
   '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -9368,6 +10046,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@emoji-mart/data@1.2.1': {}
 
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
@@ -9576,6 +10256,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@floating-ui/react@0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tabbable: 6.4.0
+
   '@floating-ui/utils@0.2.11': {}
 
   '@fontsource-variable/lora@5.2.8': {}
@@ -9604,6 +10292,14 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.2
       yargs: 17.7.2
+
+  '@handlewithcare/prosemirror-inputrules@0.1.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)':
+    dependencies:
+      prosemirror-history: 1.5.0
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
 
   '@hexagon/base64@1.1.28': {}
 
@@ -9827,6 +10523,28 @@ snapshots:
     optional: true
 
   '@lukeed/ms@2.0.2': {}
+
+  '@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mantine/hooks': 8.3.18(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-number-format: 5.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+      react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.7)
+      type-fest: 4.41.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mantine/hooks@8.3.18(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
+  '@mantine/utils@6.0.22(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -11537,6 +12255,13 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.12.0
 
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@simplewebauthn/browser@13.3.0': {}
 
   '@simplewebauthn/server@13.3.1':
@@ -11692,6 +12417,15 @@ snapshots:
       '@tanstack/query-core': 5.101.0
       react: 19.2.7
 
+  '@tanstack/react-store@0.7.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/store': 0.7.7
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  '@tanstack/store@0.7.7': {}
+
   '@testcontainers/postgresql@12.0.1':
     dependencies:
       testcontainers: 12.0.1
@@ -11700,6 +12434,188 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@tiptap/core@3.26.0(@tiptap/pm@3.26.0)':
+    dependencies:
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-blockquote@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-bold@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-bubble-menu@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+    optional: true
+
+  '@tiptap/extension-bullet-list@3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-code-block@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-code@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-document@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-dropcursor@3.26.0(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/extensions': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-floating-menu@3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+    optional: true
+
+  '@tiptap/extension-gapcursor@3.26.0(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/extensions': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-hard-break@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-heading@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-horizontal-rule@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-image@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-italic@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-link@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+      linkifyjs: 4.3.3
+
+  '@tiptap/extension-list-item@3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-list-keymap@3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/extension-ordered-list@3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-paragraph@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-strike@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-text@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extension-underline@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+
+  '@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+
+  '@tiptap/markdown@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+      marked: 17.0.6
+
+  '@tiptap/pm@3.26.0':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.7
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  '@tiptap/react@3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/use-sync-external-store': 0.0.6
+      fast-equals: 5.4.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/extension-floating-menu': 3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+
+  '@tiptap/starter-kit@3.26.0':
+    dependencies:
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/extension-blockquote': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-bold': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-bullet-list': 3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-code': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-code-block': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/extension-document': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-dropcursor': 3.26.0(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-gapcursor': 3.26.0(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-hard-break': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-heading': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-horizontal-rule': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/extension-italic': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-link': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/extension-list': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/extension-list-item': 3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-list-keymap': 3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-ordered-list': 3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-paragraph': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-strike': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-text': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-underline': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extensions': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/pm': 3.26.0
 
   '@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1':
     dependencies:
@@ -11907,6 +12823,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/use-sync-external-store@1.5.0': {}
 
   '@types/web-push@3.6.4':
     dependencies:
@@ -12916,6 +13834,8 @@ snapshots:
 
   electron-to-chromium@1.5.353: {}
 
+  emoji-mart@5.6.0: {}
+
   emoji-regex-xs@1.0.0: {}
 
   emoji-regex@8.0.0: {}
@@ -12951,6 +13871,8 @@ snapshots:
       tapable: 2.3.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   entities@7.0.1: {}
 
@@ -13285,6 +14207,8 @@ snapshots:
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-fifo@1.3.2: {}
 
@@ -13684,6 +14608,79 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-embedded@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-is-element: 3.0.0
+
+  hast-util-format@1.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-minify-whitespace: 1.0.1
+      hast-util-phrasing: 3.0.1
+      hast-util-whitespace: 3.0.0
+      html-whitespace-sensitive-tag-names: 3.0.1
+      unist-util-visit-parents: 6.0.2
+
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-has-property@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-body-ok-link@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-minify-whitespace@1.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-is-element: 3.0.0
+      hast-util-whitespace: 3.0.0
+      unist-util-is: 6.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-phrasing@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-has-property: 3.0.0
+      hast-util-is-body-ok-link: 3.0.1
+      hast-util-is-element: 3.0.0
+
   hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -13705,6 +14702,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -13725,9 +14736,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-mdast@10.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-phrasing: 3.0.1
+      hast-util-to-html: 9.0.5
+      hast-util-to-text: 4.0.2
+      hast-util-whitespace: 3.0.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-hast: 13.2.1
+      mdast-util-to-string: 4.0.0
+      rehype-minify-whitespace: 6.0.2
+      trim-trailing-lines: 2.1.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   help-me@5.0.0: {}
 
@@ -13762,6 +14805,10 @@ snapshots:
       selderee: 0.11.0
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
+
+  html-whitespace-sensitive-tag-names@3.0.1: {}
 
   htmlparser2@10.1.0:
     dependencies:
@@ -14002,6 +15049,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic.js@0.2.5: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -14166,6 +15215,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
+
   libphonenumber-js@1.13.5: {}
 
   libsql@0.5.29:
@@ -14245,6 +15298,8 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkifyjs@4.3.3: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -14252,6 +15307,8 @@ snapshots:
   lodash.camelcase@4.3.0: {}
 
   lodash.debounce@4.0.8: {}
+
+  lodash.merge@4.6.2: {}
 
   lodash.sortby@4.7.0: {}
 
@@ -14303,6 +15360,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@15.0.12: {}
+
+  marked@17.0.6: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -14961,6 +16020,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  orderedmap@2.1.1: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -15041,6 +16102,10 @@ snapshots:
       type-fest: 4.41.0
 
   parse-svg-path@0.1.2: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseley@0.12.1:
     dependencies:
@@ -15238,6 +16303,89 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+
+  prosemirror-highlight@0.13.1(@shikijs/types@3.23.0)(@types/hast@3.0.4)(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8):
+    optionalDependencies:
+      '@shikijs/types': 3.23.0
+      '@types/hast': 3.0.4
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-model@1.25.7:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.7
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.7
+
+  prosemirror-view@1.41.8:
+    dependencies:
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
   proto3-json-serializer@3.0.4:
     dependencies:
       protobufjs: 7.6.2
@@ -15349,6 +16497,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-number-format@5.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   react-qr-code@2.0.21(react@19.2.7):
     dependencies:
       prop-types: 15.8.1
@@ -15398,6 +16551,15 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  react-textarea-autosize@8.5.9(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      react: 19.2.7
+      use-composed-ref: 1.4.0(@types/react@19.2.17)(react@19.2.7)
+      use-latest: 1.3.0(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
 
   react@19.2.7: {}
 
@@ -15531,6 +16693,22 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  rehype-format@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-format: 1.1.0
+
+  rehype-minify-whitespace@6.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-minify-whitespace: 1.0.1
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+
   rehype-recma@1.0.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -15538,6 +16716,20 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-remark@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      hast-util-to-mdast: 10.1.2
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
 
   remark-frontmatter@5.0.0:
     dependencies:
@@ -15701,6 +16893,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.61.1
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
+
+  rope-sequence@1.3.4: {}
 
   rou3@0.7.12: {}
 
@@ -16124,6 +17318,8 @@ snapshots:
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)
 
+  tabbable@6.4.0: {}
+
   tagged-tag@1.0.0: {}
 
   tailwind-merge@3.6.0: {}
@@ -16280,6 +17476,8 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  trim-trailing-lines@2.1.0: {}
+
   trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
@@ -16427,6 +17625,11 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -16487,6 +17690,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  use-composed-ref@1.4.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-latest@1.3.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       detect-node-es: 1.1.0
@@ -16501,9 +17723,16 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid@8.3.2: {}
+
   uuid@9.0.1: {}
 
   vary@1.1.2: {}
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
 
   vfile-message@4.0.3:
     dependencies:
@@ -16602,6 +17831,10 @@ snapshots:
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
+
+  w3c-keyname@2.2.8: {}
+
+  web-namespaces@2.0.1: {}
 
   web-push@3.6.7:
     dependencies:
@@ -16835,6 +18068,20 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y-prosemirror@1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+      y-protocols: 1.0.7(yjs@13.6.31)
+      yjs: 13.6.31
+
+  y-protocols@1.0.7(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.31
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -16854,6 +18101,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yjs@13.6.31:
+    dependencies:
+      lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "apps/*"
+  - "apps/proto/*"
   - "packages/*"
   - "infra"
 # Postinstall script policy. pnpm 11 requires an explicit decision per


### PR DESCRIPTION
## Summary

Spike for #484: two standalone prototype apps under `apps/proto/` comparing the shortlisted editors, plus ADR 047 recording the decision.

**Decision (ADR 047): BlockNote, with the editor JSON document as the canonical body format.** No markdown after migration - the legacy MDX corpus imports once via markdown parsing, then nothing stores, derives, or serves markdown. Revision comparison is render-before/after, not text diff. Chosen for out-of-box authoring UX for non-technical volunteers; the markdown round-trip problem disappears once markdown stops being the storage format.

## Prototypes

Both demo rich text (bold/italic/headings/lists/links), a person card custom block rendered read-only in-editor, and image insert via file picker/drag-drop with an object-URL placeholder:

- `apps/proto/tiptap` (port 5275) - the rejected markdown-canonical architecture: official `@tiptap/markdown`, custom `::person` directive tokenizer, byte-identical round-trip, hand-built toolbar
- `apps/proto/blocknote` (port 5276) - the chosen JSON-canonical architecture: custom person block in the slash menu, built-in image block with `uploadFile` hook, live canonical-JSON panel, one-time markdown import path

```sh
pnpm --filter @percy-main/proto-blocknote dev   # --host to try on a phone
```

## Notes

- Spike findings (bundle sizes, licence check incl. the MPL-2.0 correction, round-trip evidence) are in the ADR and in the comment on #484
- Supersedes #501, which cherry-picked just the ADR while the prototypes were staying unmerged
- Build-out is scoped separately in #486

Part of #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)