### PR TITLE
feat(web): admin Content section - list, BlockNote editor, preview, publish (#486)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,9 @@
   "dependencies": {
     "@ai-sdk/react": "3.0.199",
     "@better-auth/passkey": "^1.6.14",
+    "@blocknote/core": "^0.47.2",
+    "@blocknote/react": "^0.47.2",
+    "@blocknote/shadcn": "^0.47.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -206,4 +206,50 @@ describe("ContentBody", () => {
     ]);
     expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
   });
+
+  it("renders contentImage blocks responsively from the picture descriptor", () => {
+    const picture = {
+      sources: {
+        avif: "/uploads/content/img-1/320.avif 320w, /uploads/content/img-1/640.avif 640w",
+        webp: "/uploads/content/img-1/320.webp 320w, /uploads/content/img-1/640.webp 640w",
+      },
+      img: { src: "/uploads/content/img-1/640.jpg", w: 640, h: 480 },
+    };
+    const html = renderBody([
+      block("contentImage", {
+        props: {
+          src: "/uploads/content/img-1/640.jpg",
+          alt: "The winning six",
+          caption: "Scenes",
+          picture: JSON.stringify(picture),
+        },
+      }),
+    ]);
+    expect(html).toContain("<picture>");
+    expect(html).toContain('type="image/avif"');
+    expect(html).toContain('src="/uploads/content/img-1/640.jpg"');
+    expect(html).toContain("Scenes");
+  });
+
+  it("rejects contentImage descriptors with unsafe urls", () => {
+    const picture = {
+      sources: {
+        avif: "javascript:alert(1) 320w",
+      },
+      img: { src: "/uploads/content/img-1/640.jpg", w: 640, h: 480 },
+    };
+    const html = renderBody([
+      block("contentImage", {
+        props: {
+          src: "/uploads/content/img-1/640.jpg",
+          alt: "x",
+          caption: "",
+          picture: JSON.stringify(picture),
+        },
+      }),
+    ]);
+    expect(html).not.toContain("javascript:");
+    // Falls back to the plain (safe) src
+    expect(html).toContain('src="/uploads/content/img-1/640.jpg"');
+  });
 });

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -1,4 +1,8 @@
 import { mdxComponents } from "@/components/mdx-components.js";
