### PR TITLE
fix(docker): apk upgrade in API runner stage to clear OpenSSL CVE

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -21,8 +21,12 @@ RUN pnpm --filter '!@percy-main/web' --filter '!email-viewer' run build
 FROM node:24-alpine AS runner
 RUN corepack enable && corepack prepare pnpm@11.1.2 --activate
 
-# Install fonts for Sharp SVG rendering (OG images) and AWS RDS CA bundle
-RUN apk add --no-cache fontconfig font-noto ca-certificates wget && \
+# Install fonts for Sharp SVG rendering (OG images) and AWS RDS CA bundle.
+# The leading upgrade picks up Alpine security fixes published ahead of
+# node:24-alpine rebuilds (e.g. CVE-2026-45447 in libcrypto3/libssl3),
+# which otherwise fail the Trivy gate in deploy-api.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache fontconfig font-noto ca-certificates wget && \
     fc-cache -f && \
     wget -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
       -O /usr/local/share/ca-certificates/rds-global-bundle.crt && \


### PR DESCRIPTION
The epic #510 deploy failed at `deploy-api`'s Trivy gate on CVE-2026-45447 (HIGH, libcrypto3/libssl3 3.5.6-r0, fixed 3.5.7-r0) - the advisory published between the PR's image-scan pass and the merge, and `node:24-alpine` hasn't rebuilt with the fix yet.

Adds a leading `apk upgrade --no-cache` to the runner stage so Alpine security releases apply ahead of base-image rebuilds. Verified locally: the built image carries both packages at 3.5.7-r0.

Re-running the deploy after this merges also re-applies the epic's DB migrations and ships the content API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes https://github.com/percy-main/website-v2/issues/511