### PR TITLE
feat(api): content image upload pipeline (#485)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,10 @@ import { createAuth, type Auth } from "./features/auth/auth.ts";
 import { createPhoenixTracer } from "./lib/phoenix-tracer.ts";
 import { createPushSender, type SendPush } from "./lib/push-sender.ts";
 import {
+  createContentImageStore,
+  type ContentImageStore,
+} from "./lib/s3-content-images.ts";
+import {
   createS3DocumentStore,
   type S3DocumentStore,
 } from "./lib/s3-documents.ts";
@@ -40,6 +44,7 @@ import { authRoutes } from "./features/auth/routes.ts";
 import { availabilityRoutes } from "./features/availability/routes.ts";
 import { chargeRoutes } from "./features/charges/routes.ts";
 import { contactRoutes } from "./features/contact/routes.ts";
+import { contentImageRoutes } from "./features/content-images/routes.ts";
 import { contentRoutes } from "./features/content/routes.ts";
 import { cricketLeaderboardRoutes } from "./features/cricket-leaderboard/routes.ts";
 import { documentRoutes } from "./features/documents/routes.ts";
@@ -82,6 +87,7 @@ declare module "fastify" {
     scoutReports: ScoutReportStore;
     scoutAttachments: ScoutAttachmentStore;
     scoutKnowledgeBase: S3KnowledgeBaseStore;
+    contentImages: ContentImageStore;
     phoenixTracer: Tracer;
   }
 }
@@ -215,6 +221,10 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   const scoutKnowledgeBase = createS3KnowledgeBaseStore(config);
   app.decorate("scoutKnowledgeBase", scoutKnowledgeBase);
 
+  // Create and decorate the content image store (editor-uploaded images)
+  const contentImages = createContentImageStore(config);
+  app.decorate("contentImages", contentImages);
+
   // Isolated tracer provider for LLM spans. New Relic owns the global OTel
   // pipeline; this provider sits alongside it and receives only AI SDK
   // spans via the experimental_telemetry.tracer plumbed through Scout.
@@ -326,6 +336,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(webhookRoutes, { prefix: "/api" });
   await app.register(ogImageRoutes, { prefix: "/api" });
   await app.register(contentRoutes, { prefix: "/api" });