+import {
+  OptimisedImage,
+  type PictureSource,
+} from "@/components/optimised-image.js";
 import { cn } from "@/lib/utils.js";
 import {
   contentBodySchema,
@@ -135,6 +139,53 @@ function alignClass(block: ContentBlock): string | undefined {
 function stringProp(block: ContentBlock, name: string): string | undefined {
   const value = block.props[name];
   return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/**
+ * Parse a JSON-stringified PictureSource, rejecting anything whose URLs
+ * fail the image-source check (the descriptor is stored content too).
+ */
+function parsePicture(raw: string | undefined): PictureSource | undefined {
+  if (!raw) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const candidate = parsed as {
+    sources?: unknown;
+    img?: { src?: unknown; w?: unknown; h?: unknown };
+  };
+  if (
+    typeof candidate.img?.src !== "string" ||
+    !isSafeImageSrc(candidate.img.src) ||
+    typeof candidate.img.w !== "number" ||
+    typeof candidate.img.h !== "number" ||
+    typeof candidate.sources !== "object" ||
+    candidate.sources === null
+  ) {
+    return undefined;
+  }
+  const sources: Record<string, string> = {};
+  for (const [format, srcset] of Object.entries(candidate.sources)) {
+    if (typeof srcset !== "string") return undefined;
+    // Every URL in the srcset must individually be a safe image source.
+    const urls = srcset.split(",").map((part) => part.trim().split(/\s+/)[0]);
+    if (!urls.every((u) => u !== undefined && isSafeImageSrc(u))) {
+      return undefined;
+    }
+    sources[format] = srcset;
+  }
+  return {
+    sources,
+    img: {
+      src: candidate.img.src,
+      w: candidate.img.w,
+      h: candidate.img.h,
+    },
+  };
 }
 
 /** Nested children of a non-list block render indented beneath it. */
@@ -294,6 +345,35 @@ function BlockView({ block }: { block: ContentBlock }) {
       const when = stringProp(block, "when");
       if (!id || !name || !when) return null;
       return <mdxComponents.EventPreview id={id} name={name} when={when} />;
+    }
+
+    case CUSTOM_BLOCK_TYPES.contentImage: {
+      const src = stringProp(block, "src");
+      const alt = stringProp(block, "alt") ?? "";
+      const caption = stringProp(block, "caption");
+      // props.picture is the JSON-stringified PictureSource descriptor
+      // produced by the upload pipeline; with it we render the full
+      // responsive ladder, without it we fall back to the plain src.
+      const picture = parsePicture(stringProp(block, "picture"));
+      if (picture) {
+        return (
+          <figure className="my-4 max-w-lg self-center">
+            <OptimisedImage
+              picture={picture}
+              alt={alt}
+              className="h-auto max-w-full rounded-lg"
+              sizes="(max-width: 512px) 100vw, 512px"
+            />
+            {caption && (
+              <figcaption className="mt-2 text-sm text-stone-600">
+                {caption}
+              </figcaption>
+            )}
+          </figure>
+        );
+      }
+      if (!src || !isSafeImageSrc(src)) return null;
+      return <mdxComponents.Image src={src} alt={alt} caption={caption} />;
     }
 
     default:

--- a/apps/web/src/lib/content-images.ts
+++ b/apps/web/src/lib/content-images.ts
@@ -1,0 +1,75 @@
+import type { PictureSource } from "@/components/optimised-image.js";
+import { api, callApi } from "@/lib/api-client.js";
+
+const UPLOADABLE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+] as const;
+
+type UploadableType = (typeof UPLOADABLE_TYPES)[number];
+
+function isUploadableType(type: string): type is UploadableType {
+  return (UPLOADABLE_TYPES as readonly string[]).includes(type);
+}
+
+export interface UploadedContentImage {
+  id: string;
+  picture: PictureSource;
+  alt: string | null;
+  width: number;
+  height: number;
+}
+
+/**
+ * Full presigned upload flow for an editor image: presign -> browser PUT
+ * of the original -> confirm (API decodes, strips EXIF, builds the
+ * responsive ladder). The caller is responsible for having collected
+ * photo consent; the API additionally refuses both steps without it.
+ */
+export async function uploadContentImage(
+  file: File,
+  options: { alt?: string },
+): Promise<UploadedContentImage> {
+  const contentType = file.type;
+  if (!isUploadableType(contentType)) {
+    throw new Error("Use a JPEG, PNG or WebP image");
+  }
+
+  const presigned = await callApi(
+    api.POST("/api/admin/content-images/upload-url", {
+      body: { contentType, consentConfirmed: true },
+    }),
+  );
+
+  if (file.size > presigned.maxBytes) {
+    throw new Error(
+      `Image is too large - maximum size is ${String(Math.floor(presigned.maxBytes / (1024 * 1024)))}MB`,
+    );
+  }
+
+  // Browser-direct PUT to S3: the one place a raw fetch is correct, the
+  // target is the presigned S3 URL rather than our API.
+  const putRes = await fetch(presigned.uploadUrl, {
+    method: "PUT",
+    body: file,
+    headers: { "content-type": file.type },
+  });
+  if (!putRes.ok) {
+    throw new Error("Upload failed - please try again");
+  }
+
+  const confirmed = await callApi(
+    api.POST("/api/admin/content-images", {
+      body: {
+        imageId: presigned.imageId,
+        pendingKey: presigned.pendingKey,
+        consentConfirmed: true,
+        alt: options.alt ?? null,
+      },
+    }),
+  );
+
+  return confirmed;
+}

--- a/apps/web/src/lib/content-images.ts
+++ b/apps/web/src/lib/content-images.ts
@@ -1,5 +1,5 @@
-import type { PictureSource } from "@/components/optimised-image.js";
 import { api, callApi } from "@/lib/api-client.js";
+import type { paths } from "@/lib/api.gen.js";
 
 const UPLOADABLE_TYPES = [
   "image/jpeg",
@@ -14,13 +14,10 @@ function isUploadableType(type: string): type is UploadableType {
   return (UPLOADABLE_TYPES as readonly string[]).includes(type);
 }
 
-export interface UploadedContentImage {
-  id: string;
-  picture: PictureSource;
-  alt: string | null;
-  width: number;
-  height: number;
-}
+// Derived from the generated OpenAPI types per house rule; structurally
+// identical to the OptimisedImage PictureSource shape.
+export type UploadedContentImage =
+  paths["/api/admin/content-images"]["post"]["responses"][200]["content"]["application/json"];
 
 /**
  * Full presigned upload flow for an editor image: presign -> browser PUT

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -6,6 +6,7 @@ import { Link, useSearchParams } from "react-router";
 import { AccessTab } from "./access-tab";
 import { ChargesTab } from "./charges-tab";
 import { ContactsTab } from "./contacts-tab";
+import { ContentTab } from "./content-tab";
 import { DocumentsTab } from "./documents-tab";
 import { DuplicatesTab } from "./duplicates-tab";
 import { ExpenseHistoryTab } from "./expense-history-tab";
@@ -159,6 +160,18 @@ const SECTIONS: readonly SectionDef[] = [
         label: "Fantasy",
         visible: (role) => checkPermission(role, "fantasy", "manage"),
         render: () => <FantasyTab />,
+      },
+    ],
+  },
+  {
+    value: "content",
+    label: "Content",
+    subTabs: [
+      {
+        value: "game-reports",
+        label: "Match Reports",
+        visible: (role) => checkPermission(role, "content_reports", "view"),
+        render: () => <ContentTab kind="game_report" />,
       },
     ],
   },

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -44,10 +44,13 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs.js";
 import { Textarea } from "@/components/ui/textarea.js";
+import { useHasPermission } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client.js";
+import type { paths } from "@/lib/api.gen.js";
 import { uploadContentImage } from "@/lib/content-images.js";
 import { getAllPeople } from "@/lib/people.js";
 import {
+  CONTENT_KIND_RESOURCES,
   contentBodySchema,
   CUSTOM_BLOCK_TYPES,
   type ContentKind,
@@ -210,11 +213,30 @@ const eventPreviewBlock = createReactBlockSpec(
 
 function parsePictureProp(raw: string): PictureSource | null {
   if (!raw) return null;
+  let parsed: unknown;
   try {
-    return JSON.parse(raw) as PictureSource;
+    parsed = JSON.parse(raw);
   } catch {
     return null;
   }
+  // Same structural floor as the public renderer: enough shape that
+  // OptimisedImage cannot crash on a malformed stored descriptor.
+  const candidate = parsed as {
+    sources?: unknown;
+    img?: { src?: unknown; w?: unknown; h?: unknown };
+  };
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    typeof candidate.img?.src !== "string" ||
+    typeof candidate.img.w !== "number" ||
+    typeof candidate.img.h !== "number" ||
+    typeof candidate.sources !== "object" ||
+    candidate.sources === null
+  ) {
+    return null;
+  }
+  return candidate as PictureSource;
 }
 
 const contentImageBlock = createReactBlockSpec(
@@ -354,7 +376,11 @@ export default function ContentEditor({
   onClose,
   onCreated,
 }: EditorProps) {
-  const { data: item, isLoading } = useQuery({
+  const {
+    data: item,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ["admin", "content", "detail", contentId],
     queryFn: () =>
       callApi(
@@ -364,6 +390,19 @@ export default function ContentEditor({
       ),
     enabled: contentId !== null,
   });
+
+  if (contentId !== null && error) {
+    return (
+      <div className="flex flex-col items-start gap-2 py-8">
+        <p className="text-sm text-red-600">
+          Couldn't load this item - {error.message}
+        </p>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          ← Back to list
+        </Button>
+      </div>
+    );
+  }
 
   if (contentId !== null && (isLoading || !item)) {
     return <p className="py-8 text-sm text-stone-500">Loading…</p>;
@@ -380,17 +419,10 @@ export default function ContentEditor({
   );
 }
 
-interface ContentItemDetail {
-  id: string;
-  slug: string;
-  title: string;
-  description: string | null;
-  status: string;
-  metadata: Record<string, unknown>;
-  publishedAt: string | null;
-  updatedAt: string;
-  body: unknown;
-}
+// Derived from the generated OpenAPI types per house rule - never a
+// hand-written response interface.
+type ContentItemDetail =
+  paths["/api/admin/content/{contentId}"]["get"]["responses"][200]["content"]["application/json"];
 
 interface FormState {
   title: string;
@@ -466,7 +498,15 @@ function MetadataFields({
   );
 }
 
-function PublishingCard({ item }: { item: ContentItemDetail }) {
+function PublishingCard({
+  item,
+  canPublish,
+  canManage,
+}: {
+  item: ContentItemDetail;
+  canPublish: boolean;
+  canManage: boolean;
+}) {
   const queryClient = useQueryClient();
   const [publishAt, setPublishAt] = useState("");
 
@@ -511,32 +551,36 @@ function PublishingCard({ item }: { item: ContentItemDetail }) {
           {item.publishedAt &&
             ` · live from ${new Date(item.publishedAt).toLocaleString("en-GB")}`}
         </p>
-        {item.status !== "archived" && (
+        {item.status !== "archived" && (canPublish || canManage) && (
           <>
-            <div className="flex flex-col gap-1">
-              <Label htmlFor="publish-at">
-                Schedule (leave empty to publish now)
-              </Label>
-              <Input
-                id="publish-at"
-                type="datetime-local"
-                value={publishAt}
-                onChange={(e) => {
-                  setPublishAt(e.target.value);
-                }}
-              />
-            </div>
+            {canPublish && (
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="publish-at">
+                  Schedule (leave empty to publish now)
+                </Label>
+                <Input
+                  id="publish-at"
+                  type="datetime-local"
+                  value={publishAt}
+                  onChange={(e) => {
+                    setPublishAt(e.target.value);
+                  }}
+                />
+              </div>
+            )}
             <div className="flex flex-wrap gap-2">
-              <Button
-                size="sm"
-                disabled={statusMutation.isPending}
-                onClick={() => {
-                  statusMutation.mutate("publish");
-                }}
-              >
-                {publishAt ? "Schedule" : "Publish"}
-              </Button>
-              {item.status === "published" && (
+              {canPublish && (
+                <Button
+                  size="sm"
+                  disabled={statusMutation.isPending}
+                  onClick={() => {
+                    statusMutation.mutate("publish");
+                  }}
+                >
+                  {publishAt ? "Schedule" : "Publish"}
+                </Button>
+              )}
+              {canPublish && item.status === "published" && (
                 <Button
                   size="sm"
                   variant="outline"
@@ -548,16 +592,18 @@ function PublishingCard({ item }: { item: ContentItemDetail }) {
                   Unpublish
                 </Button>
               )}
-              <Button
-                size="sm"
-                variant="destructive"
-                disabled={statusMutation.isPending}
-                onClick={() => {
-                  statusMutation.mutate("archive");
-                }}
-              >
-                Archive
-              </Button>
+              {canManage && (
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  disabled={statusMutation.isPending}
+                  onClick={() => {
+                    statusMutation.mutate("archive");
+                  }}
+                >
+                  Archive
+                </Button>
+              )}
             </div>
           </>
         )}
@@ -663,6 +709,14 @@ function LoadedEditor({
   onCreated: (id: string) => void;
 }) {
   const queryClient = useQueryClient();
+  const { allowed: canManage } = useHasPermission(
+    CONTENT_KIND_RESOURCES[kind],
+    "manage",
+  );
+  const { allowed: canPublish } = useHasPermission(
+    CONTENT_KIND_RESOURCES[kind],
+    "publish",
+  );
 
   const [form, setForm] = useState<FormState>({
     title: item?.title ?? "",
@@ -857,18 +911,20 @@ function LoadedEditor({
               })}
             </span>
           )}
-          <Button
-            onClick={() => {
-              saveMutation.mutate();
-            }}
-            disabled={saveMutation.isPending || !form.title || !form.slug}
-          >
-            {saveMutation.isPending
-              ? "Saving…"
-              : item === null
-                ? "Create draft"
-                : "Save"}
-          </Button>
+          {canManage && (
+            <Button
+              onClick={() => {
+                saveMutation.mutate();
+              }}
+              disabled={saveMutation.isPending || !form.title || !form.slug}
+            >
+              {saveMutation.isPending
+                ? "Saving…"
+                : item === null
+                  ? "Create draft"
+                  : "Save"}
+            </Button>
+          )}
         </div>
       </div>
 
@@ -888,7 +944,13 @@ function LoadedEditor({
             slugLocked={slugLocked}
             onChange={onFormChange}
           />
-          {item !== null && <PublishingCard item={item} />}
+          {item !== null && (
+            <PublishingCard
+              item={item}
+              canPublish={canPublish}
+              canManage={canManage}
+            />
+          )}
           <ConsentBox
             checked={consentConfirmed}
             onChange={setConsentConfirmed}

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -1,0 +1,909 @@
+import {
+  BlockNoteSchema,
+  defaultBlockSpecs,
+  filterSuggestionItems,
+  insertOrUpdateBlockForSlashMenu,
+} from "@blocknote/core";
+import "@blocknote/core/fonts/inter.css";
+import {
+  createReactBlockSpec,
+  getDefaultReactSlashMenuItems,
+  SuggestionMenuController,
+  useCreateBlockNote,
+} from "@blocknote/react";
+import { BlockNoteView } from "@blocknote/shadcn";
+import "@blocknote/shadcn/style.css";
+
+import { ContentBody } from "@/components/content-body.js";
+import { mdxComponents } from "@/components/mdx-components.js";
+import {
+  OptimisedImage,
+  type PictureSource,
+} from "@/components/optimised-image.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { Checkbox } from "@/components/ui/checkbox.js";
+import { Input } from "@/components/ui/input.js";
+import { Label } from "@/components/ui/label.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select.js";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs.js";
+import { Textarea } from "@/components/ui/textarea.js";
+import { api, callApi } from "@/lib/api-client.js";
+import { uploadContentImage } from "@/lib/content-images.js";
+import { getAllPeople } from "@/lib/people.js";
+import {
+  contentBodySchema,
+  CUSTOM_BLOCK_TYPES,
+  type ContentKind,
+} from "@percy-main/shared/content";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+
+// ── Custom blocks ───────────────────────────────────────────────────────
+//
+// Type names come from shared CUSTOM_BLOCK_TYPES so the public renderer
+// maps them 1:1. Each block renders the real public component read-only
+// in-editor, with minimal prop controls underneath.
+
+const personBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.person,
+    propSchema: {
+      slug: { default: "" },
+      role: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => (
+      <div className="my-2 flex w-full max-w-xs flex-col gap-2">
+        {block.props.slug ? (
+          <mdxComponents.Person
+            slug={block.props.slug}
+            role={block.props.role || undefined}
+          />
+        ) : (
+          <p className="text-sm text-stone-500">Choose a person…</p>
+        )}
+        <select
+          aria-label="Person"
+          value={block.props.slug}
+          onChange={(e) => {
+            editor.updateBlock(block, {
+              props: { ...block.props, slug: e.target.value },
+            });
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        >
+          <option value="">Choose a person…</option>
+          {getAllPeople().map((p) => (
+            <option key={p.slug} value={p.slug}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <input
+          aria-label="Role shown on the card"
+          placeholder="Role (optional)"
+          value={block.props.role}
+          onChange={(e) => {
+            editor.updateBlock(block, {
+              props: { ...block.props, role: e.target.value },
+            });
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        />
+      </div>
+    ),
+  },
+);
+
+const gamePreviewBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.gamePreview,
+    propSchema: {
+      playCricketId: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => (
+      <div className="my-2 w-full">
+        {block.props.playCricketId ? (
+          <mdxComponents.GamePreview
+            playCricketId={block.props.playCricketId}
+          />
+        ) : (
+          <p className="text-sm text-stone-500">Choose a game…</p>
+        )}
+        <GameSelect
+          value={block.props.playCricketId}
+          onChange={(id) => {
+            editor.updateBlock(block, {
+              props: { ...block.props, playCricketId: id },
+            });
+          }}
+        />
+      </div>
+    ),
+  },
+);
+
+const eventPreviewBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.eventPreview,
+    propSchema: {
+      eventId: { default: "" },
+      name: { default: "" },
+      when: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const complete =
+        block.props.eventId && block.props.name && block.props.when;
+      const set = (key: "eventId" | "name" | "when", value: string) => {
+        editor.updateBlock(block, {
+          props: { ...block.props, [key]: value },
+        });
+      };
+      return (
+        <div className="my-2 flex w-full max-w-sm flex-col gap-2">
+          {complete ? (
+            <mdxComponents.EventPreview
+              id={block.props.eventId}
+              name={block.props.name}
+              when={block.props.when}
+            />
+          ) : (
+            <p className="text-sm text-stone-500">Fill in the event details…</p>
+          )}
+          <input
+            aria-label="Event id"
+            placeholder="Event id"
+            value={block.props.eventId}
+            onChange={(e) => {
+              set("eventId", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Event name"
+            placeholder="Event name"
+            value={block.props.name}
+            onChange={(e) => {
+              set("name", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Event date"
+            type="date"
+            value={block.props.when}
+            onChange={(e) => {
+              set("when", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+        </div>
+      );
+    },
+  },
+);
+
+function parsePictureProp(raw: string): PictureSource | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as PictureSource;
+  } catch {
+    return null;
+  }
+}
+
+const contentImageBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.contentImage,
+    propSchema: {
+      src: { default: "" },
+      alt: { default: "" },
+      caption: { default: "" },
+      picture: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const picture = parsePictureProp(block.props.picture);
+      return (
+        <figure className="my-2 flex w-full max-w-lg flex-col gap-2">
+          {picture ? (
+            <OptimisedImage
+              picture={picture}
+              alt={block.props.alt}
+              className="h-auto max-w-full rounded-lg"
+              sizes="(max-width: 512px) 100vw, 512px"
+            />
+          ) : block.props.src ? (
+            <img
+              src={block.props.src}
+              alt={block.props.alt}
+              className="h-auto max-w-full rounded-lg"
+            />
+          ) : (
+            <p className="text-sm text-stone-500">Image uploading…</p>
+          )}
+          <input
+            aria-label="Caption"
+            placeholder="Caption (optional)"
+            value={block.props.caption}
+            onChange={(e) => {
+              editor.updateBlock(block, {
+                props: { ...block.props, caption: e.target.value },
+              });
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Alt text for screen readers"
+            placeholder="Describe the photo (alt text)"
+            value={block.props.alt}
+            onChange={(e) => {
+              editor.updateBlock(block, {
+                props: { ...block.props, alt: e.target.value },
+              });
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+        </figure>
+      );
+    },
+  },
+);
+
+// BlockNote's built-in media blocks are removed: their URL-embed tab
+// would bypass the consent + EXIF-strip + responsive pipeline that the
+// contentImage block (slash menu "Upload photo") goes through.
+const {
+  image: _image,
+  video: _video,
+  audio: _audio,
+  file: _file,
+  ...allowedDefaultBlocks
+} = defaultBlockSpecs;
+
+const schema = BlockNoteSchema.create({
+  blockSpecs: {
+    ...allowedDefaultBlocks,
+    [CUSTOM_BLOCK_TYPES.person]: personBlock(),
+    [CUSTOM_BLOCK_TYPES.gamePreview]: gamePreviewBlock(),
+    [CUSTOM_BLOCK_TYPES.eventPreview]: eventPreviewBlock(),
+    [CUSTOM_BLOCK_TYPES.contentImage]: contentImageBlock(),
+  },
+});
+
+type Editor = typeof schema.BlockNoteEditor;
+type PartialBlock = typeof schema.PartialBlock;
+
+// ── Games picker (shared by metadata form + gamePreview block) ──────────
+
+function GameSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  const season = new Date().getFullYear();
+  const { data: games } = useQuery({
+    queryKey: ["games", season],
+    queryFn: () =>
+      callApi(api.GET("/api/games", { params: { query: { season } } })),
+  });
+
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder="Choose a game…" />
+      </SelectTrigger>
+      <SelectContent>
+        {(games ?? []).map((game) => (
+          <SelectItem key={game.id} value={game.id}>
+            {game.team.name} vs {game.opposition.club.name} · {game.matchDate}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+// ── Editor screen ───────────────────────────────────────────────────────
+
+const slugify = (title: string) =>
+  title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+interface EditorProps {
+  kind: ContentKind;
+  contentId: string | null;
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}
+
+export default function ContentEditor({
+  kind,
+  contentId,
+  onClose,
+  onCreated,
+}: EditorProps) {
+  const { data: item, isLoading } = useQuery({
+    queryKey: ["admin", "content", "detail", contentId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/content/{contentId}", {
+          params: { path: { contentId: contentId ?? "" } },
+        }),
+      ),
+    enabled: contentId !== null,
+  });
+
+  if (contentId !== null && (isLoading || !item)) {
+    return <p className="py-8 text-sm text-stone-500">Loading…</p>;
+  }
+
+  return (
+    <LoadedEditor
+      key={contentId ?? "new"}
+      kind={kind}
+      item={item ?? null}
+      onClose={onClose}
+      onCreated={onCreated}
+    />
+  );
+}
+
+interface ContentItemDetail {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  status: string;
+  metadata: Record<string, unknown>;
+  publishedAt: string | null;
+  updatedAt: string;
+  body: unknown;
+}
+
+interface FormState {
+  title: string;
+  slug: string;
+  description: string;
+  playCricketId: string;
+}
+
+function MetadataFields({
+  kind,
+  form,
+  slugLocked,
+  onChange,
+}: {
+  kind: ContentKind;
+  form: FormState;
+  slugLocked: boolean;
+  onChange: (updates: Partial<FormState>) => void;
+}) {
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="content-title">Title</Label>
+        <Input
+          id="content-title"
+          value={form.title}
+          onChange={(e) => {
+            onChange({ title: e.target.value });
+          }}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="content-slug">
+          Slug{slugLocked ? " (locked after publish)" : ""}
+        </Label>
+        <Input
+          id="content-slug"
+          value={form.slug}
+          disabled={slugLocked}
+          onChange={(e) => {
+            onChange({ slug: e.target.value });
+          }}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="content-description">Description (optional)</Label>
+        <Textarea
+          id="content-description"
+          rows={2}
+          value={form.description}
+          onChange={(e) => {
+            onChange({ description: e.target.value });
+          }}
+        />
+      </div>
+      {kind === "game_report" && (
+        <div className="flex flex-col gap-1">
+          <Label>Play-Cricket game</Label>
+          <GameSelect
+            value={form.playCricketId}
+            onChange={(playCricketId) => {
+              onChange({ playCricketId });
+            }}
+          />
+          {form.playCricketId && (
+            <span className="text-xs text-stone-500">
+              Match id: {form.playCricketId}
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+function PublishingCard({ item }: { item: ContentItemDetail }) {
+  const queryClient = useQueryClient();
+  const [publishAt, setPublishAt] = useState("");
+
+  const statusMutation = useMutation({
+    mutationFn: async (action: "publish" | "unpublish" | "archive") => {
+      if (action === "publish") {
+        await callApi(
+          api.POST("/api/admin/content/{contentId}/publish", {
+            params: { path: { contentId: item.id } },
+            body: publishAt
+              ? { publishedAt: new Date(publishAt).toISOString() }
+              : {},
+          }),
+        );
+      } else if (action === "unpublish") {
+        await callApi(
+          api.POST("/api/admin/content/{contentId}/unpublish", {
+            params: { path: { contentId: item.id } },
+          }),
+        );
+      } else {
+        await callApi(
+          api.POST("/api/admin/content/{contentId}/archive", {
+            params: { path: { contentId: item.id } },
+          }),
+        );
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Publishing</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        <p className="text-sm text-stone-600">
+          Status: <strong>{item.status}</strong>
+          {item.publishedAt &&
+            ` · live from ${new Date(item.publishedAt).toLocaleString("en-GB")}`}
+        </p>
+        {item.status !== "archived" && (
+          <>
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="publish-at">
+                Schedule (leave empty to publish now)
+              </Label>
+              <Input
+                id="publish-at"
+                type="datetime-local"
+                value={publishAt}
+                onChange={(e) => {
+                  setPublishAt(e.target.value);
+                }}
+              />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                disabled={statusMutation.isPending}
+                onClick={() => {
+                  statusMutation.mutate("publish");
+                }}
+              >
+                {publishAt ? "Schedule" : "Publish"}
+              </Button>
+              {item.status === "published" && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={statusMutation.isPending}
+                  onClick={() => {
+                    statusMutation.mutate("unpublish");
+                  }}
+                >
+                  Unpublish
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="destructive"
+                disabled={statusMutation.isPending}
+                onClick={() => {
+                  statusMutation.mutate("archive");
+                }}
+              >
+                Archive
+              </Button>
+            </div>
+          </>
+        )}
+        {statusMutation.error && (
+          <p className="text-sm text-red-600">
+            {statusMutation.error instanceof Error
+              ? statusMutation.error.message
+              : "Action failed"}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ConsentBox({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-stone-200 bg-stone-50 p-3">
+      <Checkbox
+        id="photo-consent"
+        checked={checked}
+        onCheckedChange={(value) => {
+          onChange(value === true);
+        }}
+      />
+      <Label
+        htmlFor="photo-consent"
+        className="text-xs leading-snug text-stone-700"
+      >
+        I confirm everyone identifiable in photos I upload has given consent for
+        publication on the club website - for under-18s, that means
+        parent/guardian consent.
+      </Label>
+    </div>
+  );
+}
+
+function EditorPane({
+  editor,
+  slashItems,
+  currentBody,
+}: {
+  editor: Editor;
+  slashItems: () => ReturnType<typeof getDefaultReactSlashMenuItems>;
+  currentBody: () => unknown;
+}) {
+  const [activeTab, setActiveTab] = useState("edit");
+  const [previewBlocks, setPreviewBlocks] = useState<unknown>([]);
+
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={(tab) => {
+        if (tab === "preview") setPreviewBlocks(currentBody());
+        setActiveTab(tab);
+      }}
+    >
+      <TabsList>
+        <TabsTrigger value="edit">Edit</TabsTrigger>
+        <TabsTrigger value="preview">Preview</TabsTrigger>
+      </TabsList>
+      <TabsContent value="edit">
+        <div className="rounded-lg border border-stone-200 bg-white py-4">
+          <BlockNoteView editor={editor} theme="light" slashMenu={false}>
+            <SuggestionMenuController
+              triggerCharacter="/"
+              getItems={(query) =>
+                Promise.resolve(
+                  filterSuggestionItems(
+                    [...slashItems(), ...getDefaultReactSlashMenuItems(editor)],
+                    query,
+                  ),
+                )
+              }
+            />
+          </BlockNoteView>
+        </div>
+      </TabsContent>
+      <TabsContent value="preview">
+        <div className="rounded-lg border border-stone-200 bg-white p-4">
+          <ContentBody body={previewBlocks} />
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function LoadedEditor({
+  kind,
+  item,
+  onClose,
+  onCreated,
+}: {
+  kind: ContentKind;
+  item: ContentItemDetail | null;
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const queryClient = useQueryClient();
+
+  const [form, setForm] = useState<FormState>({
+    title: item?.title ?? "",
+    slug: item?.slug ?? "",
+    description: item?.description ?? "",
+    playCricketId:
+      typeof item?.metadata.playCricketId === "string"
+        ? item.metadata.playCricketId
+        : "",
+  });
+  const [consentConfirmed, setConsentConfirmed] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(
+    item?.updatedAt ?? null,
+  );
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  // Whether the author has manually edited the slug (handler-only flag:
+  // it never affects what's on screen, only how title edits behave).
+  const slugTouchedRef = useRef(item !== null);
+
+  const slugLocked = item?.publishedAt != null;
+
+  const onFormChange = (updates: Partial<FormState>) => {
+    if (updates.slug !== undefined) slugTouchedRef.current = true;
+    setForm((prev) => {
+      const next = { ...prev, ...updates };
+      if (updates.title !== undefined && !slugTouchedRef.current) {
+        next.slug = slugify(updates.title);
+      }
+      return next;
+    });
+  };
+
+  const editor = useCreateBlockNote({
+    schema,
+    initialContent:
+      item && Array.isArray(item.body) && item.body.length > 0
+        ? (item.body as PartialBlock[])
+        : undefined,
+  });
+
+  const editorBody = () =>
+    contentBodySchema.parse(JSON.parse(JSON.stringify(editor.document)));
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const body = editorBody();
+      const metadata = { playCricketId: form.playCricketId };
+      if (item === null) {
+        return await callApi(
+          api.POST("/api/admin/content", {
+            body: {
+              kind,
+              slug: form.slug,
+              title: form.title,
+              description: form.description || null,
+              body,
+              metadata,
+            },
+          }),
+        );
+      }
+      return await callApi(
+        api.PUT("/api/admin/content/{contentId}", {
+          params: { path: { contentId: item.id } },
+          body: {
+            ...(slugLocked ? {} : { slug: form.slug }),
+            title: form.title,
+            description: form.description || null,
+            body,
+            metadata,
+          },
+        }),
+      );
+    },
+    onSuccess: (result) => {
+      setLastSavedAt(new Date().toISOString());
+      void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
+      if (item === null) onCreated(result.id);
+    },
+  });
+
+  const startImageUpload = () => {
+    setUploadError(null);
+    if (!consentConfirmed) {
+      setUploadError(
+        "Tick the photo consent box above before uploading images.",
+      );
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  const onFileChosen = async (file: File) => {
+    try {
+      const uploaded = await uploadContentImage(file, {});
+      const cursor = editor.getTextCursorPosition();
+      editor.insertBlocks(
+        [
+          {
+            type: CUSTOM_BLOCK_TYPES.contentImage,
+            props: {
+              src: uploaded.picture.img.src,
+              alt: "",
+              caption: "",
+              picture: JSON.stringify(uploaded.picture),
+            },
+          },
+        ],
+        cursor.block,
+        "after",
+      );
+    } catch (err) {
+      setUploadError(
+        err instanceof Error ? err.message : "Upload failed - try again",
+      );
+    }
+  };
+
+  const slashItems = () => [
+    {
+      title: "Person card",
+      subtext: "Embed a club member profile card",
+      group: "Club content",
+      aliases: ["person", "player", "profile"],
+      icon: <span aria-hidden>👤</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.person,
+        });
+      },
+    },
+    {
+      title: "Game preview",
+      subtext: "Link a Play-Cricket fixture or result",
+      group: "Club content",
+      aliases: ["game", "match", "fixture"],
+      icon: <span aria-hidden>🏏</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.gamePreview,
+        });
+      },
+    },
+    {
+      title: "Event preview",
+      subtext: "Link a calendar event",
+      group: "Club content",
+      aliases: ["event", "calendar"],
+      icon: <span aria-hidden>📅</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.eventPreview,
+        });
+      },
+    },
+    {
+      title: "Upload photo",
+      subtext: "Add an image (consent required)",
+      group: "Club content",
+      aliases: ["image", "photo", "picture"],
+      icon: <span aria-hidden>📷</span>,
+      onItemClick: startImageUpload,
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = "";
+          if (file) void onFileChosen(file);
+        }}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          ← Back to list
+        </Button>
+        <div className="flex items-center gap-3">
+          {lastSavedAt && (
+            <span className="text-xs text-stone-500">
+              Last saved{" "}
+              {new Date(lastSavedAt).toLocaleTimeString("en-GB", {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </span>
+          )}
+          <Button
+            onClick={() => {
+              saveMutation.mutate();
+            }}
+            disabled={saveMutation.isPending || !form.title || !form.slug}
+          >
+            {saveMutation.isPending
+              ? "Saving…"
+              : item === null
+                ? "Create draft"
+                : "Save"}
+          </Button>
+        </div>
+      </div>
+
+      {saveMutation.error && (
+        <p className="text-sm text-red-600">
+          {saveMutation.error instanceof Error
+            ? saveMutation.error.message
+            : "Save failed"}
+        </p>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-3 lg:col-span-1">
+          <MetadataFields
+            kind={kind}
+            form={form}
+            slugLocked={slugLocked}
+            onChange={onFormChange}
+          />
+          {item !== null && <PublishingCard item={item} />}
+          <ConsentBox
+            checked={consentConfirmed}
+            onChange={setConsentConfirmed}
+          />
+          {uploadError && <p className="text-sm text-red-600">{uploadError}</p>}
+        </div>
+
+        <div className="lg:col-span-2">
+          <EditorPane
+            editor={editor}
+            slashItems={slashItems}
+            currentBody={editorBody}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -16,8 +16,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useHasPermission } from "@/hooks/use-has-permission";
 import { api, callApi } from "@/lib/api-client";
-import type { ContentKind } from "@percy-main/shared/content";
+import {
+  CONTENT_KIND_RESOURCES,
+  CONTENT_STATUSES,
+  type ContentKind,
+  type ContentStatus,
+} from "@percy-main/shared/content";
 import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense } from "react";
 import { useSearchParams } from "react-router";
@@ -33,6 +39,9 @@ const STATUS_BADGES: Record<string, "default" | "secondary" | "outline"> = {
 };
 
 const PAGE_SIZE = 20;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function formatDateTime(iso: string): string {
   return new Date(iso).toLocaleString("en-GB", {
@@ -52,8 +61,24 @@ function formatDateTime(iso: string): string {
 export function ContentTab({ kind }: { kind: ContentKind }) {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const openItem = searchParams.get("item");
-  const status = searchParams.get("status") ?? "all";
+  const { allowed: canManage } = useHasPermission(
+    CONTENT_KIND_RESOURCES[kind],
+    "manage",
+  );
+
+  // URL state is user input: anything unexpected degrades to the default
+  // rather than reaching the typed API call.
+  const itemParam = searchParams.get("item");
+  const openItem =
+    itemParam === "new" || (itemParam !== null && UUID_RE.test(itemParam))
+      ? itemParam
+      : null;
+  const statusParam = searchParams.get("status");
+  const status: ContentStatus | "all" = (
+    CONTENT_STATUSES as readonly string[]
+  ).includes(statusParam ?? "")
+    ? (statusParam as ContentStatus)
+    : "all";
   const search = searchParams.get("q") ?? "";
   const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
 
@@ -66,7 +91,7 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
     setSearchParams(params, { replace: true });
   };
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ["admin", "content", kind, status, search, page],
     queryFn: () =>
       callApi(
@@ -74,9 +99,7 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
           params: {
             query: {
               kind,
-              ...(status !== "all"
-                ? { status: status as "draft" | "published" | "archived" }
-                : {}),
+              ...(status !== "all" ? { status } : {}),
               ...(search ? { search } : {}),
               page,
               pageSize: PAGE_SIZE,
@@ -141,16 +164,22 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
             </SelectContent>
           </Select>
         </div>
-        <Button
-          onClick={() => {
-            setParams({ item: "new" });
-          }}
-        >
-          New report
-        </Button>
+        {canManage && (
+          <Button
+            onClick={() => {
+              setParams({ item: "new" });
+            }}
+          >
+            New report
+          </Button>
+        )}
       </div>
 
-      {isLoading ? (
+      {error ? (
+        <p className="py-8 text-sm text-red-600">
+          Couldn't load content - {error.message}
+        </p>
+      ) : isLoading ? (
         <p className="py-8 text-sm text-stone-500">Loading…</p>
       ) : items.length === 0 ? (
         <p className="py-8 text-sm text-stone-500">

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -1,0 +1,222 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { api, callApi } from "@/lib/api-client";
+import type { ContentKind } from "@percy-main/shared/content";
+import { useQuery } from "@tanstack/react-query";
+import { lazy, Suspense } from "react";
+import { useSearchParams } from "react-router";
+
+// The editor pulls in BlockNote (the single heaviest dependency in the
+// admin panel), so it loads as its own chunk only when an item is open.
+const ContentEditor = lazy(() => import("./content-editor.js"));
+
+const STATUS_BADGES: Record<string, "default" | "secondary" | "outline"> = {
+  published: "default",
+  draft: "secondary",
+  archived: "outline",
+};
+
+const PAGE_SIZE = 20;
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Content list + editor for one content kind. All UI state (open item,
+ * status filter, search, page) lives in the URL alongside the admin
+ * panel's section/sub params, so deep links restore the full view.
+ */
+export function ContentTab({ kind }: { kind: ContentKind }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const openItem = searchParams.get("item");
+  const status = searchParams.get("status") ?? "all";
+  const search = searchParams.get("q") ?? "";
+  const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+
+  const setParams = (updates: Record<string, string | null>) => {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === null || value === "") params.delete(key);
+      else params.set(key, value);
+    }
+    setSearchParams(params, { replace: true });
+  };
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["admin", "content", kind, status, search, page],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/content", {
+          params: {
+            query: {
+              kind,
+              ...(status !== "all"
+                ? { status: status as "draft" | "published" | "archived" }
+                : {}),
+              ...(search ? { search } : {}),
+              page,
+              pageSize: PAGE_SIZE,
+            },
+          },
+        }),
+      ),
+    enabled: openItem === null,
+  });
+
+  if (openItem !== null) {
+    return (
+      <Suspense
+        fallback={
+          <p className="py-8 text-sm text-stone-500">Loading editor…</p>
+        }
+      >
+        <ContentEditor
+          kind={kind}
+          contentId={openItem === "new" ? null : openItem}
+          onClose={() => {
+            setParams({ item: null });
+          }}
+          onCreated={(id) => {
+            setParams({ item: id });
+          }}
+        />
+      </Suspense>
+    );
+  }
+
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            placeholder="Search titles…"
+            value={search}
+            onChange={(e) => {
+              setParams({ q: e.target.value, page: null });
+            }}
+            className="w-56"
+          />
+          <Select
+            value={status}
+            onValueChange={(value) => {
+              setParams({ status: value === "all" ? null : value, page: null });
+            }}
+          >
+            <SelectTrigger className="w-36">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All statuses</SelectItem>
+              <SelectItem value="draft">Draft</SelectItem>
+              <SelectItem value="published">Published</SelectItem>
+              <SelectItem value="archived">Archived</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Button
+          onClick={() => {
+            setParams({ item: "new" });
+          }}
+        >
+          New report
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <p className="py-8 text-sm text-stone-500">Loading…</p>
+      ) : items.length === 0 ? (
+        <p className="py-8 text-sm text-stone-500">
+          No content yet - create the first one.
+        </p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Title</TableHead>
+              <TableHead className="w-28">Status</TableHead>
+              <TableHead className="w-56">Last updated</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((item) => (
+              <TableRow
+                key={item.id}
+                className="cursor-pointer"
+                onClick={() => {
+                  setParams({ item: item.id });
+                }}
+              >
+                <TableCell className="font-medium">{item.title}</TableCell>
+                <TableCell>
+                  <Badge variant={STATUS_BADGES[item.status] ?? "secondary"}>
+                    {item.status}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-sm text-stone-600">
+                  {formatDateTime(item.updatedAt)}
+                  {item.updatedByName ? ` · ${item.updatedByName}` : ""}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1}
+            onClick={() => {
+              setParams({ page: page <= 2 ? null : String(page - 1) });
+            }}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-stone-600">
+            Page {page} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= totalPages}
+            onClick={() => {
+              setParams({ page: String(page + 1) });
+            }}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -109,6 +109,12 @@ export const CUSTOM_BLOCK_TYPES = {
   personGrid: "personGrid",
   gamePreview: "gamePreview",
   eventPreview: "eventPreview",
+  // Editor-uploaded image. Replaces BlockNote's built-in image block in
+  // the editor schema (whose URL-embed tab would bypass the consent +
+  // processing pipeline). props.picture carries the JSON-stringified
+  // PictureSource descriptor from the upload API so public pages render
+  // the responsive ladder without any lookup.
+  contentImage: "contentImage",
 } as const;
 
 // ── Slugs ───────────────────────────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,15 @@ importers:
       '@better-auth/passkey':
         specifier: ^1.6.14
         version: 1.6.14(@better-auth/core@1.6.14(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.14(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)
+      '@blocknote/core':
+        specifier: ^0.47.2
+        version: 0.47.3(@types/hast@3.0.4)
+      '@blocknote/react':
+        specifier: ^0.47.2
+        version: 0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@blocknote/shadcn':
+        specifier: ^0.47.2
+        version: 0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1604,6 +1613,13 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || >= 19.0.0-rc
       react-dom: ^18.0 || ^19.0 || >= 19.0.0-rc
+
+  '@blocknote/shadcn@0.47.3':
+    resolution: {integrity: sha512-UEJxaKVJwtd8NQVjpjjxAIcKcUxusRmh6OZ3ssZmXRkFusex/g+WO+PteSC/xHNLdT1C4gJpPi135vtwK7JFLw==}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || >= 19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || >= 19.0.0-rc
+      tailwindcss: ^4.1.12
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -3121,6 +3137,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.1.12':
+    resolution: {integrity: sha512-NQCQyWC7QrDPhjMn8hUqFeU0lUrprIgm1AyMgLbzuQJibNnatdc3SSMo3/UGFu/eUkJUU1cEcKCnyhXTQzq6tA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.3.4':
     resolution: {integrity: sha512-m3JmIOAX5ZzZ6VPjxEU2dbTOhoHi0nT5riwcDwe8idocsWf4a5DXJLDtZ6LfJwMBx7W+A2b7kp2TgPEKtaiF6A==}
     peerDependencies:
@@ -3231,8 +3260,34 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.9':
+    resolution: {integrity: sha512-rDoTeMbCwRVcnmo7NGT9IlPo1yXmEI+xc1URP3oeewwZEV4mdTp1dYUhYbQdo4D1q2SjKVvv4N1gNY77QAQtjA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-menu@2.1.17':
     resolution: {integrity: sha512-fmbNnFyf+JYCN0DhhWnEdUTDnZD1mXaPQWivdsPIb8oOSbARfD3LIQJbLCG8a8QLCwoMxiJ7GVPIFcC8Dw8v2Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.16':
+    resolution: {integrity: sha512-8brVpAU5Uq7Bh0c8EFc4ZTf2JJTYn0o+1L+CUJB3UYIOkTjKGMgoHvduylrahdmNlr3DfH0rFq2DrbNZXgaspw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3331,6 +3386,45 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-tabs@1.1.14':
+    resolution: {integrity: sha512-D5jwp9JNuwDeCw3CYD2Fz+sSHo0droQjC8u75dJHe4aWr5q6yBiXZU+hurXnKudRgEpUkD5TsI6bjHPo5ThUxA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.11':
+    resolution: {integrity: sha512-FikrKJemoBGZQ6uRID0HJqSPBP6D7OppdD2OhLl0ZYLlAyPXI7MezoYGmumwNkrAoRm35xXkb4C8JPfJZZzcaw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.9':
+    resolution: {integrity: sha512-u6F9MmTtBSLkiXNVDrtB/yPCZarM9smNswC24YYLV/M+bth6J3Gs3vlJezEoFwKZvPvxhCpUYdUnOsNG/0XOlA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.2':
     resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
     peerDependencies:
@@ -3360,6 +3454,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.2':
     resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4670,6 +4773,13 @@ packages:
   atomically@2.1.1:
     resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
 
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: '>=8.5.10'
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -5725,6 +5835,9 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -6560,6 +6673,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.525.0:
+    resolution: {integrity: sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lucide-react@1.17.0:
     resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
@@ -7426,6 +7544,12 @@ packages:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  react-hook-form@7.78.0:
+    resolution: {integrity: sha512-EEZqc+N23moyzTlz61Pj+JvcXo76ICkpfOZo8JZw+sM4+wLQGh6nI2Ms+PdMOYNluFu0ghlM7B8mCzhRYtJCnA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-icons@5.6.0:
     resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
     peerDependencies:
@@ -8044,6 +8168,9 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -10009,6 +10136,40 @@ snapshots:
       - sugar-high
       - supports-color
 
+  '@blocknote/shadcn@0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)':
+    dependencies:
+      '@blocknote/core': 0.47.3(@types/hast@3.0.4)
+      '@blocknote/react': 0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-avatar': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu': 2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-label': 2.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popover': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-select': 2.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-tabs': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tooltip': 1.2.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      autoprefixer: 10.5.0(postcss@8.5.15)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      lucide-react: 0.525.0(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-hook-form: 7.78.0(react@19.2.7)
+      tailwind-merge: 2.6.1
+      tailwindcss: 4.3.0
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+      - '@types/hast'
+      - '@types/react'
+      - '@types/react-dom'
+      - highlight.js
+      - lowlight
+      - postcss
+      - refractor
+      - sugar-high
+      - supports-color
+
   '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -11620,6 +11781,19 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-avatar@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-checkbox@1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -11718,6 +11892,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-label@2.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-menu@2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -11736,6 +11919,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-popover@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -11844,6 +12050,53 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-tabs@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-toggle@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-tooltip@1.2.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -11868,6 +12121,12 @@ snapshots:
   '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
@@ -13221,6 +13480,15 @@ snapshots:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
 
+  autoprefixer@10.5.0(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001793
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -14380,6 +14648,8 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  fraction.js@5.3.4: {}
+
   fs-constants@1.0.0: {}
 
   fs-extra@9.1.0:
@@ -15339,6 +15609,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.525.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   lucide-react@1.17.0(react@19.2.7):
     dependencies:
@@ -16476,6 +16750,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  react-hook-form@7.78.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   react-icons@5.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -17324,6 +17602,8 @@ snapshots:
   tabbable@6.4.0: {}
 
   tagged-tag@1.0.0: {}
+
+  tailwind-merge@2.6.1: {}
 
   tailwind-merge@3.6.0: {}
 


### PR DESCRIPTION
Part of epic #479. Closes #486.

## Content section

New "Content > Match Reports" section in the admin panel, visible with `content_reports:view` (mirrors the API gate). List view: status filter, title search, pagination, status badges, updated-by/at. Every piece of UI state - open item, status, search, page - lives in the URL with the panel's section/sub params, so deep links restore the full view.

## Editor

Lazy-loaded chunk (~353 kB gzip) so BlockNote ships only when an item is actually open; the public bundle is untouched.

- **@blocknote/shadcn** chosen over `@blocknote/mantine` (ADR 047 asked for this evaluation first): stays on the Tailwind/shadcn stack, no Mantine runtime. No `@blocknote/xl-*` (AGPL) anywhere.
- Custom blocks registered under the shared `CUSTOM_BLOCK_TYPES` names so the public renderer maps them 1:1: **person** (people picker), **gamePreview** (picker backed by the existing games API - no raw id field), **eventPreview**, **contentImage**. Each renders the real public component read-only in-editor.
- **Built-in image/video/audio/file blocks removed from the schema**: their URL-embed tab would bypass the consent + EXIF-strip + responsive pipeline. Photos go through the slash menu's "Upload photo", which is hard-blocked until the photo-consent checkbox (with junior guidance text) is ticked, then runs the presigned flow from #485 and inserts a `contentImage` block carrying the PictureSource descriptor - so uploaded photos render responsively via OptimisedImage on public pages with zero lookups.
- Slug auto-derives from the title until manually edited; locked once ever published.
- Draft preview renders through the real public `ContentBody` renderer (same component, same output).
- Publish now / schedule (datetime-local) / unpublish / archive; last-saved indicator; revisions are written API-side on every save.
- Body is validated through the shared recursive block schema before every save.

## Renderer

`ContentBody` gains the `contentImage` case: parses the stored descriptor with every srcset URL re-validated against the image-source allowlist, renders via OptimisedImage, falls back to plain src. 2 new tests (15 total).

Mobile: sidebar/editor stack on small viewports; BlockNote's touch UX is its headline feature (per the spike).

🤖 Generated with [Claude Code](https://claude.com/claude-code)