### PR TITLE
feat(api): content feature - CRUD, publish, revisions, public reads (#482)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -40,6 +40,7 @@ import { authRoutes } from "./features/auth/routes.ts";
 import { availabilityRoutes } from "./features/availability/routes.ts";
 import { chargeRoutes } from "./features/charges/routes.ts";
 import { contactRoutes } from "./features/contact/routes.ts";
+import { contentRoutes } from "./features/content/routes.ts";
 import { cricketLeaderboardRoutes } from "./features/cricket-leaderboard/routes.ts";
 import { documentRoutes } from "./features/documents/routes.ts";
 import { fantasyRoutes } from "./features/fantasy/routes.ts";
@@ -324,6 +325,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(pushSubscriptionRoutes, { prefix: "/api" });
   await app.register(webhookRoutes, { prefix: "/api" });
   await app.register(ogImageRoutes, { prefix: "/api" });
+  await app.register(contentRoutes, { prefix: "/api" });
 
   // Marketing forwarder: periodic drain of marketing_outbox -> Google Ads.
   // No-op when GOOGLE_ADS_* env vars are absent.

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -1,0 +1,225 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import {
+  archiveContent,
+  createContent,
+  getContent,
+  getPublishedContent,
+  getPublishedGameReport,
+  listContent,
+  listRevisions,
+  publishContent,
+  unpublishContent,
+  updateContent,
+} from "./service.ts";
+
+const body = (text: string) => [
+  {
+    id: crypto.randomUUID(),
+    type: "paragraph",
+    props: {},
+    content: [{ type: "text", text, styles: {} }],
+    children: [],
+  },
+];
+
+describe("content service (integration)", () => {
+  let ctx: TestContext;
+  let userId: string;
+
+  beforeAll(async () => {
+    ctx = await startTestContainer();
+    ({ userId } = await seedTestUser(ctx.db, { withMember: false }));
+  }, 120_000);
+
+  afterAll(async () => {
+    await stopTestContainer(ctx);
+  });
+
+  it("walks a game report through its full lifecycle", async () => {
+    // Create: starts draft, writes the creation revision
+    const { id } = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "firsts-vs-tynemouth",
+      title: "Firsts vs Tynemouth",
+      description: "A nail-biter at Preston Avenue",
+      body: body("What a game."),
+      metadata: { playCricketId: "111111" },
+      userId,
+    });
+
+    const draft = await getContent(ctx.db)(id);
+    expect(draft.status).toBe("draft");
+    expect(draft.publishedAt).toBeNull();
+
+    // Draft content is never served publicly
+    await expect(
+      getPublishedContent(ctx.db)({
+        kind: "game_report",
+        slug: "firsts-vs-tynemouth",
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+
+    // Update writes a second revision
+    await updateContent(ctx.db)({
+      contentId: id,
+      title: "Firsts vs Tynemouth CC",
+      body: body("What a game. Updated."),
+      userId,
+    });
+    const { revisions } = await listRevisions(ctx.db)(id);
+    expect(revisions).toHaveLength(2);
+    expect(revisions[0]?.title).toBe("Firsts vs Tynemouth CC");
+
+    // Publish: now publicly visible by slug and by playCricketId
+    await publishContent(ctx.db)({ contentId: id, userId });
+    const pub = await getPublishedContent(ctx.db)({
+      kind: "game_report",
+      slug: "firsts-vs-tynemouth",
+    });
+    expect(pub.title).toBe("Firsts vs Tynemouth CC");
+    const byPcId = await getPublishedGameReport(ctx.db)("111111");
+    expect(byPcId.id).toBe(id);
+
+    // Slug locks after first publish
+    await expect(
+      updateContent(ctx.db)({ contentId: id, slug: "new-slug", userId }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    // Unpublish hides it again, slug stays locked
+    await unpublishContent(ctx.db)({ contentId: id, userId });
+    await expect(
+      getPublishedGameReport(ctx.db)("111111"),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    await expect(
+      updateContent(ctx.db)({ contentId: id, slug: "new-slug", userId }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    // Archive blocks re-publish
+    await archiveContent(ctx.db)({ contentId: id, userId });
+    await expect(
+      publishContent(ctx.db)({ contentId: id, userId }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("hides scheduled content until its publish time", async () => {
+    const { id } = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "scheduled-report",
+      title: "Scheduled report",
+      description: null,
+      body: body("Coming soon."),
+      metadata: { playCricketId: "222222" },
+      userId,
+    });
+
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const result = await publishContent(ctx.db)({
+      contentId: id,
+      publishedAt: future,
+      userId,
+    });
+    expect(result.publishedAt).toBe(future);
+
+    await expect(
+      getPublishedGameReport(ctx.db)("222222"),
+    ).rejects.toMatchObject({ statusCode: 404 });
+
+    // Re-publish with a past time -> immediately visible
+    const past = new Date(Date.now() - 1000).toISOString();
+    await publishContent(ctx.db)({ contentId: id, publishedAt: past, userId });
+    const pub = await getPublishedGameReport(ctx.db)("222222");
+    expect(pub.id).toBe(id);
+  });
+
+  it("enforces per-kind slug uniqueness on create", async () => {
+    await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "dupe-slug",
+      title: "First",
+      description: null,
+      body: body("One."),
+      metadata: { playCricketId: "333333" },
+      userId,
+    });
+
+    await expect(
+      createContent(ctx.db)({
+        kind: "game_report",
+        slug: "dupe-slug",
+        title: "Second",
+        description: null,
+        body: body("Two."),
+        metadata: { playCricketId: "444444" },
+        userId,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("filters and paginates the admin list", async () => {
+    const mk = (n: number) =>
+      createContent(ctx.db)({
+        kind: "game_report",
+        slug: `list-report-${n}`,
+        title: `List report ${n}`,
+        description: null,
+        body: body(`Report ${n}.`),
+        metadata: { playCricketId: `55${n}` },
+        userId,
+      });
+    const created = [];
+    for (let n = 0; n < 3; n++) created.push(await mk(n));
+    const [first] = created;
+    if (!first) throw new Error("expected created items");
+    await publishContent(ctx.db)({ contentId: first.id, userId });
+
+    const drafts = await listContent(ctx.db)({
+      kind: "game_report",
+      status: "draft",
+      search: "List report",
+      page: 1,
+      pageSize: 10,
+    });
+    expect(drafts.total).toBe(2);
+    expect(drafts.items.every((i) => i.status === "draft")).toBe(true);
+
+    const paged = await listContent(ctx.db)({
+      kind: "game_report",
+      search: "List report",
+      page: 2,
+      pageSize: 2,
+      status: undefined,
+    });
+    expect(paged.total).toBe(3);
+    expect(paged.items).toHaveLength(1);
+  });
+
+  it("keeps every revision forever, attributed to the saver", async () => {
+    const { id } = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "revision-history",
+      title: "v1",
+      description: null,
+      body: body("v1"),
+      metadata: { playCricketId: "666666" },
+      userId,
+    });
+    await updateContent(ctx.db)({ contentId: id, title: "v2", userId });
+    await updateContent(ctx.db)({ contentId: id, title: "v3", userId });
+
+    const { revisions } = await listRevisions(ctx.db)(id);
+    expect(revisions.map((r) => r.title)).toEqual(["v3", "v2", "v1"]);
+    expect(revisions.every((r) => r.savedBy === userId)).toBe(true);
+  });
+
+  it("404s revision listing for unknown content", async () => {
+    await expect(
+      listRevisions(ctx.db)(crypto.randomUUID()),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -100,10 +100,13 @@ describe("content service (integration)", () => {
       updateContent(ctx.db)({ contentId: id, slug: "new-slug", userId }),
     ).rejects.toMatchObject({ statusCode: 409 });
 
-    // Archive blocks re-publish
+    // Archive blocks re-publish, and unpublish offers no back door out
     await archiveContent(ctx.db)({ contentId: id, userId });
     await expect(
       publishContent(ctx.db)({ contentId: id, userId }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    await expect(
+      unpublishContent(ctx.db)({ contentId: id, userId }),
     ).rejects.toMatchObject({ statusCode: 409 });
   });
 
@@ -156,6 +159,49 @@ describe("content service (integration)", () => {
         description: null,
         body: body("Two."),
         metadata: { playCricketId: "444444" },
+        userId,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("rejects a second game report for the same Play-Cricket match", async () => {
+    await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "pc-dupe-one",
+      title: "First",
+      description: null,
+      body: body("One."),
+      metadata: { playCricketId: "777777" },
+      userId,
+    });
+
+    // Duplicate on create (even as a draft)
+    await expect(
+      createContent(ctx.db)({
+        kind: "game_report",
+        slug: "pc-dupe-two",
+        title: "Second",
+        description: null,
+        body: body("Two."),
+        metadata: { playCricketId: "777777" },
+        userId,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    // Duplicate via metadata update
+    const other = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "pc-dupe-three",
+      title: "Third",
+      description: null,
+      body: body("Three."),
+      metadata: { playCricketId: "888888" },
+      userId,
+    });
+    await expect(
+      updateContent(ctx.db)({
+        contentId: other.id,
+        metadata: { playCricketId: "777777" },
         userId,
       }),
     ).rejects.toMatchObject({ statusCode: 409 });

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -1,0 +1,275 @@
+import {
+  checkPermission,
+  type Action,
+} from "@percy-main/shared/auth/permissions";
+import {
+  CONTENT_KIND_RESOURCES,
+  type ContentKind,
+} from "@percy-main/shared/content";
+import type { FastifyRequest } from "fastify";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { getAuthSession, requireAuth } from "../auth/middleware.ts";
+import {
+  contentDetailResponseSchema,
+  contentIdParamSchema,
+  createContentSchema,
+  listContentQuerySchema,
+  listContentResponseSchema,
+  listRevisionsResponseSchema,
+  playCricketIdParamSchema,
+  publicContentParamsSchema,
+  publicContentResponseSchema,
+  publishContentSchema,
+  updateContentSchema,
+} from "./schemas.ts";
+import {
+  archiveContent,
+  createContent,
+  getContent,
+  getContentKind,
+  getPublishedContent,
+  getPublishedGameReport,
+  listContent,
+  listRevisions,
+  publishContent,
+  unpublishContent,
+  updateContent,
+} from "./service.ts";
+
+/**
+ * Per-kind permission gate. The resource depends on the item's kind
+ * (content / content_news / content_reports / content_people), which for
+ * most routes is only known from the body or the existing row - so this
+ * runs in the handler after requireAuth, not as a static preHandler.
+ */
+function assertContentPermission(
+  request: FastifyRequest,
+  kind: ContentKind,
+  action: Action<"content">,
+) {
+  const { user } = getAuthSession(request);
+  const role = (user as { role?: string | null }).role ?? "user";
+  if (!checkPermission(role, CONTENT_KIND_RESOURCES[kind], action)) {
+    throw Object.assign(new Error("Forbidden"), { statusCode: 403 });
+  }
+}
+
+const idResponseSchema = z.object({ id: z.string() });
+const publishResponseSchema = z.object({
+  id: z.string(),
+  publishedAt: z.string().nullable(),
+});
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
+  const list = listContent(app.db);
+  const get = getContent(app.db);
+  const kindOf = getContentKind(app.db);
+  const create = createContent(app.db);
+  const update = updateContent(app.db);
+  const publish = publishContent(app.db);
+  const unpublish = unpublishContent(app.db);
+  const archive = archiveContent(app.db);
+  const revisions = listRevisions(app.db);
+  const publicGet = getPublishedContent(app.db);
+  const publicGameReport = getPublishedGameReport(app.db);
+
+  // ── Admin ──
+
+  app.get(
+    "/admin/content",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        querystring: listContentQuerySchema,
+        response: { 200: listContentResponseSchema },
+      },
+    },
+    async (request) => {
+      assertContentPermission(request, request.query.kind, "view");
+      return await list(request.query);
+    },
+  );
+
+  app.get(
+    "/admin/content/:contentId",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        response: { 200: contentDetailResponseSchema },
+      },
+    },
+    async (request) => {
+      const item = await get(request.params.contentId);
+      assertContentPermission(request, item.kind, "view");
+      return item;
+    },
+  );
+
+  app.post(
+    "/admin/content",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        body: createContentSchema,
+        response: { 200: idResponseSchema },
+      },
+    },
+    async (request) => {
+      assertContentPermission(request, request.body.kind, "manage");
+      const { user } = getAuthSession(request);
+      return await create({ ...request.body, userId: user.id });
+    },
+  );
+
+  app.put(
+    "/admin/content/:contentId",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        body: updateContentSchema,
+        response: { 200: idResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "manage");
+      const { user } = getAuthSession(request);
+      return await update({
+        ...request.body,
+        contentId: request.params.contentId,
+        userId: user.id,
+      });
+    },
+  );
+
+  app.post(
+    "/admin/content/:contentId/publish",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        body: publishContentSchema,
+        response: { 200: publishResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "publish");
+      const { user } = getAuthSession(request);
+      return await publish({
+        contentId: request.params.contentId,
+        publishedAt: request.body.publishedAt,
+        userId: user.id,
+      });
+    },
+  );
+
+  app.post(
+    "/admin/content/:contentId/unpublish",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        response: { 200: idResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "publish");
+      const { user } = getAuthSession(request);
+      return await unpublish({
+        contentId: request.params.contentId,
+        userId: user.id,
+      });
+    },
+  );
+
+  app.post(
+    "/admin/content/:contentId/archive",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        response: { 200: idResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "manage");
+      const { user } = getAuthSession(request);
+      return await archive({
+        contentId: request.params.contentId,
+        userId: user.id,
+      });
+    },
+  );
+
+  app.get(
+    "/admin/content/:contentId/revisions",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        response: { 200: listRevisionsResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "view");
+      return await revisions(request.params.contentId);
+    },
+  );
+
+  // ── Public (no auth) ──
+  //
+  // Serves only status='published' AND published_at <= now(). The API is
+  // not behind CloudFront, so publish-to-visible is instant; ETag/304
+  // keeps repeat navigation cheap without any invalidation machinery.
+
+  // Strong ETag from id + last modification time; Fastify discards the
+  // body it is handed on a 304, so send(null) produces an empty response.
+  const etagFor = (item: { id: string; updatedAt: string }) =>
+    `"${item.id}-${Date.parse(item.updatedAt)}"`;
+
+  app.get(
+    "/content/game-report/by-play-cricket-id/:playCricketId",
+    {
+      schema: {
+        params: playCricketIdParamSchema,
+        response: { 200: publicContentResponseSchema, 304: z.null() },
+      },
+    },
+    async (request, reply) => {
+      const item = await publicGameReport(request.params.playCricketId);
+      const etag = etagFor(item);
+      void reply.header("etag", etag);
+      if (request.headers["if-none-match"] === etag) {
+        return await reply.code(304).send(null);
+      }
+      return item;
+    },
+  );
+
+  app.get(
+    "/content/:kind/:slug",
+    {
+      schema: {
+        params: publicContentParamsSchema,
+        response: { 200: publicContentResponseSchema, 304: z.null() },
+      },
+    },
+    async (request, reply) => {
+      const item = await publicGet(request.params);
+      const etag = etagFor(item);
+      void reply.header("etag", etag);
+      if (request.headers["if-none-match"] === etag) {
+        return await reply.code(304).send(null);
+      }
+      return item;
+    },
+  );
+};

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -162,7 +162,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       const { user } = getAuthSession(request);
       return await publish({
         contentId: request.params.contentId,
-        publishedAt: request.body.publishedAt,
+        publishedAt: request.body?.publishedAt,
         userId: user.id,
       });
     },

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -1,0 +1,137 @@
+import {
+  blockPropValueSchema,
+  contentKindSchema,
+  contentSlugSchema,
+  contentStatusSchema,
+} from "@percy-main/shared/content";
+import { z } from "zod";
+
+// ── Shared shapes ───────────────────────────────────────────────────────
+
+/**
+ * Kind-specific metadata. Each kind's concrete schema lives in
+ * packages/shared (CONTENT_METADATA_SCHEMAS) and is enforced by the
+ * service on every write; at the transport layer it is an open object.
+ */
+export const contentMetadataSchema = z.record(z.string(), z.unknown());
+
+/**
+ * Transport-level body schema: one level of the BlockNote block envelope
+ * with children left opaque. The fully recursive schema
+ * (contentBodySchema in packages/shared) produces self-referencing $refs
+ * that openapi-typescript cannot resolve, so the route layer validates
+ * depth 1 and the service re-validates the whole tree recursively on
+ * every write.
+ */
+const transportBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.string().min(1),
+  props: z.record(z.string(), blockPropValueSchema),
+  content: z.unknown().optional(),
+  children: z.array(z.unknown()),
+});
+
+export const contentBodyTransportSchema = z.array(transportBlockSchema);
+
+export const contentSummarySchema = z.object({
+  id: z.string(),
+  kind: contentKindSchema,
+  slug: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  status: contentStatusSchema,
+  metadata: contentMetadataSchema,
+  publishedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  updatedBy: z.string(),
+  updatedByName: z.string().nullable(),
+});
+
+export const contentDetailSchema = contentSummarySchema.extend({
+  body: contentBodyTransportSchema,
+});
+
+// ── Admin: list ─────────────────────────────────────────────────────────
+
+export const listContentQuerySchema = z.object({
+  kind: contentKindSchema,
+  status: contentStatusSchema.optional(),
+  search: z.string().min(1).max(200).optional(),
+  page: z.coerce.number().int().positive().default(1),
+  pageSize: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export const listContentResponseSchema = z.object({
+  items: z.array(contentSummarySchema),
+  total: z.number().int().nonnegative(),
+});
+
+// ── Admin: get / create / update ────────────────────────────────────────
+
+export const contentIdParamSchema = z.object({
+  contentId: z.uuid(),
+});
+
+export const createContentSchema = z.object({
+  kind: contentKindSchema,
+  slug: contentSlugSchema,
+  title: z.string().min(1).max(300),
+  description: z.string().min(1).max(1000).nullish(),
+  body: contentBodyTransportSchema,
+  metadata: contentMetadataSchema,
+});
+
+export const updateContentSchema = z.object({
+  slug: contentSlugSchema.optional(),
+  title: z.string().min(1).max(300).optional(),
+  description: z.string().min(1).max(1000).nullish(),
+  body: contentBodyTransportSchema.optional(),
+  metadata: contentMetadataSchema.optional(),
+});
+
+export const contentDetailResponseSchema = contentDetailSchema;
+
+// ── Admin: publish / unpublish / archive ────────────────────────────────
+
+export const publishContentSchema = z.object({
+  /** Omit to publish immediately; a future datetime schedules the publish. */
+  publishedAt: z.iso.datetime({ offset: true }).optional(),
+});
+
+// ── Admin: revisions ────────────────────────────────────────────────────
+
+export const listRevisionsResponseSchema = z.object({
+  revisions: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      savedAt: z.string(),
+      savedBy: z.string(),
+      savedByName: z.string().nullable(),
+    }),
+  ),
+});
+
+// ── Public ──────────────────────────────────────────────────────────────
+
+export const publicContentParamsSchema = z.object({
+  kind: contentKindSchema,
+  slug: contentSlugSchema,
+});
+
+export const playCricketIdParamSchema = z.object({
+  playCricketId: z.string().min(1).max(50),
+});
+
+export const publicContentResponseSchema = z.object({
+  id: z.string(),
+  kind: contentKindSchema,
+  slug: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  body: contentBodyTransportSchema,
+  metadata: contentMetadataSchema,
+  publishedAt: z.string(),
+  updatedAt: z.string(),
+});

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -94,10 +94,13 @@ export const contentDetailResponseSchema = contentDetailSchema;
 
 // ── Admin: publish / unpublish / archive ────────────────────────────────
 
-export const publishContentSchema = z.object({
-  /** Omit to publish immediately; a future datetime schedules the publish. */
-  publishedAt: z.iso.datetime({ offset: true }).optional(),
-});
+export const publishContentSchema = z
+  .object({
+    /** Omit to publish immediately; a future datetime schedules it. */
+    publishedAt: z.iso.datetime({ offset: true }).optional(),
+  })
+  // Optional so "publish now" needs no request body at all.
+  .optional();
 
 // ── Admin: revisions ────────────────────────────────────────────────────
 

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -1,0 +1,233 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockExecuteTakeFirst, mockExecuteTakeFirstOrThrow, mockQueryBuilder } =
+  vi.hoisted(() => {
+    const mockExecuteTakeFirst = vi.fn();
+    const mockExecuteTakeFirstOrThrow = vi.fn();
+    const mockExecute = vi.fn();
+
+    const mockQueryBuilder: Record<string, unknown> = {
+      selectFrom: vi.fn().mockReturnThis(),
+      updateTable: vi.fn().mockReturnThis(),
+      insertInto: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      set: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockReturnThis(),
+      executeTakeFirst: mockExecuteTakeFirst,
+      executeTakeFirstOrThrow: mockExecuteTakeFirstOrThrow,
+      execute: mockExecute,
+    };
+
+    return {
+      mockExecuteTakeFirst,
+      mockExecuteTakeFirstOrThrow,
+      mockExecute,
+      mockQueryBuilder,
+    };
+  });
+
+import {
+  createContent,
+  getPublishedGameReport,
+  publishContent,
+  updateContent,
+} from "./service.ts";
+
+const db = mockQueryBuilder as unknown as Kysely<DB>;
+
+const validBody = [
+  {
+    id: "block-1",
+    type: "paragraph",
+    props: {},
+    content: [{ type: "text", text: "A fine win.", styles: {} }],
+    children: [],
+  },
+];
+
+function validCreate(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "game_report" as const,
+    slug: "firsts-vs-tynemouth",
+    title: "Firsts vs Tynemouth",
+    description: null,
+    body: validBody,
+    metadata: { playCricketId: "6819685" },
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(mockQueryBuilder)) {
+    const val = mockQueryBuilder[key];
+    if (typeof val === "function" && "mockReturnValue" in (val as object)) {
+      (val as ReturnType<typeof vi.fn>).mockReturnValue(mockQueryBuilder);
+    }
+  }
+  // Transactions run the callback against the same mock builder.
+  (mockQueryBuilder as { transaction?: unknown }).transaction = vi
+    .fn()
+    .mockReturnValue({
+      execute: (cb: (tx: unknown) => unknown) => cb(mockQueryBuilder),
+    });
+  mockExecuteTakeFirst.mockResolvedValue(undefined);
+  mockExecuteTakeFirstOrThrow.mockResolvedValue({ id: "content-1" });
+});
+
+describe("createContent", () => {
+  it("rejects kinds that are not editable yet", async () => {
+    await expect(
+      createContent(db)(validCreate({ kind: "person", metadata: {} })),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects metadata that fails the kind schema", async () => {
+    await expect(
+      createContent(db)(validCreate({ metadata: {} })),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    await expect(
+      createContent(db)(validCreate({ metadata: {} })),
+    ).rejects.toThrow(/playCricketId/);
+  });
+
+  it("rejects a structurally invalid body", async () => {
+    await expect(
+      createContent(db)(validCreate({ body: [{ type: "paragraph" }] })),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects a duplicate slug for the kind", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({ id: "existing" });
+    await expect(createContent(db)(validCreate())).rejects.toMatchObject({
+      statusCode: 409,
+    });
+  });
+
+  it("creates the item and returns its id", async () => {
+    const result = await createContent(db)(validCreate());
+    expect(result).toEqual({ id: "content-1" });
+  });
+});
+
+describe("updateContent", () => {
+  const currentRow = {
+    id: "content-1",
+    kind: "game_report",
+    slug: "firsts-vs-tynemouth",
+    title: "Firsts vs Tynemouth",
+    description: null,
+    body: validBody,
+    metadata: { playCricketId: "6819685" },
+    published_at: null,
+  };
+
+  it("404s when the item does not exist", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
+    await expect(
+      updateContent(db)({
+        contentId: "missing",
+        userId: "user-1",
+        title: "New",
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("locks the slug once the item has ever been published", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      ...currentRow,
+      published_at: new Date("2026-06-01T10:00:00Z"),
+    });
+    await expect(
+      updateContent(db)({
+        contentId: "content-1",
+        userId: "user-1",
+        slug: "different-slug",
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("allows a slug change while never published", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(currentRow) // fetch current
+      .mockResolvedValueOnce(undefined); // slug clash check
+    const result = await updateContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+      slug: "different-slug",
+    });
+    expect(result).toEqual({ id: "content-1" });
+  });
+});
+
+describe("publishContent", () => {
+  it("404s when the item does not exist", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined) // update returning nothing
+      .mockResolvedValueOnce(undefined); // existence check
+    await expect(
+      publishContent(db)({ contentId: "missing", userId: "user-1" }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("409s when the item is archived", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined) // update skipped archived row
+      .mockResolvedValueOnce({ id: "content-1" }); // but it exists
+    await expect(
+      publishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("returns the effective publishedAt", async () => {
+    const at = new Date("2026-07-01T10:00:00Z");
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "content-1",
+      published_at: at,
+    });
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      publishedAt: at.toISOString(),
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      id: "content-1",
+      publishedAt: at.toISOString(),
+    });
+  });
+});
+
+describe("getPublishedGameReport", () => {
+  it("404s when no published report matches", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
+    await expect(getPublishedGameReport(db)("6819685")).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("maps a published row to the public shape", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "content-1",
+      kind: "game_report",
+      slug: "firsts-vs-tynemouth",
+      title: "Firsts vs Tynemouth",
+      description: null,
+      body: validBody,
+      metadata: { playCricketId: "6819685" },
+      published_at: new Date("2026-06-01T10:00:00Z"),
+      updated_at: new Date("2026-06-02T10:00:00Z"),
+    });
+    const result = await getPublishedGameReport(db)("6819685");
+    expect(result.publishedAt).toBe("2026-06-01T10:00:00.000Z");
+    expect(result.body).toEqual(validBody);
+  });
+});

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -38,6 +38,7 @@ import {
   createContent,
   getPublishedGameReport,
   publishContent,
+  unpublishContent,
   updateContent,
 } from "./service.ts";
 
@@ -203,6 +204,26 @@ describe("publishContent", () => {
       id: "content-1",
       publishedAt: at.toISOString(),
     });
+  });
+});
+
+describe("unpublishContent", () => {
+  it("409s when the item is not currently published", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined) // update matched nothing
+      .mockResolvedValueOnce({ id: "content-1" }); // but it exists
+    await expect(
+      unpublishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("404s when the item does not exist", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    await expect(
+      unpublishContent(db)({ contentId: "missing", userId: "user-1" }),
+    ).rejects.toMatchObject({ statusCode: 404 });
   });
 });
 

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -1,0 +1,535 @@
+import type { DB } from "@percy-main/db";
+import {
+  CONTENT_METADATA_SCHEMAS,
+  contentBodySchema,
+  type ContentKind,
+  type ContentStatus,
+} from "@percy-main/shared/content";
+import { sql, type Kysely, type Transaction } from "kysely";
+import type { z } from "zod";
+import type {
+  createContentSchema,
+  listContentQuerySchema,
+  updateContentSchema,
+} from "./schemas.ts";
+
+function throwHttpError(statusCode: number, message: string): never {
+  throw Object.assign(new Error(message), { statusCode });
+}
+
+/**
+ * Validate kind-specific metadata against the shared schema map. Kinds
+ * without a schema are not editable through the API yet (later phases
+ * add theirs).
+ */
+function parseMetadata(kind: ContentKind, metadata: Record<string, unknown>) {
+  const schema = CONTENT_METADATA_SCHEMAS[kind];
+  if (!schema) {
+    throwHttpError(400, `Content kind '${kind}' is not editable yet`);
+  }
+  const result = schema.safeParse(metadata);
+  if (!result.success) {
+    throwHttpError(
+      400,
+      `Invalid metadata for kind '${kind}': ${result.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ")}`,
+    );
+  }
+  return result.data;
+}
+
+/** Validate the body is a structurally sound BlockNote block array. */
+function parseBody(body: unknown) {
+  const result = contentBodySchema.safeParse(body);
+  if (!result.success) {
+    throwHttpError(400, "Body is not a valid block document");
+  }
+  return result.data;
+}
+
+interface ContentItemRow {
+  id: string;
+  kind: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  status: string;
+  metadata: unknown;
+  published_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  updated_by: string;
+  updated_by_name: string | null;
+}
+
+function toSummary(row: ContentItemRow) {
+  return {
+    id: row.id,
+    kind: row.kind as ContentKind,
+    slug: row.slug,
+    title: row.title,
+    description: row.description,
+    status: row.status as ContentStatus,
+    metadata: row.metadata as Record<string, unknown>,
+    publishedAt: row.published_at?.toISOString() ?? null,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+    updatedBy: row.updated_by,
+    updatedByName: row.updated_by_name,
+  };
+}
+
+const summaryColumns = [
+  "content_item.id",
+  "content_item.kind",
+  "content_item.slug",
+  "content_item.title",
+  "content_item.description",
+  "content_item.status",
+  "content_item.metadata",
+  "content_item.published_at",
+  "content_item.created_at",
+  "content_item.updated_at",
+  "content_item.updated_by",
+] as const;
+
+function selectSummary(db: Kysely<DB>) {
+  return db
+    .selectFrom("content_item")
+    .leftJoin("user as updater", "updater.id", "content_item.updated_by")
+    .select([...summaryColumns, "updater.name as updated_by_name"]);
+}
+
+/** Snapshot the item's editorial fields into content_revision. */
+async function writeRevision(
+  tx: Transaction<DB>,
+  item: {
+    id: string;
+    title: string;
+    description: string | null;
+    body: unknown;
+    metadata: unknown;
+  },
+  savedBy: string,
+) {
+  await tx
+    .insertInto("content_revision")
+    .values({
+      content_id: item.id,
+      title: item.title,
+      description: item.description,
+      body: JSON.stringify(item.body),
+      metadata: JSON.stringify(item.metadata),
+      saved_by: savedBy,
+    })
+    .execute();
+}
+
+// ── Admin: list ─────────────────────────────────────────────────────────
+
+export function listContent(db: Kysely<DB>) {
+  return async (params: z.infer<typeof listContentQuerySchema>) => {
+    let base = db.selectFrom("content_item").where("kind", "=", params.kind);
+    if (params.status !== undefined) {
+      base = base.where("status", "=", params.status);
+    }
+    if (params.search !== undefined) {
+      base = base.where("title", "ilike", `%${params.search}%`);
+    }
+
+    const [items, totalRow] = await Promise.all([
+      base
+        .leftJoin("user as updater", "updater.id", "content_item.updated_by")
+        .select([...summaryColumns, "updater.name as updated_by_name"])
+        .orderBy("content_item.updated_at", "desc")
+        .limit(params.pageSize)
+        .offset((params.page - 1) * params.pageSize)
+        .execute(),
+      base.select(sql<string>`COUNT(*)`.as("total")).executeTakeFirstOrThrow(),
+    ]);
+
+    return {
+      items: items.map(toSummary),
+      total: Number(totalRow.total),
+    };
+  };
+}
+
+// ── Admin: get ──────────────────────────────────────────────────────────
+
+export function getContent(db: Kysely<DB>) {
+  return async (contentId: string) => {
+    const row = await selectSummary(db)
+      .select("content_item.body")
+      .where("content_item.id", "=", contentId)
+      .executeTakeFirst();
+
+    if (!row) throwHttpError(404, "Content not found");
+
+    return { ...toSummary(row), body: parseBody(row.body) };
+  };
+}
+
+/** Kind lookup used by routes to resolve the permission resource. */
+export function getContentKind(db: Kysely<DB>) {
+  return async (contentId: string) => {
+    const row = await db
+      .selectFrom("content_item")
+      .select("kind")
+      .where("id", "=", contentId)
+      .executeTakeFirst();
+    if (!row) throwHttpError(404, "Content not found");
+    return row.kind as ContentKind;
+  };
+}
+
+// ── Admin: create ───────────────────────────────────────────────────────
+
+export function createContent(db: Kysely<DB>) {
+  return async (
+    params: z.infer<typeof createContentSchema> & { userId: string },
+  ) => {
+    const metadata = parseMetadata(params.kind, params.metadata);
+    const body = parseBody(params.body);
+    const description = params.description ?? null;
+
+    return await db.transaction().execute(async (tx) => {
+      const existing = await tx
+        .selectFrom("content_item")
+        .select("id")
+        .where("kind", "=", params.kind)
+        .where("slug", "=", params.slug)
+        .where("parent_id", "is", null)
+        .executeTakeFirst();
+      if (existing) {
+        throwHttpError(
+          409,
+          `A ${params.kind} item with slug '${params.slug}' already exists`,
+        );
+      }
+
+      const item = await tx
+        .insertInto("content_item")
+        .values({
+          kind: params.kind,
+          slug: params.slug,
+          title: params.title,
+          description,
+          body: JSON.stringify(body),
+          metadata: JSON.stringify(metadata),
+          status: "draft",
+          created_by: params.userId,
+          updated_by: params.userId,
+        })
+        .returning(["id"])
+        .executeTakeFirstOrThrow();
+
+      await writeRevision(
+        tx,
+        {
+          id: item.id,
+          title: params.title,
+          description,
+          body,
+          metadata,
+        },
+        params.userId,
+      );
+
+      return { id: item.id };
+    });
+  };
+}
+
+// ── Admin: update ───────────────────────────────────────────────────────
+
+export function updateContent(db: Kysely<DB>) {
+  return async (
+    params: z.infer<typeof updateContentSchema> & {
+      contentId: string;
+      userId: string;
+    },
+  ) => {
+    return await db.transaction().execute(async (tx) => {
+      const current = await tx
+        .selectFrom("content_item")
+        .select([
+          "id",
+          "kind",
+          "slug",
+          "title",
+          "description",
+          "body",
+          "metadata",
+          "published_at",
+        ])
+        .where("id", "=", params.contentId)
+        .executeTakeFirst();
+
+      if (!current) throwHttpError(404, "Content not found");
+
+      const kind = current.kind as ContentKind;
+
+      // Slug locks once the item has ever been published (published_at is
+      // never cleared on unpublish, precisely so it can serve as the
+      // ever-published marker). No redirect handling exists anywhere.
+      if (
+        params.slug !== undefined &&
+        params.slug !== current.slug &&
+        current.published_at !== null
+      ) {
+        throwHttpError(409, "Slug is locked once an item has been published");
+      }
+
+      const title = params.title ?? current.title;
+      const description =
+        params.description !== undefined
+          ? params.description
+          : current.description;
+      const body =
+        params.body !== undefined
+          ? parseBody(params.body)
+          : parseBody(current.body);
+      const metadata =
+        params.metadata !== undefined
+          ? parseMetadata(kind, params.metadata)
+          : parseMetadata(kind, current.metadata as Record<string, unknown>);
+      const slug = params.slug ?? current.slug;
+
+      if (slug !== current.slug) {
+        const clash = await tx
+          .selectFrom("content_item")
+          .select("id")
+          .where("kind", "=", kind)
+          .where("slug", "=", slug)
+          .where("parent_id", "is", null)
+          .where("id", "!=", current.id)
+          .executeTakeFirst();
+        if (clash) {
+          throwHttpError(
+            409,
+            `A ${kind} item with slug '${slug}' already exists`,
+          );
+        }
+      }
+
+      await tx
+        .updateTable("content_item")
+        .set({
+          slug,
+          title,
+          description,
+          body: JSON.stringify(body),
+          metadata: JSON.stringify(metadata),
+          updated_by: params.userId,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", current.id)
+        .execute();
+
+      await writeRevision(
+        tx,
+        { id: current.id, title, description, body, metadata },
+        params.userId,
+      );
+
+      return { id: current.id };
+    });
+  };
+}
+
+// ── Admin: status transitions ───────────────────────────────────────────
+
+export function publishContent(db: Kysely<DB>) {
+  return async (params: {
+    contentId: string;
+    publishedAt?: string;
+    userId: string;
+  }) => {
+    const result = await db
+      .updateTable("content_item")
+      .set({
+        status: "published",
+        published_at: params.publishedAt
+          ? new Date(params.publishedAt)
+          : sql`CURRENT_TIMESTAMP`,
+        updated_by: params.userId,
+        updated_at: sql`CURRENT_TIMESTAMP`,
+      })
+      .where("id", "=", params.contentId)
+      .where("status", "!=", "archived")
+      .returning(["id", "published_at"])
+      .executeTakeFirst();
+
+    if (!result) {
+      // Either missing or archived; disambiguate for a useful error.
+      const exists = await db
+        .selectFrom("content_item")
+        .select("id")
+        .where("id", "=", params.contentId)
+        .executeTakeFirst();
+      throwHttpError(
+        exists ? 409 : 404,
+        exists ? "Archived content cannot be published" : "Content not found",
+      );
+    }
+
+    return {
+      id: result.id,
+      publishedAt: result.published_at?.toISOString() ?? null,
+    };
+  };
+}
+
+export function unpublishContent(db: Kysely<DB>) {
+  return async (params: { contentId: string; userId: string }) => {
+    // published_at is deliberately retained: it marks "ever published",
+    // which locks the slug. Visibility is governed by status alone.
+    const result = await db
+      .updateTable("content_item")
+      .set({
+        status: "draft",
+        updated_by: params.userId,
+        updated_at: sql`CURRENT_TIMESTAMP`,
+      })
+      .where("id", "=", params.contentId)
+      .returning("id")
+      .executeTakeFirst();
+
+    if (!result) throwHttpError(404, "Content not found");
+    return { id: result.id };
+  };
+}
+
+export function archiveContent(db: Kysely<DB>) {
+  return async (params: { contentId: string; userId: string }) => {
+    const result = await db
+      .updateTable("content_item")
+      .set({
+        status: "archived",
+        updated_by: params.userId,
+        updated_at: sql`CURRENT_TIMESTAMP`,
+      })
+      .where("id", "=", params.contentId)
+      .returning("id")
+      .executeTakeFirst();
+
+    if (!result) throwHttpError(404, "Content not found");
+    return { id: result.id };
+  };
+}
+
+// ── Admin: revisions ────────────────────────────────────────────────────
+
+export function listRevisions(db: Kysely<DB>) {
+  return async (contentId: string) => {
+    // 404 on unknown content id so a typo'd URL doesn't read as "no
+    // revisions yet" (every item has at least its creation revision).
+    const exists = await db
+      .selectFrom("content_item")
+      .select("id")
+      .where("id", "=", contentId)
+      .executeTakeFirst();
+    if (!exists) throwHttpError(404, "Content not found");
+
+    const rows = await db
+      .selectFrom("content_revision")
+      .leftJoin("user as saver", "saver.id", "content_revision.saved_by")
+      .select([
+        "content_revision.id",
+        "content_revision.title",
+        "content_revision.saved_at",
+        "content_revision.saved_by",
+        "saver.name as saved_by_name",
+      ])
+      .where("content_revision.content_id", "=", contentId)
+      .orderBy("content_revision.saved_at", "desc")
+      .execute();
+
+    return {
+      revisions: rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        savedAt: r.saved_at.toISOString(),
+        savedBy: r.saved_by,
+        savedByName: r.saved_by_name,
+      })),
+    };
+  };
+}
+
+// ── Public reads ────────────────────────────────────────────────────────
+
+function toPublic(row: {
+  id: string;
+  kind: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  body: unknown;
+  metadata: unknown;
+  published_at: Date | null;
+  updated_at: Date;
+}) {
+  // Non-null by check constraint when status='published'; guard anyway so
+  // a future constraint change fails loudly instead of serving garbage.
+  if (!row.published_at) {
+    throwHttpError(500, "Published content missing published_at");
+  }
+  return {
+    id: row.id,
+    kind: row.kind as ContentKind,
+    slug: row.slug,
+    title: row.title,
+    description: row.description,
+    body: row.body as z.infer<typeof contentBodySchema>,
+    metadata: row.metadata as Record<string, unknown>,
+    publishedAt: row.published_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+}
+
+const publicColumns = [
+  "id",
+  "kind",
+  "slug",
+  "title",
+  "description",
+  "body",
+  "metadata",
+  "published_at",
+  "updated_at",
+] as const;
+
+function publishedOnly(db: Kysely<DB>) {
+  return db
+    .selectFrom("content_item")
+    .select(publicColumns)
+    .where("status", "=", "published")
+    .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`);
+}
+
+export function getPublishedContent(db: Kysely<DB>) {
+  return async (params: { kind: ContentKind; slug: string }) => {
+    const row = await publishedOnly(db)
+      .where("kind", "=", params.kind)
+      .where("slug", "=", params.slug)
+      .executeTakeFirst();
+
+    if (!row) throwHttpError(404, "Content not found");
+    return toPublic(row);
+  };
+}
+
+export function getPublishedGameReport(db: Kysely<DB>) {
+  return async (playCricketId: string) => {
+    const row = await publishedOnly(db)
+      .where("kind", "=", "game_report")
+      .where(sql<string>`metadata->>'playCricketId'`, "=", playCricketId)
+      .executeTakeFirst();
+
+    if (!row) throwHttpError(404, "Content not found");
+    return toPublic(row);
+  };
+}

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -48,6 +48,40 @@ function parseBody(body: unknown) {
   return result.data;
 }
 
+/**
+ * The public game-report lookup is by playCricketId, so it must be unique
+ * across game reports regardless of status (a draft duplicate would make
+ * the lookup nondeterministic the moment it published). A unique
+ * expression index backs this; the explicit check exists for a friendly
+ * 409 instead of a raw constraint violation.
+ */
+async function assertPlayCricketIdAvailable(
+  tx: Transaction<DB>,
+  kind: ContentKind,
+  metadata: Record<string, unknown>,
+  excludeId?: string,
+) {
+  if (kind !== "game_report") return;
+  const playCricketId = metadata.playCricketId;
+  if (typeof playCricketId !== "string") return;
+
+  let query = tx
+    .selectFrom("content_item")
+    .select("id")
+    .where("kind", "=", "game_report")
+    .where(sql<string>`metadata->>'playCricketId'`, "=", playCricketId);
+  if (excludeId !== undefined) {
+    query = query.where("id", "!=", excludeId);
+  }
+  const clash = await query.executeTakeFirst();
+  if (clash) {
+    throwHttpError(
+      409,
+      `A game report for Play-Cricket match ${playCricketId} already exists`,
+    );
+  }
+}
+
 interface ContentItemRow {
   id: string;
   kind: string;
@@ -209,6 +243,8 @@ export function createContent(db: Kysely<DB>) {
         );
       }
 
+      await assertPlayCricketIdAvailable(tx, params.kind, metadata);
+
       const item = await tx
         .insertInto("content_item")
         .values({
@@ -314,6 +350,10 @@ export function updateContent(db: Kysely<DB>) {
         }
       }
 
+      if (params.metadata !== undefined) {
+        await assertPlayCricketIdAvailable(tx, kind, metadata, current.id);
+      }
+
       await tx
         .updateTable("content_item")
         .set({
@@ -386,6 +426,10 @@ export function unpublishContent(db: Kysely<DB>) {
   return async (params: { contentId: string; userId: string }) => {
     // published_at is deliberately retained: it marks "ever published",
     // which locks the slug. Visibility is governed by status alone.
+    // Only a published item can be unpublished - in particular this must
+    // not offer a back door out of 'archived' (archive -> unpublish ->
+    // publish would resurrect archived content past the manage-only
+    // archive control).
     const result = await db
       .updateTable("content_item")
       .set({
@@ -394,10 +438,23 @@ export function unpublishContent(db: Kysely<DB>) {
         updated_at: sql`CURRENT_TIMESTAMP`,
       })
       .where("id", "=", params.contentId)
+      .where("status", "=", "published")
       .returning("id")
       .executeTakeFirst();
 
-    if (!result) throwHttpError(404, "Content not found");
+    if (!result) {
+      const exists = await db
+        .selectFrom("content_item")
+        .select("id")
+        .where("id", "=", params.contentId)
+        .executeTakeFirst();
+      throwHttpError(
+        exists ? 409 : 404,
+        exists
+          ? "Only published content can be unpublished"
+          : "Content not found",
+      );
+    }
     return { id: result.id };
   };
 }
@@ -477,14 +534,27 @@ function toPublic(row: {
   if (!row.published_at) {
     throwHttpError(500, "Published content missing published_at");
   }
+  const kind = row.kind as ContentKind;
+  // The metadata schema map doubles as the allowlist of kinds the public
+  // API serves at all, and projecting through it strips undeclared keys.
+  // NOTE for later phases: a kind whose declared metadata is itself not
+  // fully public (person carries safeguarding-adjacent flags) must add a
+  // dedicated public projection schema here rather than reusing its write
+  // schema.
+  const schema = CONTENT_METADATA_SCHEMAS[kind];
+  if (!schema) throwHttpError(404, "Content not found");
+  const metadata = schema.safeParse(row.metadata);
+  if (!metadata.success) {
+    throwHttpError(500, "Stored metadata does not match its kind schema");
+  }
   return {
     id: row.id,
-    kind: row.kind as ContentKind,
+    kind,
     slug: row.slug,
     title: row.title,
     description: row.description,
     body: row.body as z.infer<typeof contentBodySchema>,
-    metadata: row.metadata as Record<string, unknown>,
+    metadata: metadata.data,
     publishedAt: row.published_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
   };

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13276,6 +13276,521 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    kind: "page" | "news" | "event" | "game_report" | "person";
+                    status?: "draft" | "published" | "archived";
+                    search?: string;
+                    page?: number;
+                    pageSize?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                /** @enum {string} */
+                                kind: "page" | "news" | "event" | "game_report" | "person";
+                                slug: string;
+                                title: string;
+                                description: string | null;
+                                /** @enum {string} */
+                                status: "draft" | "published" | "archived";
+                                metadata: {
+                                    [key: string]: unknown;
+                                };
+                                publishedAt: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                                updatedBy: string;
+                                updatedByName: string | null;
+                            }[];
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        kind: "page" | "news" | "event" | "game_report" | "person";
+                        slug: string;
+                        title: string;
+                        description?: string | null;
+                        body: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        metadata: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            /** @enum {string} */
+                            status: "draft" | "published" | "archived";
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string | null;
+                            createdAt: string;
+                            updatedAt: string;
+                            updatedBy: string;
+                            updatedByName: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        slug?: string;
+                        title?: string;
+                        description?: string | null;
+                        body?: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        metadata?: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: date-time */
+                        publishedAt?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            publishedAt: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/unpublish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/revisions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            revisions: {
+                                id: string;
+                                title: string;
+                                savedAt: string;
+                                savedBy: string;
+                                savedByName: string | null;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    playCricketId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/{kind}/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    kind: "page" | "news" | "event" | "game_report" | "person";
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -23825,6 +23825,1023 @@
           }
         }
       }
+    },
+    "/api/admin/content": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "page",
+                "news",
+                "event",
+                "game_report",
+                "person"
+              ]
+            },
+            "in": "query",
+            "name": "kind",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "published",
+                "archived"
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "page",
+                              "news",
+                              "event",
+                              "game_report",
+                              "person"
+                            ]
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "draft",
+                              "published",
+                              "archived"
+                            ]
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "publishedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "updatedBy": {
+                            "type": "string"
+                          },
+                          "updatedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "kind",
+                          "slug",
+                          "title",
+                          "description",
+                          "status",
+                          "metadata",
+                          "publishedAt",
+                          "createdAt",
+                          "updatedAt",
+                          "updatedBy",
+                          "updatedByName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "total"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "page",
+                      "news",
+                      "event",
+                      "game_report",
+                      "person"
+                    ]
+                  },
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "description": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "kind",
+                  "slug",
+                  "title",
+                  "body",
+                  "metadata"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "draft",
+                        "published",
+                        "archived"
+                      ]
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "updatedBy": {
+                      "type": "string"
+                    },
+                    "updatedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "status",
+                    "metadata",
+                    "publishedAt",
+                    "createdAt",
+                    "updatedAt",
+                    "updatedBy",
+                    "updatedByName",
+                    "body"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "description": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/publish": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "publishedAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "publishedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "publishedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/unpublish": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/archive": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/revisions": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "revisions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "savedAt": {
+                            "type": "string"
+                          },
+                          "savedBy": {
+                            "type": "string"
+                          },
+                          "savedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "savedAt",
+                          "savedBy",
+                          "savedByName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "revisions"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 50
+            },
+            "in": "path",
+            "name": "playCricketId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/{kind}/{slug}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "page",
+                "news",
+                "event",
+                "game_report",
+                "person"
+              ]
+            },
+            "in": "path",
+            "name": "kind",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            },
+            "in": "path",
+            "name": "slug",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13276,6 +13276,521 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    kind: "page" | "news" | "event" | "game_report" | "person";
+                    status?: "draft" | "published" | "archived";
+                    search?: string;
+                    page?: number;
+                    pageSize?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                /** @enum {string} */
+                                kind: "page" | "news" | "event" | "game_report" | "person";
+                                slug: string;
+                                title: string;
+                                description: string | null;
+                                /** @enum {string} */
+                                status: "draft" | "published" | "archived";
+                                metadata: {
+                                    [key: string]: unknown;
+                                };
+                                publishedAt: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                                updatedBy: string;
+                                updatedByName: string | null;
+                            }[];
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        kind: "page" | "news" | "event" | "game_report" | "person";
+                        slug: string;
+                        title: string;
+                        description?: string | null;
+                        body: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        metadata: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            /** @enum {string} */
+                            status: "draft" | "published" | "archived";
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string | null;
+                            createdAt: string;
+                            updatedAt: string;
+                            updatedBy: string;
+                            updatedByName: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        slug?: string;
+                        title?: string;
+                        description?: string | null;
+                        body?: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        metadata?: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: date-time */
+                        publishedAt?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            publishedAt: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/unpublish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/revisions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            revisions: {
+                                id: string;
+                                title: string;
+                                savedAt: string;
+                                savedBy: string;
+                                savedByName: string | null;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    playCricketId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/{kind}/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    kind: "page" | "news" | "event" | "game_report" | "person";
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -23825,6 +23825,1023 @@
           }
         }
       }
+    },
+    "/api/admin/content": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "page",
+                "news",
+                "event",
+                "game_report",
+                "person"
+              ]
+            },
+            "in": "query",
+            "name": "kind",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "published",
+                "archived"
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "page",
+                              "news",
+                              "event",
+                              "game_report",
+                              "person"
+                            ]
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "draft",
+                              "published",
+                              "archived"
+                            ]
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "publishedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "updatedBy": {
+                            "type": "string"
+                          },
+                          "updatedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "kind",
+                          "slug",
+                          "title",
+                          "description",
+                          "status",
+                          "metadata",
+                          "publishedAt",
+                          "createdAt",
+                          "updatedAt",
+                          "updatedBy",
+                          "updatedByName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "total"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "page",
+                      "news",
+                      "event",
+                      "game_report",
+                      "person"
+                    ]
+                  },
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "description": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "kind",
+                  "slug",
+                  "title",
+                  "body",
+                  "metadata"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "draft",
+                        "published",
+                        "archived"
+                      ]
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "updatedBy": {
+                      "type": "string"
+                    },
+                    "updatedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "status",
+                    "metadata",
+                    "publishedAt",
+                    "createdAt",
+                    "updatedAt",
+                    "updatedBy",
+                    "updatedByName",
+                    "body"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "description": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/publish": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "publishedAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "publishedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "publishedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/unpublish": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/archive": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/revisions": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "revisions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "savedAt": {
+                            "type": "string"
+                          },
+                          "savedBy": {
+                            "type": "string"
+                          },
+                          "savedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "savedAt",
+                          "savedBy",
+                          "savedByName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "revisions"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 50
+            },
+            "in": "path",
+            "name": "playCricketId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/{kind}/{slug}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "page",
+                "news",
+                "event",
+                "game_report",
+                "person"
+              ]
+            },
+            "in": "path",
+            "name": "kind",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            },
+            "in": "path",
+            "name": "slug",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/db/src/migrations/2026-06-10T14:02:52.406Z.ts
+++ b/packages/db/src/migrations/2026-06-10T14:02:52.406Z.ts
@@ -1,0 +1,22 @@
+import { type Kysely, sql } from "kysely";
+
+// The public game-report endpoint looks content up by the playCricketId
+// held in JSONB metadata. Make that lookup deterministic: at most one
+// game report per Play-Cricket match, across all statuses (a draft
+// duplicate would corrupt the public lookup the moment it published).
+// The content service performs an explicit pre-check for a friendly 409;
+// this index is the backstop against races.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE UNIQUE INDEX content_item_game_report_play_cricket_id_key
+    ON content_item ((metadata->>'playCricketId'))
+    WHERE kind = 'game_report'
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DROP INDEX content_item_game_report_play_cricket_id_key
+  `.execute(db);
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,7 +5,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./marketing": "./src/marketing/index.ts",
-    "./auth/permissions": "./src/auth/permissions.ts"
+    "./auth/permissions": "./src/auth/permissions.ts",
+    "./content": "./src/content/index.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+import type { Resource } from "../auth/permissions.ts";
+
+// ── Content kinds + statuses ────────────────────────────────────────────
+//
+// Live content editing (#479). One content_item table holds every kind;
+// these constants are the single source of truth for the discriminator
+// values (the DB check constraints mirror them).
+
+export const CONTENT_KINDS = [
+  "page",
+  "news",
+  "event",
+  "game_report",
+  "person",
+] as const;
+
+export const contentKindSchema = z.enum(CONTENT_KINDS);
+export type ContentKind = z.infer<typeof contentKindSchema>;
+
+export const CONTENT_STATUSES = ["draft", "published", "archived"] as const;
+
+export const contentStatusSchema = z.enum(CONTENT_STATUSES);
+export type ContentStatus = z.infer<typeof contentStatusSchema>;
+
+/**
+ * Which permission resource gates each kind. Pages are `content`, news and
+ * events share `content_news`, game reports are `content_reports`, and
+ * people are `content_people` (separate because person profiles carry
+ * safeguarding-adjacent flags).
+ */
+export const CONTENT_KIND_RESOURCES = {
+  page: "content",
+  news: "content_news",
+  event: "content_news",
+  game_report: "content_reports",
+  person: "content_people",
+} as const satisfies Record<ContentKind, Resource>;
+
+export type ContentResource = (typeof CONTENT_KIND_RESOURCES)[ContentKind];
+
+// ── Body format: BlockNote document JSON ────────────────────────────────
+//
+// Per ADR 047 the canonical body is the BlockNote editor JSON block array
+// stored as JSONB - not markdown. This schema validates the structural
+// envelope every BlockNote block shares (id/type/props/content/children);
+// the public renderer narrows per block type and ignores anything it does
+// not recognise, so unknown types are safe to store. There is deliberately
+// no raw-HTML block type anywhere in the pipeline.
+
+export const blockPropValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+]);
+
+export interface ContentBlock {
+  id: string;
+  type: string;
+  props: Record<string, string | number | boolean>;
+  content?: unknown;
+  children: ContentBlock[];
+}
+
+export const contentBlockSchema: z.ZodType<ContentBlock> = z.lazy(() =>
+  z.object({
+    id: z.string().min(1),
+    type: z.string().min(1),
+    props: z.record(z.string(), blockPropValueSchema),
+    content: z.unknown().optional(),
+    children: z.array(contentBlockSchema),
+  }),
+);
+
+/** A content body: the top-level BlockNote block array. */
+export const contentBodySchema = z.array(contentBlockSchema);
+export type ContentBody = z.infer<typeof contentBodySchema>;
+
+// ── Kind-specific metadata (replaces MDX frontmatter) ───────────────────
+//
+// Validated on every write by the content API. Only kinds with a schema
+// here are editable through the API; later phases add their kinds.
+
+export const gameReportMetadataSchema = z.object({
+  playCricketId: z.string().min(1),
+});
+export type GameReportMetadata = z.infer<typeof gameReportMetadataSchema>;
+
+export const CONTENT_METADATA_SCHEMAS: Partial<
+  Record<ContentKind, z.ZodType<Record<string, unknown>>>
+> = {
+  game_report: gameReportMetadataSchema,
+};
+
+/** Kinds currently editable through the content API (grows per phase). */
+export const ENABLED_CONTENT_KINDS = Object.keys(
+  CONTENT_METADATA_SCHEMAS,
+) as ContentKind[];
+
+// ── Slugs ───────────────────────────────────────────────────────────────
+//
+// Locked after first publish (no redirect handling exists anywhere), so
+// they are validated strictly from the start.
+
+export const contentSlugSchema = z
+  .string()
+  .min(1)
+  .max(200)
+  .regex(
+    /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+    "Slug must be lowercase letters, numbers and hyphens",
+  );