+  await app.register(contentImageRoutes, { prefix: "/api" });
 
   // Marketing forwarder: periodic drain of marketing_outbox -> Google Ads.
   // No-op when GOOGLE_ADS_* env vars are absent.

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -77,11 +77,10 @@ const configSchema = z.object({
   S3_ENDPOINT: z.url().optional(),
 
   // S3 (editor-uploaded content images). Reuses the CloudFront-served
-  // uploads bucket (S3_BUCKET): only keys under uploads/* are publicly
-  // routable, so pending browser PUTs land under a non-served prefix and
-  // the processed variant ladder is written under uploads/content/.
-  CONTENT_IMAGE_PENDING_PREFIX: z.string().default("content-images/pending"),
-  CONTENT_IMAGES_PREFIX: z.string().default("uploads/content"),
+  // uploads bucket (S3_BUCKET). Key prefixes are deliberately NOT
+  // configurable - they are structural, coupled to the CloudFront
+  // /uploads/* routing and the Terraform lifecycle rule (see
+  // lib/s3-content-images.ts).
   CONTENT_IMAGE_MAX_BYTES: z.coerce
     .number()
     .int()

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -76,6 +76,23 @@ const configSchema = z.object({
   S3_RECEIPT_PREFIX: z.string().default("receipts"),
   S3_ENDPOINT: z.url().optional(),
 
+  // S3 (editor-uploaded content images). Reuses the CloudFront-served
+  // uploads bucket (S3_BUCKET): only keys under uploads/* are publicly
+  // routable, so pending browser PUTs land under a non-served prefix and
+  // the processed variant ladder is written under uploads/content/.
+  CONTENT_IMAGE_PENDING_PREFIX: z.string().default("content-images/pending"),
+  CONTENT_IMAGES_PREFIX: z.string().default("uploads/content"),
+  CONTENT_IMAGE_MAX_BYTES: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(10 * 1024 * 1024),
+  CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(900),
+
   // S3 (policy documents)
   S3_DOCUMENTS_BUCKET: z.string().min(1),
   S3_DOCUMENTS_PREFIX: z.string().default("documents"),

--- a/apps/api/src/features/content-images/integration.test.ts
+++ b/apps/api/src/features/content-images/integration.test.ts
@@ -1,0 +1,157 @@
+import sharp from "sharp";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Config } from "../../config.ts";
+import type { ContentImageStore } from "../../lib/s3-content-images.ts";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import { confirmUpload } from "./service.ts";
+
+const config = {
+  CONTENT_IMAGE_PENDING_PREFIX: "content-images/pending",
+  CONTENT_IMAGES_PREFIX: "uploads/content",
+  CONTENT_IMAGE_MAX_BYTES: 10 * 1024 * 1024,
+  CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
+} as Config;
+
+// In-memory S3 stand-in: integration tests exercise the real DB and the
+// real sharp pipeline; only the bucket is faked.
+function createMemoryStore(): ContentImageStore & {
+  objects: Map<string, { body: Buffer; contentType: string }>;
+} {
+  const objects = new Map<string, { body: Buffer; contentType: string }>();
+  return {
+    objects,
+    getSignedUploadUrl(imageId, extension) {
+      const pendingKey = `content-images/pending/${imageId}.${extension}`;
+      return Promise.resolve({
+        uploadUrl: `https://mock-s3.example.com/${pendingKey}?presigned=true`,
+        pendingKey,
+      });
+    },
+    headPending(pendingKey) {
+      const obj = objects.get(pendingKey);
+      return Promise.resolve(
+        obj
+          ? { contentLength: obj.body.byteLength, contentType: obj.contentType }
+          : null,
+      );
+    },
+    getPending(pendingKey) {
+      const obj = objects.get(pendingKey);
+      if (!obj) throw new Error(`missing ${pendingKey}`);
+      return Promise.resolve(obj.body);
+    },
+    putVariant(key, body, contentType) {
+      objects.set(key, { body, contentType });
+      return Promise.resolve();
+    },
+    deletePending(pendingKey) {
+      objects.delete(pendingKey);
+      return Promise.resolve();
+    },
+  };
+}
+
+/** A JPEG with GPS + camera EXIF, the privacy-sensitive case. */
+async function makeGpsTaggedJpeg(): Promise<Buffer> {
+  return await sharp({
+    create: {
+      width: 1400,
+      height: 900,
+      channels: 3,
+      background: { r: 200, g: 50, b: 50 },
+    },
+  })
+    .jpeg()
+    .withExif({
+      IFD0: {
+        Make: "TestCam",
+        Model: "TestCam 3000",
+        Copyright: "Percy Main CSC",
+      },
+      IFD3: {
+        GPSLatitudeRef: "N",
+        GPSLatitude: "55/1 0/1 4200/100",
+        GPSLongitudeRef: "W",
+        GPSLongitude: "1/1 27/1 1800/100",
+      },
+    })
+    .toBuffer();
+}
+
+describe("content image pipeline (integration)", () => {
+  let ctx: TestContext;
+  let userId: string;
+
+  beforeAll(async () => {
+    ctx = await startTestContainer();
+    ({ userId } = await seedTestUser(ctx.db, { withMember: false }));
+  }, 120_000);
+
+  afterAll(async () => {
+    await stopTestContainer(ctx);
+  });
+
+  it("processes a GPS-tagged upload into clean responsive variants", async () => {
+    const store = createMemoryStore();
+    const original = await makeGpsTaggedJpeg();
+
+    // Sanity: the fixture really does carry EXIF before processing
+    const originalMeta = await sharp(original).metadata();
+    expect(originalMeta.exif).toBeDefined();
+
+    const imageId = crypto.randomUUID();
+    const pendingKey = `content-images/pending/${imageId}.jpg`;
+    store.objects.set(pendingKey, {
+      body: original,
+      contentType: "image/jpeg",
+    });
+
+    const result = await confirmUpload(
+      ctx.db,
+      store,
+      config,
+    )({
+      imageId,
+      pendingKey,
+      alt: "The winning six",
+      userId,
+    });
+
+    // Every variant written to the public prefix, pending cleaned up
+    const keys = [...store.objects.keys()];
+    expect(store.objects.has(pendingKey)).toBe(false);
+    expect(keys.every((k) => k.startsWith(`uploads/content/${imageId}/`))).toBe(
+      true,
+    );
+    // 1400px source -> 320/640/960/1280 in avif + webp, + jpeg fallback
+    expect(keys).toHaveLength(9);
+
+    // Zero EXIF/GPS metadata in every variant
+    for (const [, obj] of store.objects) {
+      const meta = await sharp(obj.body).metadata();
+      expect(meta.exif).toBeUndefined();
+    }
+
+    // PictureSource descriptor is consumable by OptimisedImage
+    expect(result.picture.img.src).toBe(`/uploads/content/${imageId}/1280.jpg`);
+    expect(result.picture.sources.avif?.split(", ")).toHaveLength(4);
+    expect(result.picture.sources.webp?.split(", ")).toHaveLength(4);
+
+    // Registered in the DB with consent + audit fields
+    const row = await ctx.db
+      .selectFrom("content_image")
+      .selectAll()
+      .where("id", "=", imageId)
+      .executeTakeFirstOrThrow();
+    expect(row.consent_confirmed).toBe(true);
+    expect(row.uploaded_by).toBe(userId);
+    expect(row.alt).toBe("The winning six");
+    expect(row.width).toBe(1400);
+    expect(row.height).toBe(900);
+  });
+});

--- a/apps/api/src/features/content-images/integration.test.ts
+++ b/apps/api/src/features/content-images/integration.test.ts
@@ -11,8 +11,6 @@ import {
 import { confirmUpload } from "./service.ts";
 
 const config = {
-  CONTENT_IMAGE_PENDING_PREFIX: "content-images/pending",
-  CONTENT_IMAGES_PREFIX: "uploads/content",
   CONTENT_IMAGE_MAX_BYTES: 10 * 1024 * 1024,
   CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
 } as Config;

--- a/apps/api/src/features/content-images/routes.ts
+++ b/apps/api/src/features/content-images/routes.ts
@@ -1,0 +1,58 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { getAuthSession, requireAnyPermission } from "../auth/middleware.ts";
+import {
+  confirmUploadSchema,
+  contentImageResponseSchema,
+  uploadUrlResponseSchema,
+  uploadUrlSchema,
+} from "./schemas.ts";
+import { confirmUpload, createUploadUrl } from "./service.ts";
+
+// Any content editor can upload images - the image library is shared
+// across content kinds, so the gate is "may manage any content".
+const requireAnyContentManage = requireAnyPermission(
+  { resource: "content", action: "manage" },
+  { resource: "content_news", action: "manage" },
+  { resource: "content_reports", action: "manage" },
+  { resource: "content_people", action: "manage" },
+);
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const contentImageRoutes: FastifyPluginAsyncZod = async (app) => {
+  const uploadUrl = createUploadUrl(app.contentImages, app.config);
+  const confirm = confirmUpload(app.db, app.contentImages, app.config);
+
+  app.post(
+    "/admin/content-images/upload-url",
+    {
+      preHandler: [requireAnyContentManage],
+      schema: {
+        body: uploadUrlSchema,
+        response: { 200: uploadUrlResponseSchema },
+      },
+    },
+    async (request) => {
+      return await uploadUrl({ contentType: request.body.contentType });
+    },
+  );
+
+  app.post(
+    "/admin/content-images",
+    {
+      preHandler: [requireAnyContentManage],
+      schema: {
+        body: confirmUploadSchema,
+        response: { 200: contentImageResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await confirm({
+        imageId: request.body.imageId,
+        pendingKey: request.body.pendingKey,
+        alt: request.body.alt,
+        userId: user.id,
+      });
+    },
+  );
+};

--- a/apps/api/src/features/content-images/schemas.ts
+++ b/apps/api/src/features/content-images/schemas.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const CONTENT_IMAGE_CONTENT_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+] as const;
+
+// ── Upload URL ──────────────────────────────────────────────────────────
+
+export const uploadUrlSchema = z.object({
+  contentType: z.enum(CONTENT_IMAGE_CONTENT_TYPES),
+  /**
+   * The uploader must confirm photo consent (especially for juniors)
+   * before a presigned URL is ever issued; it is re-asserted and stored
+   * on the confirm call.
+   */
+  consentConfirmed: z.literal(true),
+});
+
+export const uploadUrlResponseSchema = z.object({
+  imageId: z.string(),
+  uploadUrl: z.string(),
+  pendingKey: z.string(),
+  maxBytes: z.number().int(),
+});
+
+// ── Confirm (process + register) ────────────────────────────────────────
+
+export const confirmUploadSchema = z.object({
+  imageId: z.uuid(),
+  pendingKey: z.string().min(1).max(500),
+  consentConfirmed: z.literal(true),
+  alt: z.string().min(1).max(500).nullish(),
+});
+
+/** Matches the frontend PictureSource shape consumed by OptimisedImage. */
+export const pictureSourceSchema = z.object({
+  sources: z.record(z.string(), z.string()),
+  img: z.object({
+    src: z.string(),
+    w: z.number().int(),
+    h: z.number().int(),
+  }),
+});
+
+export const contentImageResponseSchema = z.object({
+  id: z.string(),
+  picture: pictureSourceSchema,
+  alt: z.string().nullable(),
+  width: z.number().int(),
+  height: z.number().int(),
+});

--- a/apps/api/src/features/content-images/service.test.ts
+++ b/apps/api/src/features/content-images/service.test.ts
@@ -1,0 +1,193 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import sharp from "sharp";
+import { describe, expect, it, vi } from "vitest";
+import type { Config } from "../../config.ts";
+import type {
+  ContentImageStore,
+  PendingImageHead,
+} from "../../lib/s3-content-images.ts";
+import { confirmUpload, createUploadUrl, processImage } from "./service.ts";
+
+const config = {
+  CONTENT_IMAGE_PENDING_PREFIX: "content-images/pending",
+  CONTENT_IMAGES_PREFIX: "uploads/content",
+  CONTENT_IMAGE_MAX_BYTES: 10 * 1024 * 1024,
+  CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
+} as Config;
+
+function makeStore(
+  overrides: Partial<ContentImageStore> = {},
+): ContentImageStore {
+  return {
+    getSignedUploadUrl: vi.fn().mockResolvedValue({
+      uploadUrl: "https://s3.example/put?sig=1",
+      pendingKey: "content-images/pending/img-1.jpg",
+    }),
+    headPending: vi
+      .fn()
+      .mockResolvedValue({ contentLength: 100, contentType: "image/jpeg" }),
+    getPending: vi.fn(),
+    putVariant: vi.fn().mockResolvedValue(undefined),
+    deletePending: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+async function makeJpeg(width: number, height: number): Promise<Buffer> {
+  return await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 30, g: 120, b: 60 },
+    },
+  })
+    .jpeg()
+    .toBuffer();
+}
+
+describe("processImage", () => {
+  it("builds the full ladder for a large image", async () => {
+    const original = await makeJpeg(2400, 1600);
+    const result = await processImage(original, "img-1", "uploads/content");
+
+    const avifWidths = result.variants
+      .filter((v) => v.format === "avif")
+      .map((v) => v.width);
+    expect(avifWidths).toEqual([320, 640, 960, 1280, 1920]);
+    const webpWidths = result.variants
+      .filter((v) => v.format === "webp")
+      .map((v) => v.width);
+    expect(webpWidths).toEqual([320, 640, 960, 1280, 1920]);
+
+    // Fallback at the largest ladder width in the original format
+    const fallback = result.variants.find((v) => v.format === "jpeg");
+    expect(fallback?.width).toBe(1920);
+    expect(fallback?.key).toBe("uploads/content/img-1/1920.jpg");
+
+    expect(result.picture.img.src).toBe("/uploads/content/img-1/1920.jpg");
+    expect(result.picture.sources.avif).toContain(
+      "/uploads/content/img-1/320.avif 320w",
+    );
+    expect(result.width).toBe(2400);
+    expect(result.height).toBe(1600);
+  });
+
+  it("never upscales a small image", async () => {
+    const original = await makeJpeg(500, 400);
+    const result = await processImage(original, "img-2", "uploads/content");
+
+    const widths = result.variants.map((v) => v.width);
+    expect(Math.max(...widths)).toBeLessThanOrEqual(500);
+    expect(
+      result.variants.filter((v) => v.format === "avif").map((v) => v.width),
+    ).toEqual([320]);
+  });
+
+  it("rejects non-image bytes", async () => {
+    await expect(
+      processImage(Buffer.from("not an image"), "img-3", "uploads/content"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects decodable-but-unsupported formats", async () => {
+    const gif = Buffer.from(
+      "R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
+      "base64",
+    );
+    await expect(
+      processImage(gif, "img-4", "uploads/content"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});
+
+describe("createUploadUrl", () => {
+  it("issues a presigned URL with the size cap", async () => {
+    const store = makeStore();
+    const result = await createUploadUrl(
+      store,
+      config,
+    )({
+      contentType: "image/jpeg",
+    });
+    expect(result.uploadUrl).toContain("https://");
+    expect(result.maxBytes).toBe(config.CONTENT_IMAGE_MAX_BYTES);
+    expect(result.imageId).toMatch(/[0-9a-f-]{36}/);
+  });
+});
+
+describe("confirmUpload", () => {
+  const db = {} as Kysely<DB>;
+  const imageId = "5a0f9c4e-3b6f-4af3-9f30-3d6a52e3b111";
+
+  it("rejects a pendingKey that does not match the imageId", async () => {
+    const store = makeStore();
+    await expect(
+      confirmUpload(
+        db,
+        store,
+        config,
+      )({
+        imageId,
+        pendingKey: "content-images/pending/other-image.jpg",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects a pendingKey outside the pending prefix", async () => {
+    const store = makeStore();
+    await expect(
+      confirmUpload(
+        db,
+        store,
+        config,
+      )({
+        imageId,
+        pendingKey: `receipts/${imageId}.jpg`,
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("404s when the pending object is missing", async () => {
+    const store = makeStore({
+      headPending: vi.fn().mockResolvedValue(null),
+    });
+    await expect(
+      confirmUpload(
+        db,
+        store,
+        config,
+      )({
+        imageId,
+        pendingKey: `content-images/pending/${imageId}.jpg`,
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("rejects and deletes an oversized pending object", async () => {
+    const deletePending = vi.fn().mockResolvedValue(undefined);
+    const store = makeStore({
+      headPending: vi.fn().mockResolvedValue({
+        contentLength: config.CONTENT_IMAGE_MAX_BYTES + 1,
+        contentType: "image/jpeg",
+      } satisfies PendingImageHead),
+      deletePending,
+    });
+    await expect(
+      confirmUpload(
+        db,
+        store,
+        config,
+      )({
+        imageId,
+        pendingKey: `content-images/pending/${imageId}.jpg`,
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(deletePending).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/features/content-images/service.test.ts
+++ b/apps/api/src/features/content-images/service.test.ts
@@ -10,8 +10,6 @@ import type {
 import { confirmUpload, createUploadUrl, processImage } from "./service.ts";
 
 const config = {
-  CONTENT_IMAGE_PENDING_PREFIX: "content-images/pending",
-  CONTENT_IMAGES_PREFIX: "uploads/content",
   CONTENT_IMAGE_MAX_BYTES: 10 * 1024 * 1024,
   CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
 } as Config;

--- a/apps/api/src/features/content-images/service.ts
+++ b/apps/api/src/features/content-images/service.ts
@@ -2,7 +2,11 @@ import type { DB } from "@percy-main/db";
 import type { Kysely } from "kysely";
 import sharp from "sharp";
 import type { Config } from "../../config.ts";
-import type { ContentImageStore } from "../../lib/s3-content-images.ts";
+import {
+  CONTENT_IMAGE_PENDING_PREFIX,
+  CONTENT_IMAGES_PREFIX,
+  type ContentImageStore,
+} from "../../lib/s3-content-images.ts";
 
 function throwHttpError(statusCode: number, message: string): never {
   throw Object.assign(new Error(message), { statusCode });
@@ -218,37 +222,57 @@ export function confirmUpload(
     // The pending key must be one this feature issued: under our pending
     // prefix and named by the caller's imageId. Prevents pointing the
     // processor at arbitrary bucket objects.
-    const expectedPrefix = `${config.CONTENT_IMAGE_PENDING_PREFIX}/${params.imageId}.`;
+    const expectedPrefix = `${CONTENT_IMAGE_PENDING_PREFIX}/${params.imageId}.`;
     if (!params.pendingKey.startsWith(expectedPrefix)) {
       throwHttpError(400, "pendingKey does not match imageId");
     }
+
+    const tooLarge = async () => {
+      await store.deletePending(params.pendingKey);
+      throwHttpError(
+        400,
+        `Image is too large - maximum size is ${String(Math.floor(config.CONTENT_IMAGE_MAX_BYTES / (1024 * 1024)))}MB`,
+      );
+    };
 
     const head = await store.headPending(params.pendingKey);
     if (!head) {
       throwHttpError(404, "Uploaded file not found - upload may have expired");
     }
     if (head.contentLength > config.CONTENT_IMAGE_MAX_BYTES) {
-      await store.deletePending(params.pendingKey);
-      throwHttpError(
-        400,
-        `Image is too large - maximum size is ${String(Math.floor(config.CONTENT_IMAGE_MAX_BYTES / (1024 * 1024)))}MB`,
-      );
+      await tooLarge();
     }
 
     const original = await store.getPending(params.pendingKey);
-    const processed = await processImage(
-      original,
-      params.imageId,
-      config.CONTENT_IMAGES_PREFIX,
-    );
+    // Re-check actual bytes: a presigned URL can be reused between the
+    // HEAD and the GET, so the HEAD's content-length is advisory only.
+    if (original.byteLength > config.CONTENT_IMAGE_MAX_BYTES) {
+      await tooLarge();
+    }
+
+    let processed;
+    try {
+      processed = await processImage(
+        original,
+        params.imageId,
+        CONTENT_IMAGES_PREFIX,
+      );
+    } catch (err) {
+      // A 400 here is a verdict on the uploaded bytes (corrupt, GIF,
+      // HEIC...): the pending object is permanently useless, so clean it
+      // up now instead of waiting for lifecycle expiry.
+      if ((err as { statusCode?: number }).statusCode === 400) {
+        await store.deletePending(params.pendingKey);
+      }
+      throw err;
+    }
 
     for (const variant of processed.variants) {
       await store.putVariant(variant.key, variant.body, variant.contentType);
     }
-    await store.deletePending(params.pendingKey);
 
     const alt = params.alt ?? null;
-    const keyPrefix = `${config.CONTENT_IMAGES_PREFIX}/${params.imageId}`;
+    const keyPrefix = `${CONTENT_IMAGES_PREFIX}/${params.imageId}`;
 
     await db
       .insertInto("content_image")
@@ -265,6 +289,11 @@ export function confirmUpload(
         uploaded_by: params.userId,
       })
       .execute();
+
+    // Deleted last: if the row insert fails the original survives, so a
+    // retry of the confirm call can succeed (variant keys are
+    // deterministic and simply get overwritten).
+    await store.deletePending(params.pendingKey);
 
     return {
       id: params.imageId,

--- a/apps/api/src/features/content-images/service.ts
+++ b/apps/api/src/features/content-images/service.ts
@@ -1,0 +1,277 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import sharp from "sharp";
+import type { Config } from "../../config.ts";
+import type { ContentImageStore } from "../../lib/s3-content-images.ts";
+
+function throwHttpError(statusCode: number, message: string): never {
+  throw Object.assign(new Error(message), { statusCode });
+}
+
+/**
+ * Responsive ladder widths, matching what vite-imagetools generates for
+ * the static corpus. Widths larger than the source are skipped (no
+ * upscaling); the source width itself caps the largest variant.
+ */
+const LADDER_WIDTHS = [320, 640, 960, 1280, 1920] as const;
+
+/** Modern formats every image gets, in <picture> source order. */
+const MODERN_FORMATS = ["avif", "webp"] as const;
+
+/**
+ * Input formats sharp can decode here. HEIC is accepted at presign time
+ * (iPhones produce it) but the prebuilt sharp binaries cannot decode
+ * HEVC-compressed HEIC, so it fails at processing with a clear message
+ * rather than silently - most iOS browsers transcode to JPEG on upload
+ * anyway.
+ */
+const DECODABLE_FORMATS = new Set(["jpeg", "png", "webp"]);
+
+const FALLBACK_CONTENT_TYPES: Record<string, string> = {
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+const EXTENSIONS: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/heic": "heic",
+};
+
+export interface ProcessedVariant {
+  key: string;
+  format: string;
+  width: number;
+  height: number;
+  body: Buffer;
+  contentType: string;
+}
+
+export interface ProcessedImage {
+  variants: ProcessedVariant[];
+  picture: {
+    sources: Record<string, string>;
+    img: { src: string; w: number; h: number };
+  };
+  sourceFormat: string;
+  width: number;
+  height: number;
+}
+
+/**
+ * Decode + validate the original, then build the full responsive ladder:
+ * AVIF + WebP at each ladder width plus an original-format fallback at
+ * the largest width. EXIF/GPS and all other metadata are stripped by
+ * construction - sharp only carries metadata through when withMetadata()
+ * is called, which it never is here. Orientation is applied to pixels
+ * (rotate()) before the EXIF that described it is dropped.
+ */
+export async function processImage(
+  original: Buffer,
+  imageId: string,
+  publicPrefix: string,
+): Promise<ProcessedImage> {
+  let meta;
+  try {
+    meta = await sharp(original).metadata();
+  } catch {
+    throwHttpError(400, "File is not a decodable image");
+  }
+
+  const format = meta.format ?? "unknown";
+  if (!DECODABLE_FORMATS.has(format)) {
+    throwHttpError(
+      400,
+      format === "heif"
+        ? "HEIC images can't be processed here - please convert to JPEG and re-upload"
+        : `Unsupported image format '${format}' - use JPEG, PNG or WebP`,
+    );
+  }
+
+  // rotate() with no args applies the EXIF orientation to the pixels, so
+  // the stored variants render upright everywhere with no metadata.
+  const base = sharp(original).rotate();
+  const { width: sourceWidth, height: sourceHeight } = orientedDimensions(
+    meta.width ?? 0,
+    meta.height ?? 0,
+    meta.orientation,
+  );
+  if (sourceWidth === 0 || sourceHeight === 0) {
+    throwHttpError(400, "Image has no measurable dimensions");
+  }
+
+  const widths: number[] = LADDER_WIDTHS.filter((w) => w <= sourceWidth);
+  if (widths.length === 0) widths.push(Math.min(sourceWidth, 320));
+  const largest = widths[widths.length - 1] ?? sourceWidth;
+
+  const variants: ProcessedVariant[] = [];
+
+  for (const targetFormat of MODERN_FORMATS) {
+    for (const width of widths) {
+      const pipeline = base.clone().resize({ width, withoutEnlargement: true });
+      const encoded =
+        targetFormat === "avif"
+          ? pipeline.avif({ quality: 60 })
+          : pipeline.webp({ quality: 80 });
+      const { data, info } = await encoded.toBuffer({
+        resolveWithObject: true,
+      });
+      variants.push({
+        key: `${publicPrefix}/${imageId}/${String(width)}.${targetFormat}`,
+        format: targetFormat,
+        width: info.width,
+        height: info.height,
+        body: data,
+        contentType: `image/${targetFormat}`,
+      });
+    }
+  }
+
+  // Original-format fallback at the largest ladder width, for browsers
+  // that take the <img> src directly.
+  const fallback = await base
+    .clone()
+    .resize({ width: largest, withoutEnlargement: true })
+    .toFormat(format)
+    .toBuffer({ resolveWithObject: true });
+  const fallbackKey = `${publicPrefix}/${imageId}/${String(largest)}.${format === "jpeg" ? "jpg" : format}`;
+  variants.push({
+    key: fallbackKey,
+    format,
+    width: fallback.info.width,
+    height: fallback.info.height,
+    body: fallback.data,
+    contentType: FALLBACK_CONTENT_TYPES[format] ?? "application/octet-stream",
+  });
+
+  const sources: Record<string, string> = {};
+  for (const targetFormat of MODERN_FORMATS) {
+    sources[targetFormat] = variants
+      .filter((v) => v.format === targetFormat)
+      .map((v) => `/${v.key} ${String(v.width)}w`)
+      .join(", ");
+  }
+
+  return {
+    variants,
+    picture: {
+      sources,
+      img: {
+        src: `/${fallbackKey}`,
+        w: fallback.info.width,
+        h: fallback.info.height,
+      },
+    },
+    sourceFormat: format,
+    width: sourceWidth,
+    height: sourceHeight,
+  };
+}
+
+/** EXIF orientations 5-8 swap the visual width/height. */
+function orientedDimensions(
+  width: number,
+  height: number,
+  orientation: number | undefined,
+): { width: number; height: number } {
+  if (orientation !== undefined && orientation >= 5) {
+    return { width: height, height: width };
+  }
+  return { width, height };
+}
+
+// ── Upload URL ──────────────────────────────────────────────────────────
+
+export function createUploadUrl(store: ContentImageStore, config: Config) {
+  return async (params: { contentType: string }) => {
+    const imageId = crypto.randomUUID();
+    const extension = EXTENSIONS[params.contentType] ?? "bin";
+    const { uploadUrl, pendingKey } = await store.getSignedUploadUrl(
+      imageId,
+      extension,
+      params.contentType,
+    );
+    return {
+      imageId,
+      uploadUrl,
+      pendingKey,
+      maxBytes: config.CONTENT_IMAGE_MAX_BYTES,
+    };
+  };
+}
+
+// ── Confirm: process, write variants, register ──────────────────────────
+
+export function confirmUpload(
+  db: Kysely<DB>,
+  store: ContentImageStore,
+  config: Config,
+) {
+  return async (params: {
+    imageId: string;
+    pendingKey: string;
+    alt?: string | null;
+    userId: string;
+  }) => {
+    // The pending key must be one this feature issued: under our pending
+    // prefix and named by the caller's imageId. Prevents pointing the
+    // processor at arbitrary bucket objects.
+    const expectedPrefix = `${config.CONTENT_IMAGE_PENDING_PREFIX}/${params.imageId}.`;
+    if (!params.pendingKey.startsWith(expectedPrefix)) {
+      throwHttpError(400, "pendingKey does not match imageId");
+    }
+
+    const head = await store.headPending(params.pendingKey);
+    if (!head) {
+      throwHttpError(404, "Uploaded file not found - upload may have expired");
+    }
+    if (head.contentLength > config.CONTENT_IMAGE_MAX_BYTES) {
+      await store.deletePending(params.pendingKey);
+      throwHttpError(
+        400,
+        `Image is too large - maximum size is ${String(Math.floor(config.CONTENT_IMAGE_MAX_BYTES / (1024 * 1024)))}MB`,
+      );
+    }
+
+    const original = await store.getPending(params.pendingKey);
+    const processed = await processImage(
+      original,
+      params.imageId,
+      config.CONTENT_IMAGES_PREFIX,
+    );
+
+    for (const variant of processed.variants) {
+      await store.putVariant(variant.key, variant.body, variant.contentType);
+    }
+    await store.deletePending(params.pendingKey);
+
+    const alt = params.alt ?? null;
+    const keyPrefix = `${config.CONTENT_IMAGES_PREFIX}/${params.imageId}`;
+
+    await db
+      .insertInto("content_image")
+      .values({
+        id: params.imageId,
+        key_prefix: keyPrefix,
+        original_format: processed.sourceFormat,
+        width: processed.width,
+        height: processed.height,
+        bytes: original.byteLength,
+        picture: JSON.stringify(processed.picture),
+        alt,
+        consent_confirmed: true,
+        uploaded_by: params.userId,
+      })
+      .execute();
+
+    return {
+      id: params.imageId,
+      picture: processed.picture,
+      alt,
+      width: processed.width,
+      height: processed.height,
+    };
+  };
+}

--- a/apps/api/src/lib/s3-content-images.ts
+++ b/apps/api/src/lib/s3-content-images.ts
@@ -8,6 +8,16 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import type { Config } from "../config.ts";
 
+/**
+ * Key prefixes are structural, not configuration: pending must stay
+ * outside CloudFront's /uploads/* routing (so unprocessed originals are
+ * never publicly served) and must match the Terraform lifecycle rule
+ * that expires it (infra/modules/cdn/main.tf, expire-pending-content-images);
+ * public must stay inside /uploads/* to be served at all.
+ */
+export const CONTENT_IMAGE_PENDING_PREFIX = "content-images/pending";
+export const CONTENT_IMAGES_PREFIX = "uploads/content";
+
 export interface PendingImageHead {
   contentLength: number;
   contentType: string | null;
@@ -50,7 +60,7 @@ export function createContentImageStore(config: Config): ContentImageStore {
 
   const client = new S3Client(clientOptions);
   const bucket = config.S3_BUCKET;
-  const pendingPrefix = config.CONTENT_IMAGE_PENDING_PREFIX;
+  const pendingPrefix = CONTENT_IMAGE_PENDING_PREFIX;
   const expirySeconds = config.CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS;
 
   return {

--- a/apps/api/src/lib/s3-content-images.ts
+++ b/apps/api/src/lib/s3-content-images.ts
@@ -1,0 +1,140 @@
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import type { Config } from "../config.ts";
+
+export interface PendingImageHead {
+  contentLength: number;
+  contentType: string | null;
+}
+
+/**
+ * Store for editor-uploaded content images. Everything lives in the
+ * CloudFront-served uploads bucket (S3_BUCKET): pending browser PUTs go
+ * under a prefix CloudFront does not route, processed variants go under
+ * uploads/content/* where they are served at /uploads/content/*.
+ */
+export interface ContentImageStore {
+  /** Pre-sign a PUT URL for browser-direct upload of the original. */
+  getSignedUploadUrl: (
+    imageId: string,
+    extension: string,
+    contentType: string,
+  ) => Promise<{ uploadUrl: string; pendingKey: string }>;
+
+  /** HEAD the pending object. Returns null if it does not exist. */
+  headPending: (pendingKey: string) => Promise<PendingImageHead | null>;
+
+  /** Download the pending original as a Buffer. */
+  getPending: (pendingKey: string) => Promise<Buffer>;
+
+  /** Write one processed variant under the public prefix. */
+  putVariant: (key: string, body: Buffer, contentType: string) => Promise<void>;
+
+  deletePending: (pendingKey: string) => Promise<void>;
+}
+
+export function createContentImageStore(config: Config): ContentImageStore {
+  const clientOptions: ConstructorParameters<typeof S3Client>[0] = {
+    region: config.S3_REGION,
+  };
+  if (config.S3_ENDPOINT) {
+    clientOptions.endpoint = config.S3_ENDPOINT;
+    clientOptions.forcePathStyle = true;
+  }
+
+  const client = new S3Client(clientOptions);
+  const bucket = config.S3_BUCKET;
+  const pendingPrefix = config.CONTENT_IMAGE_PENDING_PREFIX;
+  const expirySeconds = config.CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS;
+
+  return {
+    async getSignedUploadUrl(imageId, extension, contentType) {
+      const pendingKey = `${pendingPrefix}/${imageId}.${extension}`;
+      const command = new PutObjectCommand({
+        Bucket: bucket,
+        Key: pendingKey,
+        ContentType: contentType,
+      });
+      const uploadUrl = await getSignedUrl(client, command, {
+        expiresIn: expirySeconds,
+      });
+      return { uploadUrl, pendingKey };
+    },
+
+    async headPending(pendingKey) {
+      try {
+        const res = await client.send(
+          new HeadObjectCommand({ Bucket: bucket, Key: pendingKey }),
+        );
+        return {
+          contentLength: res.ContentLength ?? 0,
+          contentType: res.ContentType ?? null,
+        };
+      } catch (err) {
+        if (isNotFound(err)) return null;
+        throw err;
+      }
+    },
+
+    async getPending(pendingKey) {
+      const res = await client.send(
+        new GetObjectCommand({ Bucket: bucket, Key: pendingKey }),
+      );
+      if (!res.Body) {
+        throw new Error(`No body returned for pending key ${pendingKey}`);
+      }
+      const bytes = await res.Body.transformToByteArray();
+      return Buffer.from(bytes);
+    },
+
+    async putVariant(key, body, contentType) {
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: body,
+          ContentType: contentType,
+          // Variants are content-addressed by image id and never rewritten,
+          // so let CloudFront + browsers cache them indefinitely.
+          CacheControl: "public, max-age=31536000, immutable",
+        }),
+      );
+    },
+
+    async deletePending(pendingKey) {
+      await client.send(
+        new DeleteObjectCommand({ Bucket: bucket, Key: pendingKey }),
+      );
+    },
+  };
+}
+
+function isNotFound(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return e.name === "NotFound" || e.$metadata?.httpStatusCode === 404;
+}
+
+export const noopContentImageStore: ContentImageStore = {
+  getSignedUploadUrl() {
+    throw new Error("Content image store not configured in test");
+  },
+  headPending() {
+    throw new Error("Content image store not configured in test");
+  },
+  getPending() {
+    throw new Error("Content image store not configured in test");
+  },
+  putVariant() {
+    throw new Error("Content image store not configured in test");
+  },
+  deletePending() {
+    throw new Error("Content image store not configured in test");
+  },
+};

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13791,6 +13791,116 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content-images/upload-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        contentType: "image/jpeg" | "image/png" | "image/webp" | "image/heic";
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            imageId: string;
+                            uploadUrl: string;
+                            pendingKey: string;
+                            maxBytes: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content-images": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        imageId: string;
+                        pendingKey: string;
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                        alt?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            picture: {
+                                sources: {
+                                    [key: string]: string;
+                                };
+                                img: {
+                                    src: string;
+                                    w: number;
+                                    h: number;
+                                };
+                            };
+                            alt: string | null;
+                            width: number;
+                            height: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -24842,6 +24842,198 @@
           }
         }
       }
+    },
+    "/api/admin/content-images/upload-url": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contentType": {
+                    "type": "string",
+                    "enum": [
+                      "image/jpeg",
+                      "image/png",
+                      "image/webp",
+                      "image/heic"
+                    ]
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "contentType",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "imageId": {
+                      "type": "string"
+                    },
+                    "uploadUrl": {
+                      "type": "string"
+                    },
+                    "pendingKey": {
+                      "type": "string"
+                    },
+                    "maxBytes": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "imageId",
+                    "uploadUrl",
+                    "pendingKey",
+                    "maxBytes"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content-images": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "imageId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "pendingKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  },
+                  "alt": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "imageId",
+                  "pendingKey",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "picture": {
+                      "type": "object",
+                      "properties": {
+                        "sources": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "img": {
+                          "type": "object",
+                          "properties": {
+                            "src": {
+                              "type": "string"
+                            },
+                            "w": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "h": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "src",
+                            "w",
+                            "h"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "sources",
+                        "img"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "alt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "width": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "height": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "picture",
+                    "alt",
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13791,6 +13791,116 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content-images/upload-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        contentType: "image/jpeg" | "image/png" | "image/webp" | "image/heic";
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            imageId: string;
+                            uploadUrl: string;
+                            pendingKey: string;
+                            maxBytes: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content-images": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        imageId: string;
+                        pendingKey: string;
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                        alt?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            picture: {
+                                sources: {
+                                    [key: string]: string;
+                                };
+                                img: {
+                                    src: string;
+                                    w: number;
+                                    h: number;
+                                };
+                            };
+                            alt: string | null;
+                            width: number;
+                            height: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -24842,6 +24842,198 @@
           }
         }
       }
+    },
+    "/api/admin/content-images/upload-url": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contentType": {
+                    "type": "string",
+                    "enum": [
+                      "image/jpeg",
+                      "image/png",
+                      "image/webp",
+                      "image/heic"
+                    ]
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "contentType",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "imageId": {
+                      "type": "string"
+                    },
+                    "uploadUrl": {
+                      "type": "string"
+                    },
+                    "pendingKey": {
+                      "type": "string"
+                    },
+                    "maxBytes": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "imageId",
+                    "uploadUrl",
+                    "pendingKey",
+                    "maxBytes"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content-images": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "imageId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "pendingKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  },
+                  "alt": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "imageId",
+                  "pendingKey",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "picture": {
+                      "type": "object",
+                      "properties": {
+                        "sources": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "img": {
+                          "type": "object",
+                          "properties": {
+                            "src": {
+                              "type": "string"
+                            },
+                            "w": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "h": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "src",
+                            "w",
+                            "h"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "sources",
+                        "img"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "alt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "width": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "height": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "picture",
+                    "alt",
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/infra/modules/cdn/main.tf
+++ b/infra/modules/cdn/main.tf
@@ -195,6 +195,27 @@ resource "aws_s3_bucket_lifecycle_configuration" "uploads" {
       noncurrent_days = 30
     }
   }
+
+  # Browser-direct content-image uploads land here before the API
+  # processes them into uploads/content/*; anything the confirm step
+  # didn't consume (abandoned uploads) is junk after a day. Mirrors the
+  # 24h expiry the dedicated *-uploads buckets use.
+  rule {
+    id     = "expire-pending-content-images"
+    status = "Enabled"
+
+    filter {
+      prefix = "content-images/pending/"
+    }
+
+    expiration {
+      days = 1
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
 }
 
 resource "aws_s3_bucket_cors_configuration" "uploads" {

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -172,6 +172,20 @@ export interface ContactSubmission {
   page: string;
 }
 
+export interface ContentImage {
+  alt: string | null;
+  bytes: number;
+  consent_confirmed: boolean;
+  created_at: Generated<Timestamp>;
+  height: number;
+  id: Generated<string>;
+  key_prefix: string;
+  original_format: string;
+  picture: Json;
+  uploaded_by: string;
+  width: number;
+}
+
 export interface ContentItem {
   body: Json;
   created_at: Generated<Timestamp>;
@@ -1022,6 +1036,7 @@ export interface DB {
   charge: Charge;
   charge_dependent: ChargeDependent;
   contact_submission: ContactSubmission;
+  content_image: ContentImage;
   content_item: ContentItem;
   content_revision: ContentRevision;
   dependent: Dependent;

--- a/packages/db/src/migrations/2026-06-10T14:37:22.573Z.ts
+++ b/packages/db/src/migrations/2026-06-10T14:37:22.573Z.ts
@@ -1,0 +1,41 @@
+import { type Kysely, sql } from "kysely";
+
+// Editor-uploaded content images (#485). One row per uploaded image; the
+// API generates the responsive variant ladder (AVIF/WebP at several
+// widths + an original-format fallback) into the public uploads bucket
+// and stores the PictureSource-shaped descriptor here. consent_confirmed
+// records that the uploader ticked the photo-consent checkbox (required,
+// particularly for juniors) - kept for audit, not as a workflow gate.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("content_image")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("key_prefix", "text", (col) => col.notNull().unique())
+    .addColumn("original_format", "text", (col) => col.notNull())
+    .addColumn("width", "integer", (col) => col.notNull())
+    .addColumn("height", "integer", (col) => col.notNull())
+    .addColumn("bytes", "integer", (col) => col.notNull())
+    .addColumn("picture", "jsonb", (col) => col.notNull())
+    .addColumn("alt", "text")
+    .addColumn("consent_confirmed", "boolean", (col) => col.notNull())
+    .addColumn("uploaded_by", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("content_image_uploaded_by_idx")
+    .on("content_image")
+    .column("uploaded_by")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("content_image").execute();
+}


### PR DESCRIPTION
Part of epic #479. Closes #485.

## Flow

1. `POST /api/admin/content-images/upload-url` (consent checkbox required as `z.literal(true)` - the API physically can't issue a URL without it) -> presigned PUT into the existing CloudFront-served uploads bucket, under `content-images/pending/` which the CDN does **not** route.
2. Browser PUTs the original.
3. `POST /api/admin/content-images` (consent re-asserted + stored) -> sharp pipeline -> variants written to `uploads/content/<id>/<width>.<format>` (public at `/uploads/content/...`, immutable cache headers) -> `content_image` row -> returns a PictureSource-shaped descriptor consumable by the existing `OptimisedImage`.

## Pipeline

- Full responsive ladder from the start (per issue decision): AVIF + WebP at 320/640/960/1280/1920 (no upscaling) + original-format fallback at the largest width.
- EXIF orientation applied to pixels, then **all** metadata stripped by construction (sharp only carries metadata through `withMetadata()`, never called). Integration test uploads a GPS+camera-EXIF-tagged fixture and asserts zero EXIF in every variant.
- Decode-validates JPEG/PNG/WebP. HEIC is accepted at presign (iPhones produce it; iOS browsers usually transcode on upload) but prebuilt sharp can't decode HEVC, so it fails processing with a clear convert-to-JPEG message rather than a crash.
- `pendingKey` must match the caller's `imageId` under our pending prefix - the processor can't be aimed at arbitrary bucket objects.
- Routes gated on manage permission for **any** content resource (image library is shared across kinds).

## Infra / config

- Terraform: additive lifecycle rule expiring `content-images/pending/` after 1 day (mirrors the dedicated *-uploads buckets). No conditional count/for_each. Bucket CORS already allows PUT; ECS task already has Put/Get/Delete on this bucket.
- No new required env vars - reuses `S3_BUCKET`; tunables have defaults per the existing SCOUT_* precedent.
- sharp was already an API dependency (OG images) and runs on the current alpine image.

9 unit + 1 integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)