### PR TITLE
feat(content): page hierarchy, nav + breadcrumb API, slug lock (#493)

### DIFF
--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -815,31 +815,112 @@ describe("content service (integration)", () => {
     });
 
     it("pins a draft ancestor's slug via an ever-published descendant", async () => {
-      // The only route to this state: schedule the parent (status
-      // 'published', never live), publish the child immediately, then
-      // unwind bottom-up. The child keeps its ever-published marker; the
-      // parent's cancelled schedule clears its own.
+      // Under the publish-ordering rules a descendant can only have gone
+      // live if its ancestors did too, so a never-published ancestor
+      // with an ever-published child needs the ancestor's own marker
+      // cleared by hand (ops-level intervention; same direct-flip
+      // technique as the visibility-boundary test). The descendant lock
+      // is defense in depth for exactly such states.
       const parent = await mkPage("sections");
       const child = await mkPage("alpha", { parentId: parent });
 
-      const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
-      await publishContent(ctx.db)({
-        contentId: parent,
-        publishedAt: future,
-        userId,
-      });
+      await publishContent(ctx.db)({ contentId: parent, userId });
       await publishContent(ctx.db)({ contentId: child, userId });
       await unpublishContent(ctx.db)({ contentId: child, userId });
       await unpublishContent(ctx.db)({ contentId: parent, userId });
+      await ctx.db
+        .updateTable("content_item")
+        .set({ published_at: null })
+        .where("id", "=", parent)
+        .execute();
 
-      // The parent itself was never live, so its own lock is off...
+      // The parent's own ever-published marker is gone...
       expect((await getContent(ctx.db)(parent)).publishedAt).toBeNull();
-      // ...but the ever-published child pins its slug and parent.
+      // ...but the ever-published child still pins its slug and parent.
       await expect(
         updateContent(ctx.db)({ contentId: parent, slug: "chapters", userId }),
       ).rejects.toMatchObject({
         statusCode: 409,
         message: /descendant page '\/sections\/alpha' has been published/,
+      });
+    });
+
+    it("keeps a child's go-live at or after its parent's", async () => {
+      const parent = await mkPage("season");
+      const child = await mkPage("fixtures", { parentId: parent });
+      const parentAt = new Date(Date.now() + 60 * 60 * 1000);
+      await publishContent(ctx.db)({
+        contentId: parent,
+        publishedAt: parentAt.toISOString(),
+        userId,
+      });
+
+      const tooEarly = `Parent page goes live at ${parentAt.toISOString()}; schedule this page for that time or later`;
+
+      // Publish-now while the parent is still scheduled: the child would
+      // be live on a URL prefix the public cannot see yet
+      await expect(
+        publishContent(ctx.db)({ contentId: child, userId }),
+      ).rejects.toMatchObject({ statusCode: 400, message: tooEarly });
+
+      // Scheduling before the parent's go-live is equally rejected...
+      await expect(
+        publishContent(ctx.db)({
+          contentId: child,
+          publishedAt: new Date(
+            parentAt.getTime() - 30 * 60 * 1000,
+          ).toISOString(),
+          userId,
+        }),
+      ).rejects.toMatchObject({ statusCode: 400, message: tooEarly });
+
+      // ...as is backdating the child into the past
+      await expect(
+        publishContent(ctx.db)({
+          contentId: child,
+          publishedAt: new Date(Date.now() - 1000).toISOString(),
+          userId,
+        }),
+      ).rejects.toMatchObject({ statusCode: 400, message: tooEarly });
+
+      // The parent's exact go-live instant works: a whole section can be
+      // scheduled together, top-down
+      const scheduled = await publishContent(ctx.db)({
+        contentId: child,
+        publishedAt: parentAt.toISOString(),
+        userId,
+      });
+      expect(scheduled.publishedAt).toBe(parentAt.toISOString());
+
+      // Unwind bottom-up (never live, so the markers clear and the nav
+      // test below keeps its exact payload)
+      await unpublishContent(ctx.db)({ contentId: child, userId });
+      await unpublishContent(ctx.db)({ contentId: parent, userId });
+    });
+
+    it("archives a page only after its children are unpublished", async () => {
+      const parent = await mkPage("vault");
+      const child = await mkPage("records", { parentId: parent });
+      await publishContent(ctx.db)({ contentId: parent, userId });
+      await publishContent(ctx.db)({ contentId: child, userId });
+
+      await expect(
+        archiveContent(ctx.db)({ contentId: parent, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: /published child pages/,
+      });
+
+      await unpublishContent(ctx.db)({ contentId: child, userId });
+      // A draft child under an archived parent is acceptable...
+      await archiveContent(ctx.db)({ contentId: parent, userId });
+      expect((await getContent(ctx.db)(parent)).status).toBe("archived");
+      // ...it just cannot be published (parent-not-published gate)
+      await expect(
+        publishContent(ctx.db)({ contentId: child, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Cannot publish this page until its parent page is published",
       });
     });
 

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -680,4 +680,261 @@ describe("content service (integration)", () => {
       }
     });
   });
