### PR TITLE
feat: game report cutover - API-first with MDX fallback + migration script (#487)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -72,6 +72,7 @@
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^12.0.1",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^25.9.2",
     "@types/opentype.js": "^1.3.10",
     "@types/pg": "^8.20.0",
@@ -82,10 +83,13 @@
     "@vitest/coverage-v8": "^4.1.8",
     "dotenv": "^17.4.2",
     "pino-pretty": "^13.1.3",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
     "supertest": "^7.2.2",
     "testcontainers": "^12.0.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
+    "unified": "^11.0.5",
     "vitest": "^4.1.8"
   }
 }

--- a/apps/api/scripts/markdown-to-blocks.test.ts
+++ b/apps/api/scripts/markdown-to-blocks.test.ts
@@ -1,0 +1,120 @@
+import { contentBodySchema } from "@percy-main/shared/content";
+import { describe, expect, it } from "vitest";
+import {
+  blocksEqualIgnoringIds,
+  markdownToBlocks,
+} from "./markdown-to-blocks.ts";
+
+describe("markdownToBlocks", () => {
+  it("converts a representative legacy report", () => {
+    const blocks = markdownToBlocks(
+      [
+        "#### Result",
+        "",
+        "Percy Main won by 6 wickets",
+        "",
+        "#### Highlights",
+        "",
+        "**First win for PMCC 2nd XI in 1001 days!**",
+        "",
+        "MW Munir 35\\* & 1-19 (economy 2.38)",
+        "",
+        "Full scorecard on [Play-Cricket](https://percymain.play-cricket.com).",
+      ].join("\n"),
+    );
+
+    // Valid against the schema the API enforces on write
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+
+    expect(blocks[0]).toMatchObject({
+      type: "heading",
+      props: { level: 4 },
+      content: [{ type: "text", text: "Result" }],
+    });
+    expect(blocks[1]).toMatchObject({ type: "paragraph" });
+
+    // Bold survives as a style
+    const highlight = blocks[3];
+    expect(highlight?.content).toEqual([
+      {
+        type: "text",
+        text: "First win for PMCC 2nd XI in 1001 days!",
+        styles: { bold: true },
+      },
+    ]);
+
+    // Escaped asterisk is unescaped to a literal
+    const munir = blocks[4];
+    expect(JSON.stringify(munir?.content)).toContain("35* & 1-19");
+
+    // Links become inline link nodes
+    const last = blocks[5];
+    expect(JSON.stringify(last?.content)).toContain(
+      '"href":"https://percymain.play-cricket.com"',
+    );
+  });
+
+  it("converts lists with nesting", () => {
+    const blocks = markdownToBlocks(
+      ["- one", "- two", "  - nested", "1. first"].join("\n"),
+    );
+    expect(blocks.map((b) => b.type)).toEqual([
+      "bulletListItem",
+      "bulletListItem",
+      "numberedListItem",
+    ]);
+    expect(blocks[1]?.children[0]).toMatchObject({ type: "bulletListItem" });
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+  });
+
+  it("converts blockquotes, code and tables", () => {
+    const blocks = markdownToBlocks(
+      [
+        "> quoted wisdom",
+        "",
+        "```",
+        "raw scores",
+        "```",
+        "",
+        "| Player | Runs |",
+        "| --- | --- |",
+        "| Slaven | 78 |",
+      ].join("\n"),
+    );
+    expect(blocks.map((b) => b.type)).toEqual(["quote", "codeBlock", "table"]);
+    const table = blocks[2];
+    expect(table?.content).toMatchObject({
+      type: "tableContent",
+      rows: [{ cells: [[{ text: "Player" }], [{ text: "Runs" }]] }, {}],
+    });
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+  });
+
+  it("refuses constructs it does not understand", () => {
+    expect(() => markdownToBlocks("![alt](image.png)")).toThrow(/Unsupported/);
+  });
+
+  it("compares blocks ignoring generated ids", () => {
+    const a = markdownToBlocks("# Title\n\nBody");
+    const b = markdownToBlocks("# Title\n\nBody");
+    const c = markdownToBlocks("# Title\n\nDifferent body");
+    expect(a[0]?.id).not.toBe(b[0]?.id);
+    expect(blocksEqualIgnoringIds(a, b)).toBe(true);
+    expect(blocksEqualIgnoringIds(a, c)).toBe(false);
+  });
+
+  it("converts the entire legacy corpus without errors", async () => {
+    const { promises: fs } = await import("fs");
+    const path = await import("path");
+    const dir = path.resolve(import.meta.dirname, "../../web/content/games");
+    const files = (await fs.readdir(dir)).filter((f) => f.endsWith(".mdx"));
+    expect(files.length).toBeGreaterThanOrEqual(10);
+    for (const file of files) {
+      const source = await fs.readFile(path.join(dir, file), "utf8");
+      const body = source.replace(/^---\n[\s\S]*?\n---\n?/, "");
+      const blocks = markdownToBlocks(body);
+      expect(blocks.length).toBeGreaterThan(0);
+      expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+    }
+  });
+});

