### PR TITLE
Epic: Live content editing - Phase 1: Foundations + game reports (#479)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ test-results/
 
 # Database dumps
 dumps/
+
+# Live content editing planning notes (tickets are source of truth)
+NON_STATIC_CONTENT.md

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -72,6 +72,7 @@
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^12.0.1",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^25.9.2",
     "@types/opentype.js": "^1.3.10",
     "@types/pg": "^8.20.0",
@@ -82,10 +83,13 @@
     "@vitest/coverage-v8": "^4.1.8",
     "dotenv": "^17.4.2",
     "pino-pretty": "^13.1.3",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
     "supertest": "^7.2.2",
     "testcontainers": "^12.0.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
+    "unified": "^11.0.5",
     "vitest": "^4.1.8"
   }
 }

--- a/apps/api/scripts/markdown-to-blocks.test.ts
+++ b/apps/api/scripts/markdown-to-blocks.test.ts
@@ -1,0 +1,120 @@
+import { contentBodySchema } from "@percy-main/shared/content";
+import { describe, expect, it } from "vitest";
+import {
+  blocksEqualIgnoringIds,
+  markdownToBlocks,
+} from "./markdown-to-blocks.ts";
+
+describe("markdownToBlocks", () => {
+  it("converts a representative legacy report", () => {
+    const blocks = markdownToBlocks(
+      [
+        "#### Result",
+        "",
+        "Percy Main won by 6 wickets",
+        "",
+        "#### Highlights",
+        "",
+        "**First win for PMCC 2nd XI in 1001 days!**",
+        "",
+        "MW Munir 35\\* & 1-19 (economy 2.38)",
+        "",
+        "Full scorecard on [Play-Cricket](https://percymain.play-cricket.com).",
+      ].join("\n"),
+    );
+
+    // Valid against the schema the API enforces on write
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+
+    expect(blocks[0]).toMatchObject({
+      type: "heading",
+      props: { level: 4 },
+      content: [{ type: "text", text: "Result" }],
+    });
+    expect(blocks[1]).toMatchObject({ type: "paragraph" });
+
+    // Bold survives as a style
+    const highlight = blocks[3];
+    expect(highlight?.content).toEqual([
+      {
+        type: "text",
+        text: "First win for PMCC 2nd XI in 1001 days!",
+        styles: { bold: true },
+      },
+    ]);
+
+    // Escaped asterisk is unescaped to a literal
+    const munir = blocks[4];
+    expect(JSON.stringify(munir?.content)).toContain("35* & 1-19");
+
+    // Links become inline link nodes
+    const last = blocks[5];
+    expect(JSON.stringify(last?.content)).toContain(
+      '"href":"https://percymain.play-cricket.com"',
+    );
+  });
+
+  it("converts lists with nesting", () => {
+    const blocks = markdownToBlocks(
+      ["- one", "- two", "  - nested", "1. first"].join("\n"),
+    );
+    expect(blocks.map((b) => b.type)).toEqual([
+      "bulletListItem",
+      "bulletListItem",
+      "numberedListItem",
+    ]);
+    expect(blocks[1]?.children[0]).toMatchObject({ type: "bulletListItem" });
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+  });
+
+  it("converts blockquotes, code and tables", () => {
+    const blocks = markdownToBlocks(
+      [
+        "> quoted wisdom",
+        "",
+        "```",
+        "raw scores",
+        "```",
+        "",
+        "| Player | Runs |",
+        "| --- | --- |",
+        "| Slaven | 78 |",
+      ].join("\n"),
+    );
+    expect(blocks.map((b) => b.type)).toEqual(["quote", "codeBlock", "table"]);
+    const table = blocks[2];
+    expect(table?.content).toMatchObject({
+      type: "tableContent",
+      rows: [{ cells: [[{ text: "Player" }], [{ text: "Runs" }]] }, {}],
+    });
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+  });
+
+  it("refuses constructs it does not understand", () => {
+    expect(() => markdownToBlocks("![alt](image.png)")).toThrow(/Unsupported/);
+  });
+
+  it("compares blocks ignoring generated ids", () => {
+    const a = markdownToBlocks("# Title\n\nBody");
+    const b = markdownToBlocks("# Title\n\nBody");
+    const c = markdownToBlocks("# Title\n\nDifferent body");
+    expect(a[0]?.id).not.toBe(b[0]?.id);
+    expect(blocksEqualIgnoringIds(a, b)).toBe(true);
+    expect(blocksEqualIgnoringIds(a, c)).toBe(false);
+  });
+
+  it("converts the entire legacy corpus without errors", async () => {
+    const { promises: fs } = await import("fs");
+    const path = await import("path");
+    const dir = path.resolve(import.meta.dirname, "../../web/content/games");
+    const files = (await fs.readdir(dir)).filter((f) => f.endsWith(".mdx"));
+    expect(files.length).toBeGreaterThanOrEqual(10);
+    for (const file of files) {
+      const source = await fs.readFile(path.join(dir, file), "utf8");
+      const body = source.replace(/^---\n[\s\S]*?\n---\n?/, "");
+      const blocks = markdownToBlocks(body);
+      expect(blocks.length).toBeGreaterThan(0);
+      expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+    }
+  });
+});