### PR DESCRIPTION
Part of epic #479. Closes #482.

## What's here

**packages/shared/content** (new export): content kinds/statuses, kind-to-permission-resource map, BlockNote block envelope Zod schema (per ADR 047 the body is editor JSON, not markdown + directives as the issue text predates), per-kind metadata schemas (`game_report`: `{ playCricketId }`), slug format schema.

**apps/api features/content**: standard feature folder.

- Admin: list / get / create / update / publish / unpublish / archive / list-revisions. Permission is per-kind (`content_reports` for game reports etc.) resolved from the request body or the existing row, so the gate runs in-handler after `requireAuth` rather than as a static preHandler.
- Every create/update writes a `content_revision` snapshot transactionally.
- Slug locks after first publish. `published_at` is deliberately never cleared on unpublish - it doubles as the ever-published marker; visibility is governed by `status` alone.
- Publish takes an optional future `publishedAt` (scheduled publishing, no scheduler infra).
- Public (no auth): `GET /api/content/:kind/:slug` and `GET /api/content/game-report/by-play-cricket-id/:playCricketId`, serving only `status='published' AND published_at <= now()`, with strong ETag + If-None-Match 304.

## Notable implementation decision

The fully recursive block schema produces self-referencing $refs that openapi-typescript cannot resolve, so route schemas validate a depth-1 block envelope (children opaque) and the service re-validates the entire tree with the recursive shared schema on every write. Reads return whatever was validated at write time.

## Tests

13 unit (mock DB) + 6 integration (testcontainers): full lifecycle, draft/scheduled invisibility, slug lock incl. after unpublish, per-kind slug uniqueness, list filter/pagination, revision history + attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)