+
+  describe("page hierarchy", () => {
+    const mkPage = async (
+      slug: string,
+      opts: {
+        parentId?: string | null;
+        metadata?: Record<string, unknown>;
+      } = {},
+    ) => {
+      const { id } = await createContent(ctx.db)({
+        kind: "page",
+        slug,
+        title: `Page ${slug}`,
+        description: null,
+        body: body(slug),
+        metadata: opts.metadata ?? {},
+        parentId: opts.parentId ?? null,
+        userId,
+      });
+      return id;
+    };
+
+    const pathOf = async (id: string) => (await getContent(ctx.db)(id)).path;
+
+    it("computes materialised paths and cascades pre-publish renames and moves", async () => {
+      const parent = await mkPage("cricket");
+      const child = await mkPage("juniors", { parentId: parent });
+      const grandchild = await mkPage("coaches", { parentId: child });
+
+      expect(await pathOf(parent)).toBe("/cricket");
+      expect(await pathOf(child)).toBe("/cricket/juniors");
+      expect(await pathOf(grandchild)).toBe("/cricket/juniors/coaches");
+
+      // Hierarchy fields surface in the admin detail/summary shape
+      const detail = await getContent(ctx.db)(child);
+      expect(detail.parentId).toBe(parent);
+      expect(detail.menuOrder).toBe(99);
+
+      // A pre-publish rename cascades through every descendant
+      await updateContent(ctx.db)({
+        contentId: parent,
+        slug: "playing",
+        userId,
+      });
+      expect(await pathOf(parent)).toBe("/playing");
+      expect(await pathOf(child)).toBe("/playing/juniors");
+      expect(await pathOf(grandchild)).toBe("/playing/juniors/coaches");
+
+      // Reparent: move the grandchild up a level, then to the site root
+      await updateContent(ctx.db)({
+        contentId: grandchild,
+        parentId: parent,
+        userId,
+      });
+      expect(await pathOf(grandchild)).toBe("/playing/coaches");
+      await updateContent(ctx.db)({
+        contentId: grandchild,
+        parentId: null,
+        userId,
+      });
+      expect(await pathOf(grandchild)).toBe("/coaches");
+
+      // Cycle prevention: self and descendant parents are rejected
+      await expect(
+        updateContent(ctx.db)({ contentId: parent, parentId: parent, userId }),
+      ).rejects.toMatchObject({ statusCode: 400, message: /own parent/ });
+      await expect(
+        updateContent(ctx.db)({ contentId: parent, parentId: child, userId }),
+      ).rejects.toMatchObject({ statusCode: 400, message: /descendant/ });
+
+      // Sibling slug uniqueness: among one parent's children...
+      await expect(
+        mkPage("juniors", { parentId: parent }),
+      ).rejects.toMatchObject({ statusCode: 409 });
+      // ...and among root pages (the grandchild now owns /coaches)
+      await expect(mkPage("coaches")).rejects.toMatchObject({
+        statusCode: 409,
+      });
+    });
+
+    it("rejects a parent on non-page kinds", async () => {
+      await expect(
+        createContent(ctx.db)({
+          kind: "news",
+          slug: "hierarchy-news",
+          title: "Hierarchy news",
+          description: null,
+          body: body("No parents for news."),
+          metadata: { tags: [] },
+          parentId: crypto.randomUUID(),
+          userId,
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Only pages can have a parent page",
+      });
+    });
+
+    it("publishes top-down, unpublishes bottom-up, and locks live paths", async () => {
+      const parent = await mkPage("rules");
+      const child = await mkPage("code-of-conduct", { parentId: parent });
+
+      // Child first → blocked until the parent is published
+      await expect(
+        publishContent(ctx.db)({ contentId: child, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Cannot publish this page until its parent page is published",
+      });
+      await publishContent(ctx.db)({ contentId: parent, userId });
+      await publishContent(ctx.db)({ contentId: child, userId });
+
+      // Both ever-published: slug AND parent are locked
+      await expect(
+        updateContent(ctx.db)({ contentId: parent, slug: "renamed", userId }),
+      ).rejects.toMatchObject({ statusCode: 409, message: /locked/ });
+      await expect(
+        updateContent(ctx.db)({ contentId: child, parentId: null, userId }),
+      ).rejects.toMatchObject({ statusCode: 409, message: /locked/ });
+
+      // The parent cannot be unpublished over a live child
+      await expect(
+        unpublishContent(ctx.db)({ contentId: parent, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: /published child pages/,
+      });
+
+      // Bottom-up works (also returns this test's pages to draft so the
+      // nav test below can assert an exact payload)
+      await unpublishContent(ctx.db)({ contentId: child, userId });
+      await unpublishContent(ctx.db)({ contentId: parent, userId });
+    });
+
+    it("pins a draft ancestor's slug via an ever-published descendant", async () => {
+      // The only route to this state: schedule the parent (status
+      // 'published', never live), publish the child immediately, then
+      // unwind bottom-up. The child keeps its ever-published marker; the
+      // parent's cancelled schedule clears its own.
+      const parent = await mkPage("sections");
+      const child = await mkPage("alpha", { parentId: parent });
+
+      const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      await publishContent(ctx.db)({
+        contentId: parent,
+        publishedAt: future,
+        userId,
+      });
+      await publishContent(ctx.db)({ contentId: child, userId });
+      await unpublishContent(ctx.db)({ contentId: child, userId });
+      await unpublishContent(ctx.db)({ contentId: parent, userId });
+
+      // The parent itself was never live, so its own lock is off...
+      expect((await getContent(ctx.db)(parent)).publishedAt).toBeNull();
+      // ...but the ever-published child pins its slug and parent.
+      await expect(
+        updateContent(ctx.db)({ contentId: parent, slug: "chapters", userId }),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: /descendant page '\/sections\/alpha' has been published/,
+      });
+    });
+
+    it("serves nav and page-by-path for exactly the published pages (HTTP)", async () => {
+      const navA = await mkPage("nav-a", {
+        metadata: { menuOrder: 1, isMainMenu: true },
+      });
+      const navB = await mkPage("nav-b", { parentId: navA });
+      await mkPage("nav-draft");
+      const navSched = await mkPage("nav-sched");
+
+      await publishContent(ctx.db)({ contentId: navA, userId });
+      await publishContent(ctx.db)({ contentId: navB, userId });
+      await publishContent(ctx.db)({
+        contentId: navSched,
+        publishedAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        userId,
+      });
+
+      // Root pages stay resolvable through the generic kind+slug route
+      const rootBySlug = await getPublishedContent(ctx.db)({
+        kind: "page",
+        slug: "nav-a",
+      });
+      expect(rootBySlug.id).toBe(navA);
+
+      const logger = createTestLogger();
+      const app = Fastify({ logger: { level: "info", stream: logger.stream } });
+      app.setValidatorCompiler(validatorCompiler);
+      app.setSerializerCompiler(serializerCompiler);
+      app.decorate("db", ctx.db);
+      await app.register(contentRoutes);
+      try {
+        // Nav: exactly the live pages (no draft, no still-future
+        // schedule), ordered by path, defaults applied from the schema.
+        const nav = await app.inject({ method: "GET", url: "/content/nav" });
+        expect(nav.statusCode).toBe(200);
+        expect(nav.json()).toEqual({
+          items: [
+            {
+              path: "/nav-a",
+              title: "Page nav-a",
+              menuOrder: 1,
+              isMainMenu: true,
+            },
+            {
+              path: "/nav-a/nav-b",
+              title: "Page nav-b",
+              menuOrder: 99,
+              isMainMenu: false,
+            },
+          ],
+        });
+
+        // by-path serves the nested page with an ETag + 304 revalidation
+        const byPath = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=/nav-a/nav-b",
+        });
+        expect(byPath.statusCode).toBe(200);
+        expect(byPath.json<{ kind: string; slug: string }>()).toMatchObject({
+          kind: "page",
+          slug: "nav-b",
+        });
+        const etag = byPath.headers.etag;
+        expect(etag).toBeDefined();
+        const revalidated = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=/nav-a/nav-b",
+          headers: { "if-none-match": etag ?? "" },
+        });
+        expect(revalidated.statusCode).toBe(304);
+
+        // Drafts and scheduled pages 404 (and never leak an ETag)
+        const draft = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=/nav-draft",
+        });
+        expect(draft.statusCode).toBe(404);
+        expect(draft.headers.etag).toBeUndefined();
+        const sched = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=/nav-sched",
+        });
+        expect(sched.statusCode).toBe(404);
+
+        // Path shape is validated at the route: no leading slash → 400
+        const bad = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=nav-a",
+        });
+        expect(bad.statusCode).toBe(400);
+      } finally {
+        await app.close();
+      }
+    });
+  });
 });

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -20,6 +20,8 @@ import {
   listNewsQuerySchema,
   listNewsResponseSchema,
   listRevisionsResponseSchema,
+  navResponseSchema,
+  pageByPathQuerySchema,
   playCricketIdParamSchema,
   publicContentParamsSchema,
   publicContentResponseSchema,
@@ -33,6 +35,8 @@ import {
   getContentMeta,
   getPublishedContent,
   getPublishedGameReport,
+  getPublishedNav,
+  getPublishedPageByPath,
   listContent,
   listPublishedEvents,
   listPublishedNews,
@@ -81,6 +85,8 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const publicGameReport = getPublishedGameReport(app.db);
   const publicNews = listPublishedNews(app.db);
   const publicEvents = listPublishedEvents(app.db);
+  const publicNav = getPublishedNav(app.db);
+  const publicPageByPath = getPublishedPageByPath(app.db);
 
   // ── Admin ──
 
@@ -287,6 +293,28 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   );
 
+  // Page lookup by full materialised path - the canonical public page
+  // route (nested page slugs are only unique among siblings). Static
+  // segments, so find-my-way prefers it over /content/:kind/:slug.
+  app.get(
+    "/content/page/by-path",
+    {
+      schema: {
+        querystring: pageByPathQuerySchema,
+        response: { 200: publicContentResponseSchema, 304: z.null() },
+      },
+    },
+    async (request, reply) => {
+      const item = await publicPageByPath(request.query.path);
+      const etag = etagFor(item);
+      void reply.header("etag", etag);
+      if (request.headers["if-none-match"] === etag) {
+        return await reply.code(304).send(null);
+      }
+      return item;
+    },
+  );
+
   // List endpoints. One static segment, so no clash with the two-segment
   // /content/:kind/:slug above. No ETag here: any item edit, publish or
   // scheduled publish crossing now() would have to invalidate it.
@@ -313,6 +341,18 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async () => {
       return await publicEvents();
+    },
+  );
+
+  app.get(
+    "/content/nav",
+    {
+      schema: {
+        response: { 200: navResponseSchema },
+      },
+    },
+    async () => {
+      return await publicNav();
     },
   );
 };

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -1,6 +1,7 @@
 import {
   blockPropValueSchema,
   contentKindSchema,
+  contentPathSchema,
   contentSlugSchema,
   contentStatusSchema,
   newsTagSchema,
@@ -42,6 +43,12 @@ export const contentSummarySchema = z.object({
   description: z.string().nullable(),
   status: contentStatusSchema,
   metadata: contentMetadataSchema,
+  // Hierarchy fields: populated for pages, null for every other kind.
+  // menuOrder is hoisted out of metadata so the admin tree view can sort
+  // without re-parsing the metadata jsonb.
+  parentId: z.string().nullable(),
+  path: z.string().nullable(),
+  menuOrder: z.number().int().nullable(),
   publishedAt: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
@@ -81,6 +88,8 @@ export const createContentSchema = z.object({
   description: z.string().min(1).max(1000).nullish(),
   body: contentBodyTransportSchema,
   metadata: contentMetadataSchema,
+  /** Pages only: parent page id (omit/null for a root page). */
+  parentId: z.uuid().nullish(),
 });
 
 export const updateContentSchema = z.object({
@@ -89,6 +98,11 @@ export const updateContentSchema = z.object({
   description: z.string().min(1).max(1000).nullish(),
   body: contentBodyTransportSchema.optional(),
   metadata: contentMetadataSchema.optional(),
+  /**
+   * Pages only: omit to leave the parent unchanged, null to move to the
+   * root, an id to move under that page. Locked once ever published.
+   */
+  parentId: z.uuid().nullish(),
 });
 
 export const contentDetailResponseSchema = contentDetailSchema;
@@ -183,4 +197,27 @@ export const listNewsResponseSchema = z.object({
 
 export const listEventsResponseSchema = z.object({
   items: z.array(publicListItemSchema),
+});
+
+// ── Public: pages (nav + by-path) ───────────────────────────────────────
+
+/**
+ * Every published page's nav fields, ordered by path. A few KB for the
+ * whole site, so no pagination; tree assembly stays client-side
+ * (replaces the build-time getNavigationTree/getBreadcrumbs/
+ * getMainMenuItems over static frontmatter).
+ */
+export const navResponseSchema = z.object({
+  items: z.array(
+    z.object({
+      path: z.string(),
+      title: z.string(),
+      menuOrder: z.number().int(),
+      isMainMenu: z.boolean(),
+    }),
+  ),
+});
+
+export const pageByPathQuerySchema = z.object({
+  path: contentPathSchema,
 });

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -29,6 +29,7 @@ const {
     set: vi.fn().mockReturnThis(),
     values: vi.fn().mockReturnThis(),
     returning: vi.fn().mockReturnThis(),
+    forUpdate: vi.fn().mockReturnThis(),
     orderBy: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
     offset: vi.fn().mockReturnThis(),
@@ -578,21 +579,28 @@ describe("page hierarchy: updateContent", () => {
 });
 
 describe("publishContent", () => {
-  // The prefetch (kind/status/parent_id) is the first executeTakeFirst.
-  const prefetched = { kind: "game_report", status: "draft", parent_id: null };
+  // Call order inside the transaction: 1. unlocked peek (kind/parent_id)
+  // 2. [pages with a parent] parent row FOR UPDATE 3. item row FOR
+  // UPDATE 4. the UPDATE itself.
+  const peeked = { kind: "game_report", status: "draft", parent_id: null };
+  const pagePeek = { kind: "page", status: "draft", parent_id: "p1" };
+  const liveParent = {
+    status: "published",
+    published_at: new Date("2026-06-01T10:00:00Z"),
+    live_now: true,
+  };
 
   it("404s when the item does not exist", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // prefetch
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // peek
     await expect(
       publishContent(db)({ contentId: "missing", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 404 });
   });
 
   it("409s when the item is archived", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      ...prefetched,
-      status: "archived",
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce({ ...peeked, status: "archived" }); // locked item
     await expect(
       publishContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({
@@ -604,7 +612,8 @@ describe("publishContent", () => {
   it("returns the effective publishedAt", async () => {
     const at = new Date("2026-07-01T10:00:00Z");
     mockExecuteTakeFirst
-      .mockResolvedValueOnce(prefetched)
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce(peeked) // locked item
       .mockResolvedValueOnce({ id: "content-1", published_at: at });
     const result = await publishContent(db)({
       contentId: "content-1",
@@ -620,7 +629,8 @@ describe("publishContent", () => {
   it("passes an explicit publishedAt through as a concrete date", async () => {
     const at = new Date("2026-07-01T10:00:00Z");
     mockExecuteTakeFirst
-      .mockResolvedValueOnce(prefetched)
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce(peeked) // locked item
       .mockResolvedValueOnce({ id: "content-1", published_at: at });
     await publishContent(db)({
       contentId: "content-1",
@@ -632,7 +642,8 @@ describe("publishContent", () => {
 
   it("publish-now keeps published_at only when already past (DB-clock CASE)", async () => {
     mockExecuteTakeFirst
-      .mockResolvedValueOnce(prefetched)
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce(peeked) // locked item
       .mockResolvedValueOnce({
         id: "content-1",
         published_at: new Date("2026-06-01T10:00:00Z"),
@@ -650,7 +661,8 @@ describe("publishContent", () => {
 
   it("guards the ever-live invariant in the UPDATE's WHERE (DB clock)", async () => {
     mockExecuteTakeFirst
-      .mockResolvedValueOnce(prefetched)
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce(peeked) // locked item
       .mockResolvedValueOnce({
         id: "content-1",
         published_at: new Date("2027-01-01T10:00:00Z"),
@@ -669,9 +681,9 @@ describe("publishContent", () => {
 
   it("409s when scheduling an item that has already been live", async () => {
     mockExecuteTakeFirst
-      .mockResolvedValueOnce({ ...prefetched, status: "published" }) // prefetch
-      .mockResolvedValueOnce(undefined) // ever-live guard excluded the row
-      .mockResolvedValueOnce({ status: "published" }); // re-check: not archived
+      .mockResolvedValueOnce({ ...peeked, status: "published" }) // peek
+      .mockResolvedValueOnce({ ...peeked, status: "published" }) // locked item
+      .mockResolvedValueOnce(undefined); // ever-live guard excluded the row
     await expect(
       publishContent(db)({
         contentId: "content-1",
@@ -687,8 +699,13 @@ describe("publishContent", () => {
 
   it("400s when publishing a page whose parent is not published", async () => {
     mockExecuteTakeFirst
-      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: "p1" })
-      .mockResolvedValueOnce({ status: "draft" }); // parent status
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce({
+        status: "draft",
+        published_at: null,
+        live_now: null,
+      }) // locked parent
+      .mockResolvedValueOnce(pagePeek); // locked item
     await expect(
       publishContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({
@@ -697,11 +714,12 @@ describe("publishContent", () => {
     });
   });
 
-  it("publishes a page whose parent is published", async () => {
-    const at = new Date("2026-06-01T10:00:00Z");
+  it("publishes a page under a live parent", async () => {
+    const at = new Date("2026-06-02T10:00:00Z");
     mockExecuteTakeFirst
-      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: "p1" })
-      .mockResolvedValueOnce({ status: "published" }) // parent status
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce(liveParent) // locked parent
+      .mockResolvedValueOnce(pagePeek) // locked item
       .mockResolvedValueOnce({ id: "content-1", published_at: at }); // update
     const result = await publishContent(db)({
       contentId: "content-1",
@@ -714,6 +732,7 @@ describe("publishContent", () => {
     const at = new Date("2026-06-01T10:00:00Z");
     mockExecuteTakeFirst
       .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: null })
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: null })
       .mockResolvedValueOnce({ id: "content-1", published_at: at }); // update
     const result = await publishContent(db)({
       contentId: "content-1",
@@ -721,13 +740,73 @@ describe("publishContent", () => {
     });
     expect(result).toEqual({ id: "content-1", publishedAt: at.toISOString() });
   });
+
+  it("rejects publish-now while the parent is still scheduled", async () => {
+    const parentAt = new Date("2027-01-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce({
+        status: "published",
+        published_at: parentAt,
+        live_now: false, // scheduled: not yet live on the DB clock
+      })
+      .mockResolvedValueOnce(pagePeek); // locked item
+    await expect(
+      publishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: `Parent page goes live at ${parentAt.toISOString()}; schedule this page for that time or later`,
+    });
+  });
+
+  it("rejects scheduling (or backdating) a child before the parent's go-live", async () => {
+    const parentAt = new Date("2027-01-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce({
+        status: "published",
+        published_at: parentAt,
+        live_now: false,
+      })
+      .mockResolvedValueOnce(pagePeek); // locked item
+    await expect(
+      publishContent(db)({
+        contentId: "content-1",
+        publishedAt: "2026-12-31T10:00:00Z",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: `Parent page goes live at ${parentAt.toISOString()}; schedule this page for that time or later`,
+    });
+  });
+
+  it("allows scheduling a child at the parent's exact go-live time", async () => {
+    const parentAt = new Date("2027-01-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce({
+        status: "published",
+        published_at: parentAt,
+        live_now: false,
+      })
+      .mockResolvedValueOnce(pagePeek) // locked item
+      .mockResolvedValueOnce({ id: "content-1", published_at: parentAt });
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      publishedAt: parentAt.toISOString(),
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      id: "content-1",
+      publishedAt: parentAt.toISOString(),
+    });
+  });
 });
 
 describe("archiveContent", () => {
   it("404s when the item does not exist", async () => {
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update matched nothing
-      .mockResolvedValueOnce(undefined); // and it does not exist
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // locked item
     await expect(
       archiveContent(db)({ contentId: "missing", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 404 });
@@ -735,9 +814,10 @@ describe("archiveContent", () => {
 
   it("409s when the item is already archived", async () => {
     // Re-archiving must not silently bump updated_at/updated_by.
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update skipped the archived row
-      .mockResolvedValueOnce({ id: "content-1" }); // but it exists
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      kind: "game_report",
+      status: "archived",
+    });
     await expect(
       archiveContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({
@@ -747,7 +827,34 @@ describe("archiveContent", () => {
   });
 
   it("archives a non-archived item", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({ id: "content-1" });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "game_report", status: "draft" })
+      .mockResolvedValueOnce({ id: "content-1" }); // update
+    const result = await archiveContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1" });
+  });
+
+  it("409s when archiving a page that has published children", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // locked item
+      .mockResolvedValueOnce({ id: "child-1" }); // published-child probe
+    await expect(
+      archiveContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message:
+        "Cannot archive a page that has published child pages - unpublish or archive the children first",
+    });
+  });
+
+  it("archives a page whose children are all drafts", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // locked item
+      .mockResolvedValueOnce(undefined) // no published child
+      .mockResolvedValueOnce({ id: "content-1" }); // update
     const result = await archiveContent(db)({
       contentId: "content-1",
       userId: "user-1",

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -9,37 +9,41 @@ import {
 } from "kysely";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockExecuteTakeFirst, mockExecuteTakeFirstOrThrow, mockQueryBuilder } =
-  vi.hoisted(() => {
-    const mockExecuteTakeFirst = vi.fn();
-    const mockExecuteTakeFirstOrThrow = vi.fn();
-    const mockExecute = vi.fn();
+const {
+  mockExecuteTakeFirst,
+  mockExecuteTakeFirstOrThrow,
+  mockExecute,
+  mockQueryBuilder,
+} = vi.hoisted(() => {
+  const mockExecuteTakeFirst = vi.fn();
+  const mockExecuteTakeFirstOrThrow = vi.fn();
+  const mockExecute = vi.fn();
 
-    const mockQueryBuilder: Record<string, unknown> = {
-      selectFrom: vi.fn().mockReturnThis(),
-      updateTable: vi.fn().mockReturnThis(),
-      insertInto: vi.fn().mockReturnThis(),
-      leftJoin: vi.fn().mockReturnThis(),
-      where: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      set: vi.fn().mockReturnThis(),
-      values: vi.fn().mockReturnThis(),
-      returning: vi.fn().mockReturnThis(),
-      orderBy: vi.fn().mockReturnThis(),
-      limit: vi.fn().mockReturnThis(),
-      offset: vi.fn().mockReturnThis(),
-      executeTakeFirst: mockExecuteTakeFirst,
-      executeTakeFirstOrThrow: mockExecuteTakeFirstOrThrow,
-      execute: mockExecute,
-    };
+  const mockQueryBuilder: Record<string, unknown> = {
+    selectFrom: vi.fn().mockReturnThis(),
+    updateTable: vi.fn().mockReturnThis(),
+    insertInto: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
+    executeTakeFirst: mockExecuteTakeFirst,
+    executeTakeFirstOrThrow: mockExecuteTakeFirstOrThrow,
+    execute: mockExecute,
+  };
 
-    return {
-      mockExecuteTakeFirst,
-      mockExecuteTakeFirstOrThrow,
-      mockExecute,
-      mockQueryBuilder,
-    };
-  });
+  return {
+    mockExecuteTakeFirst,
+    mockExecuteTakeFirstOrThrow,
+    mockExecute,
+    mockQueryBuilder,
+  };
+});
 
 import {
   archiveContent,
@@ -63,13 +67,32 @@ const compilerDb = new Kysely<DB>({
   },
 });
 
-/** SQL text (whitespace-normalised) of a column's value in the first .set() call. */
-function setSqlFor(column: string): string {
-  const setArg = (mockQueryBuilder.set as ReturnType<typeof vi.fn>).mock
-    .calls[0]?.[0] as Record<string, RawBuilder<unknown>>;
+/** SQL text (whitespace-normalised) of a column's value in the nth .set() call. */
+function setSqlFor(column: string, callIndex = 0): string {
+  const setArg = (mockQueryBuilder.set as ReturnType<typeof vi.fn>).mock.calls[
+    callIndex
+  ]?.[0] as Record<string, RawBuilder<unknown>>;
   const builder = setArg[column];
   if (!builder) throw new Error(`.set() did not include ${column}`);
   return builder.compile(compilerDb).sql.replace(/\s+/g, " ").trim();
+}
+
+/** The argument object of the nth .set() call (for plain, non-SQL values). */
+function setArgFor(callIndex = 0): Record<string, unknown> {
+  const setArg = (mockQueryBuilder.set as ReturnType<typeof vi.fn>).mock.calls[
+    callIndex
+  ]?.[0] as Record<string, unknown> | undefined;
+  if (!setArg) throw new Error(`.set() was not called ${callIndex + 1} times`);
+  return setArg;
+}
+
+/** The argument object of the nth .values() call. */
+function valuesArgFor(callIndex = 0): Record<string, unknown> {
+  const arg = (mockQueryBuilder.values as ReturnType<typeof vi.fn>).mock.calls[
+    callIndex
+  ]?.[0] as Record<string, unknown> | undefined;
+  if (!arg) throw new Error(`.values() was not called ${callIndex + 1} times`);
+  return arg;
 }
 
 /**
@@ -313,22 +336,263 @@ describe("updateContent", () => {
     });
     expect(result).toEqual({ id: "content-1" });
   });
+
+  it("rejects a parentId on non-page kinds", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(currentRow); // game_report
+    await expect(
+      updateContent(db)({
+        contentId: "content-1",
+        userId: "user-1",
+        parentId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Only pages can have a parent page",
+    });
+  });
+});
+
+describe("page hierarchy: createContent", () => {
+  const pageCreate = (overrides: Record<string, unknown> = {}) =>
+    validCreate({
+      kind: "page" as const,
+      slug: "about",
+      title: "About",
+      metadata: {},
+      ...overrides,
+    });
+
+  it("rejects a parentId on non-page kinds", async () => {
+    await expect(
+      createContent(db)(validCreate({ parentId: "parent-1" })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Only pages can have a parent page",
+    });
+  });
+
+  it("computes a root page's path and applies metadata defaults", async () => {
+    const result = await createContent(db)(pageCreate());
+    expect(result).toEqual({ id: "content-1" });
+    const inserted = valuesArgFor() as { metadata: string };
+    expect(valuesArgFor()).toMatchObject({
+      parent_id: null,
+      path: "/about",
+    });
+    expect(JSON.parse(inserted.metadata)).toEqual({
+      menuOrder: 99,
+      isMainMenu: false,
+      hideTitle: false,
+    });
+  });
+
+  it("computes a child page's path from its parent's", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ id: "parent-1", kind: "page", path: "/cricket" }) // parent fetch
+      .mockResolvedValueOnce(undefined); // sibling slug check
+    const result = await createContent(db)(
+      pageCreate({ slug: "juniors", parentId: "parent-1" }),
+    );
+    expect(result).toEqual({ id: "content-1" });
+    expect(valuesArgFor()).toMatchObject({
+      parent_id: "parent-1",
+      path: "/cricket/juniors",
+    });
+  });
+
+  it("rejects a parent that does not exist", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // parent fetch
+    await expect(
+      createContent(db)(pageCreate({ parentId: "missing" })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Parent page not found",
+    });
+  });
+
+  it("rejects a parent that is not a page", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "news-1",
+      kind: "news",
+      path: null,
+    });
+    await expect(
+      createContent(db)(pageCreate({ parentId: "news-1" })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Parent page not found",
+    });
+  });
+
+  it("keeps parent_id and path NULL for non-page kinds", async () => {
+    await createContent(db)(validCreate());
+    expect(valuesArgFor()).toMatchObject({ parent_id: null, path: null });
+  });
+});
+
+describe("page hierarchy: updateContent", () => {
+  const pageRow = {
+    id: "page-1",
+    kind: "page",
+    slug: "cricket",
+    parent_id: null,
+    path: "/cricket",
+    title: "Cricket",
+    description: null,
+    body: validBody,
+    metadata: { menuOrder: 1, isMainMenu: true, hideTitle: false },
+    published_at: null,
+  };
+
+  it("recomputes the path on slug change and cascades to descendants", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pageRow) // fetch current
+      .mockResolvedValueOnce(undefined); // sibling slug check
+    mockExecute.mockResolvedValueOnce([
+      { id: "child-1", path: "/cricket/juniors", published_at: null },
+      {
+        id: "grandchild-1",
+        path: "/cricket/juniors/coaches",
+        published_at: null,
+      },
+    ]); // descendants
+    const result = await updateContent(db)({
+      contentId: "page-1",
+      userId: "user-1",
+      slug: "playing",
+    });
+    expect(result).toEqual({ id: "page-1" });
+    // Main update rewrites the page's own path...
+    expect(setArgFor(0)).toMatchObject({
+      slug: "playing",
+      parent_id: null,
+      path: "/playing",
+    });
+    // ...and the cascade re-prefixes every descendant in one statement:
+    // new prefix ($1) + the tail of the old path (substr past '/cricket').
+    expect(setSqlFor("path", 1)).toBe("$1 || substr(path, 9)");
+    const cascadeWhere = (
+      mockQueryBuilder.where as ReturnType<typeof vi.fn>
+    ).mock.calls.find((call) => call[1] === "in");
+    expect(cascadeWhere?.[2]).toEqual(["child-1", "grandchild-1"]);
+  });
+
+  it("recomputes the path on parent change", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pageRow) // fetch current
+      .mockResolvedValueOnce({ id: "parent-2", kind: "page", path: "/club" }) // new parent
+      .mockResolvedValueOnce(undefined); // sibling slug check
+    mockExecute.mockResolvedValueOnce([]); // no descendants
+    await updateContent(db)({
+      contentId: "page-1",
+      userId: "user-1",
+      parentId: "parent-2",
+    });
+    expect(setArgFor(0)).toMatchObject({
+      slug: "cricket",
+      parent_id: "parent-2",
+      path: "/club/cricket",
+    });
+  });
+
+  it("locks slug and parent once the page has ever been published", async () => {
+    const published = {
+      ...pageRow,
+      published_at: new Date("2026-06-01T10:00:00Z"),
+    };
+    mockExecuteTakeFirst.mockResolvedValueOnce(published);
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        slug: "playing",
+      }),
+    ).rejects.toMatchObject({ statusCode: 409, message: /locked/ });
+
+    mockExecuteTakeFirst.mockResolvedValueOnce(published);
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        parentId: "parent-2",
+      }),
+    ).rejects.toMatchObject({ statusCode: 409, message: /locked/ });
+  });
+
+  it("rejects a slug change that would move an ever-published descendant", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(pageRow);
+    mockExecute.mockResolvedValueOnce([
+      {
+        id: "child-1",
+        path: "/cricket/juniors",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      },
+    ]);
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        slug: "playing",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message: /descendant page '\/cricket\/juniors' has been published/,
+    });
+  });
+
+  it("rejects making a page its own parent", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(pageRow);
+    mockExecute.mockResolvedValueOnce([]); // descendants
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        parentId: "page-1",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "A page cannot be its own parent",
+    });
+  });
+
+  it("rejects moving a page under one of its own descendants", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(pageRow).mockResolvedValueOnce({
+      id: "child-1",
+      kind: "page",
+      path: "/cricket/juniors",
+    }); // new parent = descendant
+    mockExecute.mockResolvedValueOnce([
+      { id: "child-1", path: "/cricket/juniors", published_at: null },
+    ]);
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        parentId: "child-1",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "A page cannot be moved under one of its own descendants",
+    });
+  });
 });
 
 describe("publishContent", () => {
+  // The prefetch (kind/status/parent_id) is the first executeTakeFirst.
+  const prefetched = { kind: "game_report", status: "draft", parent_id: null };
+
   it("404s when the item does not exist", async () => {
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update returning nothing
-      .mockResolvedValueOnce(undefined); // existence check
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // prefetch
     await expect(
       publishContent(db)({ contentId: "missing", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 404 });
   });
 
   it("409s when the item is archived", async () => {
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update skipped archived row
-      .mockResolvedValueOnce({ status: "archived" }); // but it exists
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      ...prefetched,
+      status: "archived",
+    });
     await expect(
       publishContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({
@@ -339,10 +603,9 @@ describe("publishContent", () => {
 
   it("returns the effective publishedAt", async () => {
     const at = new Date("2026-07-01T10:00:00Z");
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      id: "content-1",
-      published_at: at,
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(prefetched)
+      .mockResolvedValueOnce({ id: "content-1", published_at: at });
     const result = await publishContent(db)({
       contentId: "content-1",
       publishedAt: at.toISOString(),
@@ -356,25 +619,24 @@ describe("publishContent", () => {
 
   it("passes an explicit publishedAt through as a concrete date", async () => {
     const at = new Date("2026-07-01T10:00:00Z");
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      id: "content-1",
-      published_at: at,
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(prefetched)
+      .mockResolvedValueOnce({ id: "content-1", published_at: at });
     await publishContent(db)({
       contentId: "content-1",
       publishedAt: at.toISOString(),
       userId: "user-1",
     });
-    const setArg = (mockQueryBuilder.set as ReturnType<typeof vi.fn>).mock
-      .calls[0]?.[0] as { published_at: unknown };
-    expect(setArg.published_at).toEqual(at);
+    expect(setArgFor().published_at).toEqual(at);
   });
 
   it("publish-now keeps published_at only when already past (DB-clock CASE)", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      id: "content-1",
-      published_at: new Date("2026-06-01T10:00:00Z"),
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(prefetched)
+      .mockResolvedValueOnce({
+        id: "content-1",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      });
     await publishContent(db)({ contentId: "content-1", userId: "user-1" });
     // NULL or a still-future schedule must fall through to now(); only a
     // past live-from date survives a dateless publish.
@@ -387,10 +649,12 @@ describe("publishContent", () => {
   });
 
   it("guards the ever-live invariant in the UPDATE's WHERE (DB clock)", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      id: "content-1",
-      published_at: new Date("2027-01-01T10:00:00Z"),
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(prefetched)
+      .mockResolvedValueOnce({
+        id: "content-1",
+        published_at: new Date("2027-01-01T10:00:00Z"),
+      });
     await publishContent(db)({
       contentId: "content-1",
       publishedAt: "2027-01-01T10:00:00Z",
@@ -405,8 +669,9 @@ describe("publishContent", () => {
 
   it("409s when scheduling an item that has already been live", async () => {
     mockExecuteTakeFirst
+      .mockResolvedValueOnce({ ...prefetched, status: "published" }) // prefetch
       .mockResolvedValueOnce(undefined) // ever-live guard excluded the row
-      .mockResolvedValueOnce({ status: "published" }); // exists, not archived
+      .mockResolvedValueOnce({ status: "published" }); // re-check: not archived
     await expect(
       publishContent(db)({
         contentId: "content-1",
@@ -418,6 +683,43 @@ describe("publishContent", () => {
       message:
         "This item has already been live - it can only be published immediately",
     });
+  });
+
+  it("400s when publishing a page whose parent is not published", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: "p1" })
+      .mockResolvedValueOnce({ status: "draft" }); // parent status
+    await expect(
+      publishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Cannot publish this page until its parent page is published",
+    });
+  });
+
+  it("publishes a page whose parent is published", async () => {
+    const at = new Date("2026-06-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: "p1" })
+      .mockResolvedValueOnce({ status: "published" }) // parent status
+      .mockResolvedValueOnce({ id: "content-1", published_at: at }); // update
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1", publishedAt: at.toISOString() });
+  });
+
+  it("publishes a root page without any parent check", async () => {
+    const at = new Date("2026-06-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: null })
+      .mockResolvedValueOnce({ id: "content-1", published_at: at }); // update
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1", publishedAt: at.toISOString() });
   });
 });
 
@@ -456,25 +758,26 @@ describe("archiveContent", () => {
 
 describe("unpublishContent", () => {
   it("409s when the item is not currently published", async () => {
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update matched nothing
-      .mockResolvedValueOnce({ id: "content-1" }); // but it exists
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      kind: "game_report",
+      status: "draft",
+    }); // prefetch
     await expect(
       unpublishContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 409 });
   });
 
   it("404s when the item does not exist", async () => {
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined);
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // prefetch
     await expect(
       unpublishContent(db)({ contentId: "missing", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 404 });
   });
 
   it("clears published_at only while it is still in the future (DB-clock CASE)", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({ id: "content-1" });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "game_report", status: "published" })
+      .mockResolvedValueOnce({ id: "content-1" }); // update
     await unpublishContent(db)({ contentId: "content-1", userId: "user-1" });
     // Cancelling a schedule that never went live clears the
     // ever-published marker (unlocking the slug); a past published_at -
@@ -482,6 +785,31 @@ describe("unpublishContent", () => {
     expect(setSqlFor("published_at")).toBe(
       "CASE WHEN published_at > CURRENT_TIMESTAMP THEN NULL ELSE published_at END",
     );
+  });
+
+  it("400s when unpublishing a page that has published children", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // prefetch
+      .mockResolvedValueOnce({ id: "child-1" }); // published-child probe
+    await expect(
+      unpublishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message:
+        "Cannot unpublish a page that has published child pages - unpublish the children first",
+    });
+  });
+
+  it("unpublishes a page whose children are all unpublished", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // prefetch
+      .mockResolvedValueOnce(undefined) // no published child
+      .mockResolvedValueOnce({ id: "content-1" }); // update
+    const result = await unpublishContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1" });
   });
 });
 

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -4,6 +4,7 @@ import {
   contentBodySchema,
   eventMetadataSchema,
   newsMetadataSchema,
+  pageMetadataSchema,
   type ContentKind,
   type ContentStatus,
 } from "@percy-main/shared/content";
@@ -93,11 +94,27 @@ interface ContentItemRow {
   description: string | null;
   status: string;
   metadata: unknown;
+  parent_id: string | null;
+  path: string | null;
   published_at: Date | null;
   created_at: Date;
   updated_at: Date;
   updated_by: string;
   updated_by_name: string | null;
+}
+
+/**
+ * menuOrder hoisted out of a page's metadata for the admin tree view
+ * (null for every other kind). Falls back to the schema default rather
+ * than failing the whole list if a stored row somehow predates the page
+ * metadata schema.
+ */
+function pageMenuOrder(kind: string, metadata: unknown): number | null {
+  if (kind !== "page") return null;
+  const parsed = pageMetadataSchema.safeParse(metadata);
+  return parsed.success
+    ? parsed.data.menuOrder
+    : pageMetadataSchema.parse({}).menuOrder;
 }
 
 function toSummary(row: ContentItemRow) {
@@ -109,6 +126,9 @@ function toSummary(row: ContentItemRow) {
     description: row.description,
     status: row.status as ContentStatus,
     metadata: row.metadata as Record<string, unknown>,
+    parentId: row.parent_id,
+    path: row.path,
+    menuOrder: pageMenuOrder(row.kind, row.metadata),
     publishedAt: row.published_at?.toISOString() ?? null,
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
@@ -125,6 +145,8 @@ const summaryColumns = [
   "content_item.description",
   "content_item.status",
   "content_item.metadata",
+  "content_item.parent_id",
+  "content_item.path",
   "content_item.published_at",
   "content_item.created_at",
   "content_item.updated_at",
@@ -236,6 +258,65 @@ export function getContentMeta(db: Kysely<DB>) {
   };
 }
 
+// ── Hierarchy helpers (pages only) ──────────────────────────────────────
+//
+// Pages form an adjacency list via parent_id with a materialised URL
+// path; every other kind keeps both NULL. A page's path is computed on
+// every create and on slug/parent changes (never client-supplied), so a
+// path is canonical by construction: descendants of a page are exactly
+// the rows whose path extends its own.
+
+/**
+ * Resolve a prospective parent: must exist and be a page. Returns its
+ * path (set at create for every page, so non-null - a NULL here means
+ * the row predates hierarchy support, which cannot happen: pages were
+ * not editable through the API before it).
+ */
+async function resolveParentPage(tx: Transaction<DB>, parentId: string) {
+  const parent = await tx
+    .selectFrom("content_item")
+    .select(["id", "kind", "path"])
+    .where("id", "=", parentId)
+    .executeTakeFirst();
+  if (parent?.kind !== "page") {
+    throwHttpError(400, "Parent page not found");
+  }
+  if (parent.path === null) {
+    throwHttpError(500, "Parent page is missing its path");
+  }
+  return { id: parent.id, path: parent.path };
+}
+
+/**
+ * Friendly 409 for a slug clash among siblings (root pages and flat
+ * kinds: per-kind among parentless rows; child pages: among the
+ * parent's children). The partial unique indexes are the backstop.
+ */
+async function assertSlugAvailable(
+  tx: Transaction<DB>,
+  kind: ContentKind,
+  slug: string,
+  parentId: string | null,
+  excludeId?: string,
+) {
+  let query = tx
+    .selectFrom("content_item")
+    .select("id")
+    .where("kind", "=", kind)
+    .where("slug", "=", slug);
+  query =
+    parentId === null
+      ? query.where("parent_id", "is", null)
+      : query.where("parent_id", "=", parentId);
+  if (excludeId !== undefined) {
+    query = query.where("id", "!=", excludeId);
+  }
+  const clash = await query.executeTakeFirst();
+  if (clash) {
+    throwHttpError(409, `A ${kind} item with slug '${slug}' already exists`);
+  }
+}
+
 // ── Admin: create ───────────────────────────────────────────────────────
 
 export function createContent(db: Kysely<DB>) {
@@ -245,21 +326,27 @@ export function createContent(db: Kysely<DB>) {
     const metadata = parseMetadata(params.kind, params.metadata);
     const body = parseBody(params.body);
     const description = params.description ?? null;
+    const parentId = params.parentId ?? null;
+
+    if (parentId !== null && params.kind !== "page") {
+      throwHttpError(400, "Only pages can have a parent page");
+    }
 
     return await db.transaction().execute(async (tx) => {
-      const existing = await tx
-        .selectFrom("content_item")
-        .select("id")
-        .where("kind", "=", params.kind)
-        .where("slug", "=", params.slug)
-        .where("parent_id", "is", null)
-        .executeTakeFirst();
-      if (existing) {
-        throwHttpError(
-          409,
-          `A ${params.kind} item with slug '${params.slug}' already exists`,
-        );
+      let path: string | null = null;
+      if (params.kind === "page") {
+        if (parentId !== null) {
+          const parent = await resolveParentPage(tx, parentId);
+          path = `${parent.path}/${params.slug}`;
+        } else {
+          path = `/${params.slug}`;
+        }
       }
+
+      // Sibling-slug uniqueness implies path uniqueness too (a path is
+      // parent path + slug, and parent paths are unique), so this is the
+      // friendly 409 for both; the unique indexes catch races.
+      await assertSlugAvailable(tx, params.kind, params.slug, parentId);
 
       await assertPlayCricketIdAvailable(tx, params.kind, metadata);
 
@@ -268,6 +355,8 @@ export function createContent(db: Kysely<DB>) {
         .values({
           kind: params.kind,
           slug: params.slug,
+          parent_id: parentId,
+          path,
           title: params.title,
           description,
           body: JSON.stringify(body),
@@ -312,6 +401,8 @@ export function updateContent(db: Kysely<DB>) {
           "id",
           "kind",
           "slug",
+          "parent_id",
+          "path",
           "title",
           "description",
           "body",
@@ -324,18 +415,32 @@ export function updateContent(db: Kysely<DB>) {
       if (!current) throwHttpError(404, "Content not found");
 
       const kind = current.kind as ContentKind;
+      const isPage = kind === "page";
 
-      // Slug locks once the item has ever been publicly visible.
+      if (!isPage && params.parentId != null) {
+        throwHttpError(400, "Only pages can have a parent page");
+      }
+
+      const slug = params.slug ?? current.slug;
+      const slugChanged = slug !== current.slug;
+      // undefined = unchanged, null = move to root, id = move under it.
+      const parentId =
+        params.parentId !== undefined ? params.parentId : current.parent_id;
+      const parentChanged = parentId !== current.parent_id;
+
+      // The slug - and for pages the parent too, since path = parent path
+      // + slug - locks once the item has ever been publicly visible.
       // published_at is the ever-published marker: unpublish keeps it for
       // items that went live, and clears it when cancelling a schedule
       // that never did - which re-unlocks the slug, deliberately. No
       // redirect handling exists anywhere.
-      if (
-        params.slug !== undefined &&
-        params.slug !== current.slug &&
-        current.published_at !== null
-      ) {
-        throwHttpError(409, "Slug is locked once an item has been published");
+      if ((slugChanged || parentChanged) && current.published_at !== null) {
+        throwHttpError(
+          409,
+          isPage
+            ? "Slug and parent are locked once a page has been published - its path is its public URL"
+            : "Slug is locked once an item has been published",
+        );
       }
 
       const title = params.title ?? current.title;
@@ -351,23 +456,75 @@ export function updateContent(db: Kysely<DB>) {
         params.metadata !== undefined
           ? parseMetadata(kind, params.metadata)
           : parseMetadata(kind, current.metadata as Record<string, unknown>);
-      const slug = params.slug ?? current.slug;
 
-      if (slug !== current.slug) {
-        const clash = await tx
+      // Pages: a slug or parent change recomputes this page's path and
+      // every descendant's. Descendants are exactly the rows whose path
+      // extends this page's (paths are materialised from the parent
+      // chain, so the prefix relation is canonical).
+      let path = current.path;
+      let cascade: {
+        ids: string[];
+        newPrefix: string;
+        oldPrefixLength: number;
+      } | null = null;
+
+      if (isPage && (slugChanged || parentChanged)) {
+        const oldPath = current.path;
+        if (oldPath === null) {
+          throwHttpError(500, "Page is missing its path");
+        }
+
+        const descendants = await tx
           .selectFrom("content_item")
-          .select("id")
-          .where("kind", "=", kind)
-          .where("slug", "=", slug)
-          .where("parent_id", "is", null)
-          .where("id", "!=", current.id)
-          .executeTakeFirst();
-        if (clash) {
+          .select(["id", "path", "published_at"])
+          .where("path", "like", `${oldPath}/%`)
+          .execute();
+
+        // An ever-published descendant's URL is (or was) live, which pins
+        // every ancestor slug on its path - same lock as its own.
+        const locked = descendants.find((d) => d.published_at !== null);
+        if (locked) {
           throwHttpError(
             409,
-            `A ${kind} item with slug '${slug}' already exists`,
+            `Cannot change this page's slug or parent: descendant page '${locked.path ?? locked.id}' has been published, which pins its ancestors' slugs`,
           );
         }
+
+        let newPath: string;
+        if (parentId === null) {
+          newPath = `/${slug}`;
+        } else {
+          if (parentId === current.id) {
+            throwHttpError(400, "A page cannot be its own parent");
+          }
+          const parent = await resolveParentPage(tx, parentId);
+          if (parent.path.startsWith(`${oldPath}/`)) {
+            throwHttpError(
+              400,
+              "A page cannot be moved under one of its own descendants",
+            );
+          }
+          newPath = `${parent.path}/${slug}`;
+        }
+        path = newPath;
+
+        if (descendants.length > 0) {
+          cascade = {
+            ids: descendants.map((d) => d.id),
+            newPrefix: newPath,
+            oldPrefixLength: oldPath.length,
+          };
+        }
+      }
+
+      if (slugChanged || parentChanged) {
+        await assertSlugAvailable(
+          tx,
+          kind,
+          slug,
+          isPage ? parentId : null,
+          current.id,
+        );
       }
 
       if (params.metadata !== undefined) {
@@ -378,6 +535,8 @@ export function updateContent(db: Kysely<DB>) {
         .updateTable("content_item")
         .set({
           slug,
+          parent_id: parentId,
+          path,
           title,
           description,
           body: JSON.stringify(body),
@@ -387,6 +546,22 @@ export function updateContent(db: Kysely<DB>) {
         })
         .where("id", "=", current.id)
         .execute();
+
+      if (cascade !== null) {
+        // Re-prefix every descendant path in one statement. Paths only
+        // contain [a-z0-9-/], so the LIKE above and the substr here need
+        // no escaping. Bump updated_at/updated_by: the row's public URL
+        // changed, and admin list ordering + ETags key off updated_at.
+        await tx
+          .updateTable("content_item")
+          .set({
+            path: sql`${cascade.newPrefix} || substr(path, ${sql.lit(cascade.oldPrefixLength + 1)})`,
+            updated_by: params.userId,
+            updated_at: sql`CURRENT_TIMESTAMP`,
+          })
+          .where("id", "in", cascade.ids)
+          .execute();
+      }
 
       await writeRevision(
         tx,
@@ -407,6 +582,35 @@ export function publishContent(db: Kysely<DB>) {
     publishedAt?: string;
     userId: string;
   }) => {
+    const item = await db
+      .selectFrom("content_item")
+      .select(["kind", "status", "parent_id"])
+      .where("id", "=", params.contentId)
+      .executeTakeFirst();
+    if (!item) throwHttpError(404, "Content not found");
+    if (item.status === "archived") {
+      throwHttpError(409, "Archived content cannot be published");
+    }
+
+    // A page goes live at parent path + slug, so publishing it under an
+    // unpublished parent would put a live page on a dead URL prefix
+    // (broken breadcrumbs/nav). Publish top-down. Status-based on
+    // purpose: a scheduled parent counts, so a whole section can be
+    // scheduled together.
+    if (item.kind === "page" && item.parent_id !== null) {
+      const parent = await db
+        .selectFrom("content_item")
+        .select("status")
+        .where("id", "=", item.parent_id)
+        .executeTakeFirst();
+      if (parent?.status !== "published") {
+        throwHttpError(
+          400,
+          "Cannot publish this page until its parent page is published",
+        );
+      }
+    }
+
     let query = db
       .updateTable("content_item")
       .set({
@@ -455,8 +659,8 @@ export function publishContent(db: Kysely<DB>) {
       .executeTakeFirst();
 
     if (!result) {
-      // Missing, archived, or scheduling an ever-live item; disambiguate
-      // for a useful error.
+      // The prefetch passed, so this is the ever-live scheduling guard
+      // (or a concurrent archive, which the same re-check catches).
       const existing = await db
         .selectFrom("content_item")
         .select("status")
@@ -481,15 +685,43 @@ export function publishContent(db: Kysely<DB>) {
 
 export function unpublishContent(db: Kysely<DB>) {
   return async (params: { contentId: string; userId: string }) => {
+    const item = await db
+      .selectFrom("content_item")
+      .select(["kind", "status"])
+      .where("id", "=", params.contentId)
+      .executeTakeFirst();
+    if (!item) throwHttpError(404, "Content not found");
+    if (item.status !== "published") {
+      // Only a published item can be unpublished - in particular this
+      // must not offer a back door out of 'archived' (archive ->
+      // unpublish -> publish would resurrect archived content past the
+      // manage-only archive control).
+      throwHttpError(409, "Only published content can be unpublished");
+    }
+
+    // Mirror of the publish rule: pulling a page out from under a
+    // published (or scheduled) child would leave live URLs on a dead
+    // prefix. Unpublish bottom-up.
+    if (item.kind === "page") {
+      const publishedChild = await db
+        .selectFrom("content_item")
+        .select("id")
+        .where("parent_id", "=", params.contentId)
+        .where("status", "=", "published")
+        .executeTakeFirst();
+      if (publishedChild) {
+        throwHttpError(
+          400,
+          "Cannot unpublish a page that has published child pages - unpublish the children first",
+        );
+      }
+    }
+
     // A past published_at is deliberately retained: it marks "ever
     // published", which locks the slug. A still-future published_at means
     // a schedule being cancelled before the public ever saw the item, so
     // the ever-published marker is cleared and the slug unlocks.
     // Visibility is otherwise governed by status alone.
-    // Only a published item can be unpublished - in particular this must
-    // not offer a back door out of 'archived' (archive -> unpublish ->
-    // publish would resurrect archived content past the manage-only
-    // archive control).
     const result = await db
       .updateTable("content_item")
       .set({
@@ -502,22 +734,13 @@ export function unpublishContent(db: Kysely<DB>) {
         updated_at: sql`CURRENT_TIMESTAMP`,
       })
       .where("id", "=", params.contentId)
+      // Race backstop for the prefetched status check.
       .where("status", "=", "published")
       .returning("id")
       .executeTakeFirst();
 
     if (!result) {
-      const exists = await db
-        .selectFrom("content_item")
-        .select("id")
-        .where("id", "=", params.contentId)
-        .executeTakeFirst();
-      throwHttpError(
-        exists ? 409 : 404,
-        exists
-          ? "Only published content can be unpublished"
-          : "Content not found",
-      );
+      throwHttpError(409, "Only published content can be unpublished");
     }
     return { id: result.id };
   };
@@ -660,10 +883,32 @@ function publishedOnly(db: Kysely<DB>) {
 
 export function getPublishedContent(db: Kysely<DB>) {
   return async (params: { kind: ContentKind; slug: string }) => {
-    const row = await publishedOnly(db)
+    let query = publishedOnly(db)
       .select(publicColumns)
       .where("kind", "=", params.kind)
-      .where("slug", "=", params.slug)
+      .where("slug", "=", params.slug);
+
+    // Page slugs are only unique among siblings, so a bare kind+slug
+    // lookup is ambiguous for nested pages. Root pages stay resolvable
+    // here (kind+slug is unique where parent_id is null); everything
+    // deeper goes through getPublishedPageByPath.
+    if (params.kind === "page") {
+      query = query.where("parent_id", "is", null);
+    }
+
+    const row = await query.executeTakeFirst();
+
+    if (!row) throwHttpError(404, "Content not found");
+    return toPublic(row);
+  };
+}
+
+export function getPublishedPageByPath(db: Kysely<DB>) {
+  return async (path: string) => {
+    const row = await publishedOnly(db)
+      .select(publicColumns)
+      .where("kind", "=", "page")
+      .where("path", "=", path)
       .executeTakeFirst();
 
     if (!row) throwHttpError(404, "Content not found");
@@ -811,6 +1056,40 @@ export function listPublishedNews(db: Kysely<DB>) {
         authorCount: Number(authorRow.authors),
       };
     });
+  };
+}
+
+export function getPublishedNav(db: Kysely<DB>) {
+  return async () => {
+    // Every published page's nav fields in one small payload (~30 rows
+    // sitewide); the client assembles the tree, breadcrumbs and main
+    // menu from the path prefixes. Ordered by path so the order is
+    // stable and ancestors precede their descendants.
+    const rows = await publishedOnly(db)
+      .select(["path", "title", "metadata"])
+      .where("kind", "=", "page")
+      .orderBy("path", "asc")
+      .execute();
+
+    return {
+      items: rows.map((row) => {
+        if (row.path === null) {
+          throwHttpError(500, "Published page missing its path");
+        }
+        // Parsing applies the schema defaults (menuOrder 99, flags
+        // false) for any keys absent from the stored metadata.
+        const metadata = pageMetadataSchema.safeParse(row.metadata);
+        if (!metadata.success) {
+          throwHttpError(500, "Stored metadata does not match its kind schema");
+        }
+        return {
+          path: row.path,
+          title: row.title,
+          menuOrder: metadata.data.menuOrder,
+          isMainMenu: metadata.data.isMainMenu,
+        };
+      }),
+    };
   };
 }
 

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -582,200 +582,277 @@ export function publishContent(db: Kysely<DB>) {
     publishedAt?: string;
     userId: string;
   }) => {
-    const item = await db
-      .selectFrom("content_item")
-      .select(["kind", "status", "parent_id"])
-      .where("id", "=", params.contentId)
-      .executeTakeFirst();
-    if (!item) throwHttpError(404, "Content not found");
-    if (item.status === "archived") {
-      throwHttpError(409, "Archived content cannot be published");
-    }
-
-    // A page goes live at parent path + slug, so publishing it under an
-    // unpublished parent would put a live page on a dead URL prefix
-    // (broken breadcrumbs/nav). Publish top-down. Status-based on
-    // purpose: a scheduled parent counts, so a whole section can be
-    // scheduled together.
-    if (item.kind === "page" && item.parent_id !== null) {
-      const parent = await db
+    // The hierarchy gates are check-then-update, so they run in a
+    // transaction over FOR UPDATE row locks. Lock order is parent ->
+    // child everywhere (unpublish/archive lock the item, then its
+    // children), so the parent row must be locked before the item; the
+    // unlocked peek only discovers which parent that is.
+    return await db.transaction().execute(async (tx) => {
+      const peek = await tx
         .selectFrom("content_item")
-        .select("status")
-        .where("id", "=", item.parent_id)
+        .select(["kind", "parent_id"])
+        .where("id", "=", params.contentId)
         .executeTakeFirst();
-      if (parent?.status !== "published") {
-        throwHttpError(
-          400,
-          "Cannot publish this page until its parent page is published",
-        );
-      }
-    }
+      if (!peek) throwHttpError(404, "Content not found");
 
-    let query = db
-      .updateTable("content_item")
-      .set({
-        status: "published",
-        // No explicit date: keep the original "live from" time only when
-        // it is already in the past (re-publish after unpublish must not
-        // rewrite history). NULL (first publish) or a still-future
-        // schedule (the editor pressed "Publish now" on a scheduled
-        // item) becomes now(). NULL <= now() is NULL, so both fall to
-        // the ELSE branch. Expressed in SQL so the comparison uses the
-        // DB clock, consistent with publishedOnly().
-        published_at: params.publishedAt
-          ? new Date(params.publishedAt)
-          : sql`CASE
+      const lockParent = (parentId: string) =>
+        tx
+          .selectFrom("content_item")
+          .select([
+            "status",
+            "published_at",
+            // DB-clock liveness, consistent with publishedOnly().
+            // NULL published_at propagates: live_now is then NULL too.
+            sql<boolean | null>`published_at <= CURRENT_TIMESTAMP`.as(
+              "live_now",
+            ),
+          ])
+          .where("id", "=", parentId)
+          .forUpdate()
+          .executeTakeFirst();
+
+      let parent =
+        peek.kind === "page" && peek.parent_id !== null
+          ? await lockParent(peek.parent_id)
+          : undefined;
+
+      const item = await tx
+        .selectFrom("content_item")
+        .select(["kind", "status", "parent_id"])
+        .where("id", "=", params.contentId)
+        .forUpdate()
+        .executeTakeFirst();
+      if (!item) throwHttpError(404, "Content not found");
+      if (item.status === "archived") {
+        throwHttpError(409, "Archived content cannot be published");
+      }
+
+      // A page goes live at parent path + slug, so a child must never be
+      // publicly visible while its parent is not (dead URL prefix,
+      // broken breadcrumbs/nav). Publish top-down...
+      if (item.kind === "page" && item.parent_id !== null) {
+        if (item.parent_id !== peek.parent_id) {
+          // Reparented between the peek and the item lock: lock the
+          // actual parent. Out of lock order, but the race is
+          // vanishingly rare and PostgreSQL resolves any deadlock by
+          // aborting one transaction.
+          parent = await lockParent(item.parent_id);
+        }
+        if (parent?.status !== "published" || parent.published_at === null) {
+          throwHttpError(
+            400,
+            "Cannot publish this page until its parent page is published",
+          );
+        }
+        // ...and never ahead of the parent: the child's effective
+        // go-live (the explicit date, or now) may not precede the
+        // parent's published_at. Scheduling a whole section for one
+        // instant stays allowed; backdating a child before its parent
+        // is not.
+        const beforeParent =
+          params.publishedAt !== undefined
+            ? new Date(params.publishedAt) < parent.published_at
+            : parent.live_now !== true;
+        if (beforeParent) {
+          throwHttpError(
+            400,
+            `Parent page goes live at ${parent.published_at.toISOString()}; schedule this page for that time or later`,
+          );
+        }
+      }
+
+      let query = tx
+        .updateTable("content_item")
+        .set({
+          status: "published",
+          // No explicit date: keep the original "live from" time only when
+          // it is already in the past (re-publish after unpublish must not
+          // rewrite history). NULL (first publish) or a still-future
+          // schedule (the editor pressed "Publish now" on a scheduled
+          // item) becomes now(). NULL <= now() is NULL, so both fall to
+          // the ELSE branch. Expressed in SQL so the comparison uses the
+          // DB clock, consistent with publishedOnly().
+          published_at: params.publishedAt
+            ? new Date(params.publishedAt)
+            : sql`CASE
               WHEN published_at <= CURRENT_TIMESTAMP THEN published_at
               ELSE CURRENT_TIMESTAMP
             END`,
-        updated_by: params.userId,
-        updated_at: sql`CURRENT_TIMESTAMP`,
-      })
-      .where("id", "=", params.contentId)
-      .where("status", "!=", "archived");
+          updated_by: params.userId,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", params.contentId)
+        .where("status", "!=", "archived");
 
-    if (params.publishedAt !== undefined) {
-      // Invariant: published_at in the past <=> the item has been
-      // publicly visible. An explicit FUTURE date on an item whose
-      // published_at is already past would silently pull a page that WAS
-      // public - and a later cancel-schedule would see a future
-      // published_at, clear it, and unlock the slug of a page whose URL
-      // was live. Guarded inside the UPDATE's WHERE on the DB clock so
-      // it cannot race the publish boundary; the IS NOT NULL keeps a
-      // first publish (NULL published_at) out of the NULL-propagating
-      // comparison. Explicit past/current dates stay allowed (idempotent
-      // re-publish, migration-style backdating).
-      query = query.where(
-        sql<boolean>`NOT (
+      if (params.publishedAt !== undefined) {
+        // Invariant: published_at in the past <=> the item has been
+        // publicly visible. An explicit FUTURE date on an item whose
+        // published_at is already past would silently pull a page that WAS
+        // public - and a later cancel-schedule would see a future
+        // published_at, clear it, and unlock the slug of a page whose URL
+        // was live. Guarded inside the UPDATE's WHERE on the DB clock so
+        // it cannot race the publish boundary; the IS NOT NULL keeps a
+        // first publish (NULL published_at) out of the NULL-propagating
+        // comparison. Explicit past/current dates stay allowed (idempotent
+        // re-publish, migration-style backdating).
+        query = query.where(
+          sql<boolean>`NOT (
           published_at IS NOT NULL
           AND published_at <= CURRENT_TIMESTAMP
           AND ${new Date(params.publishedAt)}::timestamptz > CURRENT_TIMESTAMP
         )`,
-      );
-    }
-
-    const result = await query
-      .returning(["id", "published_at"])
-      .executeTakeFirst();
-
-    if (!result) {
-      // The prefetch passed, so this is the ever-live scheduling guard
-      // (or a concurrent archive, which the same re-check catches).
-      const existing = await db
-        .selectFrom("content_item")
-        .select("status")
-        .where("id", "=", params.contentId)
-        .executeTakeFirst();
-      if (!existing) throwHttpError(404, "Content not found");
-      if (existing.status === "archived") {
-        throwHttpError(409, "Archived content cannot be published");
+        );
       }
-      throwHttpError(
-        409,
-        "This item has already been live - it can only be published immediately",
-      );
-    }
 
-    return {
-      id: result.id,
-      publishedAt: result.published_at?.toISOString() ?? null,
-    };
+      const result = await query
+        .returning(["id", "published_at"])
+        .executeTakeFirst();
+
+      if (!result) {
+        // The item row is locked and passed the archived check, so the
+        // only remaining exclusion is the ever-live scheduling guard.
+        throwHttpError(
+          409,
+          "This item has already been live - it can only be published immediately",
+        );
+      }
+
+      return {
+        id: result.id,
+        publishedAt: result.published_at?.toISOString() ?? null,
+      };
+    });
   };
 }
 
 export function unpublishContent(db: Kysely<DB>) {
   return async (params: { contentId: string; userId: string }) => {
-    const item = await db
-      .selectFrom("content_item")
-      .select(["kind", "status"])
-      .where("id", "=", params.contentId)
-      .executeTakeFirst();
-    if (!item) throwHttpError(404, "Content not found");
-    if (item.status !== "published") {
-      // Only a published item can be unpublished - in particular this
-      // must not offer a back door out of 'archived' (archive ->
-      // unpublish -> publish would resurrect archived content past the
-      // manage-only archive control).
-      throwHttpError(409, "Only published content can be unpublished");
-    }
-
-    // Mirror of the publish rule: pulling a page out from under a
-    // published (or scheduled) child would leave live URLs on a dead
-    // prefix. Unpublish bottom-up.
-    if (item.kind === "page") {
-      const publishedChild = await db
+    // Transaction + FOR UPDATE: the published-children gate must not
+    // race a concurrent child publish. Lock order parent -> child (the
+    // item IS the parent here), consistent with publishContent.
+    return await db.transaction().execute(async (tx) => {
+      const item = await tx
         .selectFrom("content_item")
-        .select("id")
-        .where("parent_id", "=", params.contentId)
-        .where("status", "=", "published")
+        .select(["kind", "status"])
+        .where("id", "=", params.contentId)
+        .forUpdate()
         .executeTakeFirst();
-      if (publishedChild) {
-        throwHttpError(
-          400,
-          "Cannot unpublish a page that has published child pages - unpublish the children first",
-        );
+      if (!item) throwHttpError(404, "Content not found");
+      if (item.status !== "published") {
+        // Only a published item can be unpublished - in particular this
+        // must not offer a back door out of 'archived' (archive ->
+        // unpublish -> publish would resurrect archived content past the
+        // manage-only archive control).
+        throwHttpError(409, "Only published content can be unpublished");
       }
-    }
 
-    // A past published_at is deliberately retained: it marks "ever
-    // published", which locks the slug. A still-future published_at means
-    // a schedule being cancelled before the public ever saw the item, so
-    // the ever-published marker is cleared and the slug unlocks.
-    // Visibility is otherwise governed by status alone.
-    const result = await db
-      .updateTable("content_item")
-      .set({
-        status: "draft",
-        published_at: sql`CASE
-          WHEN published_at > CURRENT_TIMESTAMP THEN NULL
-          ELSE published_at
-        END`,
-        updated_by: params.userId,
-        updated_at: sql`CURRENT_TIMESTAMP`,
-      })
-      .where("id", "=", params.contentId)
-      // Race backstop for the prefetched status check.
-      .where("status", "=", "published")
-      .returning("id")
-      .executeTakeFirst();
+      // Mirror of the publish rule: pulling a page out from under a
+      // published (or scheduled) child would leave live URLs on a dead
+      // prefix. Unpublish bottom-up. (A child publish locks this row
+      // before its own, so holding it already serialises the gate; the
+      // child lock makes the pattern uniform.)
+      if (item.kind === "page") {
+        const publishedChild = await tx
+          .selectFrom("content_item")
+          .select("id")
+          .where("parent_id", "=", params.contentId)
+          .where("status", "=", "published")
+          .forUpdate()
+          .executeTakeFirst();
+        if (publishedChild) {
+          throwHttpError(
+            400,
+            "Cannot unpublish a page that has published child pages - unpublish the children first",
+          );
+        }
+      }
 
-    if (!result) {
-      throwHttpError(409, "Only published content can be unpublished");
-    }
-    return { id: result.id };
+      // A past published_at is deliberately retained: it marks "ever
+      // published", which locks the slug. A still-future published_at
+      // means a schedule being cancelled before the public ever saw the
+      // item, so the ever-published marker is cleared and the slug
+      // unlocks. Visibility is otherwise governed by status alone.
+      const result = await tx
+        .updateTable("content_item")
+        .set({
+          status: "draft",
+          published_at: sql`CASE
+            WHEN published_at > CURRENT_TIMESTAMP THEN NULL
+            ELSE published_at
+          END`,
+          updated_by: params.userId,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", params.contentId)
+        .where("status", "=", "published")
+        .returning("id")
+        .executeTakeFirst();
+
+      if (!result) {
+        throwHttpError(409, "Only published content can be unpublished");
+      }
+      return { id: result.id };
+    });
   };
 }
 
 export function archiveContent(db: Kysely<DB>) {
   return async (params: { contentId: string; userId: string }) => {
-    // Re-archiving must not silently succeed: it would bump
-    // updated_at/updated_by for a no-op, misattributing the archive.
-    const result = await db
-      .updateTable("content_item")
-      .set({
-        status: "archived",
-        updated_by: params.userId,
-        updated_at: sql`CURRENT_TIMESTAMP`,
-      })
-      .where("id", "=", params.contentId)
-      .where("status", "!=", "archived")
-      .returning("id")
-      .executeTakeFirst();
-
-    if (!result) {
-      // Either missing or already archived; disambiguate for a useful
-      // error (same pattern as publishContent).
-      const exists = await db
+    // Same transaction + lock pattern as unpublishContent: the
+    // published-children gate must not race a concurrent child publish.
+    return await db.transaction().execute(async (tx) => {
+      const item = await tx
         .selectFrom("content_item")
-        .select("id")
+        .select(["kind", "status"])
         .where("id", "=", params.contentId)
+        .forUpdate()
         .executeTakeFirst();
-      throwHttpError(
-        exists ? 409 : 404,
-        exists ? "Content is already archived" : "Content not found",
-      );
-    }
-    return { id: result.id };
+      if (!item) throwHttpError(404, "Content not found");
+      if (item.status === "archived") {
+        // Re-archiving must not silently succeed: it would bump
+        // updated_at/updated_by for a no-op, misattributing the archive.
+        throwHttpError(409, "Content is already archived");
+      }
+
+      // Archiving a page over a live child is the unpublish hole in a
+      // different coat: the child's URL would sit on a dead prefix.
+      // Direct children suffice - the publish gate guarantees a
+      // published grandchild implies a published middle page. A DRAFT
+      // child under an archived parent is fine; it just cannot publish
+      // (parent-not-published gate).
+      if (item.kind === "page") {
+        const publishedChild = await tx
+          .selectFrom("content_item")
+          .select("id")
+          .where("parent_id", "=", params.contentId)
+          .where("status", "=", "published")
+          .forUpdate()
+          .executeTakeFirst();
+        if (publishedChild) {
+          throwHttpError(
+            409,
+            "Cannot archive a page that has published child pages - unpublish or archive the children first",
+          );
+        }
+      }
+
+      const result = await tx
+        .updateTable("content_item")
+        .set({
+          status: "archived",
+          updated_by: params.userId,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", params.contentId)
+        .where("status", "!=", "archived")
+        .returning("id")
+        .executeTakeFirst();
+
+      if (!result) {
+        throwHttpError(409, "Content is already archived");
+      }
+      return { id: result.id };
+    });
   };
 }
 

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13317,6 +13317,9 @@ export interface paths {
                                 metadata: {
                                     [key: string]: unknown;
                                 };
+                                parentId: string | null;
+                                path: string | null;
+                                menuOrder: number | null;
                                 publishedAt: string | null;
                                 createdAt: string;
                                 updatedAt: string;
@@ -13357,6 +13360,8 @@ export interface paths {
                         metadata: {
                             [key: string]: unknown;
                         };
+                        /** Format: uuid */
+                        parentId?: string | null;
                     };
                 };
             };
@@ -13416,6 +13421,9 @@ export interface paths {
                             metadata: {
                                 [key: string]: unknown;
                             };
+                            parentId: string | null;
+                            path: string | null;
+                            menuOrder: number | null;
                             publishedAt: string | null;
                             createdAt: string;
                             updatedAt: string;
@@ -13462,6 +13470,8 @@ export interface paths {
                         metadata?: {
                             [key: string]: unknown;
                         };
+                        /** Format: uuid */
+                        parentId?: string | null;
                     };
                 };
             };
@@ -13791,6 +13801,73 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/content/page/by-path": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    path: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/news": {
         parameters: {
             query?: never;
@@ -13885,6 +13962,48 @@ export interface paths {
                                 };
                                 publishedAt: string;
                                 updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/nav": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                path: string;
+                                title: string;
+                                menuOrder: number;
+                                isMainMenu: boolean;
                             }[];
                         };
                     };

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -23940,6 +23940,20 @@
                             "type": "object",
                             "additionalProperties": {}
                           },
+                          "parentId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "path": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
                           "publishedAt": {
                             "nullable": true,
                             "type": "string"
@@ -23966,6 +23980,9 @@
                           "description",
                           "status",
                           "metadata",
+                          "parentId",
+                          "path",
+                          "menuOrder",
                           "publishedAt",
                           "createdAt",
                           "updatedAt",
@@ -24073,6 +24090,12 @@
                   "metadata": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "parentId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   }
                 },
                 "required": [
@@ -24166,6 +24189,20 @@
                       "type": "object",
                       "additionalProperties": {}
                     },
+                    "parentId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "path": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "menuOrder": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
                     "publishedAt": {
                       "nullable": true,
                       "type": "string"
@@ -24236,6 +24273,9 @@
                     "description",
                     "status",
                     "metadata",
+                    "parentId",
+                    "path",
+                    "menuOrder",
                     "publishedAt",
                     "createdAt",
                     "updatedAt",
@@ -24321,6 +24361,12 @@
                   "metadata": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "parentId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   }
                 }
               }
@@ -24843,6 +24889,140 @@
         }
       }
     },
+    "/api/content/page/by-path": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 1000,
+              "pattern": "^(?:\\/[a-z0-9]+(?:-[a-z0-9]+)*)+$"
+            },
+            "in": "query",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/news": {
       "get": {
         "parameters": [
@@ -25045,6 +25225,57 @@
                           "metadata",
                           "publishedAt",
                           "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/nav": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "isMainMenu": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "title",
+                          "menuOrder",
+                          "isMainMenu"
                         ],
                         "additionalProperties": false
                       }

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -1,8 +1,10 @@
+import { useSiteNav } from "@/hooks/use-site-nav.js";
 import { useSession } from "@/lib/auth-client.js";
-import { getMainMenuItems } from "@/lib/content.js";
+import { getMainMenuItems } from "@/lib/nav.js";
 import { getPriceId } from "@/lib/stripe-env.js";
 import {
   useEffect,
+  useMemo,
   useRef,
   useState,
   type FC,
@@ -28,18 +30,29 @@ const fixedMenuEnd: MenuItem[] = [
   { name: "Fantasy", url: "/fantasy", match: { start: "/fantasy" } },
 ];
 
-/** Content pages with isMainMenu: true, sorted by menuOrder */
-const contentMenuItems: MenuItem[] = getMainMenuItems().map((page) => ({
-  name: page.title,
-  url: page.path,
-  match: { start: page.path },
-}));
-
-const menu: MenuItem[] = [
-  ...fixedMenuStart,
-  ...contentMenuItems,
-  ...fixedMenuEnd,
-];
+/**
+ * Fixed items wrapped around the merged nav's main-menu pages (#493):
+ * isMainMenu pages sorted by menuOrder, DB pages overriding static ones
+ * at the same path. useSiteNav's static placeholder means the first
+ * render already shows the full static menu - no flash or jump while the
+ * nav query is in flight, and pre-migration (empty API list) the menu is
+ * identical to the old module-level static assembly.
+ */
+function useMenu(): MenuItem[] {
+  const navPages = useSiteNav();
+  return useMemo<MenuItem[]>(
+    () => [
+      ...fixedMenuStart,
+      ...getMainMenuItems(navPages).map((page) => ({
+        name: page.title,
+        url: page.path,
+        match: { start: page.path },
+      })),
+      ...fixedMenuEnd,
+    ],
+    [navPages],
+  );
+}
 
 function isActive(pathname: string, item: MenuItem): boolean {
   if (item.match === "exact") return pathname === item.url;
@@ -128,6 +141,7 @@ const NavItem: FC<{
 
 export const SiteHeader: FC = () => {
   const location = useLocation();
+  const menu = useMenu();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [stickyVisible, setStickyVisible] = useState(false);
   const mastheadRef = useRef<HTMLDivElement>(null);

--- a/apps/web/src/hooks/use-site-nav.ts
+++ b/apps/web/src/hooks/use-site-nav.ts
@@ -1,0 +1,28 @@
+import { navQueryOptions } from "@/lib/content-queries.js";
+import { staticNavPages } from "@/lib/content.js";
+import { mergeNavPages, type NavPage } from "@/lib/nav.js";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+// While the nav query is in flight the placeholder stands in: an empty
+// API list merges to the static-only nav, so headers and sidebars render
+// immediately with no flash - pre-migration (DB holds no published
+// pages) the settled output is byte-identical to the placeholder, so
+// nothing ever jumps. Module-level constant for referential stability.
+const EMPTY_NAV: { items: NavPage[] } = { items: [] };
+
+/**
+ * The merged site nav (#493): published DB pages from the API plus
+ * static MDX pages not shadowed by a DB page at the same path. On API
+ * error the query data stays unset and this degrades to the static-only
+ * list - nav never breaks.
+ */
+export function useSiteNav(): NavPage[] {
+  const { data } = useQuery({
+    ...navQueryOptions(),
+    placeholderData: EMPTY_NAV,
+  });
+
+  const items = data?.items;
+  return useMemo(() => mergeNavPages(items ?? [], staticNavPages), [items]);
+}

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13317,6 +13317,9 @@ export interface paths {
                                 metadata: {
                                     [key: string]: unknown;
                                 };
+                                parentId: string | null;
+                                path: string | null;
+                                menuOrder: number | null;
                                 publishedAt: string | null;
                                 createdAt: string;
                                 updatedAt: string;
@@ -13357,6 +13360,8 @@ export interface paths {
                         metadata: {
                             [key: string]: unknown;
                         };
+                        /** Format: uuid */
+                        parentId?: string | null;
                     };
                 };
             };
@@ -13416,6 +13421,9 @@ export interface paths {
                             metadata: {
                                 [key: string]: unknown;
                             };
+                            parentId: string | null;
+                            path: string | null;
+                            menuOrder: number | null;
                             publishedAt: string | null;
                             createdAt: string;
                             updatedAt: string;
@@ -13462,6 +13470,8 @@ export interface paths {
                         metadata?: {
                             [key: string]: unknown;
                         };
+                        /** Format: uuid */
+                        parentId?: string | null;
                     };
                 };
             };
@@ -13791,6 +13801,73 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/content/page/by-path": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    path: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/news": {
         parameters: {
             query?: never;
@@ -13885,6 +13962,48 @@ export interface paths {
                                 };
                                 publishedAt: string;
                                 updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/nav": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                path: string;
+                                title: string;
+                                menuOrder: number;
+                                isMainMenu: boolean;
                             }[];
                         };
                     };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -23940,6 +23940,20 @@
                             "type": "object",
                             "additionalProperties": {}
                           },
+                          "parentId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "path": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
                           "publishedAt": {
                             "nullable": true,
                             "type": "string"
@@ -23966,6 +23980,9 @@
                           "description",
                           "status",
                           "metadata",
+                          "parentId",
+                          "path",
+                          "menuOrder",
                           "publishedAt",
                           "createdAt",
                           "updatedAt",
@@ -24073,6 +24090,12 @@
                   "metadata": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "parentId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   }
                 },
                 "required": [
@@ -24166,6 +24189,20 @@
                       "type": "object",
                       "additionalProperties": {}
                     },
+                    "parentId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "path": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "menuOrder": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
                     "publishedAt": {
                       "nullable": true,
                       "type": "string"
@@ -24236,6 +24273,9 @@
                     "description",
                     "status",
                     "metadata",
+                    "parentId",
+                    "path",
+                    "menuOrder",
                     "publishedAt",
                     "createdAt",
                     "updatedAt",
@@ -24321,6 +24361,12 @@
                   "metadata": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "parentId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   }
                 }
               }
@@ -24843,6 +24889,140 @@
         }
       }
     },
+    "/api/content/page/by-path": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 1000,
+              "pattern": "^(?:\\/[a-z0-9]+(?:-[a-z0-9]+)*)+$"
+            },
+            "in": "query",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/news": {
       "get": {
         "parameters": [
@@ -25045,6 +25225,57 @@
                           "metadata",
                           "publishedAt",
                           "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/nav": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "isMainMenu": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "title",
+                          "menuOrder",
+                          "isMainMenu"
                         ],
                         "additionalProperties": false
                       }

--- a/apps/web/src/lib/content-queries.ts
+++ b/apps/web/src/lib/content-queries.ts
@@ -1,8 +1,10 @@
 import {
   eventMetadataSchema,
   newsMetadataSchema,
+  pageMetadataSchema,
   type EventMetadata,
   type NewsMetadata,
+  type PageMetadata,
 } from "@percy-main/shared/content";
 import { queryOptions } from "@tanstack/react-query";
 import { api, callApi } from "./api-client.js";
@@ -70,6 +72,45 @@ export function eventQueryOptions(slug: string) {
   });
 }
 
+export function pageByPathQueryOptions(path: string) {
+  return queryOptions({
+    queryKey: ["content", "page", path],
+    queryFn: async () => {
+      try {
+        return await callApi(
+          api.GET("/api/content/page/by-path", {
+            params: { query: { path } },
+          }),
+        );
+      } catch (err) {
+        // Not published in the DB - callers fall back to the bundled MDX.
+        if ((err as { status?: number }).status === 404) return null;
+        throw err;
+      }
+    },
+    staleTime: detailStaleTime,
+    retry: false,
+  });
+}
+
+// The nav list backs the site header and every content-page sidebar, so
+// it is cached aggressively: the shared STALE_TIME bounds visible
+// staleness, while a generous gcTime keeps the last good list around for
+// instant SPA navigations long after the query unmounts. Retries stay at
+// the react-query default (like the list queries above) - consumers
+// degrade to the static-only nav while the query is pending or failed,
+// so nav never breaks on API trouble.
+const NAV_GC_TIME = 24 * 60 * 60 * 1000;
+
+export function navQueryOptions() {
+  return queryOptions({
+    queryKey: ["content", "nav"],
+    queryFn: () => callApi(api.GET("/api/content/nav")),
+    staleTime: STALE_TIME,
+    gcTime: NAV_GC_TIME,
+  });
+}
+
 export function newsListQueryOptions(params: { tag?: string; page: number }) {
   return queryOptions({
     queryKey: ["content", "news-list", params.tag ?? null, params.page],
@@ -110,5 +151,10 @@ export function parseEventMetadata(
   metadata: unknown,
 ): EventMetadata | undefined {
   const parsed = eventMetadataSchema.safeParse(metadata);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function parsePageMetadata(metadata: unknown): PageMetadata | undefined {
+  const parsed = pageMetadataSchema.safeParse(metadata);
   return parsed.success ? parsed.data : undefined;
 }

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -1,11 +1,12 @@
 import type { FC } from "react";
+import type { NavPage } from "./nav.js";
 
 interface MdxModule {
   default: FC;
   frontmatter: Record<string, unknown>;
 }
 
-interface ContentPage {
+export interface ContentPage {
   /** URL path, e.g. "/club/history/honours" */
   path: string;
   /** MDX frontmatter */
@@ -17,11 +18,6 @@ interface ContentPage {
   ldjson?: unknown;
   /** The React component that renders the MDX content */
   Component: FC;
-}
-
-export interface ContentNode {
-  page: ContentPage;
-  children: ContentNode[];
 }
 
 /**
@@ -72,71 +68,14 @@ const contentPages: ContentPage[] = loadPages().sort((a, b) =>
 export const contentPageMap = new Map(contentPages.map((p) => [p.path, p]));
 
 /**
- * Get the parent path of a given path.
- * "/club/history/honours" → "/club/history"
- * "/club" → null (top-level)
+ * Static pages projected to the lightweight NavPage shape, ready to merge
+ * with the API nav list (lib/nav.ts, #493). Path-sorted because
+ * contentPages is - mergeNavPages relies on that ordering for the
+ * static-only case to match the old behaviour exactly.
  */
-function parentPath(path: string): string | null {
-  const lastSlash = path.lastIndexOf("/");
-  if (lastSlash <= 0) return null;
-  return path.substring(0, lastSlash);
-}
-
-/**
- * Build a tree of ContentNodes for sidebar navigation.
- * Given a page path, finds the top-level ancestor and returns
- * the full subtree under that ancestor.
- */
-export function getNavigationTree(currentPath: string): ContentNode | null {
-  // Find the top-level section (e.g. "/club" from "/club/history/honours")
-  const segments = currentPath.split("/").filter(Boolean);
-  if (segments.length === 0) return null;
-
-  const sectionPath = "/" + segments[0];
-  const sectionPage = contentPageMap.get(sectionPath);
-  if (!sectionPage) return null;
-
-  // Build the subtree
-  function buildNode(page: ContentPage): ContentNode {
-    const children = contentPages
-      .filter((p) => parentPath(p.path) === page.path)
-      .sort((a, b) => a.menuOrder - b.menuOrder);
-
-    return {
-      page,
-      children: children.map(buildNode),
-    };
-  }
-
-  return buildNode(sectionPage);
-}
-
-/**
- * Build breadcrumb trail from root to current page.
- * Returns array of { title, path } from ancestor to current.
- */
-export function getBreadcrumbs(
-  currentPath: string,
-): Array<{ title: string; path: string }> {
-  const crumbs: Array<{ title: string; path: string }> = [];
-  let path: string | null = currentPath;
-
-  while (path) {
-    const page = contentPageMap.get(path);
-    if (page) {
-      crumbs.unshift({ title: page.title, path: page.path });
-    }
-    path = parentPath(path);
-  }
-
-  return crumbs;
-}
-
-/**
- * Get the top-level content sections that should appear in the main menu.
- */
-export function getMainMenuItems(): ContentPage[] {
-  return contentPages
-    .filter((p) => p.isMainMenu)
-    .sort((a, b) => a.menuOrder - b.menuOrder);
-}
+export const staticNavPages: NavPage[] = contentPages.map((p) => ({
+  path: p.path,
+  title: p.title,
+  menuOrder: p.menuOrder,
+  isMainMenu: p.isMainMenu,
+}));

--- a/apps/web/src/lib/nav.test.ts
+++ b/apps/web/src/lib/nav.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBreadcrumbs,
+  getMainMenuItems,
+  getNavigationTree,
+  mergeNavPages,
+  type NavPage,
+} from "./nav";
+
+function page(path: string, overrides: Partial<NavPage> = {}): NavPage {
+  return {
+    path,
+    title: path.split("/").filter(Boolean).join(" "),
+    menuOrder: 99,
+    isMainMenu: false,
+    ...overrides,
+  };
+}
+
+// A static corpus mirroring the real content layout: a section root with
+// ordered children and one grandchild level. Path-sorted, like
+// content.ts's contentPages / staticNavPages.
+const staticPages: NavPage[] = [
+  page("/club", { title: "Club", isMainMenu: true, menuOrder: 1 }),
+  page("/club/committee", { title: "Committee", menuOrder: 2 }),
+  page("/club/history", { title: "History", menuOrder: 1 }),
+  page("/club/history/honours", { title: "Honours", menuOrder: 1 }),
+  page("/cricket", { title: "Cricket", isMainMenu: true, menuOrder: 2 }),
+  page("/legal", { title: "Legal" }),
+  page("/legal/privacy", { title: "Privacy Policy" }),
+];
+
+describe("mergeNavPages", () => {
+  it("returns the static list unchanged when the API list is empty (pre-migration)", () => {
+    expect(mergeNavPages([], staticPages)).toEqual(staticPages);
+  });
+
+  it("API page overrides the static page at the same path", () => {
+    const merged = mergeNavPages(
+      [page("/club", { title: "The Club", isMainMenu: true, menuOrder: 5 })],
+      staticPages,
+    );
+    const club = merged.find((p) => p.path === "/club");
+    expect(club).toEqual({
+      path: "/club",
+      title: "The Club",
+      isMainMenu: true,
+      menuOrder: 5,
+    });
+    // No duplicate entry for the shadowed static page
+    expect(merged.filter((p) => p.path === "/club")).toHaveLength(1);
+    expect(merged).toHaveLength(staticPages.length);
+  });
+
+  it("keeps static pages not shadowed by an API path", () => {
+    const merged = mergeNavPages([page("/club")], staticPages);
+    expect(merged.map((p) => p.path)).toContain("/legal/privacy");
+    expect(merged.map((p) => p.path)).toContain("/club/history/honours");
+  });
+
+  it("sorts the merged list by path", () => {
+    const merged = mergeNavPages(
+      [page("/cricket/juniors"), page("/boxing")],
+      staticPages,
+    );
+    expect(merged.map((p) => p.path)).toEqual(
+      [...merged.map((p) => p.path)].sort((a, b) => a.localeCompare(b)),
+    );
+    expect(merged[0]?.path).toBe("/boxing");
+  });
+});
+
+describe("getNavigationTree", () => {
+  it("returns the section subtree for a nested current path", () => {
+    const tree = getNavigationTree(staticPages, "/club/history/honours");
+    expect(tree?.page.path).toBe("/club");
+    expect(tree?.children.map((c) => c.page.path)).toEqual([
+      "/club/history",
+      "/club/committee",
+    ]);
+    expect(tree?.children[0]?.children.map((c) => c.page.path)).toEqual([
+      "/club/history/honours",
+    ]);
+  });
+
+  it("sorts children by menuOrder", () => {
+    // History (menuOrder 1) before Committee (menuOrder 2) despite
+    // "committee" sorting first by path.
+    const tree = getNavigationTree(staticPages, "/club");
+    expect(tree?.children.map((c) => c.page.title)).toEqual([
+      "History",
+      "Committee",
+    ]);
+  });
+
+  it("breaks menuOrder ties by path order (stable sort)", () => {
+    const tree = getNavigationTree(staticPages, "/legal");
+    // Both legal children default to menuOrder 99... there is only one;
+    // build a tie explicitly instead.
+    expect(tree?.children).toHaveLength(1);
+
+    const tied = [
+      page("/a"),
+      page("/a/x", { menuOrder: 5 }),
+      page("/a/y", { menuOrder: 5 }),
+    ];
+    const tiedTree = getNavigationTree(tied, "/a");
+    expect(tiedTree?.children.map((c) => c.page.path)).toEqual([
+      "/a/x",
+      "/a/y",
+    ]);
+  });
+
+  it("returns null when the section root is not in the list", () => {
+    expect(getNavigationTree(staticPages, "/news/some-article")).toBeNull();
+  });
+
+  it("returns null for the root path", () => {
+    expect(getNavigationTree(staticPages, "/")).toBeNull();
+  });
+
+  it("includes DB pages merged into a static section", () => {
+    const merged = mergeNavPages(
+      [page("/club/grounds", { title: "Grounds", menuOrder: 0 })],
+      staticPages,
+    );
+    const tree = getNavigationTree(merged, "/club");
+    expect(tree?.children.map((c) => c.page.title)).toEqual([
+      "Grounds",
+      "History",
+      "Committee",
+    ]);
+  });
+});
+
+describe("getBreadcrumbs", () => {
+  it("walks ancestors from root to the current page", () => {
+    expect(getBreadcrumbs(staticPages, "/club/history/honours")).toEqual([
+      { title: "Club", path: "/club" },
+      { title: "History", path: "/club/history" },
+      { title: "Honours", path: "/club/history/honours" },
+    ]);
+  });
+
+  it("skips ancestors missing from the merged list", () => {
+    // A DB page can be published deeper than any published ancestor.
+    const pages = [page("/club/teams/firsts", { title: "First XI" })];
+    expect(getBreadcrumbs(pages, "/club/teams/firsts")).toEqual([
+      { title: "First XI", path: "/club/teams/firsts" },
+    ]);
+  });
+
+  it("returns known ancestors even when the current page is unknown", () => {
+    expect(getBreadcrumbs(staticPages, "/club/history/missing")).toEqual([
+      { title: "Club", path: "/club" },
+      { title: "History", path: "/club/history" },
+    ]);
+  });
+
+  it("returns an empty trail when nothing on the path is known", () => {
+    expect(getBreadcrumbs(staticPages, "/nowhere/at/all")).toEqual([]);
+  });
+});
+
+describe("getMainMenuItems", () => {
+  it("filters to isMainMenu pages and sorts by menuOrder", () => {
+    const items = getMainMenuItems([
+      ...staticPages,
+      page("/boxing", { title: "Boxing", isMainMenu: true, menuOrder: 0 }),
+    ]);
+    expect(items.map((p) => p.title)).toEqual(["Boxing", "Club", "Cricket"]);
+  });
+
+  it("returns an empty list when no page is flagged for the main menu", () => {
+    expect(getMainMenuItems([page("/legal")])).toEqual([]);
+  });
+
+  it("lets a DB override pull a page out of the main menu", () => {
+    const merged = mergeNavPages(
+      [page("/cricket", { title: "Cricket", isMainMenu: false })],
+      staticPages,
+    );
+    expect(getMainMenuItems(merged).map((p) => p.title)).toEqual(["Club"]);
+  });
+});

--- a/apps/web/src/lib/nav.ts
+++ b/apps/web/src/lib/nav.ts
@@ -1,0 +1,123 @@
+// Pure nav-model functions for the merged page hierarchy (#493): DB-backed
+// pages from GET /api/content/nav plus the bundled static MDX pages. Kept
+// free of Vite-only dependencies (content.ts needs import.meta.glob) so
+// the tree/breadcrumb/menu logic is unit-testable in plain vitest.
+
+/**
+ * Lightweight nav shape shared by API nav items and static content pages.
+ * Nav trees, breadcrumbs and menus only need these fields - only the page
+ * renderer needs the full static ContentPage (with its Component).
+ */
+export interface NavPage {
+  /** URL path, e.g. "/club/history/honours" */
+  path: string;
+  title: string;
+  menuOrder: number;
+  isMainMenu: boolean;
+}
+
+export interface NavNode {
+  page: NavPage;
+  children: NavNode[];
+}
+
+/**
+ * Merge API nav items with the static page list. The API wins on a path
+ * collision (a migrated page's DB title/menu placement replaces its
+ * bundled MDX ancestor); static pages without a DB counterpart pass
+ * through unchanged, so sections migrate one at a time. The result is
+ * sorted by path, mirroring the static pipeline's contentPages ordering -
+ * with an empty API list (pre-migration) the output is identical to the
+ * old static-only list.
+ */
+export function mergeNavPages(
+  apiPages: NavPage[],
+  staticPages: NavPage[],
+): NavPage[] {
+  const byPath = new Map<string, NavPage>();
+  for (const page of staticPages) byPath.set(page.path, page);
+  for (const page of apiPages) byPath.set(page.path, page);
+  return Array.from(byPath.values()).toSorted((a, b) =>
+    a.path.localeCompare(b.path),
+  );
+}
+
+/**
+ * Get the parent path of a given path.
+ * "/club/history/honours" → "/club/history"
+ * "/club" → null (top-level)
+ */
+function parentPath(path: string): string | null {
+  const lastSlash = path.lastIndexOf("/");
+  if (lastSlash <= 0) return null;
+  return path.substring(0, lastSlash);
+}
+
+/**
+ * Build a tree of NavNodes for sidebar navigation.
+ * Given a page path, finds the top-level ancestor and returns
+ * the full subtree under that ancestor.
+ *
+ * Children sort by menuOrder; the sort is stable, so equal menuOrders
+ * keep the input (path) order - same tie-break as the old static-only
+ * implementation.
+ */
+export function getNavigationTree(
+  pages: NavPage[],
+  currentPath: string,
+): NavNode | null {
+  // Find the top-level section (e.g. "/club" from "/club/history/honours")
+  const segments = currentPath.split("/").filter(Boolean);
+  if (segments.length === 0) return null;
+
+  const sectionPath = "/" + segments[0];
+  const sectionPage = pages.find((p) => p.path === sectionPath);
+  if (!sectionPage) return null;
+
+  // Build the subtree
+  function buildNode(page: NavPage): NavNode {
+    const children = pages
+      .filter((p) => parentPath(p.path) === page.path)
+      .sort((a, b) => a.menuOrder - b.menuOrder);
+
+    return {
+      page,
+      children: children.map(buildNode),
+    };
+  }
+
+  return buildNode(sectionPage);
+}
+
+/**
+ * Build breadcrumb trail from root to current page.
+ * Returns array of { title, path } from ancestor to current.
+ * Ancestors missing from the page list are skipped.
+ */
+export function getBreadcrumbs(
+  pages: NavPage[],
+  currentPath: string,
+): Array<{ title: string; path: string }> {
+  const byPath = new Map(pages.map((p) => [p.path, p]));
+  const crumbs: Array<{ title: string; path: string }> = [];
+  let path: string | null = currentPath;
+
+  while (path) {
+    const page = byPath.get(path);
+    if (page) {
+      crumbs.unshift({ title: page.title, path: page.path });
+    }
+    path = parentPath(path);
+  }
+
+  return crumbs;
+}
+
+/**
+ * Get the top-level content sections that should appear in the main menu.
+ */
+export function getMainMenuItems(pages: NavPage[]): NavPage[] {
+  return pages
+    .filter((p) => p.isMainMenu)
+    .sort((a, b) => a.menuOrder - b.menuOrder);
+}

--- a/apps/web/src/pages/content-page.tsx
+++ b/apps/web/src/pages/content-page.tsx
@@ -1,21 +1,35 @@
+import { ContentBody } from "@/components/content-body.js";
 import { mdxComponents } from "@/components/mdx-components.js";
+import { PageLoading } from "@/components/page-loading.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
+import { useSiteNav } from "@/hooks/use-site-nav.js";
+import type { paths } from "@/lib/api.gen.js";
 import {
-  contentPageMap,
+  pageByPathQueryOptions,
+  parsePageMetadata,
+} from "@/lib/content-queries.js";
+import { contentPageMap, type ContentPage } from "@/lib/content.js";
+import {
   getBreadcrumbs,
   getNavigationTree,
-  type ContentNode,
-} from "@/lib/content.js";
+  type NavNode,
+  type NavPage,
+} from "@/lib/nav.js";
 import { MDXProvider } from "@mdx-js/react";
-import { Fragment, useEffect, useState } from "react";
+import { contentPathSchema } from "@percy-main/shared/content";
+import { useQuery } from "@tanstack/react-query";
+import { Fragment, useEffect, useState, type ReactNode } from "react";
 import { IoChevronForward } from "react-icons/io5";
 import { Link, useLocation } from "react-router";
+
+type ApiPage =
+  paths["/api/content/page/by-path"]["get"]["responses"]["200"]["content"]["application/json"];
 
 function SidebarNav({
   tree,
   currentPath,
 }: {
-  tree: ContentNode;
+  tree: NavNode;
   currentPath: string;
 }) {
   return (
@@ -70,7 +84,7 @@ function MobileSidebarNav({
   currentPath,
   isOpen,
 }: {
-  tree: ContentNode;
+  tree: NavNode;
   currentPath: string;
   isOpen: boolean;
 }) {
@@ -119,47 +133,26 @@ function MobileSidebarNav({
   );
 }
 
-export function Component() {
-  const { pathname } = useLocation();
+/**
+ * Shared page chrome: breadcrumbs, mobile section nav and desktop sidebar
+ * built from the merged nav (#493) - static and DB-backed pages get
+ * identical navigation, so a section migrating to the DB never changes
+ * how its unmigrated siblings appear.
+ */
+function PageChrome({
+  navPages,
+  path,
+  children,
+}: {
+  navPages: NavPage[];
+  path: string;
+  children: ReactNode;
+}) {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
-  // Normalize: strip trailing slash
-  const path = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
-
-  const page = contentPageMap.get(path);
-
-  useDocumentMeta(page?.title, page?.description);
-
-  // 404s land here because router.tsx's catch-all `path: "*"` routes
-  // unknown paths through ContentPage rather than triggering the
-  // root errorElement (#182). Forward the miss to NR so the not-
-  // found rate is observable.
-  useEffect(() => {
-    if (!page) {
-      if (window.newrelic) {
-        window.newrelic.noticeError(new Error(`route_not_found ${path}`), {
-          kind: "route_not_found",
-          route: path,
-        });
-      } else {
-        console.warn("route_not_found (NR not loaded):", path);
-      }
-    }
-  }, [page, path]);
-
-  if (!page) {
-    return (
-      <div className="container mx-auto px-4 py-12">
-        <h1>Page Not Found</h1>
-        <p>The page you're looking for doesn't exist.</p>
-      </div>
-    );
-  }
-
-  const navTree = getNavigationTree(path);
-  const breadcrumbs = getBreadcrumbs(path);
+  const navTree = getNavigationTree(navPages, path);
+  const breadcrumbs = getBreadcrumbs(navPages, path);
   const hasSidebar = navTree && navTree.children.length > 0;
-  const PageContent = page.Component;
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -218,15 +211,133 @@ export function Component() {
         )}
 
         {/* Content */}
-        <div className="flex min-w-0 grow flex-col">
-          <MDXProvider components={mdxComponents}>
-            <div className="mdx-content flex flex-col *:mb-4">
-              {!page.hideTitle && <h2>{page.title}</h2>}
-              <PageContent />
-            </div>
-          </MDXProvider>
-        </div>
+        <div className="flex min-w-0 grow flex-col">{children}</div>
       </div>
+    </div>
+  );
+}
+
+/** DB-backed page (page hierarchy, #493). */
+function ApiPageView({
+  page,
+  navPages,
+  path,
+}: {
+  page: ApiPage;
+  navPages: NavPage[];
+  path: string;
+}) {
+  const meta = parsePageMetadata(page.metadata);
+
+  // metadata.ldjson is deliberately not rendered: the static pipeline
+  // parses ldjson from frontmatter but nothing injects it into the
+  // document (no page sets it today), so parity means carrying the field
+  // without inventing a <script type="application/ld+json"> here.
+  return (
+    <PageChrome navPages={navPages} path={path}>
+      {!meta?.hideTitle && <h2 className="mb-4">{page.title}</h2>}
+      <ContentBody body={page.body} />
+    </PageChrome>
+  );
+}
+
+/** Bundled MDX page - the static pipeline rendering. */
+function StaticPageView({
+  page,
+  navPages,
+  path,
+}: {
+  page: ContentPage;
+  navPages: NavPage[];
+  path: string;
+}) {
+  const PageContent = page.Component;
+
+  return (
+    <PageChrome navPages={navPages} path={path}>
+      <MDXProvider components={mdxComponents}>
+        <div className="mdx-content flex flex-col *:mb-4">
+          {!page.hideTitle && <h2>{page.title}</h2>}
+          <PageContent />
+        </div>
+      </MDXProvider>
+    </PageChrome>
+  );
+}
+
+export function Component() {
+  const { pathname } = useLocation();
+
+  // Normalize: strip trailing slash
+  const path = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
+
+  // Only paths the backend could ever serve (lowercase /slug segments -
+  // the shared contentPathSchema is the source of truth) hit the API;
+  // anything else skips the query and behaves exactly as the static
+  // pipeline always has.
+  const isContentPath = contentPathSchema.safeParse(path).success;
+
+  // DB-backed page first (page hierarchy, #493). Unlike the news/events
+  // TRANSITION FALLBACK (#489), the static MDX fallback here is
+  // long-lived: pages migrate to the DB one section at a time and some
+  // (e.g. legal) stay static permanently, so unmigrated paths keep
+  // rendering their bundled MDX indefinitely. The MDX renders only once
+  // the query settles (confirmed 404, or an API failure - deliberate
+  // graceful degradation) so a DB-edited page never flashes its stale
+  // MDX ancestor first.
+  const { data: apiPage, isPending } = useQuery({
+    ...pageByPathQueryOptions(path),
+    enabled: isContentPath,
+  });
+  const staticPage = contentPageMap.get(path);
+
+  // Sidebar + breadcrumbs come from the merged nav for both static and
+  // DB-backed pages.
+  const navPages = useSiteNav();
+
+  useDocumentMeta(
+    apiPage?.title ?? staticPage?.title,
+    apiPage ? (apiPage.description ?? undefined) : staticPage?.description,
+  );
+
+  // 404s land here because router.tsx's catch-all `path: "*"` routes
+  // unknown paths through ContentPage rather than triggering the
+  // root errorElement (#182). Forward the miss to NR so the not-
+  // found rate is observable. Only after the API query settles - a page
+  // that is still loading is not a miss.
+  const notFound = !apiPage && !staticPage && (!isContentPath || !isPending);
+  useEffect(() => {
+    if (!notFound) return;
+    if (window.newrelic) {
+      window.newrelic.noticeError(new Error(`route_not_found ${path}`), {
+        kind: "route_not_found",
+        route: path,
+      });
+    } else {
+      console.warn("route_not_found (NR not loaded):", path);
+    }
+  }, [notFound, path]);
+
+  if (apiPage) {
+    return <ApiPageView page={apiPage} navPages={navPages} path={path} />;
+  }
+
+  if (isContentPath && isPending) {
+    return (
+      <div className="container mx-auto px-4 py-6">
+        <PageLoading />
+      </div>
+    );
+  }
+
+  if (staticPage) {
+    return <StaticPageView page={staticPage} navPages={navPages} path={path} />;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1>Page Not Found</h1>
+      <p>The page you're looking for doesn't exist.</p>
     </div>
   );
 }

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -90,6 +90,21 @@ export const contentSlugSchema = z
     "Slug must be lowercase letters, numbers and hyphens",
   );
 
+// ── Paths (pages only) ──────────────────────────────────────────────────
+//
+// A page's materialised URL path: one or more "/" + slug segments, each
+// segment shaped exactly like contentSlugSchema. Locked (with the slug
+// and parent) once the page has ever been published.
+
+export const contentPathSchema = z
+  .string()
+  .min(2)
+  .max(1000)
+  .regex(
+    /^(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)+$/,
+    "Path must be one or more /slug segments (lowercase letters, numbers and hyphens)",
+  );
+
 // ── Kind-specific metadata (replaces MDX frontmatter) ───────────────────
 //
 // Validated on every write by the content API. Only kinds with a schema
@@ -99,6 +114,21 @@ export const gameReportMetadataSchema = z.object({
   playCricketId: z.string().min(1),
 });
 export type GameReportMetadata = z.infer<typeof gameReportMetadataSchema>;
+
+/**
+ * Page metadata mirrors the static MDX frontmatter (apps/web
+ * lib/content.ts) so a DB-backed page renders indistinguishably from its
+ * static version: menuOrder/isMainMenu drive nav placement, hideTitle
+ * suppresses the H1, ldjson is pasted structured data (omitted when
+ * unset - never an empty string).
+ */
+export const pageMetadataSchema = z.object({
+  menuOrder: z.number().int().min(0).max(999).default(99),
+  isMainMenu: z.boolean().default(false),
+  hideTitle: z.boolean().default(false),
+  ldjson: z.record(z.string(), z.unknown()).optional(),
+});
+export type PageMetadata = z.infer<typeof pageMetadataSchema>;
 
 /**
  * One news tag. Shared between stored metadata (newsMetadataSchema) and
@@ -137,6 +167,7 @@ export type EventMetadata = z.infer<typeof eventMetadataSchema>;
 export const CONTENT_METADATA_SCHEMAS: Partial<
   Record<ContentKind, z.ZodType<Record<string, unknown>>>
 > = {
+  page: pageMetadataSchema,
   news: newsMetadataSchema,
   event: eventMetadataSchema,
   game_report: gameReportMetadataSchema,


### PR DESCRIPTION
Part of epic #492 (targets the epic branch, not main). Closes #493.

## What

**Backend**
- `pageMetadataSchema` (menuOrder 0-999 default 99, isMainMenu, hideTitle, optional ldjson) registered for the `page` kind, making pages API-editable.
- Hierarchy: `parentId` on create/update (pages only), materialised `path` = parent path + slug (root = `/slug`). Renaming/moving an unpublished page cascades new paths to all descendants in one UPDATE.
- Locking: path lock reuses the ever-published marker that backs the existing slug lock. A locked page rejects slug AND parent changes; a locked descendant pins every ancestor's slug (409 names the descendant). Cycles rejected via path-prefix check.
- Publish gates: publishing a page requires its parent to be `status='published'` (deliberately includes scheduled parents so whole sections can be scheduled top-down); unpublishing rejects when published children exist.
- Public `GET /content/nav` (published pages: path/title/menuOrder/isMainMenu, ordered by path) and `GET /content/page/by-path?path=...` (canonical page lookup; `GET /content/:kind/:slug` resolves root pages only since nested slugs are only sibling-unique).

**Web**
- Merged nav model (`lib/nav.ts`): API nav items + static pages, API wins on path collision; `getNavigationTree`/`getBreadcrumbs`/`getMainMenuItems` are now pure functions over the merged list. Pre-migration output is identical to today (placeholderData renders the static-only merge with no flash).
- `content-page.tsx` catch-all mirrors the #489 news pattern: DB page first, `PageLoading` while pending, then bundled static MDX, then 404 (NR reporting kept). Static fallback is long-lived (legal stays static permanently).
- Main menu reads from the merged nav via hook; nav query cached aggressively (24h gcTime).

## Notes for review
- No DB migration: `parent_id`/`path`/partial unique indexes shipped in the Phase 1 schema.
- `ldjson` is stored but not rendered - parity with the static pipeline, which also never rendered it; flagged for a future tidy-up.
- Pre-existing gap (out of scope): `archiveContent` bypasses the unpublish child-gate.
- Trade-off per issue spec: unmigrated static pages now show a loading state until the by-path query settles on first visit.

## Tests
- api: 602 unit (+19), 463 integration (+5, testcontainers) - path computation, descendant cascade, lock rejections, cycle, publish/unpublish gates, nav payload, by-path 404-for-drafts.
- web: 509 unit (+17) - merge semantics, tree/breadcrumb/menu parity with legacy behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)