### PR TITLE
fix(web): admin URL state pushes history so back retraces steps

### DIFF
--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -267,7 +267,9 @@ export function Component() {
     const params = new URLSearchParams();
     if (next.section.value !== DEFAULT_SECTION)
       params.set("section", next.section.value);
-    setSearchParams(params, { replace: true });
+    // Push, don't replace: tab navigation should be retraceable with the
+    // browser back button.
+    setSearchParams(params);
   };
 
   const onSubChange = (value: string) => {
@@ -276,7 +278,7 @@ export function Component() {
     if (current.section.value !== DEFAULT_SECTION)
       params.set("section", current.section.value);
     if (value !== current.subTabs[0].value) params.set("sub", value);
-    setSearchParams(params, { replace: true });
+    setSearchParams(params);
   };
 
   if (!session) return null;

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -157,7 +157,9 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
           kind={kind}
           contentId={openItem === "new" ? null : openItem}
           onClose={() => {
-            setParams({ item: null });
+            // Closing the create form replaces: Back from the list must
+            // not reopen a stale ?item=new entry.
+            setParams({ item: null }, { replace: openItem === "new" });
           }}
           onCreated={(id) => {
             // Swap "new" for the created id: back must not return to the

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -109,13 +109,22 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
   const search = searchParams.get("q") ?? "";
   const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
 
-  const setParams = (updates: Record<string, string | null>) => {
+  /**
+   * Navigation-like changes (open/close item, filters, paging) push a
+   * history entry so the back button retraces steps; continuous
+   * refinements (search keystrokes) and the new->id swap replace, so
+   * history isn't spammed with intermediate states.
+   */
+  const setParams = (
+    updates: Record<string, string | null>,
+    options: { replace?: boolean } = {},
+  ) => {
     const params = new URLSearchParams(searchParams);
     for (const [key, value] of Object.entries(updates)) {
       if (value === null || value === "") params.delete(key);
       else params.set(key, value);
     }
-    setSearchParams(params, { replace: true });
+    setSearchParams(params, { replace: options.replace ?? false });
   };
 
   const { data, isLoading, error } = useQuery({
@@ -151,7 +160,9 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
             setParams({ item: null });
           }}
           onCreated={(id) => {
-            setParams({ item: id });
+            // Swap "new" for the created id: back must not return to the
+            // create form and spawn a duplicate.
+            setParams({ item: id }, { replace: true });
           }}
         />
       </Suspense>
@@ -170,7 +181,7 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
             placeholder="Search titles…"
             value={search}
             onChange={(e) => {
-              setParams({ q: e.target.value, page: null });
+              setParams({ q: e.target.value, page: null }, { replace: true });
             }}
             className="w-56"
           />


### PR DESCRIPTION
Follow-up from #510 testing: URL state worked but every `setSearchParams` used `{ replace: true }`, so the browser back button skipped all in-panel navigation and dumped you out of the admin panel.

- **Push** (back retraces): opening/closing a content item, status filter, pagination, admin section + sub-tab changes.
- **Replace** (no history spam): search box keystrokes, and the `new` -> created-id swap after first save (back must not reopen the create form and risk a duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)