--- a/apps/api/scripts/markdown-to-blocks.ts
+++ b/apps/api/scripts/markdown-to-blocks.ts
@@ -1,0 +1,211 @@
+import type {
+  List,
+  Content as MdastContent,
+  PhrasingContent,
+  Root,
+  Table,
+} from "mdast";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
+// One-time inbound migration converter (#487): GFM markdown from the
+// legacy MDX corpus -> the BlockNote-shaped block document the content
+// API stores (ADR 047). After the migration, markdown ceases to be used
+// anywhere - the editor round-trips JSON only - so this deliberately
+// supports just the constructs the corpus (and plain prose generally)
+// uses: headings, paragraphs, emphasis, links, lists, blockquotes,
+// code blocks, tables and thematic breaks.
+
+export interface MigrationBlock {
+  id: string;
+  type: string;
+  props: Record<string, string | number | boolean>;
+  content?: unknown;
+  children: MigrationBlock[];
+}
+
+interface StyledTextNode {
+  type: "text";
+  text: string;
+  styles: Record<string, boolean>;
+}
+
+interface LinkNode {
+  type: "link";
+  href: string;
+  content: StyledTextNode[];
+}
+
+type InlineNode = StyledTextNode | LinkNode;
+
+function styledText(
+  text: string,
+  styles: Record<string, boolean>,
+): StyledTextNode {
+  return { type: "text", text, styles: { ...styles } };
+}
+
+function flattenInline(
+  nodes: PhrasingContent[],
+  styles: Record<string, boolean> = {},
+): InlineNode[] {
+  const out: InlineNode[] = [];
+  for (const node of nodes) {
+    switch (node.type) {
+      case "text":
+        out.push(styledText(node.value, styles));
+        break;
+      case "strong":
+        out.push(...flattenInline(node.children, { ...styles, bold: true }));
+        break;
+      case "emphasis":
+        out.push(...flattenInline(node.children, { ...styles, italic: true }));
+        break;
+      case "delete":
+        out.push(...flattenInline(node.children, { ...styles, strike: true }));
+        break;
+      case "inlineCode":
+        out.push(styledText(node.value, { ...styles, code: true }));
+        break;
+      case "break":
+        out.push(styledText("\n", styles));
+        break;
+      case "link": {
+        const inner = flattenInline(node.children, styles).filter(
+          (n): n is StyledTextNode => n.type === "text",
+        );
+        out.push({ type: "link", href: node.url, content: inner });
+        break;
+      }
+      default:
+        throw new Error(
+          `Unsupported inline markdown node '${node.type}' - migrate this report by hand`,
+        );
+    }
+  }
+  return out;
+}
+
+function block(
+  type: string,
+  props: Record<string, string | number | boolean>,
+  content?: unknown,
+  children: MigrationBlock[] = [],
+): MigrationBlock {
+  return { id: crypto.randomUUID(), type, props, content, children };
+}
+
+function listToBlocks(list: List): MigrationBlock[] {
+  const itemType = list.ordered ? "numberedListItem" : "bulletListItem";
+  const blocks: MigrationBlock[] = [];
+  for (const item of list.children) {
+    let inline: InlineNode[] = [];
+    const children: MigrationBlock[] = [];
+    for (const child of item.children) {
+      if (child.type === "paragraph" && inline.length === 0) {
+        inline = flattenInline(child.children);
+      } else if (child.type === "list") {
+        children.push(...listToBlocks(child));
+      } else {
+        throw new Error(
+          `Unsupported list item child '${child.type}' - migrate this report by hand`,
+        );
+      }
+    }
+    blocks.push(block(itemType, {}, inline, children));
+  }
+  return blocks;
+}
+
+function tableToBlock(table: Table): MigrationBlock {
+  const rows = table.children.map((row) => ({
+    cells: row.children.map((cell) => flattenInline(cell.children)),
+  }));
+  return block("table", {}, { type: "tableContent", rows });
+}
+
+function nodeToBlocks(node: MdastContent): MigrationBlock[] {
+  switch (node.type) {
+    case "heading":
+      return [
+        block(
+          "heading",
+          { level: Math.min(node.depth, 6) },
+          flattenInline(node.children),
+        ),
+      ];
+    case "paragraph":
+      return [block("paragraph", {}, flattenInline(node.children))];
+    case "list":
+      return listToBlocks(node);
+    case "blockquote": {
+      const inline: InlineNode[] = [];
+      for (const child of node.children) {
+        if (child.type !== "paragraph") {
+          throw new Error(
+            `Unsupported blockquote child '${child.type}' - migrate this report by hand`,
+          );
+        }
+        if (inline.length > 0) inline.push(styledText("\n", {}));
+        inline.push(...flattenInline(child.children));
+      }
+      return [block("quote", {}, inline)];
+    }
+    case "code":
+      return [
+        block("codeBlock", { language: node.lang ?? "" }, [
+          styledText(node.value, {}),
+        ]),
+      ];
+    case "table":
+      return [tableToBlock(node)];
+    case "thematicBreak":
+      return [];
+    default:
+      throw new Error(
+        `Unsupported markdown node '${node.type}' - migrate this report by hand`,
+      );
+  }
+}
+
+/**
+ * Convert a GFM markdown document into the block array the content API
+ * stores. Throws on any construct it does not understand: for a one-time
+ * migration, refusing loudly beats silently dropping content.
+ */
+export function markdownToBlocks(markdown: string): MigrationBlock[] {
+  const tree = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .parse(markdown) as Root;
+
+  const blocks: MigrationBlock[] = [];
+  for (const node of tree.children) {
+    blocks.push(...nodeToBlocks(node));
+  }
+  return blocks;
+}
+
+/**
+ * Structural equality ignoring block ids (fresh UUIDs every run would
+ * otherwise defeat the upsert's change detection). Keys are sorted
+ * before comparison because Postgres JSONB does not preserve object key
+ * order.
+ */
+export function blocksEqualIgnoringIds(a: unknown, b: unknown): boolean {
+  return JSON.stringify(canonicalise(a)) === JSON.stringify(canonicalise(b));
+}
+
+function canonicalise(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalise);
+  if (typeof value === "object" && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      if (key === "id") continue;
+      out[key] = canonicalise((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}

--- a/apps/api/scripts/migrate-game-reports.ts
+++ b/apps/api/scripts/migrate-game-reports.ts
@@ -1,0 +1,215 @@
+/**
+ * One-off migration (#487): import the legacy MDX game reports into the
+ * content API's tables as published game_report items.
+ *
+ * Idempotent: upserts by playCricketId. Unchanged reports are skipped,
+ * changed ones are updated (with a revision written), new ones inserted
+ * with their creation revision.
+ *
+ * Usage (local):
+ *   DATABASE_URL=postgres://percy:percy@localhost:5433/percy_main \
+ *     pnpm exec tsx scripts/migrate-game-reports.ts --user <user-id> [--dry-run]
+ *
+ * Against prod, run with the standard prod access pattern and the
+ * admin_rw URL - coordinate first; never point this at prod casually.
+ * Optionally set GAMES_API_BASE (e.g. https://api.v2.percymain.org) to
+ * derive human titles from the games API; otherwise titles fall back to
+ * "Match report <playCricketId>".
+ */
+import { createClient } from "@percy-main/db";
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  blocksEqualIgnoringIds,
+  markdownToBlocks,
+  type MigrationBlock,
+} from "./markdown-to-blocks.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const GAMES_DIR = path.resolve(__dirname, "../../web/content/games");
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const userFlag = args.indexOf("--user");
+  const userId = userFlag >= 0 ? args[userFlag + 1] : undefined;
+  const dryRun = args.includes("--dry-run");
+  if (!userId) {
+    console.error(
+      "Usage: tsx scripts/migrate-game-reports.ts --user <user-id> [--dry-run]",
+    );
+    process.exit(1);
+  }
+  return { userId, dryRun };
+}
+
+function parseFrontmatter(source: string): {
+  playCricketId: string;
+  body: string;
+} {
+  const match = /^---\n([\s\S]*?)\n---\n?/.exec(source);
+  if (!match) throw new Error("No frontmatter block");
+  const idMatch = /playCricketId:\s*"?(\d+)"?/.exec(match[1] ?? "");
+  const playCricketId = idMatch?.[1];
+  if (!playCricketId) throw new Error("No playCricketId in frontmatter");
+  return { playCricketId, body: source.slice(match[0].length) };
+}
+
+/** Defensive: this corpus has no JSX/imports/images; refuse if one appears. */
+function assertPlainMarkdown(body: string, file: string) {
+  if (/^\s*import\s/m.test(body) || /<[A-Z][A-Za-z]*/.test(body)) {
+    throw new Error(`${file} contains JSX/imports - migrate it by hand`);
+  }
+  if (/!\[/.test(body)) {
+    throw new Error(
+      `${file} contains images - upload them through the image pipeline first`,
+    );
+  }
+}
+
+async function fetchTitle(playCricketId: string): Promise<string> {
+  const fallback = `Match report ${playCricketId}`;
+  const base = process.env.GAMES_API_BASE;
+  if (!base) return fallback;
+  try {
+    const res = await fetch(`${base}/api/games/${playCricketId}`);
+    if (!res.ok) return fallback;
+    const game = (await res.json()) as {
+      team?: { name?: string };
+      opposition?: { club?: { name?: string } };
+      matchDate?: string;
+    };
+    if (game.team?.name && game.opposition?.club?.name) {
+      const date = game.matchDate ? ` - ${game.matchDate}` : "";
+      return `${game.team.name} vs ${game.opposition.club.name}${date}`;
+    }
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function main() {
+  const { userId, dryRun } = parseArgs();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+  const { client: db } = createClient(databaseUrl);
+
+  const files = (await fs.readdir(GAMES_DIR))
+    .filter((f) => f.endsWith(".mdx"))
+    .sort();
+  console.log(`Found ${String(files.length)} reports in ${GAMES_DIR}`);
+
+  let inserted = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const file of files) {
+    const source = await fs.readFile(path.join(GAMES_DIR, file), "utf8");
+    const { playCricketId, body } = parseFrontmatter(source);
+    assertPlainMarkdown(body, file);
+
+    const blocks: MigrationBlock[] = markdownToBlocks(body);
+    const metadata = { playCricketId };
+    const title = await fetchTitle(playCricketId);
+    const slug = `match-report-${playCricketId}`;
+
+    const existing = await db
+      .selectFrom("content_item")
+      .select(["id", "body", "title"])
+      .where("kind", "=", "game_report")
+      .where((eb) =>
+        eb(
+          eb.fn("jsonb_extract_path_text", [
+            eb.ref("metadata"),
+            eb.val("playCricketId"),
+          ]),
+          "=",
+          playCricketId,
+        ),
+      )
+      .executeTakeFirst();
+
+    if (existing && blocksEqualIgnoringIds(existing.body, blocks)) {
+      skipped += 1;
+      console.log(`  = ${file} unchanged (${existing.title})`);
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(
+        `  ~ ${file} would ${existing ? "update" : "insert"} '${title}' (${String(blocks.length)} blocks)`,
+      );
+      continue;
+    }
+
+    await db.transaction().execute(async (tx) => {
+      if (existing) {
+        await tx
+          .updateTable("content_item")
+          .set({
+            body: JSON.stringify(blocks),
+            updated_by: userId,
+            updated_at: new Date(),
+          })
+          .where("id", "=", existing.id)
+          .execute();
+        await tx
+          .insertInto("content_revision")
+          .values({
+            content_id: existing.id,
+            title: existing.title,
+            description: null,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(metadata),
+            saved_by: userId,
+          })
+          .execute();
+        updated += 1;
+        console.log(`  ^ ${file} updated (${existing.title})`);
+        return;
+      }
+
+      const item = await tx
+        .insertInto("content_item")
+        .values({
+          kind: "game_report",
+          slug,
+          title,
+          description: null,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          status: "published",
+          published_at: new Date(),
+          created_by: userId,
+          updated_by: userId,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      await tx
+        .insertInto("content_revision")
+        .values({
+          content_id: item.id,
+          title,
+          description: null,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          saved_by: userId,
+        })
+        .execute();
+      inserted += 1;
+      console.log(`  + ${file} inserted as '${title}'`);
+    });
+  }
+
+  console.log(
+    `Done: ${String(inserted)} inserted, ${String(updated)} updated, ${String(skipped)} unchanged${dryRun ? " (dry run)" : ""}`,
+  );
+  await db.destroy();
+}
+
+await main();

--- a/apps/api/scripts/migrate-game-reports.ts
+++ b/apps/api/scripts/migrate-game-reports.ts
@@ -34,13 +34,14 @@ function parseArgs() {
   const userFlag = args.indexOf("--user");
   const userId = userFlag >= 0 ? args[userFlag + 1] : undefined;
   const dryRun = args.includes("--dry-run");
+  const force = args.includes("--force");
   if (!userId) {
     console.error(
-      "Usage: tsx scripts/migrate-game-reports.ts --user <user-id> [--dry-run]",
+      "Usage: tsx scripts/migrate-game-reports.ts --user <user-id> [--dry-run] [--force]",
     );
     process.exit(1);
   }
-  return { userId, dryRun };
+  return { userId, dryRun, force };
 }
 
 function parseFrontmatter(source: string): {
@@ -90,7 +91,7 @@ async function fetchTitle(playCricketId: string): Promise<string> {
 }
 
 async function main() {
-  const { userId, dryRun } = parseArgs();
+  const { userId, dryRun, force } = parseArgs();
 
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
@@ -107,6 +108,7 @@ async function main() {
   let inserted = 0;
   let updated = 0;
   let skipped = 0;
+  let warnings = 0;
 
   for (const file of files) {
     const source = await fs.readFile(path.join(GAMES_DIR, file), "utf8");
@@ -120,7 +122,7 @@ async function main() {
 
     const existing = await db
       .selectFrom("content_item")
-      .select(["id", "body", "title"])
+      .select(["id", "body", "title", "description", "metadata", "status"])
       .where("kind", "=", "game_report")
       .where((eb) =>
         eb(
@@ -134,10 +136,30 @@ async function main() {
       )
       .executeTakeFirst();
 
-    if (existing && blocksEqualIgnoringIds(existing.body, blocks)) {
-      skipped += 1;
-      console.log(`  = ${file} unchanged (${existing.title})`);
-      continue;
+    if (existing) {
+      // A row that exists but is not published would still 404 publicly -
+      // never silently treat that as migrated. Equally, never overwrite a
+      // row an editor may have touched unless explicitly forced: after
+      // cutover the DB is canonical and the MDX is the stale ancestor.
+      if (existing.status !== "published") {
+        warnings += 1;
+        console.warn(
+          `  ! ${file}: a ${existing.status} item already exists for playCricketId ${playCricketId} - the public endpoint will 404. Publish or remove it, then re-run.`,
+        );
+        continue;
+      }
+      if (blocksEqualIgnoringIds(existing.body, blocks)) {
+        skipped += 1;
+        console.log(`  = ${file} unchanged (${existing.title})`);
+        continue;
+      }
+      if (!force) {
+        warnings += 1;
+        console.warn(
+          `  ! ${file}: published item '${existing.title}' differs from the MDX conversion (likely edited in the DB). Skipping - re-run with --force to overwrite.`,
+        );
+        continue;
+      }
     }
 
     if (dryRun) {
@@ -158,14 +180,16 @@ async function main() {
           })
           .where("id", "=", existing.id)
           .execute();
+        // Revision snapshots the row's post-update state: only the body
+        // changed, so title/description/metadata come from the row.
         await tx
           .insertInto("content_revision")
           .values({
             content_id: existing.id,
             title: existing.title,
-            description: null,
+            description: existing.description,
             body: JSON.stringify(blocks),
-            metadata: JSON.stringify(metadata),
+            metadata: JSON.stringify(existing.metadata),
             saved_by: userId,
           })
           .execute();
@@ -207,8 +231,9 @@ async function main() {
   }
 
   console.log(
-    `Done: ${String(inserted)} inserted, ${String(updated)} updated, ${String(skipped)} unchanged${dryRun ? " (dry run)" : ""}`,
+    `Done: ${String(inserted)} inserted, ${String(updated)} updated, ${String(skipped)} unchanged, ${String(warnings)} warnings${dryRun ? " (dry run)" : ""}`,
   );
+  if (warnings > 0) process.exitCode = 2;
   await db.destroy();
 }
 

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
     exclude: [
       "**/node_modules/**",
       "**/dist/**",

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -1,3 +1,4 @@
+import { ContentBody } from "@/components/content-body.js";
 import { Map } from "@/components/map.js";
 import { mdxComponents } from "@/components/mdx-components.js";
 import { OutcomeBadge } from "@/components/outcome-badge.js";
@@ -254,6 +255,30 @@ function BallByBallTrigger({ game }: { game: GameData }) {
 }
 
 function GameDetailContent({ game }: { game: GameData }) {
+  // DB-backed report first (live content editing, #479); the bundled MDX
+  // corpus stays as fallback until the migration is verified in prod,
+  // then gets deleted in a follow-up.
+  const { data: apiReport } = useQuery({
+    queryKey: ["content", "game-report", game.id],
+    queryFn: async () => {
+      try {
+        return await callApi(
+          api.GET(
+            "/api/content/game-report/by-play-cricket-id/{playCricketId}",
+            {
+              params: { path: { playCricketId: game.id } },
+            },
+          ),
+        );
+      } catch (err) {
+        // No published report for this game - fall back to bundled MDX.
+        if ((err as { status?: number }).status === 404) return null;
+        throw err;
+      }
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
   const report = getGameReport(game.id);
 
   const title = `${game.team.name} vs. ${game.opposition.club.name} ${game.opposition.team.name} ${game.home ? "(H)" : "(A)"}`;
@@ -439,15 +464,22 @@ function GameDetailContent({ game }: { game: GameData }) {
             links show a fallback. */}
         <BallByBallTrigger game={game} />
 
-        {/* MDX game report */}
-        {report && (
+        {/* Game report: API-published content wins, bundled MDX is the
+            transition fallback */}
+        {apiReport ? (
           <div className="w-full">
-            <MDXProvider components={mdxComponents}>
-              <div className="mdx-content flex flex-col *:mb-4">
-                <report.Component />
-              </div>
-            </MDXProvider>
+            <ContentBody body={apiReport.body} />
           </div>
+        ) : (
+          report && (
+            <div className="w-full">
+              <MDXProvider components={mdxComponents}>
+                <div className="mdx-content flex flex-col *:mb-4">
+                  <report.Component />
+                </div>
+              </MDXProvider>
+            </div>
+          )
         )}
 
         {/* Scorecard (fetches from Play Cricket API) */}

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -258,7 +258,7 @@ function GameDetailContent({ game }: { game: GameData }) {
   // DB-backed report first (live content editing, #479); the bundled MDX
   // corpus stays as fallback until the migration is verified in prod,
   // then gets deleted in a follow-up.
-  const { data: apiReport } = useQuery({
+  const { data: apiReport, isPending: apiReportPending } = useQuery({
     queryKey: ["content", "game-report", game.id],
     queryFn: async () => {
       try {
@@ -464,13 +464,16 @@ function GameDetailContent({ game }: { game: GameData }) {
             links show a fallback. */}
         <BallByBallTrigger game={game} />
 
-        {/* Game report: API-published content wins, bundled MDX is the
-            transition fallback */}
+        {/* Game report: API-published content wins. The bundled MDX
+            renders only once the query settles (confirmed 404, or an API
+            failure - deliberate graceful degradation) so a DB-edited
+            report never flashes its stale MDX ancestor first. */}
         {apiReport ? (
           <div className="w-full">
             <ContentBody body={apiReport.body} />
           </div>
         ) : (
+          !apiReportPending &&
           report && (
             <div className="w-full">
               <MDXProvider components={mdxComponents}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^12.0.1
         version: 12.0.1
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -247,6 +250,12 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
@@ -259,6 +268,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))


### PR DESCRIPTION
Part of epic #479. Closes #487.

## Cutover

`game-detail.tsx` queries the published `game_report` by playCricketId via the typed client (react-query, 5-min staleTime). A 404 falls back to the bundled MDX report, so cutover is incremental with no flag-day. Deleting `content/games/` + the loader is the post-verification follow-up the issue specifies.

## Migration tooling (`apps/api/scripts/`)

- **markdown-to-blocks.ts**: GFM markdown -> BlockNote block converter (headings, paragraphs, bold/italic/strike/code/links, nested lists, blockquotes, code blocks, tables). It **throws on anything it doesn't understand** - for a one-time migration, refusing loudly beats silently dropping content. The corpus turned out to be pure markdown: no JSX components, no images, so the directive-rewrite/image-copy parts of the issue have nothing to do (the script still hard-refuses files containing JSX/imports/`![` as a guard).
- **migrate-game-reports.ts**: idempotent upsert by playCricketId. Change detection canonicalises JSONB key order and ignores generated block ids. Inserts as published rows + creation revisions with `--user <id>` attribution; `--dry-run` supported; optional `GAMES_API_BASE` derives human titles from the games API.

## Verification

- 6 converter tests, including converting the **entire 10-report legacy corpus** with every output validated against the shared `contentBodySchema` (the same schema the API enforces on write).
- Local end-to-end: dry-run -> 10 inserted -> re-run reports 10 unchanged -> migrated rows satisfy the public predicate (`status='published' AND published_at <= now()`).
- **Prod run deliberately not performed** - needs the standard prod access pattern and coordination first.

remark/unified added as api devDependencies only (scripts aren't part of the build); lockfile changes reuse already-resolved versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)