### PR TITLE
feat(web): ContentBody renderer for BlockNote JSON (#483)

### DIFF
--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -175,6 +175,31 @@ describe("ContentBody", () => {
     expect(html).not.toContain("javascript:");
   });
 
+  it("tolerates text nodes with missing styles", () => {
+    const html = renderBody([
+      block("paragraph", { content: [{ type: "text", text: "bare node" }] }),
+    ]);
+    expect(html).toContain("bare node");
+  });
+
+  it("refuses plain-http image sources", () => {
+    const html = renderBody([
+      block("image", { props: { url: "http://example.com/pixel.gif" } }),
+    ]);
+    expect(html).not.toContain("pixel.gif");
+  });
+
+  it("renders checklists without disc markers", () => {
+    const html = renderBody([
+      block("checkListItem", {
+        props: { checked: true },
+        content: [text("Covers on")],
+      }),
+    ]);
+    expect(html).toContain("list-none");
+    expect(html).toContain("checked");
+  });
+
   it("hides the eventPreview block when props are incomplete", () => {
     const html = renderBody([
       block("eventPreview", { props: { name: "Quiz night" } }),

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -1,0 +1,184 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+// mdx-components transitively imports the people corpus (.mdx files) and
+// the vite-imagetools image map, neither of which exists outside a Vite
+// build - stub the lookups, the renderer only needs their shapes.
+vi.mock("@/lib/people.js", () => ({
+  getPersonBySlug: (slug: string) =>
+    slug === "alex-slaven"
+      ? { name: "Alex Slaven", photo: undefined, photoPicture: undefined }
+      : undefined,
+}));
+vi.mock("@/lib/image-map.js", () => ({
+  getImageUrl: () => undefined,
+  getPicture: () => undefined,
+}));
+
+import { ContentBody } from "./content-body.js";
+
+// Person (router Link) and GamePreview (react-query) need their providers
+// even for static rendering.
+function renderBody(body: unknown): string {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, enabled: false } },
+  });
+  return renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ContentBody body={body} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+let nextId = 0;
+function block(
+  type: string,
+  overrides: {
+    props?: Record<string, string | number | boolean>;
+    content?: unknown;
+    children?: unknown[];
+  } = {},
+) {
+  nextId += 1;
+  return {
+    id: `block-${String(nextId)}`,
+    type,
+    props: overrides.props ?? {},
+    content: overrides.content ?? [],
+    children: overrides.children ?? [],
+  };
+}
+
+const text = (t: string, styles: Record<string, boolean> = {}) => ({
+  type: "text",
+  text: t,
+  styles,
+});
+
+describe("ContentBody", () => {
+  it("renders nothing for a structurally invalid document", () => {
+    expect(renderBody("not an array")).toBe("");
+    expect(renderBody([{ type: "paragraph" }])).toBe("");
+  });
+
+  it("renders paragraphs, headings and inline styles", () => {
+    const html = renderBody([
+      block("heading", { props: { level: 2 }, content: [text("Top order")] }),
+      block("paragraph", {
+        content: [
+          text("A "),
+          text("fine", { italic: true }),
+          text(" win by "),
+          text("42 runs", { bold: true }),
+        ],
+      }),
+    ]);
+    expect(html).toContain("<h2");
+    expect(html).toContain("Top order");
+    expect(html).toContain("<em>fine</em>");
+    expect(html).toContain("<strong>42 runs</strong>");
+  });
+
+  it("renders raw HTML in text content as inert text", () => {
+    const html = renderBody([
+      block("paragraph", {
+        content: [text('<script>alert("xss")</script>')],
+      }),
+    ]);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("drops unsafe link protocols but keeps the text", () => {
+    const html = renderBody([
+      block("paragraph", {
+        content: [
+          {
+            type: "link",
+
+            href: "javascript:alert(1)",
+            content: [text("click me")],
+          },
+          {
+            type: "link",
+            href: "https://percymain.org",
+            content: [text("safe link")],
+          },
+        ],
+      }),
+    ]);
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("click me");
+    expect(html).toContain('href="https://percymain.org"');
+  });
+
+  it("groups consecutive list items into one list", () => {
+    const html = renderBody([
+      block("bulletListItem", { content: [text("78* from the skipper")] }),
+      block("bulletListItem", { content: [text("4-23 off 8 overs")] }),
+      block("numberedListItem", { content: [text("First")] }),
+    ]);
+    expect(html.match(/<ul/g)).toHaveLength(1);
+    expect(html.match(/<li/g)).toHaveLength(3);
+    expect(html.match(/<ol/g)).toHaveLength(1);
+  });
+
+  it("renders unknown block types as nothing without crashing", () => {
+    const html = renderBody([
+      block("marquee", { content: [text("nope")] }),
+      block("paragraph", { content: [text("still here")] }),
+    ]);
+    expect(html).not.toContain("nope");
+    expect(html).toContain("still here");
+  });
+
+  it("renders the person custom block via the shared component map", () => {
+    const html = renderBody([
+      block("person", { props: { slug: "alex-slaven", role: "Head Coach" } }),
+    ]);
+    expect(html).toContain("person");
+    expect(html).toContain("Head Coach");
+    expect(html).toContain('href="/person/alex-slaven"');
+  });
+
+  it("renders tables", () => {
+    const html = renderBody([
+      block("table", {
+        content: {
+          type: "tableContent",
+          rows: [
+            { cells: [[text("Player")], [text("Runs")]] },
+            { cells: [[text("A. Slaven")], [text("78")]] },
+          ],
+        },
+      }),
+    ]);
+    expect(html).toContain("<table>");
+    expect(html.match(/<tr/g)).toHaveLength(2);
+    expect(html).toContain("A. Slaven");
+  });
+
+  it("renders image blocks only for safe urls", () => {
+    const html = renderBody([
+      block("image", {
+        props: { url: "/uploads/test.jpg", caption: "The winning moment" },
+      }),
+
+      block("image", { props: { url: "javascript:alert(1)" } }),
+    ]);
+    expect(html).toContain('src="/uploads/test.jpg"');
+    expect(html).toContain("The winning moment");
+    expect(html).not.toContain("javascript:");
+  });
+
+  it("hides the eventPreview block when props are incomplete", () => {
+    const html = renderBody([
+      block("eventPreview", { props: { name: "Quiz night" } }),
+    ]);
+    expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
+  });
+});

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -20,7 +20,7 @@ import { createElement, Fragment, type ReactNode } from "react";
 interface StyledText {
   type: "text";
   text: string;
-  styles: Record<string, unknown>;
+  styles?: Record<string, unknown> | null;
 }
 
 interface InlineLink {
@@ -55,9 +55,19 @@ function isSafeHref(href: string): boolean {
   return /^(https?:|mailto:|tel:)/i.test(href) || /^\/(?!\/)/.test(href);
 }
 
+/**
+ * Stricter than isSafeHref: images render only from https or
+ * site-relative paths (uploads live under /uploads/*). Keeps plain-http
+ * mixed content and protocol oddities out of public pages.
+ */
+function isSafeImageSrc(src: string): boolean {
+  return /^https:/i.test(src) || /^\/(?!\/)/.test(src);
+}
+
 function StyledTextView({ node }: { node: StyledText }) {
   let element: ReactNode = node.text;
-  const styles = node.styles;
+  // A text node with absent/null styles is still renderable text.
+  const styles = node.styles ?? {};
   // textColor / backgroundColor are deliberately not honoured: editor
   // content stays within the site palette.
   if (styles.code === true) element = <code>{element}</code>;
@@ -244,7 +254,7 @@ function BlockView({ block }: { block: ContentBlock }) {
 
     case "image": {
       const url = stringProp(block, "url");
-      if (!url || !isSafeHref(url)) return null;
+      if (!url || !isSafeImageSrc(url)) return null;
       return (
         <mdxComponents.Image
           src={url}
@@ -349,7 +359,13 @@ function BlocksView({ blocks }: { blocks: ContentBlock[] }) {
     out.push(
       createElement(
         listTag,
-        { key: block.id },
+        {
+          key: block.id,
+          // Checklists show their checkboxes, not the .mdx-content disc
+          // markers a plain ul would get.
+          className:
+            block.type === "checkListItem" ? "ml-0 list-none" : undefined,
+        },
         items.map((item) => <ListItemView key={item.id} item={item} />),
       ),
     );

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -1,0 +1,384 @@
+import { mdxComponents } from "@/components/mdx-components.js";
+import { cn } from "@/lib/utils.js";
+import {
+  contentBodySchema,
+  CUSTOM_BLOCK_TYPES,
+  type ContentBlock,
+} from "@percy-main/shared/content";
+import { createElement, Fragment, type ReactNode } from "react";
+
+// Renders DB-backed content: the BlockNote editor JSON document (ADR 047),
+// walked as plain data - the BlockNote runtime is never loaded on public
+// pages. Custom blocks resolve against the same component map MDX uses, so
+// migrated content looks identical. There is deliberately no block type
+// that emits raw HTML: everything renders through React elements, so
+// output is sanitised by construction. Unknown or malformed block types
+// render nothing rather than crashing the page.
+
+// ── Inline content ──────────────────────────────────────────────────────
+
+interface StyledText {
+  type: "text";
+  text: string;
+  styles: Record<string, unknown>;
+}
+
+interface InlineLink {
+  type: "link";
+  href: string;
+  content: unknown;
+}
+
+function isStyledText(node: unknown): node is StyledText {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    (node as { type?: unknown }).type === "text" &&
+    typeof (node as { text?: unknown }).text === "string"
+  );
+}
+
+function isInlineLink(node: unknown): node is InlineLink {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    (node as { type?: unknown }).type === "link" &&
+    typeof (node as { href?: unknown }).href === "string"
+  );
+}
+
+/**
+ * Only protocols/paths we trust ever become anchors. Anything else (e.g.
+ * javascript:) renders as its text content with no link.
+ */
+function isSafeHref(href: string): boolean {
+  return /^(https?:|mailto:|tel:)/i.test(href) || /^\/(?!\/)/.test(href);
+}
+
+function StyledTextView({ node }: { node: StyledText }) {
+  let element: ReactNode = node.text;
+  const styles = node.styles;
+  // textColor / backgroundColor are deliberately not honoured: editor
+  // content stays within the site palette.
+  if (styles.code === true) element = <code>{element}</code>;
+  if (styles.bold === true) element = <strong>{element}</strong>;
+  if (styles.italic === true) element = <em>{element}</em>;
+  if (styles.underline === true) element = <u>{element}</u>;
+  if (styles.strike === true) element = <s>{element}</s>;
+  return element;
+}
+
+/**
+ * Inline node arrays carry no ids, so position is the only available key.
+ * That is safe here: this tree is a pure projection of immutable data
+ * (no element state), and a content change replaces the whole document.
+ */
+function InlineContent({ content }: { content: unknown }) {
+  if (!Array.isArray(content)) return null;
+  return content.map((node, i) => {
+    const key = `inline-${String(i)}`;
+    if (isStyledText(node)) {
+      return (
+        <Fragment key={key}>
+          <StyledTextView node={node} />
+        </Fragment>
+      );
+    }
+    if (isInlineLink(node)) {
+      const inner = <InlineContent content={node.content} />;
+      if (!isSafeHref(node.href)) return <span key={key}>{inner}</span>;
+      return (
+        <a key={key} href={node.href}>
+          {inner}
+        </a>
+      );
+    }
+    return null;
+  });
+}
+
+/** Plain-text projection of inline content (for code blocks, alt text). */
+function inlineToText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((node) => {
+      if (isStyledText(node)) return node.text;
+      if (isInlineLink(node)) return inlineToText(node.content);
+      return "";
+    })
+    .join("");
+}
+
+// ── Block helpers ───────────────────────────────────────────────────────
+
+const ALIGN_CLASSES: Record<string, string> = {
+  center: "text-center",
+  right: "text-right",
+  justify: "text-justify",
+};
+
+function alignClass(block: ContentBlock): string | undefined {
+  const alignment = block.props.textAlignment;
+  return typeof alignment === "string" ? ALIGN_CLASSES[alignment] : undefined;
+}
+
+function stringProp(block: ContentBlock, name: string): string | undefined {
+  const value = block.props[name];
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/** Nested children of a non-list block render indented beneath it. */
+function BlockChildren({ block }: { block: ContentBlock }) {
+  if (block.children.length === 0) return null;
+  return (
+    <div className="ml-4">
+      <BlocksView blocks={block.children} />
+    </div>
+  );
+}
+
+// ── Tables ──────────────────────────────────────────────────────────────
+//
+// BlockNote table content: { type: "tableContent", rows: [{ cells }] }
+// where each cell is either an inline-content array (older shape) or a
+// { type: "tableCell", content } object.
+
+function TableCellContent({ cell }: { cell: unknown }) {
+  if (Array.isArray(cell)) return <InlineContent content={cell} />;
+  if (
+    typeof cell === "object" &&
+    cell !== null &&
+    (cell as { type?: unknown }).type === "tableCell"
+  ) {
+    return <InlineContent content={(cell as { content?: unknown }).content} />;
+  }
+  return null;
+}
+
+/** Row/cell position keys are safe for the same reason as inline keys. */
+function TableView({ block }: { block: ContentBlock }) {
+  const content = block.content;
+  if (
+    typeof content !== "object" ||
+    content === null ||
+    !Array.isArray((content as { rows?: unknown }).rows)
+  ) {
+    return null;
+  }
+  const rows = (content as { rows: unknown[] }).rows;
+  return (
+    <table>
+      <tbody>
+        {rows.map((row, ri) => {
+          const cells =
+            typeof row === "object" &&
+            row !== null &&
+            Array.isArray((row as { cells?: unknown }).cells)
+              ? (row as { cells: unknown[] }).cells
+              : [];
+          return (
+            <tr key={`row-${String(ri)}`}>
+              {cells.map((cell, ci) => (
+                <td key={`cell-${String(ci)}`}>
+                  <TableCellContent cell={cell} />
+                </td>
+              ))}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+// ── Block rendering ─────────────────────────────────────────────────────
+
+function BlockView({ block }: { block: ContentBlock }) {
+  switch (block.type) {
+    case "paragraph":
+      return (
+        <div>
+          <p className={alignClass(block)}>
+            <InlineContent content={block.content} />
+          </p>
+          <BlockChildren block={block} />
+        </div>
+      );
+
+    case "heading": {
+      const level =
+        typeof block.props.level === "number"
+          ? Math.min(Math.max(Math.trunc(block.props.level), 1), 6)
+          : 1;
+      return (
+        <div>
+          {createElement(
+            `h${level}`,
+            { className: alignClass(block) },
+            <InlineContent content={block.content} />,
+          )}
+          <BlockChildren block={block} />
+        </div>
+      );
+    }
+
+    case "quote":
+      return (
+        <div>
+          <blockquote>
+            <InlineContent content={block.content} />
+          </blockquote>
+          <BlockChildren block={block} />
+        </div>
+      );
+
+    case "codeBlock":
+      return (
+        <pre className="overflow-x-auto rounded-lg bg-stone-100 p-4 text-sm">
+          <code>{inlineToText(block.content)}</code>
+        </pre>
+      );
+
+    case "table":
+      return <TableView block={block} />;
+
+    case "image": {
+      const url = stringProp(block, "url");
+      if (!url || !isSafeHref(url)) return null;
+      return (
+        <mdxComponents.Image
+          src={url}
+          alt={stringProp(block, "name") ?? stringProp(block, "caption")}
+          caption={stringProp(block, "caption")}
+        />
+      );
+    }
+
+    // Custom blocks - same component map as MDX, so migrated content
+    // renders identically.
+    case CUSTOM_BLOCK_TYPES.person: {
+      const slug = stringProp(block, "slug");
+      if (!slug) return null;
+      return (
+        <mdxComponents.Person slug={slug} role={stringProp(block, "role")} />
+      );
+    }
+
+    case CUSTOM_BLOCK_TYPES.personGrid: {
+      const slugs = stringProp(block, "slugs");
+      if (!slugs) return null;
+      return (
+        <mdxComponents.PersonGrid slugs={slugs.split(",").filter(Boolean)} />
+      );
+    }
+
+    case CUSTOM_BLOCK_TYPES.gamePreview: {
+      const playCricketId = stringProp(block, "playCricketId");
+      if (!playCricketId) return null;
+      return <mdxComponents.GamePreview playCricketId={playCricketId} />;
+    }
+
+    case CUSTOM_BLOCK_TYPES.eventPreview: {
+      const id = stringProp(block, "eventId");
+      const name = stringProp(block, "name");
+      const when = stringProp(block, "when");
+      if (!id || !name || !when) return null;
+      return <mdxComponents.EventPreview id={id} name={name} when={when} />;
+    }
+
+    default:
+      // Unknown / not-yet-supported block types degrade silently.
+      return null;
+  }
+}
+
+const LIST_TYPES: Record<string, "ul" | "ol" | undefined> = {
+  bulletListItem: "ul",
+  numberedListItem: "ol",
+  checkListItem: "ul",
+};
+
+function ListItemView({ item }: { item: ContentBlock }) {
+  return (
+    <li className={alignClass(item)}>
+      {item.type === "checkListItem" && (
+        <input
+          type="checkbox"
+          checked={item.props.checked === true}
+          readOnly
+          className="mr-2 align-middle"
+        />
+      )}
+      <InlineContent content={item.content} />
+      {item.children.length > 0 && <BlocksView blocks={item.children} />}
+    </li>
+  );
+}
+
+/**
+ * Group consecutive list-item blocks of the same type into a single list
+ * element; render everything else block by block.
+ */
+function BlocksView({ blocks }: { blocks: ContentBlock[] }) {
+  const out: ReactNode[] = [];
+  let i = 0;
+
+  while (i < blocks.length) {
+    const block = blocks[i];
+    if (!block) break;
+
+    const listTag = LIST_TYPES[block.type];
+    if (!listTag) {
+      out.push(
+        <Fragment key={block.id}>
+          <BlockView block={block} />
+        </Fragment>,
+      );
+      i += 1;
+      continue;
+    }
+
+    const items: ContentBlock[] = [];
+    while (i < blocks.length) {
+      const candidate = blocks[i];
+      if (candidate?.type !== block.type) break;
+      items.push(candidate);
+      i += 1;
+    }
+
+    out.push(
+      createElement(
+        listTag,
+        { key: block.id },
+        items.map((item) => <ListItemView key={item.id} item={item} />),
+      ),
+    );
+  }
+
+  return out;
+}
+
+// ── Public component ────────────────────────────────────────────────────
+
+/**
+ * Single runtime renderer for DB-backed content. Shared by public pages
+ * and the admin draft preview. `body` is the raw value from the API; it
+ * is structurally validated here, and a document that fails validation
+ * renders nothing.
+ */
+export function ContentBody({
+  body,
+  className,
+}: {
+  body: unknown;
+  className?: string;
+}) {
+  const parsed = contentBodySchema.safeParse(body);
+  if (!parsed.success) return null;
+
+  return (
+    <div className={cn("mdx-content flex flex-col *:mb-4", className)}>
+      <BlocksView blocks={parsed.data} />
+    </div>
+  );
+}

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -97,6 +97,20 @@ export const ENABLED_CONTENT_KINDS = Object.keys(
   CONTENT_METADATA_SCHEMAS,
 ) as ContentKind[];
 
+// ── Custom block types ──────────────────────────────────────────────────
+//
+// The directive vocabulary from the original epic plan, as BlockNote
+// custom block type names. Single source of truth shared by the editor
+// (which registers blocks under these names) and the public renderer
+// (which maps them to the existing component map).
+
+export const CUSTOM_BLOCK_TYPES = {
+  person: "person",
+  personGrid: "personGrid",
+  gamePreview: "gamePreview",
+  eventPreview: "eventPreview",
+} as const;
+
 // ── Slugs ───────────────────────────────────────────────────────────────
 //
 // Locked after first publish (no redirect handling exists anywhere), so


### PR DESCRIPTION
Part of epic #479. Closes #483.

Note: the issue text predates ADR 047 - this is the JSON-block-tree renderer the ADR calls for, not the react-markdown + remark-directive renderer originally planned. The acceptance criteria carry over directly.

- `<ContentBody body={...} />` walks the BlockNote document as plain data; the BlockNote runtime is never loaded on public pages.
- Custom blocks (`person`, `personGrid`, `gamePreview`, `eventPreview`) resolve against the existing `mdxComponents` map, so migrated content renders through the exact same components. Block type names are exported from `packages/shared` (`CUSTOM_BLOCK_TYPES`) so the editor build-out (#486) registers blocks under the same names.
- Built-ins covered: paragraph, heading (level clamped 1-6), quote, codeBlock, bullet/numbered/check lists (consecutive items grouped into one `ul`/`ol`, nesting via children), table (both BlockNote cell shapes), image (routed through the optimised-image component).
- Sanitised by construction: no raw-HTML block type, text renders through React escaping, link and image URLs must be http(s)/mailto/tel or site-relative (`javascript:` degrades to plain text), editor colour styles ignored. Unknown/malformed blocks degrade silently; a structurally invalid document renders nothing.
- Prose styling reuses the existing `.mdx-content` rules + `flex flex-col *:mb-4` wrapper, the same classes the current MDX rendering path uses, so migrated reports look identical.

10 renderer tests (renderToStaticMarkup, node env - no new test infra): structure, inline styles, XSS inertness, unsafe-protocol suppression, list grouping, tables, custom blocks, graceful degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)