### PR TITLE
feat(db): content_item + content_revision migration (#480)

### DIFF
--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -172,6 +172,34 @@ export interface ContactSubmission {
   page: string;
 }
 
+export interface ContentItem {
+  body: Json;
+  created_at: Generated<Timestamp>;
+  created_by: string;
+  description: string | null;
+  id: Generated<string>;
+  kind: string;
+  metadata: Generated<Json>;
+  parent_id: string | null;
+  path: string | null;
+  published_at: Timestamp | null;
+  slug: string;
+  status: Generated<string>;
+  title: string;
+  updated_at: Generated<Timestamp>;
+  updated_by: string;
+}
+
+export interface ContentRevision {
+  body: Json;
+  content_id: string;
+  id: Generated<string>;
+  metadata: Json;
+  saved_at: Generated<Timestamp>;
+  saved_by: string;
+  title: string;
+}
+
 export interface Dependent {
   alt_contact_name: string | null;
   alt_contact_phone: string | null;
@@ -993,6 +1021,8 @@ export interface DB {
   charge: Charge;
   charge_dependent: ChargeDependent;
   contact_submission: ContactSubmission;
+  content_item: ContentItem;
+  content_revision: ContentRevision;
   dependent: Dependent;
   document: Document;
   document_assignment: DocumentAssignment;

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -193,6 +193,7 @@ export interface ContentItem {
 export interface ContentRevision {
   body: Json;
   content_id: string;
+  description: string | null;
   id: Generated<string>;
   metadata: Json;
   saved_at: Generated<Timestamp>;

--- a/packages/db/src/migrations/2026-06-10T12:45:17.442Z.ts
+++ b/packages/db/src/migrations/2026-06-10T12:45:17.442Z.ts
@@ -34,7 +34,9 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("title", "text", (col) => col.notNull())
     .addColumn("description", "text")
     .addColumn("body", "jsonb", (col) => col.notNull())
-    .addColumn("metadata", "jsonb", (col) => col.notNull().defaultTo("{}"))
+    .addColumn("metadata", "jsonb", (col) =>
+      col.notNull().defaultTo(sql`'{}'::jsonb`),
+    )
     .addColumn("status", "text", (col) => col.notNull().defaultTo("draft"))
     .addColumn("published_at", "timestamptz")
     .addColumn("created_by", "text", (col) =>
@@ -57,6 +59,13 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       "content_item_status_check",
       sql`status IN ('draft','published','archived')`,
     )
+    // The publish action always stamps published_at (possibly future =
+    // scheduled); a published row with NULL published_at would never satisfy
+    // the public predicate, so forbid the state outright.
+    .addCheckConstraint(
+      "content_item_published_at_check",
+      sql`status <> 'published' OR published_at IS NOT NULL`,
+    )
     .execute();
 
   // Public listing queries filter on kind + status and order/filter by
@@ -68,13 +77,22 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .execute();
 
   // Slug uniqueness is per-kind for flat kinds (everything without a parent).
-  // Hierarchical pages get uniqueness from the materialised path instead.
   await db.schema
     .createIndex("content_item_kind_slug_key")
     .on("content_item")
     .columns(["kind", "slug"])
     .unique()
     .where("parent_id", "is", null)
+    .execute();
+
+  // Children must be unique among their siblings (the materialised path
+  // can't enforce this alone: it is NULL until first publish).
+  await db.schema
+    .createIndex("content_item_parent_slug_key")
+    .on("content_item")
+    .columns(["parent_id", "slug"])
+    .unique()
+    .where("parent_id", "is not", null)
     .execute();
 
   await db.schema
@@ -88,10 +106,13 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("id", "uuid", (col) =>
       col.primaryKey().defaultTo(sql`gen_random_uuid()`),
     )
+    // No ON DELETE CASCADE: revisions are the recovery mechanism, so a
+    // content_item with history cannot be hard-deleted (archive it instead).
     .addColumn("content_id", "uuid", (col) =>
-      col.notNull().references("content_item.id").onDelete("cascade"),
+      col.notNull().references("content_item.id"),
     )
     .addColumn("title", "text", (col) => col.notNull())
+    .addColumn("description", "text")
     .addColumn("body", "jsonb", (col) => col.notNull())
     .addColumn("metadata", "jsonb", (col) => col.notNull())
     .addColumn("saved_by", "text", (col) => col.notNull().references("user.id"))

--- a/packages/db/src/migrations/2026-06-10T12:45:17.442Z.ts
+++ b/packages/db/src/migrations/2026-06-10T12:45:17.442Z.ts
@@ -82,7 +82,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .on("content_item")
     .columns(["kind", "slug"])
     .unique()
-    .where("parent_id", "is", null)
+    .where(sql.ref("parent_id"), "is", null)
     .execute();
 
   // Children must be unique among their siblings (the materialised path
@@ -92,7 +92,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .on("content_item")
     .columns(["parent_id", "slug"])
     .unique()
-    .where("parent_id", "is not", null)
+    .where(sql.ref("parent_id"), "is not", null)
     .execute();
 
   await db.schema

--- a/packages/db/src/migrations/2026-06-10T12:45:17.442Z.ts
+++ b/packages/db/src/migrations/2026-06-10T12:45:17.442Z.ts
@@ -1,0 +1,113 @@
+import { type Kysely, sql } from "kysely";
+
+// Database foundation for live content editing (#479 / #480).
+//
+// content_item is one table for every editable content kind (page | news |
+// event | game_report | person) with a kind discriminator. The kinds share
+// 90% of their shape; kind-specific fields live in Zod-validated JSONB
+// metadata (replacing MDX frontmatter). The body is the BlockNote editor
+// JSON document stored as JSONB - ADR 047 superseded the epic's original
+// markdown-canonical plan.
+//
+// content_revision captures every save from day one (history cannot be
+// retrofitted; vandalism/accidental-deletion recovery is one query).
+// Revisions are kept forever; restore/diff UI arrives in Phase 4.
+//
+// Hierarchy (pages only) is an adjacency list via parent_id plus a
+// materialised URL path - the page corpus is ~30 rows, so a single SELECT
+// rebuilds the nav tree. Slug and path lock after first publish, so no
+// redirect handling exists anywhere.
+//
+// Scheduled publishing is just a future published_at: public queries serve
+// only status = 'published' AND published_at <= now(). No scheduler.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("content_item")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("kind", "text", (col) => col.notNull())
+    .addColumn("slug", "text", (col) => col.notNull())
+    .addColumn("parent_id", "uuid", (col) => col.references("content_item.id"))
+    .addColumn("path", "text", (col) => col.unique())
+    .addColumn("title", "text", (col) => col.notNull())
+    .addColumn("description", "text")
+    .addColumn("body", "jsonb", (col) => col.notNull())
+    .addColumn("metadata", "jsonb", (col) => col.notNull().defaultTo("{}"))
+    .addColumn("status", "text", (col) => col.notNull().defaultTo("draft"))
+    .addColumn("published_at", "timestamptz")
+    .addColumn("created_by", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("updated_by", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addCheckConstraint(
+      "content_item_kind_check",
+      sql`kind IN ('page','news','event','game_report','person')`,
+    )
+    .addCheckConstraint(
+      "content_item_status_check",
+      sql`status IN ('draft','published','archived')`,
+    )
+    .execute();
+
+  // Public listing queries filter on kind + status and order/filter by
+  // published_at.
+  await db.schema
+    .createIndex("content_item_kind_status_published_at_idx")
+    .on("content_item")
+    .columns(["kind", "status", "published_at"])
+    .execute();
+
+  // Slug uniqueness is per-kind for flat kinds (everything without a parent).
+  // Hierarchical pages get uniqueness from the materialised path instead.
+  await db.schema
+    .createIndex("content_item_kind_slug_key")
+    .on("content_item")
+    .columns(["kind", "slug"])
+    .unique()
+    .where("parent_id", "is", null)
+    .execute();
+
+  await db.schema
+    .createIndex("content_item_parent_id_idx")
+    .on("content_item")
+    .column("parent_id")
+    .execute();
+
+  await db.schema
+    .createTable("content_revision")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("content_id", "uuid", (col) =>
+      col.notNull().references("content_item.id").onDelete("cascade"),
+    )
+    .addColumn("title", "text", (col) => col.notNull())
+    .addColumn("body", "jsonb", (col) => col.notNull())
+    .addColumn("metadata", "jsonb", (col) => col.notNull())
+    .addColumn("saved_by", "text", (col) => col.notNull().references("user.id"))
+    .addColumn("saved_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("content_revision_content_id_idx")
+    .on("content_revision")
+    .column("content_id")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("content_revision").execute();
+  await db.schema.dropTable("content_item").execute();
+}


### PR DESCRIPTION
Part of epic #479. Closes #480.

Creates the database foundation for DB-backed content:

- `content_item`: single table for all content kinds (`page | news | event | game_report | person`) with kind discriminator, JSONB `metadata`, and JSONB `body` - the body is the BlockNote editor JSON document per ADR 047, which superseded the issue's original `text` markdown column.
- `content_revision`: every save captured from day one, kept forever.
- Check constraints on `kind` and `status`; hierarchy via `parent_id` + unique materialised `path`; scheduled publishing is just a future `published_at`.
- Indexes: `(kind, status, published_at)` for public listing, partial unique `(kind, slug)` where `parent_id IS NULL` for flat kinds, `content_id` on revisions.

Verified: full migration set (49) applies on a fresh `pgvector/pg16` container and the new migration applies on top of the current schema. Generated types regenerated via `pnpm run db:types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)