### PR TITLE
fix(infra): allow www origin for browser PUTs to the uploads bucket

### DIFF
--- a/infra/modules/cdn/main.tf
+++ b/infra/modules/cdn/main.tf
@@ -224,7 +224,9 @@ resource "aws_s3_bucket_cors_configuration" "uploads" {
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["PUT"]
-    allowed_origins = var.domain_name != "" ? ["https://${var.domain_name}"] : ["*"]
+    # Apex + www, matching the dedicated *-uploads buckets: the SPA runs
+    # on www and PUTs content images here directly with presigned URLs.
+    allowed_origins = var.domain_name != "" ? ["https://${var.domain_name}", "https://www.${var.domain_name}"] : ["*"]
     max_age_seconds = 3600
   }
 }


### PR DESCRIPTION
Image upload from the admin editor in prod fails CORS preflight: the SPA runs on `https://www.percymain.org` but the uploads bucket's CORS rule allowed only `https://percymain.org`. The bucket never took browser-direct PUTs before #510 (receipts upload via the API), so this only surfaced with the content image pipeline.

Fix matches the apex+www pattern already used by the document/scout uploads buckets. CI applies on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)