--- a/apps/api/scripts/markdown-to-blocks.ts
+++ b/apps/api/scripts/markdown-to-blocks.ts
@@ -1,0 +1,211 @@
+import type {
+  List,
+  Content as MdastContent,
+  PhrasingContent,
+  Root,
+  Table,
+} from "mdast";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
+// One-time inbound migration converter (#487): GFM markdown from the
+// legacy MDX corpus -> the BlockNote-shaped block document the content
+// API stores (ADR 047). After the migration, markdown ceases to be used
+// anywhere - the editor round-trips JSON only - so this deliberately
+// supports just the constructs the corpus (and plain prose generally)
+// uses: headings, paragraphs, emphasis, links, lists, blockquotes,
+// code blocks, tables and thematic breaks.
+
+export interface MigrationBlock {
+  id: string;
+  type: string;
+  props: Record<string, string | number | boolean>;
+  content?: unknown;
+  children: MigrationBlock[];
+}
+
+interface StyledTextNode {
+  type: "text";
+  text: string;
+  styles: Record<string, boolean>;
+}
+
+interface LinkNode {
+  type: "link";
+  href: string;
+  content: StyledTextNode[];
+}
+
+type InlineNode = StyledTextNode | LinkNode;
+
+function styledText(
+  text: string,
+  styles: Record<string, boolean>,
+): StyledTextNode {
+  return { type: "text", text, styles: { ...styles } };
+}
+
+function flattenInline(
+  nodes: PhrasingContent[],
+  styles: Record<string, boolean> = {},
+): InlineNode[] {
+  const out: InlineNode[] = [];
+  for (const node of nodes) {
+    switch (node.type) {
+      case "text":
+        out.push(styledText(node.value, styles));
+        break;
+      case "strong":
+        out.push(...flattenInline(node.children, { ...styles, bold: true }));
+        break;
+      case "emphasis":
+        out.push(...flattenInline(node.children, { ...styles, italic: true }));
+        break;
+      case "delete":
+        out.push(...flattenInline(node.children, { ...styles, strike: true }));
+        break;
+      case "inlineCode":
+        out.push(styledText(node.value, { ...styles, code: true }));
+        break;
+      case "break":
+        out.push(styledText("\n", styles));
+        break;
+      case "link": {
+        const inner = flattenInline(node.children, styles).filter(
+          (n): n is StyledTextNode => n.type === "text",
+        );
+        out.push({ type: "link", href: node.url, content: inner });
+        break;
+      }
+      default:
+        throw new Error(
+          `Unsupported inline markdown node '${node.type}' - migrate this report by hand`,
+        );
+    }
+  }
+  return out;
+}
+
+function block(
+  type: string,
+  props: Record<string, string | number | boolean>,
+  content?: unknown,
+  children: MigrationBlock[] = [],
+): MigrationBlock {
+  return { id: crypto.randomUUID(), type, props, content, children };
+}
+
+function listToBlocks(list: List): MigrationBlock[] {
+  const itemType = list.ordered ? "numberedListItem" : "bulletListItem";
+  const blocks: MigrationBlock[] = [];
+  for (const item of list.children) {
+    let inline: InlineNode[] = [];
+    const children: MigrationBlock[] = [];
+    for (const child of item.children) {
+      if (child.type === "paragraph" && inline.length === 0) {
+        inline = flattenInline(child.children);
+      } else if (child.type === "list") {
+        children.push(...listToBlocks(child));
+      } else {
+        throw new Error(
+          `Unsupported list item child '${child.type}' - migrate this report by hand`,
+        );
+      }
+    }
+    blocks.push(block(itemType, {}, inline, children));
+  }
+  return blocks;
+}
+
+function tableToBlock(table: Table): MigrationBlock {
+  const rows = table.children.map((row) => ({
+    cells: row.children.map((cell) => flattenInline(cell.children)),
+  }));
+  return block("table", {}, { type: "tableContent", rows });
+}
+
+function nodeToBlocks(node: MdastContent): MigrationBlock[] {
+  switch (node.type) {
+    case "heading":
+      return [
+        block(
+          "heading",
+          { level: Math.min(node.depth, 6) },
+          flattenInline(node.children),
+        ),
+      ];
+    case "paragraph":
+      return [block("paragraph", {}, flattenInline(node.children))];
+    case "list":
+      return listToBlocks(node);
+    case "blockquote": {
+      const inline: InlineNode[] = [];
+      for (const child of node.children) {
+        if (child.type !== "paragraph") {
+          throw new Error(
+            `Unsupported blockquote child '${child.type}' - migrate this report by hand`,
+          );
+        }
+        if (inline.length > 0) inline.push(styledText("\n", {}));
+        inline.push(...flattenInline(child.children));
+      }
+      return [block("quote", {}, inline)];
+    }
+    case "code":
+      return [
+        block("codeBlock", { language: node.lang ?? "" }, [
+          styledText(node.value, {}),
+        ]),
+      ];
+    case "table":
+      return [tableToBlock(node)];
+    case "thematicBreak":
+      return [];
+    default:
+      throw new Error(
+        `Unsupported markdown node '${node.type}' - migrate this report by hand`,
+      );
+  }
+}
+
+/**
+ * Convert a GFM markdown document into the block array the content API
+ * stores. Throws on any construct it does not understand: for a one-time
+ * migration, refusing loudly beats silently dropping content.
+ */
+export function markdownToBlocks(markdown: string): MigrationBlock[] {
+  const tree = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .parse(markdown) as Root;
+
+  const blocks: MigrationBlock[] = [];
+  for (const node of tree.children) {
+    blocks.push(...nodeToBlocks(node));
+  }
+  return blocks;
+}
+
+/**
+ * Structural equality ignoring block ids (fresh UUIDs every run would
+ * otherwise defeat the upsert's change detection). Keys are sorted
+ * before comparison because Postgres JSONB does not preserve object key
+ * order.
+ */
+export function blocksEqualIgnoringIds(a: unknown, b: unknown): boolean {
+  return JSON.stringify(canonicalise(a)) === JSON.stringify(canonicalise(b));
+}
+
+function canonicalise(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalise);
+  if (typeof value === "object" && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      if (key === "id") continue;
+      out[key] = canonicalise((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}

--- a/apps/api/scripts/migrate-game-reports.ts
+++ b/apps/api/scripts/migrate-game-reports.ts
@@ -100,6 +100,22 @@ async function main() {
   }
   const { client: db } = createClient(databaseUrl);
 
+  // Resolve and show who the imports will be attributed to - created_by /
+  // updated_by / revision saved_by all land in the admin UI.
+  const attributedTo = await db
+    .selectFrom("user")
+    .select(["name", "email"])
+    .where("id", "=", userId)
+    .executeTakeFirst();
+  if (!attributedTo) {
+    console.error(`No user with id '${userId}'`);
+    await db.destroy();
+    process.exit(1);
+  }
+  console.log(
+    `Attributing imports to: ${attributedTo.name} <${attributedTo.email}>`,
+  );
+
   const files = (await fs.readdir(GAMES_DIR))
     .filter((f) => f.endsWith(".mdx"))
     .sort();

--- a/apps/api/scripts/migrate-game-reports.ts
+++ b/apps/api/scripts/migrate-game-reports.ts
@@ -68,8 +68,24 @@ function assertPlainMarkdown(body: string, file: string) {
   }
 }
 
-async function fetchTitle(playCricketId: string): Promise<string> {
-  const fallback = `Match report ${playCricketId}`;
+/** Play-Cricket dates are dd/MM/yyyy. */
+function parseMatchDate(raw: string | undefined): Date | null {
+  if (!raw) return null;
+  const m = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(raw);
+  if (!m) {
+    const parsed = new Date(raw);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return new Date(`${m[3]}-${m[2]}-${m[1]}T12:00:00Z`);
+}
+
+async function fetchGameDetails(
+  playCricketId: string,
+): Promise<{ title: string; matchDate: Date | null }> {
+  const fallback = {
+    title: `Match report ${playCricketId}`,
+    matchDate: null,
+  };
   const base = process.env.GAMES_API_BASE;
   if (!base) return fallback;
   try {
@@ -80,11 +96,15 @@ async function fetchTitle(playCricketId: string): Promise<string> {
       opposition?: { club?: { name?: string } };
       matchDate?: string;
     };
+    const matchDate = parseMatchDate(game.matchDate);
     if (game.team?.name && game.opposition?.club?.name) {
       const date = game.matchDate ? ` - ${game.matchDate}` : "";
-      return `${game.team.name} vs ${game.opposition.club.name}${date}`;
+      return {
+        title: `${game.team.name} vs ${game.opposition.club.name}${date}`,
+        matchDate,
+      };
     }
-    return fallback;
+    return { ...fallback, matchDate };
   } catch {
     return fallback;
   }
@@ -133,7 +153,7 @@ async function main() {
 
     const blocks: MigrationBlock[] = markdownToBlocks(body);
     const metadata = { playCricketId };
-    const title = await fetchTitle(playCricketId);
+    const { title, matchDate } = await fetchGameDetails(playCricketId);
     const slug = `match-report-${playCricketId}`;
 
     const existing = await db
@@ -224,7 +244,9 @@ async function main() {
           body: JSON.stringify(blocks),
           metadata: JSON.stringify(metadata),
           status: "published",
-          published_at: new Date(),
+          // The public "live from" date: the match date when the games
+          // API can supply it, otherwise the import time.
+          published_at: matchDate ?? new Date(),
           created_by: userId,
           updated_by: userId,
         })

--- a/apps/api/scripts/migrate-game-reports.ts
+++ b/apps/api/scripts/migrate-game-reports.ts
@@ -1,0 +1,240 @@
+/**
+ * One-off migration (#487): import the legacy MDX game reports into the
+ * content API's tables as published game_report items.
+ *
+ * Idempotent: upserts by playCricketId. Unchanged reports are skipped,
+ * changed ones are updated (with a revision written), new ones inserted
+ * with their creation revision.
+ *
+ * Usage (local):
+ *   DATABASE_URL=postgres://percy:percy@localhost:5433/percy_main \
+ *     pnpm exec tsx scripts/migrate-game-reports.ts --user <user-id> [--dry-run]
+ *
+ * Against prod, run with the standard prod access pattern and the
+ * admin_rw URL - coordinate first; never point this at prod casually.
+ * Optionally set GAMES_API_BASE (e.g. https://api.v2.percymain.org) to
+ * derive human titles from the games API; otherwise titles fall back to
+ * "Match report <playCricketId>".
+ */
+import { createClient } from "@percy-main/db";
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  blocksEqualIgnoringIds,
+  markdownToBlocks,
+  type MigrationBlock,
+} from "./markdown-to-blocks.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const GAMES_DIR = path.resolve(__dirname, "../../web/content/games");
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const userFlag = args.indexOf("--user");
+  const userId = userFlag >= 0 ? args[userFlag + 1] : undefined;
+  const dryRun = args.includes("--dry-run");
+  const force = args.includes("--force");
+  if (!userId) {
+    console.error(
+      "Usage: tsx scripts/migrate-game-reports.ts --user <user-id> [--dry-run] [--force]",
+    );
+    process.exit(1);
+  }
+  return { userId, dryRun, force };
+}
+
+function parseFrontmatter(source: string): {
+  playCricketId: string;
+  body: string;
+} {
+  const match = /^---\n([\s\S]*?)\n---\n?/.exec(source);
+  if (!match) throw new Error("No frontmatter block");
+  const idMatch = /playCricketId:\s*"?(\d+)"?/.exec(match[1] ?? "");
+  const playCricketId = idMatch?.[1];
+  if (!playCricketId) throw new Error("No playCricketId in frontmatter");
+  return { playCricketId, body: source.slice(match[0].length) };
+}
+
+/** Defensive: this corpus has no JSX/imports/images; refuse if one appears. */
+function assertPlainMarkdown(body: string, file: string) {
+  if (/^\s*import\s/m.test(body) || /<[A-Z][A-Za-z]*/.test(body)) {
+    throw new Error(`${file} contains JSX/imports - migrate it by hand`);
+  }
+  if (/!\[/.test(body)) {
+    throw new Error(
+      `${file} contains images - upload them through the image pipeline first`,
+    );
+  }
+}
+
+async function fetchTitle(playCricketId: string): Promise<string> {
+  const fallback = `Match report ${playCricketId}`;
+  const base = process.env.GAMES_API_BASE;
+  if (!base) return fallback;
+  try {
+    const res = await fetch(`${base}/api/games/${playCricketId}`);
+    if (!res.ok) return fallback;
+    const game = (await res.json()) as {
+      team?: { name?: string };
+      opposition?: { club?: { name?: string } };
+      matchDate?: string;
+    };
+    if (game.team?.name && game.opposition?.club?.name) {
+      const date = game.matchDate ? ` - ${game.matchDate}` : "";
+      return `${game.team.name} vs ${game.opposition.club.name}${date}`;
+    }
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function main() {
+  const { userId, dryRun, force } = parseArgs();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+  const { client: db } = createClient(databaseUrl);
+
+  const files = (await fs.readdir(GAMES_DIR))
+    .filter((f) => f.endsWith(".mdx"))
+    .sort();
+  console.log(`Found ${String(files.length)} reports in ${GAMES_DIR}`);
+
+  let inserted = 0;
+  let updated = 0;
+  let skipped = 0;
+  let warnings = 0;
+
+  for (const file of files) {
+    const source = await fs.readFile(path.join(GAMES_DIR, file), "utf8");
+    const { playCricketId, body } = parseFrontmatter(source);
+    assertPlainMarkdown(body, file);
+
+    const blocks: MigrationBlock[] = markdownToBlocks(body);
+    const metadata = { playCricketId };
+    const title = await fetchTitle(playCricketId);
+    const slug = `match-report-${playCricketId}`;
+
+    const existing = await db
+      .selectFrom("content_item")
+      .select(["id", "body", "title", "description", "metadata", "status"])
+      .where("kind", "=", "game_report")
+      .where((eb) =>
+        eb(
+          eb.fn("jsonb_extract_path_text", [
+            eb.ref("metadata"),
+            eb.val("playCricketId"),
+          ]),
+          "=",
+          playCricketId,
+        ),
+      )
+      .executeTakeFirst();
+
+    if (existing) {
+      // A row that exists but is not published would still 404 publicly -
+      // never silently treat that as migrated. Equally, never overwrite a
+      // row an editor may have touched unless explicitly forced: after
+      // cutover the DB is canonical and the MDX is the stale ancestor.
+      if (existing.status !== "published") {
+        warnings += 1;
+        console.warn(
+          `  ! ${file}: a ${existing.status} item already exists for playCricketId ${playCricketId} - the public endpoint will 404. Publish or remove it, then re-run.`,
+        );
+        continue;
+      }
+      if (blocksEqualIgnoringIds(existing.body, blocks)) {
+        skipped += 1;
+        console.log(`  = ${file} unchanged (${existing.title})`);
+        continue;
+      }
+      if (!force) {
+        warnings += 1;
+        console.warn(
+          `  ! ${file}: published item '${existing.title}' differs from the MDX conversion (likely edited in the DB). Skipping - re-run with --force to overwrite.`,
+        );
+        continue;
+      }
+    }
+
+    if (dryRun) {
+      console.log(
+        `  ~ ${file} would ${existing ? "update" : "insert"} '${title}' (${String(blocks.length)} blocks)`,
+      );
+      continue;
+    }
+
+    await db.transaction().execute(async (tx) => {
+      if (existing) {
+        await tx
+          .updateTable("content_item")
+          .set({
+            body: JSON.stringify(blocks),
+            updated_by: userId,
+            updated_at: new Date(),
+          })
+          .where("id", "=", existing.id)
+          .execute();
+        // Revision snapshots the row's post-update state: only the body
+        // changed, so title/description/metadata come from the row.
+        await tx
+          .insertInto("content_revision")
+          .values({
+            content_id: existing.id,
+            title: existing.title,
+            description: existing.description,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(existing.metadata),
+            saved_by: userId,
+          })
+          .execute();
+        updated += 1;
+        console.log(`  ^ ${file} updated (${existing.title})`);
+        return;
+      }
+
+      const item = await tx
+        .insertInto("content_item")
+        .values({
+          kind: "game_report",
+          slug,
+          title,
+          description: null,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          status: "published",
+          published_at: new Date(),
+          created_by: userId,
+          updated_by: userId,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      await tx
+        .insertInto("content_revision")
+        .values({
+          content_id: item.id,
+          title,
+          description: null,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          saved_by: userId,
+        })
+        .execute();
+      inserted += 1;
+      console.log(`  + ${file} inserted as '${title}'`);
+    });
+  }
+
+  console.log(
+    `Done: ${String(inserted)} inserted, ${String(updated)} updated, ${String(skipped)} unchanged, ${String(warnings)} warnings${dryRun ? " (dry run)" : ""}`,
+  );
+  if (warnings > 0) process.exitCode = 2;
+  await db.destroy();
+}
+
+await main();

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,10 @@ import { createAuth, type Auth } from "./features/auth/auth.ts";
 import { createPhoenixTracer } from "./lib/phoenix-tracer.ts";
 import { createPushSender, type SendPush } from "./lib/push-sender.ts";
 import {
+  createContentImageStore,
+  type ContentImageStore,
+} from "./lib/s3-content-images.ts";
+import {
   createS3DocumentStore,
   type S3DocumentStore,
 } from "./lib/s3-documents.ts";
@@ -40,6 +44,7 @@ import { authRoutes } from "./features/auth/routes.ts";
 import { availabilityRoutes } from "./features/availability/routes.ts";
 import { chargeRoutes } from "./features/charges/routes.ts";
 import { contactRoutes } from "./features/contact/routes.ts";
+import { contentImageRoutes } from "./features/content-images/routes.ts";
 import { contentRoutes } from "./features/content/routes.ts";
 import { cricketLeaderboardRoutes } from "./features/cricket-leaderboard/routes.ts";
 import { documentRoutes } from "./features/documents/routes.ts";
@@ -82,6 +87,7 @@ declare module "fastify" {
     scoutReports: ScoutReportStore;
     scoutAttachments: ScoutAttachmentStore;
     scoutKnowledgeBase: S3KnowledgeBaseStore;
+    contentImages: ContentImageStore;
     phoenixTracer: Tracer;
   }
 }
@@ -215,6 +221,10 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   const scoutKnowledgeBase = createS3KnowledgeBaseStore(config);
   app.decorate("scoutKnowledgeBase", scoutKnowledgeBase);
 
+  // Create and decorate the content image store (editor-uploaded images)
+  const contentImages = createContentImageStore(config);
+  app.decorate("contentImages", contentImages);
+
   // Isolated tracer provider for LLM spans. New Relic owns the global OTel
   // pipeline; this provider sits alongside it and receives only AI SDK
   // spans via the experimental_telemetry.tracer plumbed through Scout.
@@ -326,6 +336,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(webhookRoutes, { prefix: "/api" });
   await app.register(ogImageRoutes, { prefix: "/api" });
   await app.register(contentRoutes, { prefix: "/api" });
+  await app.register(contentImageRoutes, { prefix: "/api" });
 
   // Marketing forwarder: periodic drain of marketing_outbox -> Google Ads.
   // No-op when GOOGLE_ADS_* env vars are absent.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -40,6 +40,7 @@ import { authRoutes } from "./features/auth/routes.ts";
 import { availabilityRoutes } from "./features/availability/routes.ts";
 import { chargeRoutes } from "./features/charges/routes.ts";
 import { contactRoutes } from "./features/contact/routes.ts";
+import { contentRoutes } from "./features/content/routes.ts";
 import { cricketLeaderboardRoutes } from "./features/cricket-leaderboard/routes.ts";
 import { documentRoutes } from "./features/documents/routes.ts";
 import { fantasyRoutes } from "./features/fantasy/routes.ts";
@@ -324,6 +325,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(pushSubscriptionRoutes, { prefix: "/api" });
   await app.register(webhookRoutes, { prefix: "/api" });
   await app.register(ogImageRoutes, { prefix: "/api" });
+  await app.register(contentRoutes, { prefix: "/api" });
 
   // Marketing forwarder: periodic drain of marketing_outbox -> Google Ads.
   // No-op when GOOGLE_ADS_* env vars are absent.

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -76,6 +76,22 @@ const configSchema = z.object({
   S3_RECEIPT_PREFIX: z.string().default("receipts"),
   S3_ENDPOINT: z.url().optional(),
 
+  // S3 (editor-uploaded content images). Reuses the CloudFront-served
+  // uploads bucket (S3_BUCKET). Key prefixes are deliberately NOT
+  // configurable - they are structural, coupled to the CloudFront
+  // /uploads/* routing and the Terraform lifecycle rule (see
+  // lib/s3-content-images.ts).
+  CONTENT_IMAGE_MAX_BYTES: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(10 * 1024 * 1024),
+  CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(900),
+
   // S3 (policy documents)
   S3_DOCUMENTS_BUCKET: z.string().min(1),
   S3_DOCUMENTS_PREFIX: z.string().default("documents"),

--- a/apps/api/src/features/content-images/integration.test.ts
+++ b/apps/api/src/features/content-images/integration.test.ts
@@ -1,0 +1,155 @@
+import sharp from "sharp";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Config } from "../../config.ts";
+import type { ContentImageStore } from "../../lib/s3-content-images.ts";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import { confirmUpload } from "./service.ts";
+
+const config = {
+  CONTENT_IMAGE_MAX_BYTES: 10 * 1024 * 1024,
+  CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
+} as Config;
+
+// In-memory S3 stand-in: integration tests exercise the real DB and the
+// real sharp pipeline; only the bucket is faked.
+function createMemoryStore(): ContentImageStore & {
+  objects: Map<string, { body: Buffer; contentType: string }>;
+} {
+  const objects = new Map<string, { body: Buffer; contentType: string }>();
+  return {
+    objects,
+    getSignedUploadUrl(imageId, extension) {
+      const pendingKey = `content-images/pending/${imageId}.${extension}`;
+      return Promise.resolve({
+        uploadUrl: `https://mock-s3.example.com/${pendingKey}?presigned=true`,
+        pendingKey,
+      });
+    },
+    headPending(pendingKey) {
+      const obj = objects.get(pendingKey);
+      return Promise.resolve(
+        obj
+          ? { contentLength: obj.body.byteLength, contentType: obj.contentType }
+          : null,
+      );
+    },
+    getPending(pendingKey) {
+      const obj = objects.get(pendingKey);
+      if (!obj) throw new Error(`missing ${pendingKey}`);
+      return Promise.resolve(obj.body);
+    },
+    putVariant(key, body, contentType) {
+      objects.set(key, { body, contentType });
+      return Promise.resolve();
+    },
+    deletePending(pendingKey) {
+      objects.delete(pendingKey);
+      return Promise.resolve();
+    },
+  };
+}
+
+/** A JPEG with GPS + camera EXIF, the privacy-sensitive case. */
+async function makeGpsTaggedJpeg(): Promise<Buffer> {
+  return await sharp({
+    create: {
+      width: 1400,
+      height: 900,
+      channels: 3,
+      background: { r: 200, g: 50, b: 50 },
+    },
+  })
+    .jpeg()
+    .withExif({
+      IFD0: {
+        Make: "TestCam",
+        Model: "TestCam 3000",
+        Copyright: "Percy Main CSC",
+      },
+      IFD3: {
+        GPSLatitudeRef: "N",
+        GPSLatitude: "55/1 0/1 4200/100",
+        GPSLongitudeRef: "W",
+        GPSLongitude: "1/1 27/1 1800/100",
+      },
+    })
+    .toBuffer();
+}
+
+describe("content image pipeline (integration)", () => {
+  let ctx: TestContext;
+  let userId: string;
+
+  beforeAll(async () => {
+    ctx = await startTestContainer();
+    ({ userId } = await seedTestUser(ctx.db, { withMember: false }));
+  }, 120_000);
+
+  afterAll(async () => {
+    await stopTestContainer(ctx);
+  });
+
+  it("processes a GPS-tagged upload into clean responsive variants", async () => {
+    const store = createMemoryStore();
+    const original = await makeGpsTaggedJpeg();
+
+    // Sanity: the fixture really does carry EXIF before processing
+    const originalMeta = await sharp(original).metadata();
+    expect(originalMeta.exif).toBeDefined();
+
+    const imageId = crypto.randomUUID();
+    const pendingKey = `content-images/pending/${imageId}.jpg`;
+    store.objects.set(pendingKey, {
+      body: original,
+      contentType: "image/jpeg",
+    });
+
+    const result = await confirmUpload(
+      ctx.db,
+      store,
+      config,
+    )({
+      imageId,
+      pendingKey,
+      alt: "The winning six",
+      userId,
+    });
+
+    // Every variant written to the public prefix, pending cleaned up
+    const keys = [...store.objects.keys()];
+    expect(store.objects.has(pendingKey)).toBe(false);
+    expect(keys.every((k) => k.startsWith(`uploads/content/${imageId}/`))).toBe(
+      true,
+    );
+    // 1400px source -> 320/640/960/1280 in avif + webp, + jpeg fallback
+    expect(keys).toHaveLength(9);
+
+    // Zero EXIF/GPS metadata in every variant
+    for (const [, obj] of store.objects) {
+      const meta = await sharp(obj.body).metadata();
+      expect(meta.exif).toBeUndefined();
+    }
+
+    // PictureSource descriptor is consumable by OptimisedImage
+    expect(result.picture.img.src).toBe(`/uploads/content/${imageId}/1280.jpg`);
+    expect(result.picture.sources.avif?.split(", ")).toHaveLength(4);
+    expect(result.picture.sources.webp?.split(", ")).toHaveLength(4);
+
+    // Registered in the DB with consent + audit fields
+    const row = await ctx.db
+      .selectFrom("content_image")
+      .selectAll()
+      .where("id", "=", imageId)
+      .executeTakeFirstOrThrow();
+    expect(row.consent_confirmed).toBe(true);
+    expect(row.uploaded_by).toBe(userId);
+    expect(row.alt).toBe("The winning six");
+    expect(row.width).toBe(1400);
+    expect(row.height).toBe(900);
+  });
+});

--- a/apps/api/src/features/content-images/routes.ts
+++ b/apps/api/src/features/content-images/routes.ts
@@ -1,0 +1,58 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { getAuthSession, requireAnyPermission } from "../auth/middleware.ts";
+import {
+  confirmUploadSchema,
+  contentImageResponseSchema,
+  uploadUrlResponseSchema,
+  uploadUrlSchema,
+} from "./schemas.ts";
+import { confirmUpload, createUploadUrl } from "./service.ts";
+
+// Any content editor can upload images - the image library is shared
+// across content kinds, so the gate is "may manage any content".
+const requireAnyContentManage = requireAnyPermission(
+  { resource: "content", action: "manage" },
+  { resource: "content_news", action: "manage" },
+  { resource: "content_reports", action: "manage" },
+  { resource: "content_people", action: "manage" },
+);
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const contentImageRoutes: FastifyPluginAsyncZod = async (app) => {
+  const uploadUrl = createUploadUrl(app.contentImages, app.config);
+  const confirm = confirmUpload(app.db, app.contentImages, app.config);
+
+  app.post(
+    "/admin/content-images/upload-url",
+    {
+      preHandler: [requireAnyContentManage],
+      schema: {
+        body: uploadUrlSchema,
+        response: { 200: uploadUrlResponseSchema },
+      },
+    },
+    async (request) => {
+      return await uploadUrl({ contentType: request.body.contentType });
+    },
+  );
+
+  app.post(
+    "/admin/content-images",
+    {
+      preHandler: [requireAnyContentManage],
+      schema: {
+        body: confirmUploadSchema,
+        response: { 200: contentImageResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await confirm({
+        imageId: request.body.imageId,
+        pendingKey: request.body.pendingKey,
+        alt: request.body.alt,
+        userId: user.id,
+      });
+    },
+  );
+};

--- a/apps/api/src/features/content-images/schemas.ts
+++ b/apps/api/src/features/content-images/schemas.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const CONTENT_IMAGE_CONTENT_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+] as const;
+
+// ── Upload URL ──────────────────────────────────────────────────────────
+
+export const uploadUrlSchema = z.object({
+  contentType: z.enum(CONTENT_IMAGE_CONTENT_TYPES),
+  /**
+   * The uploader must confirm photo consent (especially for juniors)
+   * before a presigned URL is ever issued; it is re-asserted and stored
+   * on the confirm call.
+   */
+  consentConfirmed: z.literal(true),
+});
+
+export const uploadUrlResponseSchema = z.object({
+  imageId: z.string(),
+  uploadUrl: z.string(),
+  pendingKey: z.string(),
+  maxBytes: z.number().int(),
+});
+
+// ── Confirm (process + register) ────────────────────────────────────────
+
+export const confirmUploadSchema = z.object({
+  imageId: z.uuid(),
+  pendingKey: z.string().min(1).max(500),
+  consentConfirmed: z.literal(true),
+  alt: z.string().min(1).max(500).nullish(),
+});
+
+/** Matches the frontend PictureSource shape consumed by OptimisedImage. */
+export const pictureSourceSchema = z.object({
+  sources: z.record(z.string(), z.string()),
+  img: z.object({
+    src: z.string(),
+    w: z.number().int(),
+    h: z.number().int(),
+  }),
+});
+
+export const contentImageResponseSchema = z.object({
+  id: z.string(),
+  picture: pictureSourceSchema,
+  alt: z.string().nullable(),
+  width: z.number().int(),
+  height: z.number().int(),
+});

--- a/apps/api/src/features/content-images/service.test.ts
+++ b/apps/api/src/features/content-images/service.test.ts
@@ -1,0 +1,191 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import sharp from "sharp";
+import { describe, expect, it, vi } from "vitest";
+import type { Config } from "../../config.ts";
+import type {
+  ContentImageStore,
+  PendingImageHead,
+} from "../../lib/s3-content-images.ts";
+import { confirmUpload, createUploadUrl, processImage } from "./service.ts";
+
+const config = {
+  CONTENT_IMAGE_MAX_BYTES: 10 * 1024 * 1024,
+  CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
+} as Config;
+
+function makeStore(
+  overrides: Partial<ContentImageStore> = {},
+): ContentImageStore {
+  return {
+    getSignedUploadUrl: vi.fn().mockResolvedValue({
+      uploadUrl: "https://s3.example/put?sig=1",
+      pendingKey: "content-images/pending/img-1.jpg",
+    }),
+    headPending: vi
+      .fn()
+      .mockResolvedValue({ contentLength: 100, contentType: "image/jpeg" }),
+    getPending: vi.fn(),
+    putVariant: vi.fn().mockResolvedValue(undefined),
+    deletePending: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+async function makeJpeg(width: number, height: number): Promise<Buffer> {
+  return await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 30, g: 120, b: 60 },
+    },
+  })
+    .jpeg()
+    .toBuffer();
+}
+
+describe("processImage", () => {
+  it("builds the full ladder for a large image", async () => {
+    const original = await makeJpeg(2400, 1600);
+    const result = await processImage(original, "img-1", "uploads/content");
+
+    const avifWidths = result.variants
+      .filter((v) => v.format === "avif")
+      .map((v) => v.width);
+    expect(avifWidths).toEqual([320, 640, 960, 1280, 1920]);
+    const webpWidths = result.variants
+      .filter((v) => v.format === "webp")
+      .map((v) => v.width);
+    expect(webpWidths).toEqual([320, 640, 960, 1280, 1920]);
+
+    // Fallback at the largest ladder width in the original format
+    const fallback = result.variants.find((v) => v.format === "jpeg");
+    expect(fallback?.width).toBe(1920);
+    expect(fallback?.key).toBe("uploads/content/img-1/1920.jpg");
+
+    expect(result.picture.img.src).toBe("/uploads/content/img-1/1920.jpg");
+    expect(result.picture.sources.avif).toContain(
+      "/uploads/content/img-1/320.avif 320w",
+    );
+    expect(result.width).toBe(2400);
+    expect(result.height).toBe(1600);
+  });
+
+  it("never upscales a small image", async () => {
+    const original = await makeJpeg(500, 400);
+    const result = await processImage(original, "img-2", "uploads/content");
+
+    const widths = result.variants.map((v) => v.width);
+    expect(Math.max(...widths)).toBeLessThanOrEqual(500);
+    expect(
+      result.variants.filter((v) => v.format === "avif").map((v) => v.width),
+    ).toEqual([320]);
+  });
+
+  it("rejects non-image bytes", async () => {
+    await expect(
+      processImage(Buffer.from("not an image"), "img-3", "uploads/content"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects decodable-but-unsupported formats", async () => {
+    const gif = Buffer.from(
+      "R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
+      "base64",
+    );
+    await expect(
+      processImage(gif, "img-4", "uploads/content"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});
+
+describe("createUploadUrl", () => {
+  it("issues a presigned URL with the size cap", async () => {
+    const store = makeStore();
+    const result = await createUploadUrl(
+      store,
+      config,
+    )({
+      contentType: "image/jpeg",
+    });
+    expect(result.uploadUrl).toContain("https://");
+    expect(result.maxBytes).toBe(config.CONTENT_IMAGE_MAX_BYTES);
+    expect(result.imageId).toMatch(/[0-9a-f-]{36}/);
+  });
+});
+
+describe("confirmUpload", () => {
+  const db = {} as Kysely<DB>;
+  const imageId = "5a0f9c4e-3b6f-4af3-9f30-3d6a52e3b111";
+
+  it("rejects a pendingKey that does not match the imageId", async () => {
+    const store = makeStore();
+    await expect(
+      confirmUpload(
+        db,
+        store,
+        config,
+      )({
+        imageId,
+        pendingKey: "content-images/pending/other-image.jpg",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects a pendingKey outside the pending prefix", async () => {
+    const store = makeStore();
+    await expect(
+      confirmUpload(
+        db,
+        store,
+        config,
+      )({
+        imageId,
+        pendingKey: `receipts/${imageId}.jpg`,
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("404s when the pending object is missing", async () => {
+    const store = makeStore({
+      headPending: vi.fn().mockResolvedValue(null),
+    });
+    await expect(
+      confirmUpload(
+        db,
+        store,
+        config,
+      )({
+        imageId,
+        pendingKey: `content-images/pending/${imageId}.jpg`,
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("rejects and deletes an oversized pending object", async () => {
+    const deletePending = vi.fn().mockResolvedValue(undefined);
+    const store = makeStore({
+      headPending: vi.fn().mockResolvedValue({
+        contentLength: config.CONTENT_IMAGE_MAX_BYTES + 1,
+        contentType: "image/jpeg",
+      } satisfies PendingImageHead),
+      deletePending,
+    });
+    await expect(
+      confirmUpload(
+        db,
+        store,
+        config,
+      )({
+        imageId,
+        pendingKey: `content-images/pending/${imageId}.jpg`,
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(deletePending).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/features/content-images/service.ts
+++ b/apps/api/src/features/content-images/service.ts
@@ -274,6 +274,9 @@ export function confirmUpload(
     const alt = params.alt ?? null;
     const keyPrefix = `${CONTENT_IMAGES_PREFIX}/${params.imageId}`;
 
+    // Idempotent: a duplicate confirm (double-click, retry) re-processed
+    // and overwrote the same deterministic variant keys, so the existing
+    // row is already accurate - don't turn the race into a PK violation.
     await db
       .insertInto("content_image")
       .values({
@@ -288,6 +291,7 @@ export function confirmUpload(
         consent_confirmed: true,
         uploaded_by: params.userId,
       })
+      .onConflict((oc) => oc.column("id").doNothing())
       .execute();
 
     // Deleted last: if the row insert fails the original survives, so a

--- a/apps/api/src/features/content-images/service.ts
+++ b/apps/api/src/features/content-images/service.ts
@@ -1,0 +1,306 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import sharp from "sharp";
+import type { Config } from "../../config.ts";
+import {
+  CONTENT_IMAGE_PENDING_PREFIX,
+  CONTENT_IMAGES_PREFIX,
+  type ContentImageStore,
+} from "../../lib/s3-content-images.ts";
+
+function throwHttpError(statusCode: number, message: string): never {
+  throw Object.assign(new Error(message), { statusCode });
+}
+
+/**
+ * Responsive ladder widths, matching what vite-imagetools generates for
+ * the static corpus. Widths larger than the source are skipped (no
+ * upscaling); the source width itself caps the largest variant.
+ */
+const LADDER_WIDTHS = [320, 640, 960, 1280, 1920] as const;
+
+/** Modern formats every image gets, in <picture> source order. */
+const MODERN_FORMATS = ["avif", "webp"] as const;
+
+/**
+ * Input formats sharp can decode here. HEIC is accepted at presign time
+ * (iPhones produce it) but the prebuilt sharp binaries cannot decode
+ * HEVC-compressed HEIC, so it fails at processing with a clear message
+ * rather than silently - most iOS browsers transcode to JPEG on upload
+ * anyway.
+ */
+const DECODABLE_FORMATS = new Set(["jpeg", "png", "webp"]);
+
+const FALLBACK_CONTENT_TYPES: Record<string, string> = {
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+const EXTENSIONS: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/heic": "heic",
+};
+
+export interface ProcessedVariant {
+  key: string;
+  format: string;
+  width: number;
+  height: number;
+  body: Buffer;
+  contentType: string;
+}
+
+export interface ProcessedImage {
+  variants: ProcessedVariant[];
+  picture: {
+    sources: Record<string, string>;
+    img: { src: string; w: number; h: number };
+  };
+  sourceFormat: string;
+  width: number;
+  height: number;
+}
+
+/**
+ * Decode + validate the original, then build the full responsive ladder:
+ * AVIF + WebP at each ladder width plus an original-format fallback at
+ * the largest width. EXIF/GPS and all other metadata are stripped by
+ * construction - sharp only carries metadata through when withMetadata()
+ * is called, which it never is here. Orientation is applied to pixels
+ * (rotate()) before the EXIF that described it is dropped.
+ */
+export async function processImage(
+  original: Buffer,
+  imageId: string,
+  publicPrefix: string,
+): Promise<ProcessedImage> {
+  let meta;
+  try {
+    meta = await sharp(original).metadata();
+  } catch {
+    throwHttpError(400, "File is not a decodable image");
+  }
+
+  const format = meta.format ?? "unknown";
+  if (!DECODABLE_FORMATS.has(format)) {
+    throwHttpError(
+      400,
+      format === "heif"
+        ? "HEIC images can't be processed here - please convert to JPEG and re-upload"
+        : `Unsupported image format '${format}' - use JPEG, PNG or WebP`,
+    );
+  }
+
+  // rotate() with no args applies the EXIF orientation to the pixels, so
+  // the stored variants render upright everywhere with no metadata.
+  const base = sharp(original).rotate();
+  const { width: sourceWidth, height: sourceHeight } = orientedDimensions(
+    meta.width ?? 0,
+    meta.height ?? 0,
+    meta.orientation,
+  );
+  if (sourceWidth === 0 || sourceHeight === 0) {
+    throwHttpError(400, "Image has no measurable dimensions");
+  }
+
+  const widths: number[] = LADDER_WIDTHS.filter((w) => w <= sourceWidth);
+  if (widths.length === 0) widths.push(Math.min(sourceWidth, 320));
+  const largest = widths[widths.length - 1] ?? sourceWidth;
+
+  const variants: ProcessedVariant[] = [];
+
+  for (const targetFormat of MODERN_FORMATS) {
+    for (const width of widths) {
+      const pipeline = base.clone().resize({ width, withoutEnlargement: true });
+      const encoded =
+        targetFormat === "avif"
+          ? pipeline.avif({ quality: 60 })
+          : pipeline.webp({ quality: 80 });
+      const { data, info } = await encoded.toBuffer({
+        resolveWithObject: true,
+      });
+      variants.push({
+        key: `${publicPrefix}/${imageId}/${String(width)}.${targetFormat}`,
+        format: targetFormat,
+        width: info.width,
+        height: info.height,
+        body: data,
+        contentType: `image/${targetFormat}`,
+      });
+    }
+  }
+
+  // Original-format fallback at the largest ladder width, for browsers
+  // that take the <img> src directly.
+  const fallback = await base
+    .clone()
+    .resize({ width: largest, withoutEnlargement: true })
+    .toFormat(format)
+    .toBuffer({ resolveWithObject: true });
+  const fallbackKey = `${publicPrefix}/${imageId}/${String(largest)}.${format === "jpeg" ? "jpg" : format}`;
+  variants.push({
+    key: fallbackKey,
+    format,
+    width: fallback.info.width,
+    height: fallback.info.height,
+    body: fallback.data,
+    contentType: FALLBACK_CONTENT_TYPES[format] ?? "application/octet-stream",
+  });
+
+  const sources: Record<string, string> = {};
+  for (const targetFormat of MODERN_FORMATS) {
+    sources[targetFormat] = variants
+      .filter((v) => v.format === targetFormat)
+      .map((v) => `/${v.key} ${String(v.width)}w`)
+      .join(", ");
+  }
+
+  return {
+    variants,
+    picture: {
+      sources,
+      img: {
+        src: `/${fallbackKey}`,
+        w: fallback.info.width,
+        h: fallback.info.height,
+      },
+    },
+    sourceFormat: format,
+    width: sourceWidth,
+    height: sourceHeight,
+  };
+}
+
+/** EXIF orientations 5-8 swap the visual width/height. */
+function orientedDimensions(
+  width: number,
+  height: number,
+  orientation: number | undefined,
+): { width: number; height: number } {
+  if (orientation !== undefined && orientation >= 5) {
+    return { width: height, height: width };
+  }
+  return { width, height };
+}
+
+// ── Upload URL ──────────────────────────────────────────────────────────
+
+export function createUploadUrl(store: ContentImageStore, config: Config) {
+  return async (params: { contentType: string }) => {
+    const imageId = crypto.randomUUID();
+    const extension = EXTENSIONS[params.contentType] ?? "bin";
+    const { uploadUrl, pendingKey } = await store.getSignedUploadUrl(
+      imageId,
+      extension,
+      params.contentType,
+    );
+    return {
+      imageId,
+      uploadUrl,
+      pendingKey,
+      maxBytes: config.CONTENT_IMAGE_MAX_BYTES,
+    };
+  };
+}
+
+// ── Confirm: process, write variants, register ──────────────────────────
+
+export function confirmUpload(
+  db: Kysely<DB>,
+  store: ContentImageStore,
+  config: Config,
+) {
+  return async (params: {
+    imageId: string;
+    pendingKey: string;
+    alt?: string | null;
+    userId: string;
+  }) => {
+    // The pending key must be one this feature issued: under our pending
+    // prefix and named by the caller's imageId. Prevents pointing the
+    // processor at arbitrary bucket objects.
+    const expectedPrefix = `${CONTENT_IMAGE_PENDING_PREFIX}/${params.imageId}.`;
+    if (!params.pendingKey.startsWith(expectedPrefix)) {
+      throwHttpError(400, "pendingKey does not match imageId");
+    }
+
+    const tooLarge = async () => {
+      await store.deletePending(params.pendingKey);
+      throwHttpError(
+        400,
+        `Image is too large - maximum size is ${String(Math.floor(config.CONTENT_IMAGE_MAX_BYTES / (1024 * 1024)))}MB`,
+      );
+    };
+
+    const head = await store.headPending(params.pendingKey);
+    if (!head) {
+      throwHttpError(404, "Uploaded file not found - upload may have expired");
+    }
+    if (head.contentLength > config.CONTENT_IMAGE_MAX_BYTES) {
+      await tooLarge();
+    }
+
+    const original = await store.getPending(params.pendingKey);
+    // Re-check actual bytes: a presigned URL can be reused between the
+    // HEAD and the GET, so the HEAD's content-length is advisory only.
+    if (original.byteLength > config.CONTENT_IMAGE_MAX_BYTES) {
+      await tooLarge();
+    }
+
+    let processed;
+    try {
+      processed = await processImage(
+        original,
+        params.imageId,
+        CONTENT_IMAGES_PREFIX,
+      );
+    } catch (err) {
+      // A 400 here is a verdict on the uploaded bytes (corrupt, GIF,
+      // HEIC...): the pending object is permanently useless, so clean it
+      // up now instead of waiting for lifecycle expiry.
+      if ((err as { statusCode?: number }).statusCode === 400) {
+        await store.deletePending(params.pendingKey);
+      }
+      throw err;
+    }
+
+    for (const variant of processed.variants) {
+      await store.putVariant(variant.key, variant.body, variant.contentType);
+    }
+
+    const alt = params.alt ?? null;
+    const keyPrefix = `${CONTENT_IMAGES_PREFIX}/${params.imageId}`;
+
+    await db
+      .insertInto("content_image")
+      .values({
+        id: params.imageId,
+        key_prefix: keyPrefix,
+        original_format: processed.sourceFormat,
+        width: processed.width,
+        height: processed.height,
+        bytes: original.byteLength,
+        picture: JSON.stringify(processed.picture),
+        alt,
+        consent_confirmed: true,
+        uploaded_by: params.userId,
+      })
+      .execute();
+
+    // Deleted last: if the row insert fails the original survives, so a
+    // retry of the confirm call can succeed (variant keys are
+    // deterministic and simply get overwritten).
+    await store.deletePending(params.pendingKey);
+
+    return {
+      id: params.imageId,
+      picture: processed.picture,
+      alt,
+      width: processed.width,
+      height: processed.height,
+    };
+  };
+}

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -1,0 +1,271 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import {
+  archiveContent,
+  createContent,
+  getContent,
+  getPublishedContent,
+  getPublishedGameReport,
+  listContent,
+  listRevisions,
+  publishContent,
+  unpublishContent,
+  updateContent,
+} from "./service.ts";
+
+const body = (text: string) => [
+  {
+    id: crypto.randomUUID(),
+    type: "paragraph",
+    props: {},
+    content: [{ type: "text", text, styles: {} }],
+    children: [],
+  },
+];
+
+describe("content service (integration)", () => {
+  let ctx: TestContext;
+  let userId: string;
+
+  beforeAll(async () => {
+    ctx = await startTestContainer();
+    ({ userId } = await seedTestUser(ctx.db, { withMember: false }));
+  }, 120_000);
+
+  afterAll(async () => {
+    await stopTestContainer(ctx);
+  });
+
+  it("walks a game report through its full lifecycle", async () => {
+    // Create: starts draft, writes the creation revision
+    const { id } = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "firsts-vs-tynemouth",
+      title: "Firsts vs Tynemouth",
+      description: "A nail-biter at Preston Avenue",
+      body: body("What a game."),
+      metadata: { playCricketId: "111111" },
+      userId,
+    });
+
+    const draft = await getContent(ctx.db)(id);
+    expect(draft.status).toBe("draft");
+    expect(draft.publishedAt).toBeNull();
+
+    // Draft content is never served publicly
+    await expect(
+      getPublishedContent(ctx.db)({
+        kind: "game_report",
+        slug: "firsts-vs-tynemouth",
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+
+    // Update writes a second revision
+    await updateContent(ctx.db)({
+      contentId: id,
+      title: "Firsts vs Tynemouth CC",
+      body: body("What a game. Updated."),
+      userId,
+    });
+    const { revisions } = await listRevisions(ctx.db)(id);
+    expect(revisions).toHaveLength(2);
+    expect(revisions[0]?.title).toBe("Firsts vs Tynemouth CC");
+
+    // Publish: now publicly visible by slug and by playCricketId
+    await publishContent(ctx.db)({ contentId: id, userId });
+    const pub = await getPublishedContent(ctx.db)({
+      kind: "game_report",
+      slug: "firsts-vs-tynemouth",
+    });
+    expect(pub.title).toBe("Firsts vs Tynemouth CC");
+    const byPcId = await getPublishedGameReport(ctx.db)("111111");
+    expect(byPcId.id).toBe(id);
+
+    // Slug locks after first publish
+    await expect(
+      updateContent(ctx.db)({ contentId: id, slug: "new-slug", userId }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    // Unpublish hides it again, slug stays locked
+    await unpublishContent(ctx.db)({ contentId: id, userId });
+    await expect(
+      getPublishedGameReport(ctx.db)("111111"),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    await expect(
+      updateContent(ctx.db)({ contentId: id, slug: "new-slug", userId }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    // Archive blocks re-publish, and unpublish offers no back door out
+    await archiveContent(ctx.db)({ contentId: id, userId });
+    await expect(
+      publishContent(ctx.db)({ contentId: id, userId }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    await expect(
+      unpublishContent(ctx.db)({ contentId: id, userId }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("hides scheduled content until its publish time", async () => {
+    const { id } = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "scheduled-report",
+      title: "Scheduled report",
+      description: null,
+      body: body("Coming soon."),
+      metadata: { playCricketId: "222222" },
+      userId,
+    });
+
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const result = await publishContent(ctx.db)({
+      contentId: id,
+      publishedAt: future,
+      userId,
+    });
+    expect(result.publishedAt).toBe(future);
+
+    await expect(
+      getPublishedGameReport(ctx.db)("222222"),
+    ).rejects.toMatchObject({ statusCode: 404 });
+
+    // Re-publish with a past time -> immediately visible
+    const past = new Date(Date.now() - 1000).toISOString();
+    await publishContent(ctx.db)({ contentId: id, publishedAt: past, userId });
+    const pub = await getPublishedGameReport(ctx.db)("222222");
+    expect(pub.id).toBe(id);
+  });
+
+  it("enforces per-kind slug uniqueness on create", async () => {
+    await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "dupe-slug",
+      title: "First",
+      description: null,
+      body: body("One."),
+      metadata: { playCricketId: "333333" },
+      userId,
+    });
+
+    await expect(
+      createContent(ctx.db)({
+        kind: "game_report",
+        slug: "dupe-slug",
+        title: "Second",
+        description: null,
+        body: body("Two."),
+        metadata: { playCricketId: "444444" },
+        userId,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("rejects a second game report for the same Play-Cricket match", async () => {
+    await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "pc-dupe-one",
+      title: "First",
+      description: null,
+      body: body("One."),
+      metadata: { playCricketId: "777777" },
+      userId,
+    });
+
+    // Duplicate on create (even as a draft)
+    await expect(
+      createContent(ctx.db)({
+        kind: "game_report",
+        slug: "pc-dupe-two",
+        title: "Second",
+        description: null,
+        body: body("Two."),
+        metadata: { playCricketId: "777777" },
+        userId,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    // Duplicate via metadata update
+    const other = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "pc-dupe-three",
+      title: "Third",
+      description: null,
+      body: body("Three."),
+      metadata: { playCricketId: "888888" },
+      userId,
+    });
+    await expect(
+      updateContent(ctx.db)({
+        contentId: other.id,
+        metadata: { playCricketId: "777777" },
+        userId,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("filters and paginates the admin list", async () => {
+    const mk = (n: number) =>
+      createContent(ctx.db)({
+        kind: "game_report",
+        slug: `list-report-${n}`,
+        title: `List report ${n}`,
+        description: null,
+        body: body(`Report ${n}.`),
+        metadata: { playCricketId: `55${n}` },
+        userId,
+      });
+    const created = [];
+    for (let n = 0; n < 3; n++) created.push(await mk(n));
+    const [first] = created;
+    if (!first) throw new Error("expected created items");
+    await publishContent(ctx.db)({ contentId: first.id, userId });
+
+    const drafts = await listContent(ctx.db)({
+      kind: "game_report",
+      status: "draft",
+      search: "List report",
+      page: 1,
+      pageSize: 10,
+    });
+    expect(drafts.total).toBe(2);
+    expect(drafts.items.every((i) => i.status === "draft")).toBe(true);
+
+    const paged = await listContent(ctx.db)({
+      kind: "game_report",
+      search: "List report",
+      page: 2,
+      pageSize: 2,
+      status: undefined,
+    });
+    expect(paged.total).toBe(3);
+    expect(paged.items).toHaveLength(1);
+  });
+
+  it("keeps every revision forever, attributed to the saver", async () => {
+    const { id } = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "revision-history",
+      title: "v1",
+      description: null,
+      body: body("v1"),
+      metadata: { playCricketId: "666666" },
+      userId,
+    });
+    await updateContent(ctx.db)({ contentId: id, title: "v2", userId });
+    await updateContent(ctx.db)({ contentId: id, title: "v3", userId });
+
+    const { revisions } = await listRevisions(ctx.db)(id);
+    expect(revisions.map((r) => r.title)).toEqual(["v3", "v2", "v1"]);
+    expect(revisions.every((r) => r.savedBy === userId)).toBe(true);
+  });
+
+  it("404s revision listing for unknown content", async () => {
+    await expect(
+      listRevisions(ctx.db)(crypto.randomUUID()),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -138,6 +138,10 @@ describe("content service (integration)", () => {
     await publishContent(ctx.db)({ contentId: id, publishedAt: past, userId });
     const pub = await getPublishedGameReport(ctx.db)("222222");
     expect(pub.id).toBe(id);
+
+    // Publishing again without a date keeps the original live-from time
+    const again = await publishContent(ctx.db)({ contentId: id, userId });
+    expect(again.publishedAt).toBe(past);
   });
 
   it("enforces per-kind slug uniqueness on create", async () => {

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -27,7 +27,7 @@ import {
   archiveContent,
   createContent,
   getContent,
-  getContentKind,
+  getContentMeta,
   getPublishedContent,
   getPublishedGameReport,
   listContent,
@@ -65,7 +65,7 @@ const publishResponseSchema = z.object({
 export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const list = listContent(app.db);
   const get = getContent(app.db);
-  const kindOf = getContentKind(app.db);
+  const metaOf = getContentMeta(app.db);
   const create = createContent(app.db);
   const update = updateContent(app.db);
   const publish = publishContent(app.db);
@@ -135,8 +135,15 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      const kind = await kindOf(request.params.contentId);
+      const { kind, status } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "manage");
+      // Editing a published item changes the live page instantly (single
+      // body, no staged drafts), so it needs the publish action too. Today
+      // every content role has both; this keeps the manage/publish split
+      // meaningful if a review tier is added later.
+      if (status === "published") {
+        assertContentPermission(request, kind, "publish");
+      }
       const { user } = getAuthSession(request);
       return await update({
         ...request.body,
@@ -157,7 +164,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      const kind = await kindOf(request.params.contentId);
+      const { kind } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "publish");
       const { user } = getAuthSession(request);
       return await publish({
@@ -178,7 +185,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      const kind = await kindOf(request.params.contentId);
+      const { kind } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "publish");
       const { user } = getAuthSession(request);
       return await unpublish({
@@ -198,7 +205,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      const kind = await kindOf(request.params.contentId);
+      const { kind } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "manage");
       const { user } = getAuthSession(request);
       return await archive({
@@ -218,7 +225,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      const kind = await kindOf(request.params.contentId);
+      const { kind } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "view");
       return await revisions(request.params.contentId);
     },

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -1,0 +1,275 @@
+import {
+  checkPermission,
+  type Action,
+} from "@percy-main/shared/auth/permissions";
+import {
+  CONTENT_KIND_RESOURCES,
+  type ContentKind,
+} from "@percy-main/shared/content";
+import type { FastifyRequest } from "fastify";
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { getAuthSession, requireAuth } from "../auth/middleware.ts";
+import {
+  contentDetailResponseSchema,
+  contentIdParamSchema,
+  createContentSchema,
+  listContentQuerySchema,
+  listContentResponseSchema,
+  listRevisionsResponseSchema,
+  playCricketIdParamSchema,
+  publicContentParamsSchema,
+  publicContentResponseSchema,
+  publishContentSchema,
+  updateContentSchema,
+} from "./schemas.ts";
+import {
+  archiveContent,
+  createContent,
+  getContent,
+  getContentKind,
+  getPublishedContent,
+  getPublishedGameReport,
+  listContent,
+  listRevisions,
+  publishContent,
+  unpublishContent,
+  updateContent,
+} from "./service.ts";
+
+/**
+ * Per-kind permission gate. The resource depends on the item's kind
+ * (content / content_news / content_reports / content_people), which for
+ * most routes is only known from the body or the existing row - so this
+ * runs in the handler after requireAuth, not as a static preHandler.
+ */
+function assertContentPermission(
+  request: FastifyRequest,
+  kind: ContentKind,
+  action: Action<"content">,
+) {
+  const { user } = getAuthSession(request);
+  const role = (user as { role?: string | null }).role ?? "user";
+  if (!checkPermission(role, CONTENT_KIND_RESOURCES[kind], action)) {
+    throw Object.assign(new Error("Forbidden"), { statusCode: 403 });
+  }
+}
+
+const idResponseSchema = z.object({ id: z.string() });
+const publishResponseSchema = z.object({
+  id: z.string(),
+  publishedAt: z.string().nullable(),
+});
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
+  const list = listContent(app.db);
+  const get = getContent(app.db);
+  const kindOf = getContentKind(app.db);
+  const create = createContent(app.db);
+  const update = updateContent(app.db);
+  const publish = publishContent(app.db);
+  const unpublish = unpublishContent(app.db);
+  const archive = archiveContent(app.db);
+  const revisions = listRevisions(app.db);
+  const publicGet = getPublishedContent(app.db);
+  const publicGameReport = getPublishedGameReport(app.db);
+
+  // ── Admin ──
+
+  app.get(
+    "/admin/content",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        querystring: listContentQuerySchema,
+        response: { 200: listContentResponseSchema },
+      },
+    },
+    async (request) => {
+      assertContentPermission(request, request.query.kind, "view");
+      return await list(request.query);
+    },
+  );
+
+  app.get(
+    "/admin/content/:contentId",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        response: { 200: contentDetailResponseSchema },
+      },
+    },
+    async (request) => {
+      const item = await get(request.params.contentId);
+      assertContentPermission(request, item.kind, "view");
+      return item;
+    },
+  );
+
+  app.post(
+    "/admin/content",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        body: createContentSchema,
+        response: { 200: idResponseSchema },
+      },
+    },
+    async (request) => {
+      assertContentPermission(request, request.body.kind, "manage");
+      const { user } = getAuthSession(request);
+      return await create({ ...request.body, userId: user.id });
+    },
+  );
+
+  app.put(
+    "/admin/content/:contentId",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        body: updateContentSchema,
+        response: { 200: idResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "manage");
+      const { user } = getAuthSession(request);
+      return await update({
+        ...request.body,
+        contentId: request.params.contentId,
+        userId: user.id,
+      });
+    },
+  );
+
+  app.post(
+    "/admin/content/:contentId/publish",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        body: publishContentSchema,
+        response: { 200: publishResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "publish");
+      const { user } = getAuthSession(request);
+      return await publish({
+        contentId: request.params.contentId,
+        publishedAt: request.body?.publishedAt,
+        userId: user.id,
+      });
+    },
+  );
+
+  app.post(
+    "/admin/content/:contentId/unpublish",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        response: { 200: idResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "publish");
+      const { user } = getAuthSession(request);
+      return await unpublish({
+        contentId: request.params.contentId,
+        userId: user.id,
+      });
+    },
+  );
+
+  app.post(
+    "/admin/content/:contentId/archive",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        response: { 200: idResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "manage");
+      const { user } = getAuthSession(request);
+      return await archive({
+        contentId: request.params.contentId,
+        userId: user.id,
+      });
+    },
+  );
+
+  app.get(
+    "/admin/content/:contentId/revisions",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: contentIdParamSchema,
+        response: { 200: listRevisionsResponseSchema },
+      },
+    },
+    async (request) => {
+      const kind = await kindOf(request.params.contentId);
+      assertContentPermission(request, kind, "view");
+      return await revisions(request.params.contentId);
+    },
+  );
+
+  // ── Public (no auth) ──
+  //
+  // Serves only status='published' AND published_at <= now(). The API is
+  // not behind CloudFront, so publish-to-visible is instant; ETag/304
+  // keeps repeat navigation cheap without any invalidation machinery.
+
+  // Strong ETag from id + last modification time; Fastify discards the
+  // body it is handed on a 304, so send(null) produces an empty response.
+  const etagFor = (item: { id: string; updatedAt: string }) =>
+    `"${item.id}-${Date.parse(item.updatedAt)}"`;
+
+  app.get(
+    "/content/game-report/by-play-cricket-id/:playCricketId",
+    {
+      schema: {
+        params: playCricketIdParamSchema,
+        response: { 200: publicContentResponseSchema, 304: z.null() },
+      },
+    },
+    async (request, reply) => {
+      const item = await publicGameReport(request.params.playCricketId);
+      const etag = etagFor(item);
+      void reply.header("etag", etag);
+      if (request.headers["if-none-match"] === etag) {
+        return await reply.code(304).send(null);
+      }
+      return item;
+    },
+  );
+
+  app.get(
+    "/content/:kind/:slug",
+    {
+      schema: {
+        params: publicContentParamsSchema,
+        response: { 200: publicContentResponseSchema, 304: z.null() },
+      },
+    },
+    async (request, reply) => {
+      const item = await publicGet(request.params);
+      const etag = etagFor(item);
+      void reply.header("etag", etag);
+      if (request.headers["if-none-match"] === etag) {
+        return await reply.code(304).send(null);
+      }
+      return item;
+    },
+  );
+};

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -1,0 +1,140 @@
+import {
+  blockPropValueSchema,
+  contentKindSchema,
+  contentSlugSchema,
+  contentStatusSchema,
+} from "@percy-main/shared/content";
+import { z } from "zod";
+
+// ── Shared shapes ───────────────────────────────────────────────────────
+
+/**
+ * Kind-specific metadata. Each kind's concrete schema lives in
+ * packages/shared (CONTENT_METADATA_SCHEMAS) and is enforced by the
+ * service on every write; at the transport layer it is an open object.
+ */
+export const contentMetadataSchema = z.record(z.string(), z.unknown());
+
+/**
+ * Transport-level body schema: one level of the BlockNote block envelope
+ * with children left opaque. The fully recursive schema
+ * (contentBodySchema in packages/shared) produces self-referencing $refs
+ * that openapi-typescript cannot resolve, so the route layer validates
+ * depth 1 and the service re-validates the whole tree recursively on
+ * every write.
+ */
+const transportBlockSchema = z.object({
+  id: z.string().min(1),
+  type: z.string().min(1),
+  props: z.record(z.string(), blockPropValueSchema),
+  content: z.unknown().optional(),
+  children: z.array(z.unknown()),
+});
+
+export const contentBodyTransportSchema = z.array(transportBlockSchema);
+
+export const contentSummarySchema = z.object({
+  id: z.string(),
+  kind: contentKindSchema,
+  slug: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  status: contentStatusSchema,
+  metadata: contentMetadataSchema,
+  publishedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  updatedBy: z.string(),
+  updatedByName: z.string().nullable(),
+});
+
+export const contentDetailSchema = contentSummarySchema.extend({
+  body: contentBodyTransportSchema,
+});
+
+// ── Admin: list ─────────────────────────────────────────────────────────
+
+export const listContentQuerySchema = z.object({
+  kind: contentKindSchema,
+  status: contentStatusSchema.optional(),
+  search: z.string().min(1).max(200).optional(),
+  page: z.coerce.number().int().positive().default(1),
+  pageSize: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export const listContentResponseSchema = z.object({
+  items: z.array(contentSummarySchema),
+  total: z.number().int().nonnegative(),
+});
+
+// ── Admin: get / create / update ────────────────────────────────────────
+
+export const contentIdParamSchema = z.object({
+  contentId: z.uuid(),
+});
+
+export const createContentSchema = z.object({
+  kind: contentKindSchema,
+  slug: contentSlugSchema,
+  title: z.string().min(1).max(300),
+  description: z.string().min(1).max(1000).nullish(),
+  body: contentBodyTransportSchema,
+  metadata: contentMetadataSchema,
+});
+
+export const updateContentSchema = z.object({
+  slug: contentSlugSchema.optional(),
+  title: z.string().min(1).max(300).optional(),
+  description: z.string().min(1).max(1000).nullish(),
+  body: contentBodyTransportSchema.optional(),
+  metadata: contentMetadataSchema.optional(),
+});
+
+export const contentDetailResponseSchema = contentDetailSchema;
+
+// ── Admin: publish / unpublish / archive ────────────────────────────────
+
+export const publishContentSchema = z
+  .object({
+    /** Omit to publish immediately; a future datetime schedules it. */
+    publishedAt: z.iso.datetime({ offset: true }).optional(),
+  })
+  // Optional so "publish now" needs no request body at all.
+  .optional();
+
+// ── Admin: revisions ────────────────────────────────────────────────────
+
+export const listRevisionsResponseSchema = z.object({
+  revisions: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      savedAt: z.string(),
+      savedBy: z.string(),
+      savedByName: z.string().nullable(),
+    }),
+  ),
+});
+
+// ── Public ──────────────────────────────────────────────────────────────
+
+export const publicContentParamsSchema = z.object({
+  kind: contentKindSchema,
+  slug: contentSlugSchema,
+});
+
+export const playCricketIdParamSchema = z.object({
+  playCricketId: z.string().min(1).max(50),
+});
+
+export const publicContentResponseSchema = z.object({
+  id: z.string(),
+  kind: contentKindSchema,
+  slug: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  body: contentBodyTransportSchema,
+  metadata: contentMetadataSchema,
+  publishedAt: z.string(),
+  updatedAt: z.string(),
+});

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -1,0 +1,254 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockExecuteTakeFirst, mockExecuteTakeFirstOrThrow, mockQueryBuilder } =
+  vi.hoisted(() => {
+    const mockExecuteTakeFirst = vi.fn();
+    const mockExecuteTakeFirstOrThrow = vi.fn();
+    const mockExecute = vi.fn();
+
+    const mockQueryBuilder: Record<string, unknown> = {
+      selectFrom: vi.fn().mockReturnThis(),
+      updateTable: vi.fn().mockReturnThis(),
+      insertInto: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      set: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockReturnThis(),
+      executeTakeFirst: mockExecuteTakeFirst,
+      executeTakeFirstOrThrow: mockExecuteTakeFirstOrThrow,
+      execute: mockExecute,
+    };
+
+    return {
+      mockExecuteTakeFirst,
+      mockExecuteTakeFirstOrThrow,
+      mockExecute,
+      mockQueryBuilder,
+    };
+  });
+
+import {
+  createContent,
+  getPublishedGameReport,
+  publishContent,
+  unpublishContent,
+  updateContent,
+} from "./service.ts";
+
+const db = mockQueryBuilder as unknown as Kysely<DB>;
+
+const validBody = [
+  {
+    id: "block-1",
+    type: "paragraph",
+    props: {},
+    content: [{ type: "text", text: "A fine win.", styles: {} }],
+    children: [],
+  },
+];
+
+function validCreate(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "game_report" as const,
+    slug: "firsts-vs-tynemouth",
+    title: "Firsts vs Tynemouth",
+    description: null,
+    body: validBody,
+    metadata: { playCricketId: "6819685" },
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(mockQueryBuilder)) {
+    const val = mockQueryBuilder[key];
+    if (typeof val === "function" && "mockReturnValue" in (val as object)) {
+      (val as ReturnType<typeof vi.fn>).mockReturnValue(mockQueryBuilder);
+    }
+  }
+  // Transactions run the callback against the same mock builder.
+  (mockQueryBuilder as { transaction?: unknown }).transaction = vi
+    .fn()
+    .mockReturnValue({
+      execute: (cb: (tx: unknown) => unknown) => cb(mockQueryBuilder),
+    });
+  mockExecuteTakeFirst.mockResolvedValue(undefined);
+  mockExecuteTakeFirstOrThrow.mockResolvedValue({ id: "content-1" });
+});
+
+describe("createContent", () => {
+  it("rejects kinds that are not editable yet", async () => {
+    await expect(
+      createContent(db)(validCreate({ kind: "person", metadata: {} })),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects metadata that fails the kind schema", async () => {
+    await expect(
+      createContent(db)(validCreate({ metadata: {} })),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    await expect(
+      createContent(db)(validCreate({ metadata: {} })),
+    ).rejects.toThrow(/playCricketId/);
+  });
+
+  it("rejects a structurally invalid body", async () => {
+    await expect(
+      createContent(db)(validCreate({ body: [{ type: "paragraph" }] })),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects a duplicate slug for the kind", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({ id: "existing" });
+    await expect(createContent(db)(validCreate())).rejects.toMatchObject({
+      statusCode: 409,
+    });
+  });
+
+  it("creates the item and returns its id", async () => {
+    const result = await createContent(db)(validCreate());
+    expect(result).toEqual({ id: "content-1" });
+  });
+});
+
+describe("updateContent", () => {
+  const currentRow = {
+    id: "content-1",
+    kind: "game_report",
+    slug: "firsts-vs-tynemouth",
+    title: "Firsts vs Tynemouth",
+    description: null,
+    body: validBody,
+    metadata: { playCricketId: "6819685" },
+    published_at: null,
+  };
+
+  it("404s when the item does not exist", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
+    await expect(
+      updateContent(db)({
+        contentId: "missing",
+        userId: "user-1",
+        title: "New",
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("locks the slug once the item has ever been published", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      ...currentRow,
+      published_at: new Date("2026-06-01T10:00:00Z"),
+    });
+    await expect(
+      updateContent(db)({
+        contentId: "content-1",
+        userId: "user-1",
+        slug: "different-slug",
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("allows a slug change while never published", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(currentRow) // fetch current
+      .mockResolvedValueOnce(undefined); // slug clash check
+    const result = await updateContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+      slug: "different-slug",
+    });
+    expect(result).toEqual({ id: "content-1" });
+  });
+});
+
+describe("publishContent", () => {
+  it("404s when the item does not exist", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined) // update returning nothing
+      .mockResolvedValueOnce(undefined); // existence check
+    await expect(
+      publishContent(db)({ contentId: "missing", userId: "user-1" }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("409s when the item is archived", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined) // update skipped archived row
+      .mockResolvedValueOnce({ id: "content-1" }); // but it exists
+    await expect(
+      publishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("returns the effective publishedAt", async () => {
+    const at = new Date("2026-07-01T10:00:00Z");
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "content-1",
+      published_at: at,
+    });
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      publishedAt: at.toISOString(),
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      id: "content-1",
+      publishedAt: at.toISOString(),
+    });
+  });
+});
+
+describe("unpublishContent", () => {
+  it("409s when the item is not currently published", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined) // update matched nothing
+      .mockResolvedValueOnce({ id: "content-1" }); // but it exists
+    await expect(
+      unpublishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("404s when the item does not exist", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    await expect(
+      unpublishContent(db)({ contentId: "missing", userId: "user-1" }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe("getPublishedGameReport", () => {
+  it("404s when no published report matches", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
+    await expect(getPublishedGameReport(db)("6819685")).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("maps a published row to the public shape", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "content-1",
+      kind: "game_report",
+      slug: "firsts-vs-tynemouth",
+      title: "Firsts vs Tynemouth",
+      description: null,
+      body: validBody,
+      metadata: { playCricketId: "6819685" },
+      published_at: new Date("2026-06-01T10:00:00Z"),
+      updated_at: new Date("2026-06-02T10:00:00Z"),
+    });
+    const result = await getPublishedGameReport(db)("6819685");
+    expect(result.publishedAt).toBe("2026-06-01T10:00:00.000Z");
+    expect(result.body).toEqual(validBody);
+  });
+});

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -1,0 +1,605 @@
+import type { DB } from "@percy-main/db";
+import {
+  CONTENT_METADATA_SCHEMAS,
+  contentBodySchema,
+  type ContentKind,
+  type ContentStatus,
+} from "@percy-main/shared/content";
+import { sql, type Kysely, type Transaction } from "kysely";
+import type { z } from "zod";
+import type {
+  createContentSchema,
+  listContentQuerySchema,
+  updateContentSchema,
+} from "./schemas.ts";
+
+function throwHttpError(statusCode: number, message: string): never {
+  throw Object.assign(new Error(message), { statusCode });
+}
+
+/**
+ * Validate kind-specific metadata against the shared schema map. Kinds
+ * without a schema are not editable through the API yet (later phases
+ * add theirs).
+ */
+function parseMetadata(kind: ContentKind, metadata: Record<string, unknown>) {
+  const schema = CONTENT_METADATA_SCHEMAS[kind];
+  if (!schema) {
+    throwHttpError(400, `Content kind '${kind}' is not editable yet`);
+  }
+  const result = schema.safeParse(metadata);
+  if (!result.success) {
+    throwHttpError(
+      400,
+      `Invalid metadata for kind '${kind}': ${result.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ")}`,
+    );
+  }
+  return result.data;
+}
+
+/** Validate the body is a structurally sound BlockNote block array. */
+function parseBody(body: unknown) {
+  const result = contentBodySchema.safeParse(body);
+  if (!result.success) {
+    throwHttpError(400, "Body is not a valid block document");
+  }
+  return result.data;
+}
+
+/**
+ * The public game-report lookup is by playCricketId, so it must be unique
+ * across game reports regardless of status (a draft duplicate would make
+ * the lookup nondeterministic the moment it published). A unique
+ * expression index backs this; the explicit check exists for a friendly
+ * 409 instead of a raw constraint violation.
+ */
+async function assertPlayCricketIdAvailable(
+  tx: Transaction<DB>,
+  kind: ContentKind,
+  metadata: Record<string, unknown>,
+  excludeId?: string,
+) {
+  if (kind !== "game_report") return;
+  const playCricketId = metadata.playCricketId;
+  if (typeof playCricketId !== "string") return;
+
+  let query = tx
+    .selectFrom("content_item")
+    .select("id")
+    .where("kind", "=", "game_report")
+    .where(sql<string>`metadata->>'playCricketId'`, "=", playCricketId);
+  if (excludeId !== undefined) {
+    query = query.where("id", "!=", excludeId);
+  }
+  const clash = await query.executeTakeFirst();
+  if (clash) {
+    throwHttpError(
+      409,
+      `A game report for Play-Cricket match ${playCricketId} already exists`,
+    );
+  }
+}
+
+interface ContentItemRow {
+  id: string;
+  kind: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  status: string;
+  metadata: unknown;
+  published_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  updated_by: string;
+  updated_by_name: string | null;
+}
+
+function toSummary(row: ContentItemRow) {
+  return {
+    id: row.id,
+    kind: row.kind as ContentKind,
+    slug: row.slug,
+    title: row.title,
+    description: row.description,
+    status: row.status as ContentStatus,
+    metadata: row.metadata as Record<string, unknown>,
+    publishedAt: row.published_at?.toISOString() ?? null,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+    updatedBy: row.updated_by,
+    updatedByName: row.updated_by_name,
+  };
+}
+
+const summaryColumns = [
+  "content_item.id",
+  "content_item.kind",
+  "content_item.slug",
+  "content_item.title",
+  "content_item.description",
+  "content_item.status",
+  "content_item.metadata",
+  "content_item.published_at",
+  "content_item.created_at",
+  "content_item.updated_at",
+  "content_item.updated_by",
+] as const;
+
+function selectSummary(db: Kysely<DB>) {
+  return db
+    .selectFrom("content_item")
+    .leftJoin("user as updater", "updater.id", "content_item.updated_by")
+    .select([...summaryColumns, "updater.name as updated_by_name"]);
+}
+
+/** Snapshot the item's editorial fields into content_revision. */
+async function writeRevision(
+  tx: Transaction<DB>,
+  item: {
+    id: string;
+    title: string;
+    description: string | null;
+    body: unknown;
+    metadata: unknown;
+  },
+  savedBy: string,
+) {
+  await tx
+    .insertInto("content_revision")
+    .values({
+      content_id: item.id,
+      title: item.title,
+      description: item.description,
+      body: JSON.stringify(item.body),
+      metadata: JSON.stringify(item.metadata),
+      saved_by: savedBy,
+    })
+    .execute();
+}
+
+// ── Admin: list ─────────────────────────────────────────────────────────
+
+export function listContent(db: Kysely<DB>) {
+  return async (params: z.infer<typeof listContentQuerySchema>) => {
+    let base = db.selectFrom("content_item").where("kind", "=", params.kind);
+    if (params.status !== undefined) {
+      base = base.where("status", "=", params.status);
+    }
+    if (params.search !== undefined) {
+      base = base.where("title", "ilike", `%${params.search}%`);
+    }
+
+    const [items, totalRow] = await Promise.all([
+      base
+        .leftJoin("user as updater", "updater.id", "content_item.updated_by")
+        .select([...summaryColumns, "updater.name as updated_by_name"])
+        .orderBy("content_item.updated_at", "desc")
+        .limit(params.pageSize)
+        .offset((params.page - 1) * params.pageSize)
+        .execute(),
+      base.select(sql<string>`COUNT(*)`.as("total")).executeTakeFirstOrThrow(),
+    ]);
+
+    return {
+      items: items.map(toSummary),
+      total: Number(totalRow.total),
+    };
+  };
+}
+
+// ── Admin: get ──────────────────────────────────────────────────────────
+
+export function getContent(db: Kysely<DB>) {
+  return async (contentId: string) => {
+    const row = await selectSummary(db)
+      .select("content_item.body")
+      .where("content_item.id", "=", contentId)
+      .executeTakeFirst();
+
+    if (!row) throwHttpError(404, "Content not found");
+
+    return { ...toSummary(row), body: parseBody(row.body) };
+  };
+}
+
+/** Kind lookup used by routes to resolve the permission resource. */
+export function getContentKind(db: Kysely<DB>) {
+  return async (contentId: string) => {
+    const row = await db
+      .selectFrom("content_item")
+      .select("kind")
+      .where("id", "=", contentId)
+      .executeTakeFirst();
+    if (!row) throwHttpError(404, "Content not found");
+    return row.kind as ContentKind;
+  };
+}
+
+// ── Admin: create ───────────────────────────────────────────────────────
+
+export function createContent(db: Kysely<DB>) {
+  return async (
+    params: z.infer<typeof createContentSchema> & { userId: string },
+  ) => {
+    const metadata = parseMetadata(params.kind, params.metadata);
+    const body = parseBody(params.body);
+    const description = params.description ?? null;
+
+    return await db.transaction().execute(async (tx) => {
+      const existing = await tx
+        .selectFrom("content_item")
+        .select("id")
+        .where("kind", "=", params.kind)
+        .where("slug", "=", params.slug)
+        .where("parent_id", "is", null)
+        .executeTakeFirst();
+      if (existing) {
+        throwHttpError(
+          409,
+          `A ${params.kind} item with slug '${params.slug}' already exists`,
+        );
+      }
+
+      await assertPlayCricketIdAvailable(tx, params.kind, metadata);
+
+      const item = await tx
+        .insertInto("content_item")
+        .values({
+          kind: params.kind,
+          slug: params.slug,
+          title: params.title,
+          description,
+          body: JSON.stringify(body),
+          metadata: JSON.stringify(metadata),
+          status: "draft",
+          created_by: params.userId,
+          updated_by: params.userId,
+        })
+        .returning(["id"])
+        .executeTakeFirstOrThrow();
+
+      await writeRevision(
+        tx,
+        {
+          id: item.id,
+          title: params.title,
+          description,
+          body,
+          metadata,
+        },
+        params.userId,
+      );
+
+      return { id: item.id };
+    });
+  };
+}
+
+// ── Admin: update ───────────────────────────────────────────────────────
+
+export function updateContent(db: Kysely<DB>) {
+  return async (
+    params: z.infer<typeof updateContentSchema> & {
+      contentId: string;
+      userId: string;
+    },
+  ) => {
+    return await db.transaction().execute(async (tx) => {
+      const current = await tx
+        .selectFrom("content_item")
+        .select([
+          "id",
+          "kind",
+          "slug",
+          "title",
+          "description",
+          "body",
+          "metadata",
+          "published_at",
+        ])
+        .where("id", "=", params.contentId)
+        .executeTakeFirst();
+
+      if (!current) throwHttpError(404, "Content not found");
+
+      const kind = current.kind as ContentKind;
+
+      // Slug locks once the item has ever been published (published_at is
+      // never cleared on unpublish, precisely so it can serve as the
+      // ever-published marker). No redirect handling exists anywhere.
+      if (
+        params.slug !== undefined &&
+        params.slug !== current.slug &&
+        current.published_at !== null
+      ) {
+        throwHttpError(409, "Slug is locked once an item has been published");
+      }
+
+      const title = params.title ?? current.title;
+      const description =
+        params.description !== undefined
+          ? params.description
+          : current.description;
+      const body =
+        params.body !== undefined
+          ? parseBody(params.body)
+          : parseBody(current.body);
+      const metadata =
+        params.metadata !== undefined
+          ? parseMetadata(kind, params.metadata)
+          : parseMetadata(kind, current.metadata as Record<string, unknown>);
+      const slug = params.slug ?? current.slug;
+
+      if (slug !== current.slug) {
+        const clash = await tx
+          .selectFrom("content_item")
+          .select("id")
+          .where("kind", "=", kind)
+          .where("slug", "=", slug)
+          .where("parent_id", "is", null)
+          .where("id", "!=", current.id)
+          .executeTakeFirst();
+        if (clash) {
+          throwHttpError(
+            409,
+            `A ${kind} item with slug '${slug}' already exists`,
+          );
+        }
+      }
+
+      if (params.metadata !== undefined) {
+        await assertPlayCricketIdAvailable(tx, kind, metadata, current.id);
+      }
+
+      await tx
+        .updateTable("content_item")
+        .set({
+          slug,
+          title,
+          description,
+          body: JSON.stringify(body),
+          metadata: JSON.stringify(metadata),
+          updated_by: params.userId,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", current.id)
+        .execute();
+
+      await writeRevision(
+        tx,
+        { id: current.id, title, description, body, metadata },
+        params.userId,
+      );
+
+      return { id: current.id };
+    });
+  };
+}
+
+// ── Admin: status transitions ───────────────────────────────────────────
+
+export function publishContent(db: Kysely<DB>) {
+  return async (params: {
+    contentId: string;
+    publishedAt?: string;
+    userId: string;
+  }) => {
+    const result = await db
+      .updateTable("content_item")
+      .set({
+        status: "published",
+        published_at: params.publishedAt
+          ? new Date(params.publishedAt)
+          : sql`CURRENT_TIMESTAMP`,
+        updated_by: params.userId,
+        updated_at: sql`CURRENT_TIMESTAMP`,
+      })
+      .where("id", "=", params.contentId)
+      .where("status", "!=", "archived")
+      .returning(["id", "published_at"])
+      .executeTakeFirst();
+
+    if (!result) {
+      // Either missing or archived; disambiguate for a useful error.
+      const exists = await db
+        .selectFrom("content_item")
+        .select("id")
+        .where("id", "=", params.contentId)
+        .executeTakeFirst();
+      throwHttpError(
+        exists ? 409 : 404,
+        exists ? "Archived content cannot be published" : "Content not found",
+      );
+    }
+
+    return {
+      id: result.id,
+      publishedAt: result.published_at?.toISOString() ?? null,
+    };
+  };
+}
+
+export function unpublishContent(db: Kysely<DB>) {
+  return async (params: { contentId: string; userId: string }) => {
+    // published_at is deliberately retained: it marks "ever published",
+    // which locks the slug. Visibility is governed by status alone.
+    // Only a published item can be unpublished - in particular this must
+    // not offer a back door out of 'archived' (archive -> unpublish ->
+    // publish would resurrect archived content past the manage-only
+    // archive control).
+    const result = await db
+      .updateTable("content_item")
+      .set({
+        status: "draft",
+        updated_by: params.userId,
+        updated_at: sql`CURRENT_TIMESTAMP`,
+      })
+      .where("id", "=", params.contentId)
+      .where("status", "=", "published")
+      .returning("id")
+      .executeTakeFirst();
+
+    if (!result) {
+      const exists = await db
+        .selectFrom("content_item")
+        .select("id")
+        .where("id", "=", params.contentId)
+        .executeTakeFirst();
+      throwHttpError(
+        exists ? 409 : 404,
+        exists
+          ? "Only published content can be unpublished"
+          : "Content not found",
+      );
+    }
+    return { id: result.id };
+  };
+}
+
+export function archiveContent(db: Kysely<DB>) {
+  return async (params: { contentId: string; userId: string }) => {
+    const result = await db
+      .updateTable("content_item")
+      .set({
+        status: "archived",
+        updated_by: params.userId,
+        updated_at: sql`CURRENT_TIMESTAMP`,
+      })
+      .where("id", "=", params.contentId)
+      .returning("id")
+      .executeTakeFirst();
+
+    if (!result) throwHttpError(404, "Content not found");
+    return { id: result.id };
+  };
+}
+
+// ── Admin: revisions ────────────────────────────────────────────────────
+
+export function listRevisions(db: Kysely<DB>) {
+  return async (contentId: string) => {
+    // 404 on unknown content id so a typo'd URL doesn't read as "no
+    // revisions yet" (every item has at least its creation revision).
+    const exists = await db
+      .selectFrom("content_item")
+      .select("id")
+      .where("id", "=", contentId)
+      .executeTakeFirst();
+    if (!exists) throwHttpError(404, "Content not found");
+
+    const rows = await db
+      .selectFrom("content_revision")
+      .leftJoin("user as saver", "saver.id", "content_revision.saved_by")
+      .select([
+        "content_revision.id",
+        "content_revision.title",
+        "content_revision.saved_at",
+        "content_revision.saved_by",
+        "saver.name as saved_by_name",
+      ])
+      .where("content_revision.content_id", "=", contentId)
+      .orderBy("content_revision.saved_at", "desc")
+      .execute();
+
+    return {
+      revisions: rows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        savedAt: r.saved_at.toISOString(),
+        savedBy: r.saved_by,
+        savedByName: r.saved_by_name,
+      })),
+    };
+  };
+}
+
+// ── Public reads ────────────────────────────────────────────────────────
+
+function toPublic(row: {
+  id: string;
+  kind: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  body: unknown;
+  metadata: unknown;
+  published_at: Date | null;
+  updated_at: Date;
+}) {
+  // Non-null by check constraint when status='published'; guard anyway so
+  // a future constraint change fails loudly instead of serving garbage.
+  if (!row.published_at) {
+    throwHttpError(500, "Published content missing published_at");
+  }
+  const kind = row.kind as ContentKind;
+  // The metadata schema map doubles as the allowlist of kinds the public
+  // API serves at all, and projecting through it strips undeclared keys.
+  // NOTE for later phases: a kind whose declared metadata is itself not
+  // fully public (person carries safeguarding-adjacent flags) must add a
+  // dedicated public projection schema here rather than reusing its write
+  // schema.
+  const schema = CONTENT_METADATA_SCHEMAS[kind];
+  if (!schema) throwHttpError(404, "Content not found");
+  const metadata = schema.safeParse(row.metadata);
+  if (!metadata.success) {
+    throwHttpError(500, "Stored metadata does not match its kind schema");
+  }
+  return {
+    id: row.id,
+    kind,
+    slug: row.slug,
+    title: row.title,
+    description: row.description,
+    body: row.body as z.infer<typeof contentBodySchema>,
+    metadata: metadata.data,
+    publishedAt: row.published_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+}
+
+const publicColumns = [
+  "id",
+  "kind",
+  "slug",
+  "title",
+  "description",
+  "body",
+  "metadata",
+  "published_at",
+  "updated_at",
+] as const;
+
+function publishedOnly(db: Kysely<DB>) {
+  return db
+    .selectFrom("content_item")
+    .select(publicColumns)
+    .where("status", "=", "published")
+    .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`);
+}
+
+export function getPublishedContent(db: Kysely<DB>) {
+  return async (params: { kind: ContentKind; slug: string }) => {
+    const row = await publishedOnly(db)
+      .where("kind", "=", params.kind)
+      .where("slug", "=", params.slug)
+      .executeTakeFirst();
+
+    if (!row) throwHttpError(404, "Content not found");
+    return toPublic(row);
+  };
+}
+
+export function getPublishedGameReport(db: Kysely<DB>) {
+  return async (playCricketId: string) => {
+    const row = await publishedOnly(db)
+      .where("kind", "=", "game_report")
+      .where(sql<string>`metadata->>'playCricketId'`, "=", playCricketId)
+      .executeTakeFirst();
+
+    if (!row) throwHttpError(404, "Content not found");
+    return toPublic(row);
+  };
+}

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -169,7 +169,9 @@ export function listContent(db: Kysely<DB>) {
       base = base.where("status", "=", params.status);
     }
     if (params.search !== undefined) {
-      base = base.where("title", "ilike", `%${params.search}%`);
+      // Escape ILIKE wildcards: search box input is a literal, not a pattern.
+      const literal = params.search.replace(/[\\%_]/g, "\\$&");
+      base = base.where("title", "ilike", `%${literal}%`);
     }
 
     const [items, totalRow] = await Promise.all([
@@ -201,20 +203,33 @@ export function getContent(db: Kysely<DB>) {
 
     if (!row) throwHttpError(404, "Content not found");
 
-    return { ...toSummary(row), body: parseBody(row.body) };
+    // A stored body failing the schema is a server-side data problem, not
+    // a bad request - parseBody's 400 is for write paths.
+    const body = contentBodySchema.safeParse(row.body);
+    if (!body.success) {
+      throwHttpError(500, "Stored body does not match the block schema");
+    }
+    return { ...toSummary(row), body: body.data };
   };
 }
 
-/** Kind lookup used by routes to resolve the permission resource. */
-export function getContentKind(db: Kysely<DB>) {
+/**
+ * Kind + status lookup used by routes: kind resolves the permission
+ * resource, status decides whether editing needs the publish action
+ * (changing a published item changes the live page).
+ */
+export function getContentMeta(db: Kysely<DB>) {
   return async (contentId: string) => {
     const row = await db
       .selectFrom("content_item")
-      .select("kind")
+      .select(["kind", "status"])
       .where("id", "=", contentId)
       .executeTakeFirst();
     if (!row) throwHttpError(404, "Content not found");
-    return row.kind as ContentKind;
+    return {
+      kind: row.kind as ContentKind,
+      status: row.status as ContentStatus,
+    };
   };
 }
 
@@ -391,9 +406,12 @@ export function publishContent(db: Kysely<DB>) {
       .updateTable("content_item")
       .set({
         status: "published",
+        // No explicit date: keep the original first-publish time on a
+        // re-publish (it is the public "live from" date and the
+        // ever-published marker); only stamp now() on first publish.
         published_at: params.publishedAt
           ? new Date(params.publishedAt)
-          : sql`CURRENT_TIMESTAMP`,
+          : sql`COALESCE(published_at, CURRENT_TIMESTAMP)`,
         updated_by: params.userId,
         updated_at: sql`CURRENT_TIMESTAMP`,
       })

--- a/apps/api/src/lib/s3-content-images.ts
+++ b/apps/api/src/lib/s3-content-images.ts
@@ -1,0 +1,150 @@
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import type { Config } from "../config.ts";
+
+/**
+ * Key prefixes are structural, not configuration: pending must stay
+ * outside CloudFront's /uploads/* routing (so unprocessed originals are
+ * never publicly served) and must match the Terraform lifecycle rule
+ * that expires it (infra/modules/cdn/main.tf, expire-pending-content-images);
+ * public must stay inside /uploads/* to be served at all.
+ */
+export const CONTENT_IMAGE_PENDING_PREFIX = "content-images/pending";
+export const CONTENT_IMAGES_PREFIX = "uploads/content";
+
+export interface PendingImageHead {
+  contentLength: number;
+  contentType: string | null;
+}
+
+/**
+ * Store for editor-uploaded content images. Everything lives in the
+ * CloudFront-served uploads bucket (S3_BUCKET): pending browser PUTs go
+ * under a prefix CloudFront does not route, processed variants go under
+ * uploads/content/* where they are served at /uploads/content/*.
+ */
+export interface ContentImageStore {
+  /** Pre-sign a PUT URL for browser-direct upload of the original. */
+  getSignedUploadUrl: (
+    imageId: string,
+    extension: string,
+    contentType: string,
+  ) => Promise<{ uploadUrl: string; pendingKey: string }>;
+
+  /** HEAD the pending object. Returns null if it does not exist. */
+  headPending: (pendingKey: string) => Promise<PendingImageHead | null>;
+
+  /** Download the pending original as a Buffer. */
+  getPending: (pendingKey: string) => Promise<Buffer>;
+
+  /** Write one processed variant under the public prefix. */
+  putVariant: (key: string, body: Buffer, contentType: string) => Promise<void>;
+
+  deletePending: (pendingKey: string) => Promise<void>;
+}
+
+export function createContentImageStore(config: Config): ContentImageStore {
+  const clientOptions: ConstructorParameters<typeof S3Client>[0] = {
+    region: config.S3_REGION,
+  };
+  if (config.S3_ENDPOINT) {
+    clientOptions.endpoint = config.S3_ENDPOINT;
+    clientOptions.forcePathStyle = true;
+  }
+
+  const client = new S3Client(clientOptions);
+  const bucket = config.S3_BUCKET;
+  const pendingPrefix = CONTENT_IMAGE_PENDING_PREFIX;
+  const expirySeconds = config.CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS;
+
+  return {
+    async getSignedUploadUrl(imageId, extension, contentType) {
+      const pendingKey = `${pendingPrefix}/${imageId}.${extension}`;
+      const command = new PutObjectCommand({
+        Bucket: bucket,
+        Key: pendingKey,
+        ContentType: contentType,
+      });
+      const uploadUrl = await getSignedUrl(client, command, {
+        expiresIn: expirySeconds,
+      });
+      return { uploadUrl, pendingKey };
+    },
+
+    async headPending(pendingKey) {
+      try {
+        const res = await client.send(
+          new HeadObjectCommand({ Bucket: bucket, Key: pendingKey }),
+        );
+        return {
+          contentLength: res.ContentLength ?? 0,
+          contentType: res.ContentType ?? null,
+        };
+      } catch (err) {
+        if (isNotFound(err)) return null;
+        throw err;
+      }
+    },
+
+    async getPending(pendingKey) {
+      const res = await client.send(
+        new GetObjectCommand({ Bucket: bucket, Key: pendingKey }),
+      );
+      if (!res.Body) {
+        throw new Error(`No body returned for pending key ${pendingKey}`);
+      }
+      const bytes = await res.Body.transformToByteArray();
+      return Buffer.from(bytes);
+    },
+
+    async putVariant(key, body, contentType) {
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: body,
+          ContentType: contentType,
+          // Variants are content-addressed by image id and never rewritten,
+          // so let CloudFront + browsers cache them indefinitely.
+          CacheControl: "public, max-age=31536000, immutable",
+        }),
+      );
+    },
+
+    async deletePending(pendingKey) {
+      await client.send(
+        new DeleteObjectCommand({ Bucket: bucket, Key: pendingKey }),
+      );
+    },
+  };
+}
+
+function isNotFound(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return e.name === "NotFound" || e.$metadata?.httpStatusCode === 404;
+}
+
+export const noopContentImageStore: ContentImageStore = {
+  getSignedUploadUrl() {
+    throw new Error("Content image store not configured in test");
+  },
+  headPending() {
+    throw new Error("Content image store not configured in test");
+  },
+  getPending() {
+    throw new Error("Content image store not configured in test");
+  },
+  putVariant() {
+    throw new Error("Content image store not configured in test");
+  },
+  deletePending() {
+    throw new Error("Content image store not configured in test");
+  },
+};

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
     exclude: [
       "**/node_modules/**",
       "**/dist/**",

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13791,6 +13791,116 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content-images/upload-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        contentType: "image/jpeg" | "image/png" | "image/webp" | "image/heic";
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            imageId: string;
+                            uploadUrl: string;
+                            pendingKey: string;
+                            maxBytes: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content-images": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        imageId: string;
+                        pendingKey: string;
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                        alt?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            picture: {
+                                sources: {
+                                    [key: string]: string;
+                                };
+                                img: {
+                                    src: string;
+                                    w: number;
+                                    h: number;
+                                };
+                            };
+                            alt: string | null;
+                            width: number;
+                            height: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13276,6 +13276,521 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    kind: "page" | "news" | "event" | "game_report" | "person";
+                    status?: "draft" | "published" | "archived";
+                    search?: string;
+                    page?: number;
+                    pageSize?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                /** @enum {string} */
+                                kind: "page" | "news" | "event" | "game_report" | "person";
+                                slug: string;
+                                title: string;
+                                description: string | null;
+                                /** @enum {string} */
+                                status: "draft" | "published" | "archived";
+                                metadata: {
+                                    [key: string]: unknown;
+                                };
+                                publishedAt: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                                updatedBy: string;
+                                updatedByName: string | null;
+                            }[];
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        kind: "page" | "news" | "event" | "game_report" | "person";
+                        slug: string;
+                        title: string;
+                        description?: string | null;
+                        body: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        metadata: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            /** @enum {string} */
+                            status: "draft" | "published" | "archived";
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string | null;
+                            createdAt: string;
+                            updatedAt: string;
+                            updatedBy: string;
+                            updatedByName: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        slug?: string;
+                        title?: string;
+                        description?: string | null;
+                        body?: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        metadata?: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: date-time */
+                        publishedAt?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            publishedAt: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/unpublish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/revisions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            revisions: {
+                                id: string;
+                                title: string;
+                                savedAt: string;
+                                savedBy: string;
+                                savedByName: string | null;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    playCricketId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/{kind}/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    kind: "page" | "news" | "event" | "game_report" | "person";
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -24842,6 +24842,198 @@
           }
         }
       }
+    },
+    "/api/admin/content-images/upload-url": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contentType": {
+                    "type": "string",
+                    "enum": [
+                      "image/jpeg",
+                      "image/png",
+                      "image/webp",
+                      "image/heic"
+                    ]
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "contentType",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "imageId": {
+                      "type": "string"
+                    },
+                    "uploadUrl": {
+                      "type": "string"
+                    },
+                    "pendingKey": {
+                      "type": "string"
+                    },
+                    "maxBytes": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "imageId",
+                    "uploadUrl",
+                    "pendingKey",
+                    "maxBytes"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content-images": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "imageId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "pendingKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  },
+                  "alt": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "imageId",
+                  "pendingKey",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "picture": {
+                      "type": "object",
+                      "properties": {
+                        "sources": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "img": {
+                          "type": "object",
+                          "properties": {
+                            "src": {
+                              "type": "string"
+                            },
+                            "w": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "h": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "src",
+                            "w",
+                            "h"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "sources",
+                        "img"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "alt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "width": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "height": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "picture",
+                    "alt",
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -23825,6 +23825,1023 @@
           }
         }
       }
+    },
+    "/api/admin/content": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "page",
+                "news",
+                "event",
+                "game_report",
+                "person"
+              ]
+            },
+            "in": "query",
+            "name": "kind",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "published",
+                "archived"
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "page",
+                              "news",
+                              "event",
+                              "game_report",
+                              "person"
+                            ]
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "draft",
+                              "published",
+                              "archived"
+                            ]
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "publishedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "updatedBy": {
+                            "type": "string"
+                          },
+                          "updatedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "kind",
+                          "slug",
+                          "title",
+                          "description",
+                          "status",
+                          "metadata",
+                          "publishedAt",
+                          "createdAt",
+                          "updatedAt",
+                          "updatedBy",
+                          "updatedByName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "total"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "page",
+                      "news",
+                      "event",
+                      "game_report",
+                      "person"
+                    ]
+                  },
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "description": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "kind",
+                  "slug",
+                  "title",
+                  "body",
+                  "metadata"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "draft",
+                        "published",
+                        "archived"
+                      ]
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "updatedBy": {
+                      "type": "string"
+                    },
+                    "updatedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "status",
+                    "metadata",
+                    "publishedAt",
+                    "createdAt",
+                    "updatedAt",
+                    "updatedBy",
+                    "updatedByName",
+                    "body"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "description": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/publish": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "publishedAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "publishedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "publishedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/unpublish": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/archive": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/revisions": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "revisions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "savedAt": {
+                            "type": "string"
+                          },
+                          "savedBy": {
+                            "type": "string"
+                          },
+                          "savedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "savedAt",
+                          "savedBy",
+                          "savedByName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "revisions"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 50
+            },
+            "in": "path",
+            "name": "playCricketId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/{kind}/{slug}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "page",
+                "news",
+                "event",
+                "game_report",
+                "person"
+              ]
+            },
+            "in": "path",
+            "name": "kind",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            },
+            "in": "path",
+            "name": "slug",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,9 @@
   "dependencies": {
     "@ai-sdk/react": "3.0.199",
     "@better-auth/passkey": "^1.6.14",
+    "@blocknote/core": "^0.47.2",
+    "@blocknote/react": "^0.47.2",
+    "@blocknote/shadcn": "^0.47.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 
+/* The BlockNote shadcn package ships its UI as JS using Tailwind utility
+   classes (bg-popover, ring-ring, ...) with no precompiled CSS for them,
+   so its dist must be scanned or the editor menus render unstyled. */
+@source "../node_modules/@blocknote/shadcn/dist";
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
@@ -19,6 +24,26 @@
   --color-border: #e5e7eb;
   --color-border-light: #f3f4f6;
   --color-muted: #4b5563;
+
+  /* shadcn semantic tokens used by @blocknote/shadcn's bundled UI
+     (stone palette). Our own ui/* components use literal colours, so
+     these exist primarily for the editor; values chosen to look native
+     anywhere else they may get used. */
+  --color-background: #ffffff;
+  --color-foreground: #1c1917;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #1c1917;
+  --color-card: #ffffff;
+  --color-card-foreground: #1c1917;
+  --color-accent: #f5f5f4;
+  --color-accent-foreground: #1c1917;
+  --color-muted-foreground: #78716c;
+  --color-primary-foreground: #ffffff;
+  --color-secondary-foreground: #1c1917;
+  --color-input: #e7e5e4;
+  --color-ring: #a8a29e;
+  --color-destructive: #dc2626;
+  --color-destructive-foreground: #ffffff;
   --color-win: #16a34a;
   --color-win-bg: #dcfce7;
   --color-loss: #dc2626;
@@ -488,6 +513,15 @@
   textarea:focus-visible {
     @apply outline-primary outline-2 outline-offset-2;
   }
+}
+
+/* BlockNote editor scope: re-point the tokens whose site-wide values
+   mean something else (muted is a text gray, secondary is the brand
+   yellow) at the neutral surfaces shadcn semantics expect. Utilities
+   resolve CSS variables at use-site, so this only affects the editor. */
+.bn-shadcn {
+  --color-muted: #f5f5f4;
+  --color-secondary: #f5f5f4;
 }
 
 /* MDX content prose styles */

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -206,4 +206,50 @@ describe("ContentBody", () => {
     ]);
     expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
   });
+
+  it("renders contentImage blocks responsively from the picture descriptor", () => {
+    const picture = {
+      sources: {
+        avif: "/uploads/content/img-1/320.avif 320w, /uploads/content/img-1/640.avif 640w",
+        webp: "/uploads/content/img-1/320.webp 320w, /uploads/content/img-1/640.webp 640w",
+      },
+      img: { src: "/uploads/content/img-1/640.jpg", w: 640, h: 480 },
+    };
+    const html = renderBody([
+      block("contentImage", {
+        props: {
+          src: "/uploads/content/img-1/640.jpg",
+          alt: "The winning six",
+          caption: "Scenes",
+          picture: JSON.stringify(picture),
+        },
+      }),
+    ]);
+    expect(html).toContain("<picture>");
+    expect(html).toContain('type="image/avif"');
+    expect(html).toContain('src="/uploads/content/img-1/640.jpg"');
+    expect(html).toContain("Scenes");
+  });
+
+  it("rejects contentImage descriptors with unsafe urls", () => {
+    const picture = {
+      sources: {
+        avif: "javascript:alert(1) 320w",
+      },
+      img: { src: "/uploads/content/img-1/640.jpg", w: 640, h: 480 },
+    };
+    const html = renderBody([
+      block("contentImage", {
+        props: {
+          src: "/uploads/content/img-1/640.jpg",
+          alt: "x",
+          caption: "",
+          picture: JSON.stringify(picture),
+        },
+      }),
+    ]);
+    expect(html).not.toContain("javascript:");
+    // Falls back to the plain (safe) src
+    expect(html).toContain('src="/uploads/content/img-1/640.jpg"');
+  });
 });

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -1,0 +1,209 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+// mdx-components transitively imports the people corpus (.mdx files) and
+// the vite-imagetools image map, neither of which exists outside a Vite
+// build - stub the lookups, the renderer only needs their shapes.
+vi.mock("@/lib/people.js", () => ({
+  getPersonBySlug: (slug: string) =>
+    slug === "alex-slaven"
+      ? { name: "Alex Slaven", photo: undefined, photoPicture: undefined }
+      : undefined,
+}));
+vi.mock("@/lib/image-map.js", () => ({
+  getImageUrl: () => undefined,
+  getPicture: () => undefined,
+}));
+
+import { ContentBody } from "./content-body.js";
+
+// Person (router Link) and GamePreview (react-query) need their providers
+// even for static rendering.
+function renderBody(body: unknown): string {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, enabled: false } },
+  });
+  return renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ContentBody body={body} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+let nextId = 0;
+function block(
+  type: string,
+  overrides: {
+    props?: Record<string, string | number | boolean>;
+    content?: unknown;
+    children?: unknown[];
+  } = {},
+) {
+  nextId += 1;
+  return {
+    id: `block-${String(nextId)}`,
+    type,
+    props: overrides.props ?? {},
+    content: overrides.content ?? [],
+    children: overrides.children ?? [],
+  };
+}
+
+const text = (t: string, styles: Record<string, boolean> = {}) => ({
+  type: "text",
+  text: t,
+  styles,
+});
+
+describe("ContentBody", () => {
+  it("renders nothing for a structurally invalid document", () => {
+    expect(renderBody("not an array")).toBe("");
+    expect(renderBody([{ type: "paragraph" }])).toBe("");
+  });
+
+  it("renders paragraphs, headings and inline styles", () => {
+    const html = renderBody([
+      block("heading", { props: { level: 2 }, content: [text("Top order")] }),
+      block("paragraph", {
+        content: [
+          text("A "),
+          text("fine", { italic: true }),
+          text(" win by "),
+          text("42 runs", { bold: true }),
+        ],
+      }),
+    ]);
+    expect(html).toContain("<h2");
+    expect(html).toContain("Top order");
+    expect(html).toContain("<em>fine</em>");
+    expect(html).toContain("<strong>42 runs</strong>");
+  });
+
+  it("renders raw HTML in text content as inert text", () => {
+    const html = renderBody([
+      block("paragraph", {
+        content: [text('<script>alert("xss")</script>')],
+      }),
+    ]);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("drops unsafe link protocols but keeps the text", () => {
+    const html = renderBody([
+      block("paragraph", {
+        content: [
+          {
+            type: "link",
+
+            href: "javascript:alert(1)",
+            content: [text("click me")],
+          },
+          {
+            type: "link",
+            href: "https://percymain.org",
+            content: [text("safe link")],
+          },
+        ],
+      }),
+    ]);
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("click me");
+    expect(html).toContain('href="https://percymain.org"');
+  });
+
+  it("groups consecutive list items into one list", () => {
+    const html = renderBody([
+      block("bulletListItem", { content: [text("78* from the skipper")] }),
+      block("bulletListItem", { content: [text("4-23 off 8 overs")] }),
+      block("numberedListItem", { content: [text("First")] }),
+    ]);
+    expect(html.match(/<ul/g)).toHaveLength(1);
+    expect(html.match(/<li/g)).toHaveLength(3);
+    expect(html.match(/<ol/g)).toHaveLength(1);
+  });
+
+  it("renders unknown block types as nothing without crashing", () => {
+    const html = renderBody([
+      block("marquee", { content: [text("nope")] }),
+      block("paragraph", { content: [text("still here")] }),
+    ]);
+    expect(html).not.toContain("nope");
+    expect(html).toContain("still here");
+  });
+
+  it("renders the person custom block via the shared component map", () => {
+    const html = renderBody([
+      block("person", { props: { slug: "alex-slaven", role: "Head Coach" } }),
+    ]);
+    expect(html).toContain("person");
+    expect(html).toContain("Head Coach");
+    expect(html).toContain('href="/person/alex-slaven"');
+  });
+
+  it("renders tables", () => {
+    const html = renderBody([
+      block("table", {
+        content: {
+          type: "tableContent",
+          rows: [
+            { cells: [[text("Player")], [text("Runs")]] },
+            { cells: [[text("A. Slaven")], [text("78")]] },
+          ],
+        },
+      }),
+    ]);
+    expect(html).toContain("<table>");
+    expect(html.match(/<tr/g)).toHaveLength(2);
+    expect(html).toContain("A. Slaven");
+  });
+
+  it("renders image blocks only for safe urls", () => {
+    const html = renderBody([
+      block("image", {
+        props: { url: "/uploads/test.jpg", caption: "The winning moment" },
+      }),
+
+      block("image", { props: { url: "javascript:alert(1)" } }),
+    ]);
+    expect(html).toContain('src="/uploads/test.jpg"');
+    expect(html).toContain("The winning moment");
+    expect(html).not.toContain("javascript:");
+  });
+
+  it("tolerates text nodes with missing styles", () => {
+    const html = renderBody([
+      block("paragraph", { content: [{ type: "text", text: "bare node" }] }),
+    ]);
+    expect(html).toContain("bare node");
+  });
+
+  it("refuses plain-http image sources", () => {
+    const html = renderBody([
+      block("image", { props: { url: "http://example.com/pixel.gif" } }),
+    ]);
+    expect(html).not.toContain("pixel.gif");
+  });
+
+  it("renders checklists without disc markers", () => {
+    const html = renderBody([
+      block("checkListItem", {
+        props: { checked: true },
+        content: [text("Covers on")],
+      }),
+    ]);
+    expect(html).toContain("list-none");
+    expect(html).toContain("checked");
+  });
+
+  it("hides the eventPreview block when props are incomplete", () => {
+    const html = renderBody([
+      block("eventPreview", { props: { name: "Quiz night" } }),
+    ]);
+    expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
+  });
+});

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -1,0 +1,400 @@
+import { mdxComponents } from "@/components/mdx-components.js";
+import { cn } from "@/lib/utils.js";
+import {
+  contentBodySchema,
+  CUSTOM_BLOCK_TYPES,
+  type ContentBlock,
+} from "@percy-main/shared/content";
+import { createElement, Fragment, type ReactNode } from "react";
+
+// Renders DB-backed content: the BlockNote editor JSON document (ADR 047),
+// walked as plain data - the BlockNote runtime is never loaded on public
+// pages. Custom blocks resolve against the same component map MDX uses, so
+// migrated content looks identical. There is deliberately no block type
+// that emits raw HTML: everything renders through React elements, so
+// output is sanitised by construction. Unknown or malformed block types
+// render nothing rather than crashing the page.
+
+// ── Inline content ──────────────────────────────────────────────────────
+
+interface StyledText {
+  type: "text";
+  text: string;
+  styles?: Record<string, unknown> | null;
+}
+
+interface InlineLink {
+  type: "link";
+  href: string;
+  content: unknown;
+}
+
+function isStyledText(node: unknown): node is StyledText {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    (node as { type?: unknown }).type === "text" &&
+    typeof (node as { text?: unknown }).text === "string"
+  );
+}
+
+function isInlineLink(node: unknown): node is InlineLink {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    (node as { type?: unknown }).type === "link" &&
+    typeof (node as { href?: unknown }).href === "string"
+  );
+}
+
+/**
+ * Only protocols/paths we trust ever become anchors. Anything else (e.g.
+ * javascript:) renders as its text content with no link.
+ */
+function isSafeHref(href: string): boolean {
+  return /^(https?:|mailto:|tel:)/i.test(href) || /^\/(?!\/)/.test(href);
+}
+
+/**
+ * Stricter than isSafeHref: images render only from https or
+ * site-relative paths (uploads live under /uploads/*). Keeps plain-http
+ * mixed content and protocol oddities out of public pages.
+ */
+function isSafeImageSrc(src: string): boolean {
+  return /^https:/i.test(src) || /^\/(?!\/)/.test(src);
+}
+
+function StyledTextView({ node }: { node: StyledText }) {
+  let element: ReactNode = node.text;
+  // A text node with absent/null styles is still renderable text.
+  const styles = node.styles ?? {};
+  // textColor / backgroundColor are deliberately not honoured: editor
+  // content stays within the site palette.
+  if (styles.code === true) element = <code>{element}</code>;
+  if (styles.bold === true) element = <strong>{element}</strong>;
+  if (styles.italic === true) element = <em>{element}</em>;
+  if (styles.underline === true) element = <u>{element}</u>;
+  if (styles.strike === true) element = <s>{element}</s>;
+  return element;
+}
+
+/**
+ * Inline node arrays carry no ids, so position is the only available key.
+ * That is safe here: this tree is a pure projection of immutable data
+ * (no element state), and a content change replaces the whole document.
+ */
+function InlineContent({ content }: { content: unknown }) {
+  if (!Array.isArray(content)) return null;
+  return content.map((node, i) => {
+    const key = `inline-${String(i)}`;
+    if (isStyledText(node)) {
+      return (
+        <Fragment key={key}>
+          <StyledTextView node={node} />
+        </Fragment>
+      );
+    }
+    if (isInlineLink(node)) {
+      const inner = <InlineContent content={node.content} />;
+      if (!isSafeHref(node.href)) return <span key={key}>{inner}</span>;
+      return (
+        <a key={key} href={node.href}>
+          {inner}
+        </a>
+      );
+    }
+    return null;
+  });
+}
+
+/** Plain-text projection of inline content (for code blocks, alt text). */
+function inlineToText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((node) => {
+      if (isStyledText(node)) return node.text;
+      if (isInlineLink(node)) return inlineToText(node.content);
+      return "";
+    })
+    .join("");
+}
+
+// ── Block helpers ───────────────────────────────────────────────────────
+
+const ALIGN_CLASSES: Record<string, string> = {
+  center: "text-center",
+  right: "text-right",
+  justify: "text-justify",
+};
+
+function alignClass(block: ContentBlock): string | undefined {
+  const alignment = block.props.textAlignment;
+  return typeof alignment === "string" ? ALIGN_CLASSES[alignment] : undefined;
+}
+
+function stringProp(block: ContentBlock, name: string): string | undefined {
+  const value = block.props[name];
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/** Nested children of a non-list block render indented beneath it. */
+function BlockChildren({ block }: { block: ContentBlock }) {
+  if (block.children.length === 0) return null;
+  return (
+    <div className="ml-4">
+      <BlocksView blocks={block.children} />
+    </div>
+  );
+}
+
+// ── Tables ──────────────────────────────────────────────────────────────
+//
+// BlockNote table content: { type: "tableContent", rows: [{ cells }] }
+// where each cell is either an inline-content array (older shape) or a
+// { type: "tableCell", content } object.
+
+function TableCellContent({ cell }: { cell: unknown }) {
+  if (Array.isArray(cell)) return <InlineContent content={cell} />;
+  if (
+    typeof cell === "object" &&
+    cell !== null &&
+    (cell as { type?: unknown }).type === "tableCell"
+  ) {
+    return <InlineContent content={(cell as { content?: unknown }).content} />;
+  }
+  return null;
+}
+
+/** Row/cell position keys are safe for the same reason as inline keys. */
+function TableView({ block }: { block: ContentBlock }) {
+  const content = block.content;
+  if (
+    typeof content !== "object" ||
+    content === null ||
+    !Array.isArray((content as { rows?: unknown }).rows)
+  ) {
+    return null;
+  }
+  const rows = (content as { rows: unknown[] }).rows;
+  return (
+    <table>
+      <tbody>
+        {rows.map((row, ri) => {
+          const cells =
+            typeof row === "object" &&
+            row !== null &&
+            Array.isArray((row as { cells?: unknown }).cells)
+              ? (row as { cells: unknown[] }).cells
+              : [];
+          return (
+            <tr key={`row-${String(ri)}`}>
+              {cells.map((cell, ci) => (
+                <td key={`cell-${String(ci)}`}>
+                  <TableCellContent cell={cell} />
+                </td>
+              ))}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+// ── Block rendering ─────────────────────────────────────────────────────
+
+function BlockView({ block }: { block: ContentBlock }) {
+  switch (block.type) {
+    case "paragraph":
+      return (
+        <div>
+          <p className={alignClass(block)}>
+            <InlineContent content={block.content} />
+          </p>
+          <BlockChildren block={block} />
+        </div>
+      );
+
+    case "heading": {
+      const level =
+        typeof block.props.level === "number"
+          ? Math.min(Math.max(Math.trunc(block.props.level), 1), 6)
+          : 1;
+      return (
+        <div>
+          {createElement(
+            `h${level}`,
+            { className: alignClass(block) },
+            <InlineContent content={block.content} />,
+          )}
+          <BlockChildren block={block} />
+        </div>
+      );
+    }
+
+    case "quote":
+      return (
+        <div>
+          <blockquote>
+            <InlineContent content={block.content} />
+          </blockquote>
+          <BlockChildren block={block} />
+        </div>
+      );
+
+    case "codeBlock":
+      return (
+        <pre className="overflow-x-auto rounded-lg bg-stone-100 p-4 text-sm">
+          <code>{inlineToText(block.content)}</code>
+        </pre>
+      );
+
+    case "table":
+      return <TableView block={block} />;
+
+    case "image": {
+      const url = stringProp(block, "url");
+      if (!url || !isSafeImageSrc(url)) return null;
+      return (
+        <mdxComponents.Image
+          src={url}
+          alt={stringProp(block, "name") ?? stringProp(block, "caption")}
+          caption={stringProp(block, "caption")}
+        />
+      );
+    }
+
+    // Custom blocks - same component map as MDX, so migrated content
+    // renders identically.
+    case CUSTOM_BLOCK_TYPES.person: {
+      const slug = stringProp(block, "slug");
+      if (!slug) return null;
+      return (
+        <mdxComponents.Person slug={slug} role={stringProp(block, "role")} />
+      );
+    }
+
+    case CUSTOM_BLOCK_TYPES.personGrid: {
+      const slugs = stringProp(block, "slugs");
+      if (!slugs) return null;
+      return (
+        <mdxComponents.PersonGrid slugs={slugs.split(",").filter(Boolean)} />
+      );
+    }
+
+    case CUSTOM_BLOCK_TYPES.gamePreview: {
+      const playCricketId = stringProp(block, "playCricketId");
+      if (!playCricketId) return null;
+      return <mdxComponents.GamePreview playCricketId={playCricketId} />;
+    }
+
+    case CUSTOM_BLOCK_TYPES.eventPreview: {
+      const id = stringProp(block, "eventId");
+      const name = stringProp(block, "name");
+      const when = stringProp(block, "when");
+      if (!id || !name || !when) return null;
+      return <mdxComponents.EventPreview id={id} name={name} when={when} />;
+    }
+
+    default:
+      // Unknown / not-yet-supported block types degrade silently.
+      return null;
+  }
+}
+
+const LIST_TYPES: Record<string, "ul" | "ol" | undefined> = {
+  bulletListItem: "ul",
+  numberedListItem: "ol",
+  checkListItem: "ul",
+};
+
+function ListItemView({ item }: { item: ContentBlock }) {
+  return (
+    <li className={alignClass(item)}>
+      {item.type === "checkListItem" && (
+        <input
+          type="checkbox"
+          checked={item.props.checked === true}
+          readOnly
+          className="mr-2 align-middle"
+        />
+      )}
+      <InlineContent content={item.content} />
+      {item.children.length > 0 && <BlocksView blocks={item.children} />}
+    </li>
+  );
+}
+
+/**
+ * Group consecutive list-item blocks of the same type into a single list
+ * element; render everything else block by block.
+ */
+function BlocksView({ blocks }: { blocks: ContentBlock[] }) {
+  const out: ReactNode[] = [];
+  let i = 0;
+
+  while (i < blocks.length) {
+    const block = blocks[i];
+    if (!block) break;
+
+    const listTag = LIST_TYPES[block.type];
+    if (!listTag) {
+      out.push(
+        <Fragment key={block.id}>
+          <BlockView block={block} />
+        </Fragment>,
+      );
+      i += 1;
+      continue;
+    }
+
+    const items: ContentBlock[] = [];
+    while (i < blocks.length) {
+      const candidate = blocks[i];
+      if (candidate?.type !== block.type) break;
+      items.push(candidate);
+      i += 1;
+    }
+
+    out.push(
+      createElement(
+        listTag,
+        {
+          key: block.id,
+          // Checklists show their checkboxes, not the .mdx-content disc
+          // markers a plain ul would get.
+          className:
+            block.type === "checkListItem" ? "ml-0 list-none" : undefined,
+        },
+        items.map((item) => <ListItemView key={item.id} item={item} />),
+      ),
+    );
+  }
+
+  return out;
+}
+
+// ── Public component ────────────────────────────────────────────────────
+
+/**
+ * Single runtime renderer for DB-backed content. Shared by public pages
+ * and the admin draft preview. `body` is the raw value from the API; it
+ * is structurally validated here, and a document that fails validation
+ * renders nothing.
+ */
+export function ContentBody({
+  body,
+  className,
+}: {
+  body: unknown;
+  className?: string;
+}) {
+  const parsed = contentBodySchema.safeParse(body);
+  if (!parsed.success) return null;
+
+  return (
+    <div className={cn("mdx-content flex flex-col *:mb-4", className)}>
+      <BlocksView blocks={parsed.data} />
+    </div>
+  );
+}

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -1,4 +1,8 @@
 import { mdxComponents } from "@/components/mdx-components.js";
+import {
+  OptimisedImage,
+  type PictureSource,
+} from "@/components/optimised-image.js";
 import { cn } from "@/lib/utils.js";
 import {
   contentBodySchema,
@@ -135,6 +139,53 @@ function alignClass(block: ContentBlock): string | undefined {
 function stringProp(block: ContentBlock, name: string): string | undefined {
   const value = block.props[name];
   return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/**
+ * Parse a JSON-stringified PictureSource, rejecting anything whose URLs
+ * fail the image-source check (the descriptor is stored content too).
+ */
+function parsePicture(raw: string | undefined): PictureSource | undefined {
+  if (!raw) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const candidate = parsed as {
+    sources?: unknown;
+    img?: { src?: unknown; w?: unknown; h?: unknown };
+  };
+  if (
+    typeof candidate.img?.src !== "string" ||
+    !isSafeImageSrc(candidate.img.src) ||
+    typeof candidate.img.w !== "number" ||
+    typeof candidate.img.h !== "number" ||
+    typeof candidate.sources !== "object" ||
+    candidate.sources === null
+  ) {
+    return undefined;
+  }
+  const sources: Record<string, string> = {};
+  for (const [format, srcset] of Object.entries(candidate.sources)) {
+    if (typeof srcset !== "string") return undefined;
+    // Every URL in the srcset must individually be a safe image source.
+    const urls = srcset.split(",").map((part) => part.trim().split(/\s+/)[0]);
+    if (!urls.every((u) => u !== undefined && isSafeImageSrc(u))) {
+      return undefined;
+    }
+    sources[format] = srcset;
+  }
+  return {
+    sources,
+    img: {
+      src: candidate.img.src,
+      w: candidate.img.w,
+      h: candidate.img.h,
+    },
+  };
 }
 
 /** Nested children of a non-list block render indented beneath it. */
@@ -294,6 +345,35 @@ function BlockView({ block }: { block: ContentBlock }) {
       const when = stringProp(block, "when");
       if (!id || !name || !when) return null;
       return <mdxComponents.EventPreview id={id} name={name} when={when} />;
+    }
+
+    case CUSTOM_BLOCK_TYPES.contentImage: {
+      const src = stringProp(block, "src");
+      const alt = stringProp(block, "alt") ?? "";
+      const caption = stringProp(block, "caption");
+      // props.picture is the JSON-stringified PictureSource descriptor
+      // produced by the upload pipeline; with it we render the full
+      // responsive ladder, without it we fall back to the plain src.
+      const picture = parsePicture(stringProp(block, "picture"));
+      if (picture) {
+        return (
+          <figure className="my-4 max-w-lg self-center">
+            <OptimisedImage
+              picture={picture}
+              alt={alt}
+              className="h-auto max-w-full rounded-lg"
+              sizes="(max-width: 512px) 100vw, 512px"
+            />
+            {caption && (
+              <figcaption className="mt-2 text-sm text-stone-600">
+                {caption}
+              </figcaption>
+            )}
+          </figure>
+        );
+      }
+      if (!src || !isSafeImageSrc(src)) return null;
+      return <mdxComponents.Image src={src} alt={alt} caption={caption} />;
     }
 
     default:

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13791,6 +13791,116 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content-images/upload-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        contentType: "image/jpeg" | "image/png" | "image/webp" | "image/heic";
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            imageId: string;
+                            uploadUrl: string;
+                            pendingKey: string;
+                            maxBytes: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content-images": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        imageId: string;
+                        pendingKey: string;
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                        alt?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            picture: {
+                                sources: {
+                                    [key: string]: string;
+                                };
+                                img: {
+                                    src: string;
+                                    w: number;
+                                    h: number;
+                                };
+                            };
+                            alt: string | null;
+                            width: number;
+                            height: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13276,6 +13276,521 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    kind: "page" | "news" | "event" | "game_report" | "person";
+                    status?: "draft" | "published" | "archived";
+                    search?: string;
+                    page?: number;
+                    pageSize?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                /** @enum {string} */
+                                kind: "page" | "news" | "event" | "game_report" | "person";
+                                slug: string;
+                                title: string;
+                                description: string | null;
+                                /** @enum {string} */
+                                status: "draft" | "published" | "archived";
+                                metadata: {
+                                    [key: string]: unknown;
+                                };
+                                publishedAt: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                                updatedBy: string;
+                                updatedByName: string | null;
+                            }[];
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        kind: "page" | "news" | "event" | "game_report" | "person";
+                        slug: string;
+                        title: string;
+                        description?: string | null;
+                        body: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        metadata: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            /** @enum {string} */
+                            status: "draft" | "published" | "archived";
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string | null;
+                            createdAt: string;
+                            updatedAt: string;
+                            updatedBy: string;
+                            updatedByName: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        slug?: string;
+                        title?: string;
+                        description?: string | null;
+                        body?: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        metadata?: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: date-time */
+                        publishedAt?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            publishedAt: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/unpublish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/content/{contentId}/revisions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            revisions: {
+                                id: string;
+                                title: string;
+                                savedAt: string;
+                                savedBy: string;
+                                savedByName: string | null;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    playCricketId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/{kind}/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    kind: "page" | "news" | "event" | "game_report" | "person";
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -24842,6 +24842,198 @@
           }
         }
       }
+    },
+    "/api/admin/content-images/upload-url": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contentType": {
+                    "type": "string",
+                    "enum": [
+                      "image/jpeg",
+                      "image/png",
+                      "image/webp",
+                      "image/heic"
+                    ]
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "contentType",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "imageId": {
+                      "type": "string"
+                    },
+                    "uploadUrl": {
+                      "type": "string"
+                    },
+                    "pendingKey": {
+                      "type": "string"
+                    },
+                    "maxBytes": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "imageId",
+                    "uploadUrl",
+                    "pendingKey",
+                    "maxBytes"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content-images": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "imageId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "pendingKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  },
+                  "alt": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "imageId",
+                  "pendingKey",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "picture": {
+                      "type": "object",
+                      "properties": {
+                        "sources": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "img": {
+                          "type": "object",
+                          "properties": {
+                            "src": {
+                              "type": "string"
+                            },
+                            "w": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "h": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "src",
+                            "w",
+                            "h"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "sources",
+                        "img"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "alt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "width": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "height": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "picture",
+                    "alt",
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -23825,6 +23825,1023 @@
           }
         }
       }
+    },
+    "/api/admin/content": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "page",
+                "news",
+                "event",
+                "game_report",
+                "person"
+              ]
+            },
+            "in": "query",
+            "name": "kind",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "published",
+                "archived"
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "page",
+                              "news",
+                              "event",
+                              "game_report",
+                              "person"
+                            ]
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "draft",
+                              "published",
+                              "archived"
+                            ]
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "publishedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "updatedBy": {
+                            "type": "string"
+                          },
+                          "updatedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "kind",
+                          "slug",
+                          "title",
+                          "description",
+                          "status",
+                          "metadata",
+                          "publishedAt",
+                          "createdAt",
+                          "updatedAt",
+                          "updatedBy",
+                          "updatedByName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "total"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "page",
+                      "news",
+                      "event",
+                      "game_report",
+                      "person"
+                    ]
+                  },
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "description": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "kind",
+                  "slug",
+                  "title",
+                  "body",
+                  "metadata"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "draft",
+                        "published",
+                        "archived"
+                      ]
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "updatedBy": {
+                      "type": "string"
+                    },
+                    "updatedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "status",
+                    "metadata",
+                    "publishedAt",
+                    "createdAt",
+                    "updatedAt",
+                    "updatedBy",
+                    "updatedByName",
+                    "body"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                  },
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "description": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/publish": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "publishedAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "publishedAt": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "publishedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/unpublish": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/archive": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/content/{contentId}/revisions": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "revisions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "savedAt": {
+                            "type": "string"
+                          },
+                          "savedBy": {
+                            "type": "string"
+                          },
+                          "savedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "savedAt",
+                          "savedBy",
+                          "savedByName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "revisions"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 50
+            },
+            "in": "path",
+            "name": "playCricketId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/{kind}/{slug}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "page",
+                "news",
+                "event",
+                "game_report",
+                "person"
+              ]
+            },
+            "in": "path",
+            "name": "kind",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200,
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            },
+            "in": "path",
+            "name": "slug",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/apps/web/src/lib/content-images.ts
+++ b/apps/web/src/lib/content-images.ts
@@ -1,0 +1,72 @@
+import { api, callApi } from "@/lib/api-client.js";
+import type { paths } from "@/lib/api.gen.js";
+
+const UPLOADABLE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+] as const;
+
+type UploadableType = (typeof UPLOADABLE_TYPES)[number];
+
+function isUploadableType(type: string): type is UploadableType {
+  return (UPLOADABLE_TYPES as readonly string[]).includes(type);
+}
+
+// Derived from the generated OpenAPI types per house rule; structurally
+// identical to the OptimisedImage PictureSource shape.
+export type UploadedContentImage =
+  paths["/api/admin/content-images"]["post"]["responses"][200]["content"]["application/json"];
+
+/**
+ * Full presigned upload flow for an editor image: presign -> browser PUT
+ * of the original -> confirm (API decodes, strips EXIF, builds the
+ * responsive ladder). The caller is responsible for having collected
+ * photo consent; the API additionally refuses both steps without it.
+ */
+export async function uploadContentImage(
+  file: File,
+  options: { alt?: string },
+): Promise<UploadedContentImage> {
+  const contentType = file.type;
+  if (!isUploadableType(contentType)) {
+    throw new Error("Use a JPEG, PNG or WebP image");
+  }
+
+  const presigned = await callApi(
+    api.POST("/api/admin/content-images/upload-url", {
+      body: { contentType, consentConfirmed: true },
+    }),
+  );
+
+  if (file.size > presigned.maxBytes) {
+    throw new Error(
+      `Image is too large - maximum size is ${String(Math.floor(presigned.maxBytes / (1024 * 1024)))}MB`,
+    );
+  }
+
+  // Browser-direct PUT to S3: the one place a raw fetch is correct, the
+  // target is the presigned S3 URL rather than our API.
+  const putRes = await fetch(presigned.uploadUrl, {
+    method: "PUT",
+    body: file,
+    headers: { "content-type": file.type },
+  });
+  if (!putRes.ok) {
+    throw new Error("Upload failed - please try again");
+  }
+
+  const confirmed = await callApi(
+    api.POST("/api/admin/content-images", {
+      body: {
+        imageId: presigned.imageId,
+        pendingKey: presigned.pendingKey,
+        consentConfirmed: true,
+        alt: options.alt ?? null,
+      },
+    }),
+  );
+
+  return confirmed;
+}

--- a/apps/web/src/pages/admin/access-tab.tsx
+++ b/apps/web/src/pages/admin/access-tab.tsx
@@ -195,6 +195,15 @@ const AI_USE_ROWS = [
   { label: "AI scout", role: "ai_scout_user" },
 ] as const satisfies ReadonlyArray<{ label: string; role: RoleName }>;
 
+// Content editor roles are single roles per scope (every editor gets
+// manage + publish), so they don't fit the viewer/admin grid above.
+const CONTENT_EDITOR_ROWS = [
+  { label: "Content admin (all content)", role: "content_admin" },
+  { label: "News editor (news, events + game reports)", role: "news_editor" },
+  { label: "Reports editor (game reports only)", role: "reports_editor" },
+  { label: "People editor (people profiles)", role: "people_editor" },
+] as const satisfies ReadonlyArray<{ label: string; role: RoleName }>;
+
 function EditRolesDialog({
   user,
   onClose,
@@ -340,6 +349,7 @@ function EditRolesBody({
     <>
       <div className="max-h-[70vh] space-y-6 overflow-y-auto pr-1">
         <ViewManageGrid selected={selectedRoles} onToggle={toggleRole} />
+        <ContentEditingGrid selected={selectedRoles} onToggle={toggleRole} />
         <AiUseGrid selected={selectedRoles} onToggle={toggleRole} />
         <PerTeamGrid
           title="Junior Manager (per junior team)"
@@ -466,6 +476,43 @@ function AiUseGrid({
         </TableHeader>
         <TableBody>
           {AI_USE_ROWS.map((row) => (
+            <TableRow key={row.role}>
+              <TableCell>{row.label}</TableCell>
+              <TableCell className="text-center">
+                <Checkbox
+                  checked={selected.has(row.role)}
+                  onCheckedChange={() => onToggle(row.role)}
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </section>
+  );
+}
+
+function ContentEditingGrid({
+  selected,
+  onToggle,
+}: {
+  selected: Set<RoleName>;
+  onToggle: (role: RoleName) => void;
+}) {
+  return (
+    <section>
+      <h3 className="mb-2 text-sm font-semibold text-stone-900">
+        Content editing
+      </h3>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Scope</TableHead>
+            <TableHead className="w-24 text-center">Editor</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {CONTENT_EDITOR_ROWS.map((row) => (
             <TableRow key={row.role}>
               <TableCell>{row.label}</TableCell>
               <TableCell className="text-center">

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -6,6 +6,7 @@ import { Link, useSearchParams } from "react-router";
 import { AccessTab } from "./access-tab";
 import { ChargesTab } from "./charges-tab";
 import { ContactsTab } from "./contacts-tab";
+import { ContentTab } from "./content-tab";
 import { DocumentsTab } from "./documents-tab";
 import { DuplicatesTab } from "./duplicates-tab";
 import { ExpenseHistoryTab } from "./expense-history-tab";
@@ -159,6 +160,18 @@ const SECTIONS: readonly SectionDef[] = [
         label: "Fantasy",
         visible: (role) => checkPermission(role, "fantasy", "manage"),
         render: () => <FantasyTab />,
+      },
+    ],
+  },
+  {
+    value: "content",
+    label: "Content",
+    subTabs: [
+      {
+        value: "game-reports",
+        label: "Match Reports",
+        visible: (role) => checkPermission(role, "content_reports", "view"),
+        render: () => <ContentTab kind="game_report" />,
       },
     ],
   },

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -1,0 +1,971 @@
+import {
+  BlockNoteSchema,
+  defaultBlockSpecs,
+  filterSuggestionItems,
+  insertOrUpdateBlockForSlashMenu,
+} from "@blocknote/core";
+import "@blocknote/core/fonts/inter.css";
+import {
+  createReactBlockSpec,
+  getDefaultReactSlashMenuItems,
+  SuggestionMenuController,
+  useCreateBlockNote,
+} from "@blocknote/react";
+import { BlockNoteView } from "@blocknote/shadcn";
+import "@blocknote/shadcn/style.css";
+
+import { ContentBody } from "@/components/content-body.js";
+import { mdxComponents } from "@/components/mdx-components.js";
+import {
+  OptimisedImage,
+  type PictureSource,
+} from "@/components/optimised-image.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { Checkbox } from "@/components/ui/checkbox.js";
+import { Input } from "@/components/ui/input.js";
+import { Label } from "@/components/ui/label.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select.js";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs.js";
+import { Textarea } from "@/components/ui/textarea.js";
+import { useHasPermission } from "@/hooks/use-has-permission.js";
+import { api, callApi } from "@/lib/api-client.js";
+import type { paths } from "@/lib/api.gen.js";
+import { uploadContentImage } from "@/lib/content-images.js";
+import { getAllPeople } from "@/lib/people.js";
+import {
+  CONTENT_KIND_RESOURCES,
+  contentBodySchema,
+  CUSTOM_BLOCK_TYPES,
+  type ContentKind,
+} from "@percy-main/shared/content";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+
+// ── Custom blocks ───────────────────────────────────────────────────────
+//
+// Type names come from shared CUSTOM_BLOCK_TYPES so the public renderer
+// maps them 1:1. Each block renders the real public component read-only
+// in-editor, with minimal prop controls underneath.
+
+const personBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.person,
+    propSchema: {
+      slug: { default: "" },
+      role: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => (
+      <div className="my-2 flex w-full max-w-xs flex-col gap-2">
+        {block.props.slug ? (
+          <mdxComponents.Person
+            slug={block.props.slug}
+            role={block.props.role || undefined}
+          />
+        ) : (
+          <p className="text-sm text-stone-500">Choose a person…</p>
+        )}
+        <select
+          aria-label="Person"
+          value={block.props.slug}
+          onChange={(e) => {
+            editor.updateBlock(block, {
+              props: { ...block.props, slug: e.target.value },
+            });
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        >
+          <option value="">Choose a person…</option>
+          {getAllPeople().map((p) => (
+            <option key={p.slug} value={p.slug}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <input
+          aria-label="Role shown on the card"
+          placeholder="Role (optional)"
+          value={block.props.role}
+          onChange={(e) => {
+            editor.updateBlock(block, {
+              props: { ...block.props, role: e.target.value },
+            });
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        />
+      </div>
+    ),
+  },
+);
+
+const gamePreviewBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.gamePreview,
+    propSchema: {
+      playCricketId: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => (
+      <div className="my-2 w-full">
+        {block.props.playCricketId ? (
+          <mdxComponents.GamePreview
+            playCricketId={block.props.playCricketId}
+          />
+        ) : (
+          <p className="text-sm text-stone-500">Choose a game…</p>
+        )}
+        <GameSelect
+          value={block.props.playCricketId}
+          onChange={(id) => {
+            editor.updateBlock(block, {
+              props: { ...block.props, playCricketId: id },
+            });
+          }}
+        />
+      </div>
+    ),
+  },
+);
+
+const eventPreviewBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.eventPreview,
+    propSchema: {
+      eventId: { default: "" },
+      name: { default: "" },
+      when: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const complete =
+        block.props.eventId && block.props.name && block.props.when;
+      const set = (key: "eventId" | "name" | "when", value: string) => {
+        editor.updateBlock(block, {
+          props: { ...block.props, [key]: value },
+        });
+      };
+      return (
+        <div className="my-2 flex w-full max-w-sm flex-col gap-2">
+          {complete ? (
+            <mdxComponents.EventPreview
+              id={block.props.eventId}
+              name={block.props.name}
+              when={block.props.when}
+            />
+          ) : (
+            <p className="text-sm text-stone-500">Fill in the event details…</p>
+          )}
+          <input
+            aria-label="Event id"
+            placeholder="Event id"
+            value={block.props.eventId}
+            onChange={(e) => {
+              set("eventId", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Event name"
+            placeholder="Event name"
+            value={block.props.name}
+            onChange={(e) => {
+              set("name", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Event date"
+            type="date"
+            value={block.props.when}
+            onChange={(e) => {
+              set("when", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+        </div>
+      );
+    },
+  },
+);
+
+function parsePictureProp(raw: string): PictureSource | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  // Same structural floor as the public renderer: enough shape that
+  // OptimisedImage cannot crash on a malformed stored descriptor.
+  const candidate = parsed as {
+    sources?: unknown;
+    img?: { src?: unknown; w?: unknown; h?: unknown };
+  };
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    typeof candidate.img?.src !== "string" ||
+    typeof candidate.img.w !== "number" ||
+    typeof candidate.img.h !== "number" ||
+    typeof candidate.sources !== "object" ||
+    candidate.sources === null
+  ) {
+    return null;
+  }
+  return candidate as PictureSource;
+}
+
+const contentImageBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.contentImage,
+    propSchema: {
+      src: { default: "" },
+      alt: { default: "" },
+      caption: { default: "" },
+      picture: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const picture = parsePictureProp(block.props.picture);
+      return (
+        <figure className="my-2 flex w-full max-w-lg flex-col gap-2">
+          {picture ? (
+            <OptimisedImage
+              picture={picture}
+              alt={block.props.alt}
+              className="h-auto max-w-full rounded-lg"
+              sizes="(max-width: 512px) 100vw, 512px"
+            />
+          ) : block.props.src ? (
+            <img
+              src={block.props.src}
+              alt={block.props.alt}
+              className="h-auto max-w-full rounded-lg"
+            />
+          ) : (
+            <p className="text-sm text-stone-500">Image uploading…</p>
+          )}
+          <input
+            aria-label="Caption"
+            placeholder="Caption (optional)"
+            value={block.props.caption}
+            onChange={(e) => {
+              editor.updateBlock(block, {
+                props: { ...block.props, caption: e.target.value },
+              });
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Alt text for screen readers"
+            placeholder="Describe the photo (alt text)"
+            value={block.props.alt}
+            onChange={(e) => {
+              editor.updateBlock(block, {
+                props: { ...block.props, alt: e.target.value },
+              });
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+        </figure>
+      );
+    },
+  },
+);
+
+// BlockNote's built-in media blocks are removed: their URL-embed tab
+// would bypass the consent + EXIF-strip + responsive pipeline that the
+// contentImage block (slash menu "Upload photo") goes through.
+const {
+  image: _image,
+  video: _video,
+  audio: _audio,
+  file: _file,
+  ...allowedDefaultBlocks
+} = defaultBlockSpecs;
+
+const schema = BlockNoteSchema.create({
+  blockSpecs: {
+    ...allowedDefaultBlocks,
+    [CUSTOM_BLOCK_TYPES.person]: personBlock(),
+    [CUSTOM_BLOCK_TYPES.gamePreview]: gamePreviewBlock(),
+    [CUSTOM_BLOCK_TYPES.eventPreview]: eventPreviewBlock(),
+    [CUSTOM_BLOCK_TYPES.contentImage]: contentImageBlock(),
+  },
+});
+
+type Editor = typeof schema.BlockNoteEditor;
+type PartialBlock = typeof schema.PartialBlock;
+
+// ── Games picker (shared by metadata form + gamePreview block) ──────────
+
+function GameSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  const season = new Date().getFullYear();
+  const { data: games } = useQuery({
+    queryKey: ["games", season],
+    queryFn: () =>
+      callApi(api.GET("/api/games", { params: { query: { season } } })),
+  });
+
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder="Choose a game…" />
+      </SelectTrigger>
+      <SelectContent>
+        {(games ?? []).map((game) => (
+          <SelectItem key={game.id} value={game.id}>
+            {game.team.name} vs {game.opposition.club.name} · {game.matchDate}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+// ── Editor screen ───────────────────────────────────────────────────────
+
+const slugify = (title: string) =>
+  title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+interface EditorProps {
+  kind: ContentKind;
+  contentId: string | null;
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}
+
+export default function ContentEditor({
+  kind,
+  contentId,
+  onClose,
+  onCreated,
+}: EditorProps) {
+  const {
+    data: item,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["admin", "content", "detail", contentId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/content/{contentId}", {
+          params: { path: { contentId: contentId ?? "" } },
+        }),
+      ),
+    enabled: contentId !== null,
+  });
+
+  if (contentId !== null && error) {
+    return (
+      <div className="flex flex-col items-start gap-2 py-8">
+        <p className="text-sm text-red-600">
+          Couldn't load this item - {error.message}
+        </p>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          ← Back to list
+        </Button>
+      </div>
+    );
+  }
+
+  if (contentId !== null && (isLoading || !item)) {
+    return <p className="py-8 text-sm text-stone-500">Loading…</p>;
+  }
+
+  return (
+    <LoadedEditor
+      key={contentId ?? "new"}
+      kind={kind}
+      item={item ?? null}
+      onClose={onClose}
+      onCreated={onCreated}
+    />
+  );
+}
+
+// Derived from the generated OpenAPI types per house rule - never a
+// hand-written response interface.
+type ContentItemDetail =
+  paths["/api/admin/content/{contentId}"]["get"]["responses"][200]["content"]["application/json"];
+
+interface FormState {
+  title: string;
+  slug: string;
+  description: string;
+  playCricketId: string;
+}
+
+function MetadataFields({
+  kind,
+  form,
+  slugLocked,
+  onChange,
+}: {
+  kind: ContentKind;
+  form: FormState;
+  slugLocked: boolean;
+  onChange: (updates: Partial<FormState>) => void;
+}) {
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="content-title">Title</Label>
+        <Input
+          id="content-title"
+          value={form.title}
+          onChange={(e) => {
+            onChange({ title: e.target.value });
+          }}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="content-slug">
+          Slug{slugLocked ? " (locked after publish)" : ""}
+        </Label>
+        <Input
+          id="content-slug"
+          value={form.slug}
+          disabled={slugLocked}
+          onChange={(e) => {
+            onChange({ slug: e.target.value });
+          }}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="content-description">Description (optional)</Label>
+        <Textarea
+          id="content-description"
+          rows={2}
+          value={form.description}
+          onChange={(e) => {
+            onChange({ description: e.target.value });
+          }}
+        />
+      </div>
+      {kind === "game_report" && (
+        <div className="flex flex-col gap-1">
+          <Label>Play-Cricket game</Label>
+          <GameSelect
+            value={form.playCricketId}
+            onChange={(playCricketId) => {
+              onChange({ playCricketId });
+            }}
+          />
+          {form.playCricketId && (
+            <span className="text-xs text-stone-500">
+              Match id: {form.playCricketId}
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+function PublishingCard({
+  item,
+  canPublish,
+  canManage,
+}: {
+  item: ContentItemDetail;
+  canPublish: boolean;
+  canManage: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [publishAt, setPublishAt] = useState("");
+
+  const statusMutation = useMutation({
+    mutationFn: async (action: "publish" | "unpublish" | "archive") => {
+      if (action === "publish") {
+        await callApi(
+          api.POST("/api/admin/content/{contentId}/publish", {
+            params: { path: { contentId: item.id } },
+            body: publishAt
+              ? { publishedAt: new Date(publishAt).toISOString() }
+              : {},
+          }),
+        );
+      } else if (action === "unpublish") {
+        await callApi(
+          api.POST("/api/admin/content/{contentId}/unpublish", {
+            params: { path: { contentId: item.id } },
+          }),
+        );
+      } else {
+        await callApi(
+          api.POST("/api/admin/content/{contentId}/archive", {
+            params: { path: { contentId: item.id } },
+          }),
+        );
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Publishing</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        <p className="text-sm text-stone-600">
+          Status: <strong>{item.status}</strong>
+          {item.publishedAt &&
+            ` · live from ${new Date(item.publishedAt).toLocaleString("en-GB")}`}
+        </p>
+        {item.status !== "archived" && (canPublish || canManage) && (
+          <>
+            {canPublish && (
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="publish-at">
+                  Schedule (leave empty to publish now)
+                </Label>
+                <Input
+                  id="publish-at"
+                  type="datetime-local"
+                  value={publishAt}
+                  onChange={(e) => {
+                    setPublishAt(e.target.value);
+                  }}
+                />
+              </div>
+            )}
+            <div className="flex flex-wrap gap-2">
+              {canPublish && (
+                <Button
+                  size="sm"
+                  disabled={statusMutation.isPending}
+                  onClick={() => {
+                    statusMutation.mutate("publish");
+                  }}
+                >
+                  {publishAt ? "Schedule" : "Publish"}
+                </Button>
+              )}
+              {canPublish && item.status === "published" && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={statusMutation.isPending}
+                  onClick={() => {
+                    statusMutation.mutate("unpublish");
+                  }}
+                >
+                  Unpublish
+                </Button>
+              )}
+              {canManage && (
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  disabled={statusMutation.isPending}
+                  onClick={() => {
+                    statusMutation.mutate("archive");
+                  }}
+                >
+                  Archive
+                </Button>
+              )}
+            </div>
+          </>
+        )}
+        {statusMutation.error && (
+          <p className="text-sm text-red-600">
+            {statusMutation.error instanceof Error
+              ? statusMutation.error.message
+              : "Action failed"}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ConsentBox({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-stone-200 bg-stone-50 p-3">
+      <Checkbox
+        id="photo-consent"
+        checked={checked}
+        onCheckedChange={(value) => {
+          onChange(value === true);
+        }}
+      />
+      <Label
+        htmlFor="photo-consent"
+        className="text-xs leading-snug text-stone-700"
+      >
+        I confirm everyone identifiable in photos I upload has given consent for
+        publication on the club website - for under-18s, that means
+        parent/guardian consent.
+      </Label>
+    </div>
+  );
+}
+
+function EditorPane({
+  editor,
+  slashItems,
+  currentBody,
+}: {
+  editor: Editor;
+  slashItems: () => ReturnType<typeof getDefaultReactSlashMenuItems>;
+  currentBody: () => unknown;
+}) {
+  const [activeTab, setActiveTab] = useState("edit");
+  const [previewBlocks, setPreviewBlocks] = useState<unknown>([]);
+
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={(tab) => {
+        if (tab === "preview") setPreviewBlocks(currentBody());
+        setActiveTab(tab);
+      }}
+    >
+      <TabsList>
+        <TabsTrigger value="edit">Edit</TabsTrigger>
+        <TabsTrigger value="preview">Preview</TabsTrigger>
+      </TabsList>
+      <TabsContent value="edit">
+        <div className="rounded-lg border border-stone-200 bg-white py-4">
+          <BlockNoteView editor={editor} theme="light" slashMenu={false}>
+            <SuggestionMenuController
+              triggerCharacter="/"
+              getItems={(query) =>
+                Promise.resolve(
+                  filterSuggestionItems(
+                    [...slashItems(), ...getDefaultReactSlashMenuItems(editor)],
+                    query,
+                  ),
+                )
+              }
+            />
+          </BlockNoteView>
+        </div>
+      </TabsContent>
+      <TabsContent value="preview">
+        <div className="rounded-lg border border-stone-200 bg-white p-4">
+          <ContentBody body={previewBlocks} />
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function LoadedEditor({
+  kind,
+  item,
+  onClose,
+  onCreated,
+}: {
+  kind: ContentKind;
+  item: ContentItemDetail | null;
+  onClose: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const queryClient = useQueryClient();
+  const { allowed: canManage } = useHasPermission(
+    CONTENT_KIND_RESOURCES[kind],
+    "manage",
+  );
+  const { allowed: canPublish } = useHasPermission(
+    CONTENT_KIND_RESOURCES[kind],
+    "publish",
+  );
+
+  const [form, setForm] = useState<FormState>({
+    title: item?.title ?? "",
+    slug: item?.slug ?? "",
+    description: item?.description ?? "",
+    playCricketId:
+      typeof item?.metadata.playCricketId === "string"
+        ? item.metadata.playCricketId
+        : "",
+  });
+  const [consentConfirmed, setConsentConfirmed] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(
+    item?.updatedAt ?? null,
+  );
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  // Whether the author has manually edited the slug (handler-only flag:
+  // it never affects what's on screen, only how title edits behave).
+  const slugTouchedRef = useRef(item !== null);
+
+  const slugLocked = item?.publishedAt != null;
+
+  const onFormChange = (updates: Partial<FormState>) => {
+    if (updates.slug !== undefined) slugTouchedRef.current = true;
+    setForm((prev) => {
+      const next = { ...prev, ...updates };
+      if (updates.title !== undefined && !slugTouchedRef.current) {
+        next.slug = slugify(updates.title);
+      }
+      return next;
+    });
+  };
+
+  const editor = useCreateBlockNote({
+    schema,
+    initialContent:
+      item && Array.isArray(item.body) && item.body.length > 0
+        ? (item.body as PartialBlock[])
+        : undefined,
+  });
+
+  const editorBody = () =>
+    contentBodySchema.parse(JSON.parse(JSON.stringify(editor.document)));
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const body = editorBody();
+      const metadata = { playCricketId: form.playCricketId };
+      if (item === null) {
+        return await callApi(
+          api.POST("/api/admin/content", {
+            body: {
+              kind,
+              slug: form.slug,
+              title: form.title,
+              description: form.description || null,
+              body,
+              metadata,
+            },
+          }),
+        );
+      }
+      return await callApi(
+        api.PUT("/api/admin/content/{contentId}", {
+          params: { path: { contentId: item.id } },
+          body: {
+            ...(slugLocked ? {} : { slug: form.slug }),
+            title: form.title,
+            description: form.description || null,
+            body,
+            metadata,
+          },
+        }),
+      );
+    },
+    onSuccess: (result) => {
+      setLastSavedAt(new Date().toISOString());
+      void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
+      if (item === null) onCreated(result.id);
+    },
+  });
+
+  const startImageUpload = () => {
+    setUploadError(null);
+    if (!consentConfirmed) {
+      setUploadError(
+        "Tick the photo consent box above before uploading images.",
+      );
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  const onFileChosen = async (file: File) => {
+    try {
+      const uploaded = await uploadContentImage(file, {});
+      const cursor = editor.getTextCursorPosition();
+      editor.insertBlocks(
+        [
+          {
+            type: CUSTOM_BLOCK_TYPES.contentImage,
+            props: {
+              src: uploaded.picture.img.src,
+              alt: "",
+              caption: "",
+              picture: JSON.stringify(uploaded.picture),
+            },
+          },
+        ],
+        cursor.block,
+        "after",
+      );
+    } catch (err) {
+      setUploadError(
+        err instanceof Error ? err.message : "Upload failed - try again",
+      );
+    }
+  };
+
+  const slashItems = () => [
+    {
+      title: "Person card",
+      subtext: "Embed a club member profile card",
+      group: "Club content",
+      aliases: ["person", "player", "profile"],
+      icon: <span aria-hidden>👤</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.person,
+        });
+      },
+    },
+    {
+      title: "Game preview",
+      subtext: "Link a Play-Cricket fixture or result",
+      group: "Club content",
+      aliases: ["game", "match", "fixture"],
+      icon: <span aria-hidden>🏏</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.gamePreview,
+        });
+      },
+    },
+    {
+      title: "Event preview",
+      subtext: "Link a calendar event",
+      group: "Club content",
+      aliases: ["event", "calendar"],
+      icon: <span aria-hidden>📅</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.eventPreview,
+        });
+      },
+    },
+    {
+      title: "Upload photo",
+      subtext: "Add an image (consent required)",
+      group: "Club content",
+      aliases: ["image", "photo", "picture"],
+      icon: <span aria-hidden>📷</span>,
+      onItemClick: startImageUpload,
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = "";
+          if (file) void onFileChosen(file);
+        }}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          ← Back to list
+        </Button>
+        <div className="flex items-center gap-3">
+          {lastSavedAt && (
+            <span className="text-xs text-stone-500">
+              Last saved{" "}
+              {new Date(lastSavedAt).toLocaleTimeString("en-GB", {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </span>
+          )}
+          {canManage && (
+            <Button
+              onClick={() => {
+                saveMutation.mutate();
+              }}
+              disabled={saveMutation.isPending || !form.title || !form.slug}
+            >
+              {saveMutation.isPending
+                ? "Saving…"
+                : item === null
+                  ? "Create draft"
+                  : "Save"}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {saveMutation.error && (
+        <p className="text-sm text-red-600">
+          {saveMutation.error instanceof Error
+            ? saveMutation.error.message
+            : "Save failed"}
+        </p>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="flex flex-col gap-3 lg:col-span-1">
+          <MetadataFields
+            kind={kind}
+            form={form}
+            slugLocked={slugLocked}
+            onChange={onFormChange}
+          />
+          {item !== null && (
+            <PublishingCard
+              item={item}
+              canPublish={canPublish}
+              canManage={canManage}
+            />
+          )}
+          <ConsentBox
+            checked={consentConfirmed}
+            onChange={setConsentConfirmed}
+          />
+          {uploadError && <p className="text-sm text-red-600">{uploadError}</p>}
+        </div>
+
+        <div className="lg:col-span-2">
+          <EditorPane
+            editor={editor}
+            slashItems={slashItems}
+            currentBody={editorBody}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -363,6 +363,56 @@ const slugify = (title: string) =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 
+/** Club-content entries for the slash menu (module-level: no state). */
+function buildSlashItems(editor: Editor, startImageUpload: () => void) {
+  return [
+    {
+      title: "Person card",
+      subtext: "Embed a club member profile card",
+      group: "Club content",
+      aliases: ["person", "player", "profile"],
+      icon: <span aria-hidden>👤</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.person,
+        });
+      },
+    },
+    {
+      title: "Game preview",
+      subtext: "Link a Play-Cricket fixture or result",
+      group: "Club content",
+      aliases: ["game", "match", "fixture"],
+      icon: <span aria-hidden>🏏</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.gamePreview,
+        });
+      },
+    },
+    {
+      title: "Event preview",
+      subtext: "Link a calendar event",
+      group: "Club content",
+      aliases: ["event", "calendar"],
+      icon: <span aria-hidden>📅</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.eventPreview,
+        });
+      },
+    },
+    {
+      title: "Upload photo",
+      subtext: "Add an image (consent required)",
+      group: "Club content",
+      aliases: ["image", "photo", "picture"],
+      icon: <span aria-hidden>📷</span>,
+      onItemClick: startImageUpload,
+    },
+  ];
+}
+
 interface EditorProps {
   kind: ContentKind;
   contentId: string | null;
@@ -502,10 +552,13 @@ function PublishingCard({
   item,
   canPublish,
   canManage,
+  beforePublish,
 }: {
   item: ContentItemDetail;
   canPublish: boolean;
   canManage: boolean;
+  /** Persists the editor's current state; publish aborts if it fails. */
+  beforePublish: () => Promise<unknown>;
 }) {
   const queryClient = useQueryClient();
   const [publishAt, setPublishAt] = useState("");
@@ -513,6 +566,9 @@ function PublishingCard({
   const statusMutation = useMutation({
     mutationFn: async (action: "publish" | "unpublish" | "archive") => {
       if (action === "publish") {
+        // What goes live must be what's in the editor (and what the
+        // preview tab shows), not the last-saved state.
+        await beforePublish();
         await callApi(
           api.POST("/api/admin/content/{contentId}/publish", {
             params: { path: { contentId: item.id } },
@@ -651,10 +707,12 @@ function EditorPane({
   editor,
   slashItems,
   currentBody,
+  onDirty,
 }: {
   editor: Editor;
   slashItems: () => ReturnType<typeof getDefaultReactSlashMenuItems>;
   currentBody: () => unknown;
+  onDirty: () => void;
 }) {
   const [activeTab, setActiveTab] = useState("edit");
   const [previewBlocks, setPreviewBlocks] = useState<unknown>([]);
@@ -673,7 +731,12 @@ function EditorPane({
       </TabsList>
       <TabsContent value="edit">
         <div className="rounded-lg border border-stone-200 bg-white py-4">
-          <BlockNoteView editor={editor} theme="light" slashMenu={false}>
+          <BlockNoteView
+            editor={editor}
+            theme="light"
+            slashMenu={false}
+            onChange={onDirty}
+          >
             <SuggestionMenuController
               triggerCharacter="/"
               getItems={(query) =>
@@ -736,10 +799,14 @@ function LoadedEditor({
   // Whether the author has manually edited the slug (handler-only flag:
   // it never affects what's on screen, only how title edits behave).
   const slugTouchedRef = useRef(item !== null);
+  // Unsaved-changes flag (handler-only: read on Back, set by edits,
+  // cleared by save).
+  const dirtyRef = useRef(false);
 
   const slugLocked = item?.publishedAt != null;
 
   const onFormChange = (updates: Partial<FormState>) => {
+    dirtyRef.current = true;
     if (updates.slug !== undefined) slugTouchedRef.current = true;
     setForm((prev) => {
       const next = { ...prev, ...updates };
@@ -793,11 +860,25 @@ function LoadedEditor({
       );
     },
     onSuccess: (result) => {
+      dirtyRef.current = false;
       setLastSavedAt(new Date().toISOString());
       void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
       if (item === null) onCreated(result.id);
     },
   });
+
+  const requestClose = () => {
+    if (
+      dirtyRef.current &&
+      !window.confirm("Discard unsaved changes to this report?")
+    ) {
+      return;
+    }
+    onClose();
+  };
+
+  const canSave = canManage && (item?.status !== "published" || canPublish);
+  const missingMetadata = kind === "game_report" && !form.playCricketId;
 
   const startImageUpload = () => {
     setUploadError(null);
@@ -836,52 +917,7 @@ function LoadedEditor({
     }
   };
 
-  const slashItems = () => [
-    {
-      title: "Person card",
-      subtext: "Embed a club member profile card",
-      group: "Club content",
-      aliases: ["person", "player", "profile"],
-      icon: <span aria-hidden>👤</span>,
-      onItemClick: () => {
-        insertOrUpdateBlockForSlashMenu(editor, {
-          type: CUSTOM_BLOCK_TYPES.person,
-        });
-      },
-    },
-    {
-      title: "Game preview",
-      subtext: "Link a Play-Cricket fixture or result",
-      group: "Club content",
-      aliases: ["game", "match", "fixture"],
-      icon: <span aria-hidden>🏏</span>,
-      onItemClick: () => {
-        insertOrUpdateBlockForSlashMenu(editor, {
-          type: CUSTOM_BLOCK_TYPES.gamePreview,
-        });
-      },
-    },
-    {
-      title: "Event preview",
-      subtext: "Link a calendar event",
-      group: "Club content",
-      aliases: ["event", "calendar"],
-      icon: <span aria-hidden>📅</span>,
-      onItemClick: () => {
-        insertOrUpdateBlockForSlashMenu(editor, {
-          type: CUSTOM_BLOCK_TYPES.eventPreview,
-        });
-      },
-    },
-    {
-      title: "Upload photo",
-      subtext: "Add an image (consent required)",
-      group: "Club content",
-      aliases: ["image", "photo", "picture"],
-      icon: <span aria-hidden>📷</span>,
-      onItemClick: startImageUpload,
-    },
-  ];
+  const slashItems = () => buildSlashItems(editor, startImageUpload);
 
   return (
     <div className="flex flex-col gap-4">
@@ -898,7 +934,7 @@ function LoadedEditor({
       />
 
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <Button variant="ghost" size="sm" onClick={onClose}>
+        <Button variant="ghost" size="sm" onClick={requestClose}>
           ← Back to list
         </Button>
         <div className="flex items-center gap-3">
@@ -911,18 +947,28 @@ function LoadedEditor({
               })}
             </span>
           )}
-          {canManage && (
+          {canSave && (
             <Button
               onClick={() => {
                 saveMutation.mutate();
               }}
-              disabled={saveMutation.isPending || !form.title || !form.slug}
+              disabled={
+                saveMutation.isPending ||
+                !form.title ||
+                !form.slug ||
+                missingMetadata
+              }
+              title={
+                missingMetadata ? "Choose a Play-Cricket game first" : undefined
+              }
             >
               {saveMutation.isPending
                 ? "Saving…"
                 : item === null
                   ? "Create draft"
-                  : "Save"}
+                  : item.status === "published"
+                    ? "Save & update live page"
+                    : "Save"}
             </Button>
           )}
         </div>
@@ -949,6 +995,7 @@ function LoadedEditor({
               item={item}
               canPublish={canPublish}
               canManage={canManage}
+              beforePublish={() => saveMutation.mutateAsync()}
             />
           )}
           <ConsentBox
@@ -963,6 +1010,9 @@ function LoadedEditor({
             editor={editor}
             slashItems={slashItems}
             currentBody={editorBody}
+            onDirty={() => {
+              dirtyRef.current = true;
+            }}
           />
         </div>
       </div>

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -26,6 +26,7 @@ import {
 } from "@percy-main/shared/content";
 import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense } from "react";
+import { IoOpenOutline } from "react-icons/io5";
 import { useSearchParams } from "react-router";
 
 // The editor pulls in BlockNote (the single heaviest dependency in the
@@ -42,6 +43,32 @@ const PAGE_SIZE = 20;
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Public URL a published item is live at. Per-kind: game reports render
+ * inside their game page. Later kinds add their mappings here.
+ */
+function liveUrl(
+  kind: ContentKind,
+  item: { metadata: Record<string, unknown>; slug: string },
+): string | null {
+  if (kind === "game_report") {
+    const playCricketId = item.metadata.playCricketId;
+    return typeof playCricketId === "string" && playCricketId !== ""
+      ? `/calendar/game/${playCricketId}`
+      : null;
+  }
+  return null;
+}
+
+/** Live now = published and past its (possibly scheduled) publish time. */
+function isLive(item: { status: string; publishedAt: string | null }): boolean {
+  return (
+    item.status === "published" &&
+    item.publishedAt !== null &&
+    Date.parse(item.publishedAt) <= Date.now()
+  );
+}
 
 function formatDateTime(iso: string): string {
   return new Date(iso).toLocaleString("en-GB", {
@@ -192,6 +219,9 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
               <TableHead>Title</TableHead>
               <TableHead className="w-28">Status</TableHead>
               <TableHead className="w-56">Last updated</TableHead>
+              <TableHead className="w-16">
+                <span className="sr-only">Live page</span>
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -212,6 +242,23 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
                 <TableCell className="text-sm text-stone-600">
                   {formatDateTime(item.updatedAt)}
                   {item.updatedByName ? ` · ${item.updatedByName}` : ""}
+                </TableCell>
+                <TableCell>
+                  {isLive(item) && liveUrl(kind, item) && (
+                    <a
+                      href={liveUrl(kind, item) ?? ""}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Open live page for ${item.title}`}
+                      title="Open live page"
+                      className="inline-flex text-stone-500 hover:text-stone-900"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                      }}
+                    >
+                      <IoOpenOutline className="size-4" />
+                    </a>
+                  )}
                 </TableCell>
               </TableRow>
             ))}

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -1,0 +1,251 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useHasPermission } from "@/hooks/use-has-permission";
+import { api, callApi } from "@/lib/api-client";
+import {
+  CONTENT_KIND_RESOURCES,
+  CONTENT_STATUSES,
+  type ContentKind,
+  type ContentStatus,
+} from "@percy-main/shared/content";
+import { useQuery } from "@tanstack/react-query";
+import { lazy, Suspense } from "react";
+import { useSearchParams } from "react-router";
+
+// The editor pulls in BlockNote (the single heaviest dependency in the
+// admin panel), so it loads as its own chunk only when an item is open.
+const ContentEditor = lazy(() => import("./content-editor.js"));
+
+const STATUS_BADGES: Record<string, "default" | "secondary" | "outline"> = {
+  published: "default",
+  draft: "secondary",
+  archived: "outline",
+};
+
+const PAGE_SIZE = 20;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Content list + editor for one content kind. All UI state (open item,
+ * status filter, search, page) lives in the URL alongside the admin
+ * panel's section/sub params, so deep links restore the full view.
+ */
+export function ContentTab({ kind }: { kind: ContentKind }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const { allowed: canManage } = useHasPermission(
+    CONTENT_KIND_RESOURCES[kind],
+    "manage",
+  );
+
+  // URL state is user input: anything unexpected degrades to the default
+  // rather than reaching the typed API call.
+  const itemParam = searchParams.get("item");
+  const openItem =
+    itemParam === "new" || (itemParam !== null && UUID_RE.test(itemParam))
+      ? itemParam
+      : null;
+  const statusParam = searchParams.get("status");
+  const status: ContentStatus | "all" = (
+    CONTENT_STATUSES as readonly string[]
+  ).includes(statusParam ?? "")
+    ? (statusParam as ContentStatus)
+    : "all";
+  const search = searchParams.get("q") ?? "";
+  const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+
+  const setParams = (updates: Record<string, string | null>) => {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === null || value === "") params.delete(key);
+      else params.set(key, value);
+    }
+    setSearchParams(params, { replace: true });
+  };
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["admin", "content", kind, status, search, page],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/content", {
+          params: {
+            query: {
+              kind,
+              ...(status !== "all" ? { status } : {}),
+              ...(search ? { search } : {}),
+              page,
+              pageSize: PAGE_SIZE,
+            },
+          },
+        }),
+      ),
+    enabled: openItem === null,
+  });
+
+  if (openItem !== null) {
+    return (
+      <Suspense
+        fallback={
+          <p className="py-8 text-sm text-stone-500">Loading editor…</p>
+        }
+      >
+        <ContentEditor
+          kind={kind}
+          contentId={openItem === "new" ? null : openItem}
+          onClose={() => {
+            setParams({ item: null });
+          }}
+          onCreated={(id) => {
+            setParams({ item: id });
+          }}
+        />
+      </Suspense>
+    );
+  }
+
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            placeholder="Search titles…"
+            value={search}
+            onChange={(e) => {
+              setParams({ q: e.target.value, page: null });
+            }}
+            className="w-56"
+          />
+          <Select
+            value={status}
+            onValueChange={(value) => {
+              setParams({ status: value === "all" ? null : value, page: null });
+            }}
+          >
+            <SelectTrigger className="w-36">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All statuses</SelectItem>
+              <SelectItem value="draft">Draft</SelectItem>
+              <SelectItem value="published">Published</SelectItem>
+              <SelectItem value="archived">Archived</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {canManage && (
+          <Button
+            onClick={() => {
+              setParams({ item: "new" });
+            }}
+          >
+            New report
+          </Button>
+        )}
+      </div>
+
+      {error ? (
+        <p className="py-8 text-sm text-red-600">
+          Couldn't load content - {error.message}
+        </p>
+      ) : isLoading ? (
+        <p className="py-8 text-sm text-stone-500">Loading…</p>
+      ) : items.length === 0 ? (
+        <p className="py-8 text-sm text-stone-500">
+          No content yet - create the first one.
+        </p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Title</TableHead>
+              <TableHead className="w-28">Status</TableHead>
+              <TableHead className="w-56">Last updated</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((item) => (
+              <TableRow
+                key={item.id}
+                className="cursor-pointer"
+                onClick={() => {
+                  setParams({ item: item.id });
+                }}
+              >
+                <TableCell className="font-medium">{item.title}</TableCell>
+                <TableCell>
+                  <Badge variant={STATUS_BADGES[item.status] ?? "secondary"}>
+                    {item.status}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-sm text-stone-600">
+                  {formatDateTime(item.updatedAt)}
+                  {item.updatedByName ? ` · ${item.updatedByName}` : ""}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1}
+            onClick={() => {
+              setParams({ page: page <= 2 ? null : String(page - 1) });
+            }}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-stone-600">
+            Page {page} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= totalPages}
+            onClick={() => {
+              setParams({ page: String(page + 1) });
+            }}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -1,3 +1,4 @@
+import { ContentBody } from "@/components/content-body.js";
 import { Map } from "@/components/map.js";
 import { mdxComponents } from "@/components/mdx-components.js";
 import { OutcomeBadge } from "@/components/outcome-badge.js";
@@ -254,6 +255,30 @@ function BallByBallTrigger({ game }: { game: GameData }) {
 }
 
 function GameDetailContent({ game }: { game: GameData }) {
+  // DB-backed report first (live content editing, #479); the bundled MDX
+  // corpus stays as fallback until the migration is verified in prod,
+  // then gets deleted in a follow-up.
+  const { data: apiReport, isPending: apiReportPending } = useQuery({
+    queryKey: ["content", "game-report", game.id],
+    queryFn: async () => {
+      try {
+        return await callApi(
+          api.GET(
+            "/api/content/game-report/by-play-cricket-id/{playCricketId}",
+            {
+              params: { path: { playCricketId: game.id } },
+            },
+          ),
+        );
+      } catch (err) {
+        // No published report for this game - fall back to bundled MDX.
+        if ((err as { status?: number }).status === 404) return null;
+        throw err;
+      }
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
   const report = getGameReport(game.id);
 
   const title = `${game.team.name} vs. ${game.opposition.club.name} ${game.opposition.team.name} ${game.home ? "(H)" : "(A)"}`;
@@ -439,15 +464,25 @@ function GameDetailContent({ game }: { game: GameData }) {
             links show a fallback. */}
         <BallByBallTrigger game={game} />
 
-        {/* MDX game report */}
-        {report && (
+        {/* Game report: API-published content wins. The bundled MDX
+            renders only once the query settles (confirmed 404, or an API
+            failure - deliberate graceful degradation) so a DB-edited
+            report never flashes its stale MDX ancestor first. */}
+        {apiReport ? (
           <div className="w-full">
-            <MDXProvider components={mdxComponents}>
-              <div className="mdx-content flex flex-col *:mb-4">
-                <report.Component />
-              </div>
-            </MDXProvider>
+            <ContentBody body={apiReport.body} />
           </div>
+        ) : (
+          !apiReportPending &&
+          report && (
+            <div className="w-full">
+              <MDXProvider components={mdxComponents}>
+                <div className="mdx-content flex flex-col *:mb-4">
+                  <report.Component />
+                </div>
+              </MDXProvider>
+            </div>
+          )
         )}
 
         {/* Scorecard (fetches from Play Cricket API) */}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -98,6 +98,14 @@ export default defineConfig(({ mode }) => ({
         target: "http://localhost:3000",
         changeOrigin: true,
       },
+      // In prod CloudFront serves /uploads/* from the uploads bucket;
+      // locally that bucket lives in LocalStack, so editor-uploaded
+      // content images (/uploads/content/...) resolve in dev too.
+      "/uploads": {
+        target: "http://localhost:4566",
+        changeOrigin: true,
+        rewrite: (p) => `/percy-main-receipts-local${p}`,
+      },
     },
   },
 }));

--- a/infra/modules/cdn/main.tf
+++ b/infra/modules/cdn/main.tf
@@ -195,6 +195,27 @@ resource "aws_s3_bucket_lifecycle_configuration" "uploads" {
       noncurrent_days = 30
     }
   }
+
+  # Browser-direct content-image uploads land here before the API
+  # processes them into uploads/content/*; anything the confirm step
+  # didn't consume (abandoned uploads) is junk after a day. Mirrors the
+  # 24h expiry the dedicated *-uploads buckets use.
+  rule {
+    id     = "expire-pending-content-images"
+    status = "Enabled"
+
+    filter {
+      prefix = "content-images/pending/"
+    }
+
+    expiration {
+      days = 1
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
 }
 
 resource "aws_s3_bucket_cors_configuration" "uploads" {

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -172,6 +172,20 @@ export interface ContactSubmission {
   page: string;
 }
 
+export interface ContentImage {
+  alt: string | null;
+  bytes: number;
+  consent_confirmed: boolean;
+  created_at: Generated<Timestamp>;
+  height: number;
+  id: Generated<string>;
+  key_prefix: string;
+  original_format: string;
+  picture: Json;
+  uploaded_by: string;
+  width: number;
+}
+
 export interface ContentItem {
   body: Json;
   created_at: Generated<Timestamp>;
@@ -1022,6 +1036,7 @@ export interface DB {
   charge: Charge;
   charge_dependent: ChargeDependent;
   contact_submission: ContactSubmission;
+  content_image: ContentImage;
   content_item: ContentItem;
   content_revision: ContentRevision;
   dependent: Dependent;

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -172,6 +172,35 @@ export interface ContactSubmission {
   page: string;
 }
 
+export interface ContentItem {
+  body: Json;
+  created_at: Generated<Timestamp>;
+  created_by: string;
+  description: string | null;
+  id: Generated<string>;
+  kind: string;
+  metadata: Generated<Json>;
+  parent_id: string | null;
+  path: string | null;
+  published_at: Timestamp | null;
+  slug: string;
+  status: Generated<string>;
+  title: string;
+  updated_at: Generated<Timestamp>;
+  updated_by: string;
+}
+
+export interface ContentRevision {
+  body: Json;
+  content_id: string;
+  description: string | null;
+  id: Generated<string>;
+  metadata: Json;
+  saved_at: Generated<Timestamp>;
+  saved_by: string;
+  title: string;
+}
+
 export interface Dependent {
   alt_contact_name: string | null;
   alt_contact_phone: string | null;
@@ -993,6 +1022,8 @@ export interface DB {
   charge: Charge;
   charge_dependent: ChargeDependent;
   contact_submission: ContactSubmission;
+  content_item: ContentItem;
+  content_revision: ContentRevision;
   dependent: Dependent;
   document: Document;
   document_assignment: DocumentAssignment;

--- a/packages/db/src/migrations/2026-06-10T12:45:17.442Z.ts
+++ b/packages/db/src/migrations/2026-06-10T12:45:17.442Z.ts
@@ -1,0 +1,134 @@
+import { type Kysely, sql } from "kysely";
+
+// Database foundation for live content editing (#479 / #480).
+//
+// content_item is one table for every editable content kind (page | news |
+// event | game_report | person) with a kind discriminator. The kinds share
+// 90% of their shape; kind-specific fields live in Zod-validated JSONB
+// metadata (replacing MDX frontmatter). The body is the BlockNote editor
+// JSON document stored as JSONB - ADR 047 superseded the epic's original
+// markdown-canonical plan.
+//
+// content_revision captures every save from day one (history cannot be
+// retrofitted; vandalism/accidental-deletion recovery is one query).
+// Revisions are kept forever; restore/diff UI arrives in Phase 4.
+//
+// Hierarchy (pages only) is an adjacency list via parent_id plus a
+// materialised URL path - the page corpus is ~30 rows, so a single SELECT
+// rebuilds the nav tree. Slug and path lock after first publish, so no
+// redirect handling exists anywhere.
+//
+// Scheduled publishing is just a future published_at: public queries serve
+// only status = 'published' AND published_at <= now(). No scheduler.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("content_item")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("kind", "text", (col) => col.notNull())
+    .addColumn("slug", "text", (col) => col.notNull())
+    .addColumn("parent_id", "uuid", (col) => col.references("content_item.id"))
+    .addColumn("path", "text", (col) => col.unique())
+    .addColumn("title", "text", (col) => col.notNull())
+    .addColumn("description", "text")
+    .addColumn("body", "jsonb", (col) => col.notNull())
+    .addColumn("metadata", "jsonb", (col) =>
+      col.notNull().defaultTo(sql`'{}'::jsonb`),
+    )
+    .addColumn("status", "text", (col) => col.notNull().defaultTo("draft"))
+    .addColumn("published_at", "timestamptz")
+    .addColumn("created_by", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("updated_by", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addCheckConstraint(
+      "content_item_kind_check",
+      sql`kind IN ('page','news','event','game_report','person')`,
+    )
+    .addCheckConstraint(
+      "content_item_status_check",
+      sql`status IN ('draft','published','archived')`,
+    )
+    // The publish action always stamps published_at (possibly future =
+    // scheduled); a published row with NULL published_at would never satisfy
+    // the public predicate, so forbid the state outright.
+    .addCheckConstraint(
+      "content_item_published_at_check",
+      sql`status <> 'published' OR published_at IS NOT NULL`,
+    )
+    .execute();
+
+  // Public listing queries filter on kind + status and order/filter by
+  // published_at.
+  await db.schema
+    .createIndex("content_item_kind_status_published_at_idx")
+    .on("content_item")
+    .columns(["kind", "status", "published_at"])
+    .execute();
+
+  // Slug uniqueness is per-kind for flat kinds (everything without a parent).
+  await db.schema
+    .createIndex("content_item_kind_slug_key")
+    .on("content_item")
+    .columns(["kind", "slug"])
+    .unique()
+    .where(sql.ref("parent_id"), "is", null)
+    .execute();
+
+  // Children must be unique among their siblings (the materialised path
+  // can't enforce this alone: it is NULL until first publish).
+  await db.schema
+    .createIndex("content_item_parent_slug_key")
+    .on("content_item")
+    .columns(["parent_id", "slug"])
+    .unique()
+    .where(sql.ref("parent_id"), "is not", null)
+    .execute();
+
+  await db.schema
+    .createIndex("content_item_parent_id_idx")
+    .on("content_item")
+    .column("parent_id")
+    .execute();
+
+  await db.schema
+    .createTable("content_revision")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    // No ON DELETE CASCADE: revisions are the recovery mechanism, so a
+    // content_item with history cannot be hard-deleted (archive it instead).
+    .addColumn("content_id", "uuid", (col) =>
+      col.notNull().references("content_item.id"),
+    )
+    .addColumn("title", "text", (col) => col.notNull())
+    .addColumn("description", "text")
+    .addColumn("body", "jsonb", (col) => col.notNull())
+    .addColumn("metadata", "jsonb", (col) => col.notNull())
+    .addColumn("saved_by", "text", (col) => col.notNull().references("user.id"))
+    .addColumn("saved_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("content_revision_content_id_idx")
+    .on("content_revision")
+    .column("content_id")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("content_revision").execute();
+  await db.schema.dropTable("content_item").execute();
+}

--- a/packages/db/src/migrations/2026-06-10T14:02:52.406Z.ts
+++ b/packages/db/src/migrations/2026-06-10T14:02:52.406Z.ts
@@ -1,0 +1,22 @@
+import { type Kysely, sql } from "kysely";
+
+// The public game-report endpoint looks content up by the playCricketId
+// held in JSONB metadata. Make that lookup deterministic: at most one
+// game report per Play-Cricket match, across all statuses (a draft
+// duplicate would corrupt the public lookup the moment it published).
+// The content service performs an explicit pre-check for a friendly 409;
+// this index is the backstop against races.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE UNIQUE INDEX content_item_game_report_play_cricket_id_key
+    ON content_item ((metadata->>'playCricketId'))
+    WHERE kind = 'game_report'
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DROP INDEX content_item_game_report_play_cricket_id_key
+  `.execute(db);
+}

--- a/packages/db/src/migrations/2026-06-10T14:37:22.573Z.ts
+++ b/packages/db/src/migrations/2026-06-10T14:37:22.573Z.ts
@@ -1,0 +1,41 @@
+import { type Kysely, sql } from "kysely";
+
+// Editor-uploaded content images (#485). One row per uploaded image; the
+// API generates the responsive variant ladder (AVIF/WebP at several
+// widths + an original-format fallback) into the public uploads bucket
+// and stores the PictureSource-shaped descriptor here. consent_confirmed
+// records that the uploader ticked the photo-consent checkbox (required,
+// particularly for juniors) - kept for audit, not as a workflow gate.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("content_image")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("key_prefix", "text", (col) => col.notNull().unique())
+    .addColumn("original_format", "text", (col) => col.notNull())
+    .addColumn("width", "integer", (col) => col.notNull())
+    .addColumn("height", "integer", (col) => col.notNull())
+    .addColumn("bytes", "integer", (col) => col.notNull())
+    .addColumn("picture", "jsonb", (col) => col.notNull())
+    .addColumn("alt", "text")
+    .addColumn("consent_confirmed", "boolean", (col) => col.notNull())
+    .addColumn("uploaded_by", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("content_image_uploaded_by_idx")
+    .on("content_image")
+    .column("uploaded_by")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("content_image").execute();
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,7 +5,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./marketing": "./src/marketing/index.ts",
-    "./auth/permissions": "./src/auth/permissions.ts"
+    "./auth/permissions": "./src/auth/permissions.ts",
+    "./content": "./src/content/index.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,9 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "better-auth": "^1.6.14",
@@ -19,6 +21,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/shared/src/auth/permissions.test.ts
+++ b/packages/shared/src/auth/permissions.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ASSIGNABLE_ROLES,
+  checkPermission,
+  hasAdminPanelAccess,
+  ROLE_LABELS,
+  roles,
+  type Action,
+  type Resource,
+} from "./permissions.js";
+
+const CONTENT_RESOURCES = [
+  "content",
+  "content_news",
+  "content_reports",
+  "content_people",
+] satisfies Resource[];
+
+const CONTENT_ACTIONS = ["view", "manage", "publish"] satisfies Array<
+  Action<"content">
+>;
+
+describe("content roles", () => {
+  it("content_admin has every action on every content resource", () => {
+    for (const resource of CONTENT_RESOURCES) {
+      for (const action of CONTENT_ACTIONS) {
+        expect(checkPermission("content_admin", resource, action)).toBe(true);
+      }
+    }
+  });
+
+  it("news_editor covers news and reports but not pages or people", () => {
+    for (const action of CONTENT_ACTIONS) {
+      expect(checkPermission("news_editor", "content_news", action)).toBe(true);
+      expect(checkPermission("news_editor", "content_reports", action)).toBe(
+        true,
+      );
+      expect(checkPermission("news_editor", "content", action)).toBe(false);
+      expect(checkPermission("news_editor", "content_people", action)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("reports_editor covers reports only", () => {
+    for (const action of CONTENT_ACTIONS) {
+      expect(checkPermission("reports_editor", "content_reports", action)).toBe(
+        true,
+      );
+      expect(checkPermission("reports_editor", "content", action)).toBe(false);
+      expect(checkPermission("reports_editor", "content_news", action)).toBe(
+        false,
+      );
+      expect(checkPermission("reports_editor", "content_people", action)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("people_editor covers people only", () => {
+    for (const action of CONTENT_ACTIONS) {
+      expect(checkPermission("people_editor", "content_people", action)).toBe(
+        true,
+      );
+      expect(checkPermission("people_editor", "content", action)).toBe(false);
+      expect(checkPermission("people_editor", "content_news", action)).toBe(
+        false,
+      );
+      expect(checkPermission("people_editor", "content_reports", action)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("legacy admin keeps the kitchen-sink invariant for content", () => {
+    for (const resource of CONTENT_RESOURCES) {
+      for (const action of CONTENT_ACTIONS) {
+        expect(checkPermission("admin", resource, action)).toBe(true);
+      }
+    }
+  });
+
+  it("unrelated roles get no content access", () => {
+    for (const resource of CONTENT_RESOURCES) {
+      expect(checkPermission("matchday_admin", resource, "view")).toBe(false);
+      expect(checkPermission("finance_admin", resource, "manage")).toBe(false);
+      expect(checkPermission(null, resource, "view")).toBe(false);
+    }
+  });
+
+  it("content roles work in comma-separated multi-role strings", () => {
+    expect(
+      checkPermission("user,reports_editor", "content_reports", "publish"),
+    ).toBe(true);
+    expect(
+      checkPermission(
+        "matchday_viewer,people_editor",
+        "content_people",
+        "manage",
+      ),
+    ).toBe(true);
+  });
+
+  it("every content role grants admin panel access via its view permission", () => {
+    expect(hasAdminPanelAccess("content_admin")).toBe(true);
+    expect(hasAdminPanelAccess("news_editor")).toBe(true);
+    expect(hasAdminPanelAccess("reports_editor")).toBe(true);
+    expect(hasAdminPanelAccess("people_editor")).toBe(true);
+  });
+
+  it("content roles are assignable and labelled", () => {
+    for (const role of [
+      "content_admin",
+      "news_editor",
+      "reports_editor",
+      "people_editor",
+    ] as const) {
+      expect(ASSIGNABLE_ROLES).toContain(role);
+      expect(ROLE_LABELS[role]).toBeTruthy();
+      expect(roles[role]).toBeDefined();
+    }
+  });
+});

--- a/packages/shared/src/auth/permissions.ts
+++ b/packages/shared/src/auth/permissions.ts
@@ -19,6 +19,15 @@ export const statements = {
   ai_facts: ["view", "manage"],
   ai_knowledge: ["view", "manage"],
   users: ["view", "manage", "manage_roles"],
+  // Live content editing (#479). manage and publish are separate actions
+  // deliberately - every role created today gets both (direct publish, no
+  // review workflow), but keeping them distinct means a review tier can be
+  // added later without a data migration. content_people is its own
+  // resource because person profiles carry safeguarding-adjacent flags.
+  content: ["view", "manage", "publish"],
+  content_news: ["view", "manage", "publish"],
+  content_reports: ["view", "manage", "publish"],
+  content_people: ["view", "manage", "publish"],
 } as const;
 
 export const ac = createAccessControl(statements);
@@ -37,6 +46,10 @@ const ALL_PERMS = {
   ai_facts: ["view", "manage"],
   ai_knowledge: ["view", "manage"],
   users: ["view", "manage", "manage_roles"],
+  content: ["view", "manage", "publish"],
+  content_news: ["view", "manage", "publish"],
+  content_reports: ["view", "manage", "publish"],
+  content_people: ["view", "manage", "publish"],
 } as const;
 
 export const roles = {
@@ -84,6 +97,27 @@ export const roles = {
   ai_facts_admin: ac.newRole({ ai_facts: ["view", "manage"] }),
   ai_knowledge_viewer: ac.newRole({ ai_knowledge: ["view"] }),
   ai_knowledge_admin: ac.newRole({ ai_knowledge: ["view", "manage"] }),
+
+  // Content editing (#479). All roles get manage + publish (direct publish,
+  // no review workflow - the editor pool is <5 trusted people). news_editor
+  // also covers game reports: in practice the news volunteers write up
+  // match coverage too.
+  content_admin: ac.newRole({
+    content: ["view", "manage", "publish"],
+    content_news: ["view", "manage", "publish"],
+    content_reports: ["view", "manage", "publish"],
+    content_people: ["view", "manage", "publish"],
+  }),
+  news_editor: ac.newRole({
+    content_news: ["view", "manage", "publish"],
+    content_reports: ["view", "manage", "publish"],
+  }),
+  reports_editor: ac.newRole({
+    content_reports: ["view", "manage", "publish"],
+  }),
+  people_editor: ac.newRole({
+    content_people: ["view", "manage", "publish"],
+  }),
 
   // Member management — same as admin's user CRUD minus the set-role power,
   // so a user_manager can archive/restore/link members but can't promote
@@ -141,6 +175,10 @@ export const ASSIGNABLE_ROLES: readonly RoleName[] = [
   "ai_facts_viewer",
   "ai_knowledge_admin",
   "ai_knowledge_viewer",
+  "content_admin",
+  "news_editor",
+  "reports_editor",
+  "people_editor",
   "junior_manager",
   "official",
   "admin",
@@ -169,6 +207,10 @@ export const ROLE_LABELS: Record<RoleName, string> = {
   ai_facts_admin: "AI facts admin",
   ai_knowledge_viewer: "AI knowledge viewer",
   ai_knowledge_admin: "AI knowledge admin",
+  content_admin: "Content admin",
+  news_editor: "News editor",
+  reports_editor: "Reports editor",
+  people_editor: "People editor",
   junior_manager: "Junior Manager",
   official: "Official",
 };
@@ -211,7 +253,11 @@ export function hasAdminPanelAccess(
     checkPermission(rawRole, "matchday", "view") ||
     checkPermission(rawRole, "fantasy", "manage") ||
     checkPermission(rawRole, "incidents", "view") ||
-    checkPermission(rawRole, "documents", "manage")
+    checkPermission(rawRole, "documents", "manage") ||
+    checkPermission(rawRole, "content", "view") ||
+    checkPermission(rawRole, "content_news", "view") ||
+    checkPermission(rawRole, "content_reports", "view") ||
+    checkPermission(rawRole, "content_people", "view")
   );
 }
 

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -92,11 +92,6 @@ export const CONTENT_METADATA_SCHEMAS: Partial<
   game_report: gameReportMetadataSchema,
 };
 
-/** Kinds currently editable through the content API (grows per phase). */
-export const ENABLED_CONTENT_KINDS = Object.keys(
-  CONTENT_METADATA_SCHEMAS,
-) as ContentKind[];
-
 // ── Custom block types ──────────────────────────────────────────────────
 //
 // The directive vocabulary from the original epic plan, as BlockNote

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -109,6 +109,12 @@ export const CUSTOM_BLOCK_TYPES = {
   personGrid: "personGrid",
   gamePreview: "gamePreview",
   eventPreview: "eventPreview",
+  // Editor-uploaded image. Replaces BlockNote's built-in image block in
+  // the editor schema (whose URL-embed tab would bypass the consent +
+  // processing pipeline). props.picture carries the JSON-stringified
+  // PictureSource descriptor from the upload API so public pages render
+  // the responsive ladder without any lookup.
+  contentImage: "contentImage",
 } as const;
 
 // ── Slugs ───────────────────────────────────────────────────────────────

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -97,6 +97,20 @@ export const ENABLED_CONTENT_KINDS = Object.keys(
   CONTENT_METADATA_SCHEMAS,
 ) as ContentKind[];
 
+// ── Custom block types ──────────────────────────────────────────────────
+//
+// The directive vocabulary from the original epic plan, as BlockNote
+// custom block type names. Single source of truth shared by the editor
+// (which registers blocks under these names) and the public renderer
+// (which maps them to the existing component map).
+
+export const CUSTOM_BLOCK_TYPES = {
+  person: "person",
+  personGrid: "personGrid",
+  gamePreview: "gamePreview",
+  eventPreview: "eventPreview",
+} as const;
+
 // ── Slugs ───────────────────────────────────────────────────────────────
 //
 // Locked after first publish (no redirect handling exists anywhere), so

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+import type { Resource } from "../auth/permissions.ts";
+
+// ── Content kinds + statuses ────────────────────────────────────────────
+//
+// Live content editing (#479). One content_item table holds every kind;
+// these constants are the single source of truth for the discriminator
+// values (the DB check constraints mirror them).
+
+export const CONTENT_KINDS = [
+  "page",
+  "news",
+  "event",
+  "game_report",
+  "person",
+] as const;
+
+export const contentKindSchema = z.enum(CONTENT_KINDS);
+export type ContentKind = z.infer<typeof contentKindSchema>;
+
+export const CONTENT_STATUSES = ["draft", "published", "archived"] as const;
+
+export const contentStatusSchema = z.enum(CONTENT_STATUSES);
+export type ContentStatus = z.infer<typeof contentStatusSchema>;
+
+/**
+ * Which permission resource gates each kind. Pages are `content`, news and
+ * events share `content_news`, game reports are `content_reports`, and
+ * people are `content_people` (separate because person profiles carry
+ * safeguarding-adjacent flags).
+ */
+export const CONTENT_KIND_RESOURCES = {
+  page: "content",
+  news: "content_news",
+  event: "content_news",
+  game_report: "content_reports",
+  person: "content_people",
+} as const satisfies Record<ContentKind, Resource>;
+
+export type ContentResource = (typeof CONTENT_KIND_RESOURCES)[ContentKind];
+
+// ── Body format: BlockNote document JSON ────────────────────────────────
+//
+// Per ADR 047 the canonical body is the BlockNote editor JSON block array
+// stored as JSONB - not markdown. This schema validates the structural
+// envelope every BlockNote block shares (id/type/props/content/children);
+// the public renderer narrows per block type and ignores anything it does
+// not recognise, so unknown types are safe to store. There is deliberately
+// no raw-HTML block type anywhere in the pipeline.
+
+export const blockPropValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+]);
+
+export interface ContentBlock {
+  id: string;
+  type: string;
+  props: Record<string, string | number | boolean>;
+  content?: unknown;
+  children: ContentBlock[];
+}
+
+export const contentBlockSchema: z.ZodType<ContentBlock> = z.lazy(() =>
+  z.object({
+    id: z.string().min(1),
+    type: z.string().min(1),
+    props: z.record(z.string(), blockPropValueSchema),
+    content: z.unknown().optional(),
+    children: z.array(contentBlockSchema),
+  }),
+);
+
+/** A content body: the top-level BlockNote block array. */
+export const contentBodySchema = z.array(contentBlockSchema);
+export type ContentBody = z.infer<typeof contentBodySchema>;
+
+// ── Kind-specific metadata (replaces MDX frontmatter) ───────────────────
+//
+// Validated on every write by the content API. Only kinds with a schema
+// here are editable through the API; later phases add their kinds.
+
+export const gameReportMetadataSchema = z.object({
+  playCricketId: z.string().min(1),
+});
+export type GameReportMetadata = z.infer<typeof gameReportMetadataSchema>;
+
+export const CONTENT_METADATA_SCHEMAS: Partial<
+  Record<ContentKind, z.ZodType<Record<string, unknown>>>
+> = {
+  game_report: gameReportMetadataSchema,
+};
+
+/** Kinds currently editable through the content API (grows per phase). */
+export const ENABLED_CONTENT_KINDS = Object.keys(
+  CONTENT_METADATA_SCHEMAS,
+) as ContentKind[];
+
+// ── Slugs ───────────────────────────────────────────────────────────────
+//
+// Locked after first publish (no redirect handling exists anywhere), so
+// they are validated strictly from the start.
+
+export const contentSlugSchema = z
+  .string()
+  .min(1)
+  .max(200)
+  .regex(
+    /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+    "Slug must be lowercase letters, numbers and hyphens",
+  );

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    // CI-only JUnit output → consumed by publish-unit-test-result-action
+    // in _lint-test-build.yml (globs **/test-results/*.xml).
+    reporters: process.env.CI
+      ? ["default", ["junit", { outputFile: "./test-results/shared-unit.xml" }]]
+      : ["default"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,15 @@ importers:
       '@better-auth/passkey':
         specifier: ^1.6.14
         version: 1.6.14(@better-auth/core@1.6.14(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.14(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)
+      '@blocknote/core':
+        specifier: ^0.47.2
+        version: 0.47.3(@types/hast@3.0.4)
+      '@blocknote/react':
+        specifier: ^0.47.2
+        version: 0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@blocknote/shadcn':
+        specifier: ^0.47.2
+        version: 0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1604,6 +1613,13 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || >= 19.0.0-rc
       react-dom: ^18.0 || ^19.0 || >= 19.0.0-rc
+
+  '@blocknote/shadcn@0.47.3':
+    resolution: {integrity: sha512-UEJxaKVJwtd8NQVjpjjxAIcKcUxusRmh6OZ3ssZmXRkFusex/g+WO+PteSC/xHNLdT1C4gJpPi135vtwK7JFLw==}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || >= 19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || >= 19.0.0-rc
+      tailwindcss: ^4.1.12
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -3121,6 +3137,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.1.12':
+    resolution: {integrity: sha512-NQCQyWC7QrDPhjMn8hUqFeU0lUrprIgm1AyMgLbzuQJibNnatdc3SSMo3/UGFu/eUkJUU1cEcKCnyhXTQzq6tA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.3.4':
     resolution: {integrity: sha512-m3JmIOAX5ZzZ6VPjxEU2dbTOhoHi0nT5riwcDwe8idocsWf4a5DXJLDtZ6LfJwMBx7W+A2b7kp2TgPEKtaiF6A==}
     peerDependencies:
@@ -3231,8 +3260,34 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.9':
+    resolution: {integrity: sha512-rDoTeMbCwRVcnmo7NGT9IlPo1yXmEI+xc1URP3oeewwZEV4mdTp1dYUhYbQdo4D1q2SjKVvv4N1gNY77QAQtjA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-menu@2.1.17':
     resolution: {integrity: sha512-fmbNnFyf+JYCN0DhhWnEdUTDnZD1mXaPQWivdsPIb8oOSbARfD3LIQJbLCG8a8QLCwoMxiJ7GVPIFcC8Dw8v2Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.16':
+    resolution: {integrity: sha512-8brVpAU5Uq7Bh0c8EFc4ZTf2JJTYn0o+1L+CUJB3UYIOkTjKGMgoHvduylrahdmNlr3DfH0rFq2DrbNZXgaspw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3331,6 +3386,45 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-tabs@1.1.14':
+    resolution: {integrity: sha512-D5jwp9JNuwDeCw3CYD2Fz+sSHo0droQjC8u75dJHe4aWr5q6yBiXZU+hurXnKudRgEpUkD5TsI6bjHPo5ThUxA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.11':
+    resolution: {integrity: sha512-FikrKJemoBGZQ6uRID0HJqSPBP6D7OppdD2OhLl0ZYLlAyPXI7MezoYGmumwNkrAoRm35xXkb4C8JPfJZZzcaw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.9':
+    resolution: {integrity: sha512-u6F9MmTtBSLkiXNVDrtB/yPCZarM9smNswC24YYLV/M+bth6J3Gs3vlJezEoFwKZvPvxhCpUYdUnOsNG/0XOlA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.2':
     resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
     peerDependencies:
@@ -3360,6 +3454,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.2':
     resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4670,6 +4773,13 @@ packages:
   atomically@2.1.1:
     resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
 
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: '>=8.5.10'
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -5725,6 +5835,9 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -6560,6 +6673,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.525.0:
+    resolution: {integrity: sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lucide-react@1.17.0:
     resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
@@ -7426,6 +7544,12 @@ packages:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  react-hook-form@7.78.0:
+    resolution: {integrity: sha512-EEZqc+N23moyzTlz61Pj+JvcXo76ICkpfOZo8JZw+sM4+wLQGh6nI2Ms+PdMOYNluFu0ghlM7B8mCzhRYtJCnA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-icons@5.6.0:
     resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
     peerDependencies:
@@ -8044,6 +8168,9 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -10009,6 +10136,40 @@ snapshots:
       - sugar-high
       - supports-color
 
+  '@blocknote/shadcn@0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)':
+    dependencies:
+      '@blocknote/core': 0.47.3(@types/hast@3.0.4)
+      '@blocknote/react': 0.47.3(@types/hast@3.0.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-avatar': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu': 2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-label': 2.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popover': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-select': 2.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-tabs': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tooltip': 1.2.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      autoprefixer: 10.5.0(postcss@8.5.15)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      lucide-react: 0.525.0(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-hook-form: 7.78.0(react@19.2.7)
+      tailwind-merge: 2.6.1
+      tailwindcss: 4.3.0
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+      - '@types/hast'
+      - '@types/react'
+      - '@types/react-dom'
+      - highlight.js
+      - lowlight
+      - postcss
+      - refractor
+      - sugar-high
+      - supports-color
+
   '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -11620,6 +11781,19 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-avatar@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-checkbox@1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -11718,6 +11892,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-label@2.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-menu@2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -11736,6 +11919,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-popover@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -11844,6 +12050,53 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-tabs@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-toggle@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-tooltip@1.2.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -11868,6 +12121,12 @@ snapshots:
   '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
@@ -13221,6 +13480,15 @@ snapshots:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
 
+  autoprefixer@10.5.0(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001793
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -14380,6 +14648,8 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  fraction.js@5.3.4: {}
+
   fs-constants@1.0.0: {}
 
   fs-extra@9.1.0:
@@ -15339,6 +15609,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.525.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   lucide-react@1.17.0(react@19.2.7):
     dependencies:
@@ -16476,6 +16750,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  react-hook-form@7.78.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   react-icons@5.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -17324,6 +17602,8 @@ snapshots:
   tabbable@6.4.0: {}
 
   tagged-tag@1.0.0: {}
+
+  tailwind-merge@2.6.1: {}
 
   tailwind-merge@3.6.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^12.0.1
         version: 12.0.1
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -247,6 +250,12 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
@@ -259,6 +268,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -756,6 +756,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 

--- a/scripts/localstack-init.sh
+++ b/scripts/localstack-init.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Creates the local S3 buckets for receipt uploads and policy documents
 awslocal s3 mb s3://percy-main-receipts-local
+# CORS for browser-direct PUT of content images (LocalStack) - in prod
+# the uploads bucket has the equivalent rule via Terraform (cdn module)
+awslocal s3api put-bucket-cors --bucket percy-main-receipts-local --cors-configuration '{"CORSRules":[{"AllowedHeaders":["*"],"AllowedMethods":["PUT"],"AllowedOrigins":["*"],"ExposeHeaders":["ETag"],"MaxAgeSeconds":3600}]}'
 echo "LocalStack S3 bucket created: percy-main-receipts-local"
 
 awslocal s3 mb s3://percy-main-documents-local


### PR DESCRIPTION
Closes #479. Closes #480. Closes #481. Closes #482. Closes #483. Closes #484. Closes #485. Closes #486. Closes #487.

Phase 1 of the live content editing project: all the foundations (content tables, roles, API, renderer, image pipeline, admin section) plus the game-report cutover. Each work item was a separate PR into this branch, codex-reviewed with findings fixed before merge: #503, #504, #505, #506, #507, #508, #509. (#484, the editor spike, was completed earlier - ADR 047, merged separately.)

## What this delivers

A captain (`reports_editor` role, assignable from the existing Access tab) can write, illustrate, preview and publish a match report from the admin panel's new Content section, and published reports render on the public game page instantly (the API is not behind CloudFront). The 10 legacy MDX reports migrate via an idempotent script.

## Architecture (per ADR 047, which superseded parts of the issue texts)

The canonical body format is the **BlockNote editor JSON document** stored as JSONB - not markdown + directives as originally planned in the epic. Public pages render the JSON block tree through our own React component mapping (`ContentBody`) - the BlockNote runtime never loads outside the lazy admin editor chunk. No raw-HTML node type exists anywhere, so output is sanitised by construction (link/image URLs are additionally allowlisted).

## Piece by piece

- **DB** (#480): `content_item` (kind discriminator, JSONB body + metadata, draft/published/archived with scheduled publishing via future `published_at`) and `content_revision` (every save, kept forever, no cascade delete). Unique playCricketId per game report via expression index.
- **Roles** (#481): `content`/`content_news`/`content_reports`/`content_people` resources with view/manage/publish; roles `content_admin`, `news_editor`, `reports_editor`, `people_editor`, assignable from the Access tab (new Content editing section in the Edit Roles dialog).
- **API** (#482): full admin CRUD + publish/unpublish/archive + revisions list, per-kind permission gating, slug locked after first publish (`published_at` doubles as the ever-published marker). Public reads by kind+slug or playCricketId serve only published-and-due items, with ETag/304.
- **Renderer** (#483): `ContentBody` walks the block tree as plain data; custom blocks resolve against the same component map MDX uses; prose styling reuses `.mdx-content`, so migrated content renders identically.
- **Images** (#485): presigned PUT into the existing uploads bucket, sharp ladder (AVIF+WebP 320-1920 + fallback), ALL EXIF/GPS stripped (verified against a GPS-tagged fixture), consent required at both API steps and stored for audit, `content_image` registry, 24h lifecycle rule for abandoned pending uploads (additive Terraform).
- **Admin section** (#486): list + editor + draft preview (real renderer) + publish/schedule/unpublish/archive. Editor uses @blocknote/shadcn; built-in media blocks removed in favour of the consent-gated upload block; UI mirrors per-action permissions; all state in the URL.
- **Cutover** (#487): `game-detail.tsx` is API-first with the bundled MDX as fallback until prod verification; converter + idempotent migration script (verified locally: 10 inserted, re-run = 10 unchanged; `--force` guard protects post-cutover editor changes).

## Outstanding (deliberate)

- **Prod migration run**: needs the standard prod access pattern + coordination - not performed.
- **Follow-up PR after prod verification**: delete `content/games/` + `lib/game-reports.ts` fallback.
- **Visual spot-check** of migrated reports against production (acceptance criterion that needs human eyes).
- Phase 4 note recorded in-code: `person` kind needs a dedicated public metadata projection before it's ever served publicly.

## Verification

1,485 tests green across api (537 unit incl. converter corpus test + 447 integration via testcontainers), web (492), shared (9); typecheck/lint/format clean; production build verified; all 49 migrations apply on a fresh pgvector/pg16 container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)