### PR TITLE
feat(admin): page tree view - create, move, reorder (#494)

### DIFF
--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -19,6 +19,7 @@ import {
   getPublishedContent,
   getPublishedGameReport,
   listContent,
+  listPageTree,
   listPublishedEvents,
   listPublishedNews,
   listRevisions,
@@ -1016,6 +1017,69 @@ describe("content service (integration)", () => {
       } finally {
         await app.close();
       }
+    });
+
+    it("lists every page for the admin tree: all statuses, path-ordered, lock and defaults derived", async () => {
+      // Pages from earlier tests share the container, so assertions
+      // filter to this test's own pages; path ordering is preserved
+      // under filtering (a subsequence of an ordered list stays ordered).
+      const root = await mkPage("tree-root", {
+        metadata: { menuOrder: 2, isMainMenu: true },
+      });
+      const childBeta = await mkPage("beta", { parentId: root });
+      const childAlpha = await mkPage("alpha", { parentId: root });
+      const archived = await mkPage("tree-archived");
+      await archiveContent(ctx.db)({ contentId: archived, userId });
+      await publishContent(ctx.db)({ contentId: root, userId });
+
+      const { items } = await listPageTree(ctx.db)();
+      const mine = (id: string, list = items) => list.find((i) => i.id === id);
+      const ids = new Set([root, childAlpha, childBeta, archived]);
+      const ours = items.filter((i) => ids.has(i.id));
+
+      // Ordered by path: ancestors before descendants, siblings lexicographic
+      expect(ours.map((i) => i.path)).toEqual([
+        "/tree-archived",
+        "/tree-root",
+        "/tree-root/alpha",
+        "/tree-root/beta",
+      ]);
+
+      // Published root: explicit metadata surfaces, lock derived
+      expect(mine(root)).toMatchObject({
+        slug: "tree-root",
+        parentId: null,
+        status: "published",
+        menuOrder: 2,
+        isMainMenu: true,
+        pathLocked: true,
+      });
+      expect(mine(root)?.publishedAt).not.toBeNull();
+
+      // Draft child: schema defaults applied, no lock
+      expect(mine(childAlpha)).toMatchObject({
+        slug: "alpha",
+        parentId: root,
+        status: "draft",
+        menuOrder: 99,
+        isMainMenu: false,
+        publishedAt: null,
+        pathLocked: false,
+      });
+
+      // Archived pages stay in the tree (never published → unlocked)
+      expect(mine(archived)).toMatchObject({
+        status: "archived",
+        pathLocked: false,
+      });
+
+      // Unpublish keeps the ever-published marker: still locked as draft
+      await unpublishContent(ctx.db)({ contentId: root, userId });
+      const after = await listPageTree(ctx.db)();
+      expect(mine(root, after.items)).toMatchObject({
+        status: "draft",
+        pathLocked: true,
+      });
     });
   });
 });

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -22,6 +22,7 @@ import {
   listRevisionsResponseSchema,
   navResponseSchema,
   pageByPathQuerySchema,
+  pageTreeResponseSchema,
   playCricketIdParamSchema,
   publicContentParamsSchema,
   publicContentResponseSchema,
@@ -38,6 +39,7 @@ import {
   getPublishedNav,
   getPublishedPageByPath,
   listContent,
+  listPageTree,
   listPublishedEvents,
   listPublishedNews,
   listRevisions,
@@ -73,6 +75,7 @@ const publishResponseSchema = z.object({
 // eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
 export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const list = listContent(app.db);
+  const pageTree = listPageTree(app.db);
   const get = getContent(app.db);
   const metaOf = getContentMeta(app.db);
   const create = createContent(app.db);
@@ -102,6 +105,23 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       assertContentPermission(request, request.query.kind, "view");
       return await list(request.query);
+    },
+  );
+
+  // Static segment, so find-my-way prefers it over /admin/content/:contentId.
+  // Same permission treatment as the admin list for kind=page (resource
+  // "content", action "view").
+  app.get(
+    "/admin/content/page-tree",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        response: { 200: pageTreeResponseSchema },
+      },
+    },
+    async (request) => {
+      assertContentPermission(request, "page", "view");
+      return await pageTree();
     },
   );
 

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -75,6 +75,32 @@ export const listContentResponseSchema = z.object({
   total: z.number().int().nonnegative(),
 });
 
+// ── Admin: page tree ────────────────────────────────────────────────────
+
+/**
+ * Every page regardless of status, ordered by path - the single source
+ * for the admin tree view. pathLocked is the server-derived
+ * ever-published lock (published_at non-null, the same marker
+ * updateContent enforces) so the UI never re-derives lock semantics.
+ */
+export const pageTreeResponseSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      slug: z.string(),
+      path: z.string(),
+      parentId: z.string().nullable(),
+      menuOrder: z.number().int(),
+      isMainMenu: z.boolean(),
+      status: contentStatusSchema,
+      publishedAt: z.string().nullable(),
+      updatedAt: z.string(),
+      pathLocked: z.boolean(),
+    }),
+  ),
+});
+
 // ── Admin: get / create / update ────────────────────────────────────────
 
 export const contentIdParamSchema = z.object({

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -50,6 +50,7 @@ import {
   archiveContent,
   createContent,
   getPublishedGameReport,
+  listPageTree,
   publishContent,
   unpublishContent,
   updateContent,
@@ -917,6 +918,101 @@ describe("unpublishContent", () => {
       userId: "user-1",
     });
     expect(result).toEqual({ id: "content-1" });
+  });
+});
+
+describe("listPageTree", () => {
+  const pageRow = (overrides: Record<string, unknown> = {}) => ({
+    id: "page-1",
+    title: "Cricket",
+    slug: "cricket",
+    path: "/cricket",
+    parent_id: null,
+    metadata: { menuOrder: 1, isMainMenu: true, hideTitle: false },
+    status: "draft",
+    published_at: null,
+    updated_at: new Date("2026-06-02T10:00:00Z"),
+    ...overrides,
+  });
+
+  it("maps rows: hierarchy fields, metadata values and timestamps", async () => {
+    mockExecute.mockResolvedValueOnce([
+      pageRow(),
+      pageRow({
+        id: "page-2",
+        title: "Juniors",
+        slug: "juniors",
+        path: "/cricket/juniors",
+        parent_id: "page-1",
+        status: "published",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      }),
+    ]);
+    const { items } = await listPageTree(db)();
+    expect(items).toEqual([
+      {
+        id: "page-1",
+        title: "Cricket",
+        slug: "cricket",
+        path: "/cricket",
+        parentId: null,
+        menuOrder: 1,
+        isMainMenu: true,
+        status: "draft",
+        publishedAt: null,
+        updatedAt: "2026-06-02T10:00:00.000Z",
+        pathLocked: false,
+      },
+      {
+        id: "page-2",
+        title: "Juniors",
+        slug: "juniors",
+        path: "/cricket/juniors",
+        parentId: "page-1",
+        menuOrder: 1,
+        isMainMenu: true,
+        status: "published",
+        publishedAt: "2026-06-01T10:00:00.000Z",
+        updatedAt: "2026-06-02T10:00:00.000Z",
+        pathLocked: true,
+      },
+    ]);
+  });
+
+  it("derives pathLocked from the ever-published marker, not status", async () => {
+    // Unpublish retains a past published_at (the item WAS live), so a
+    // draft can still be locked; archive never touches the marker.
+    mockExecute.mockResolvedValueOnce([
+      pageRow({
+        status: "draft",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      }),
+      pageRow({ id: "page-2", path: "/club", status: "archived" }),
+    ]);
+    const { items } = await listPageTree(db)();
+    expect(items[0]).toMatchObject({ status: "draft", pathLocked: true });
+    expect(items[1]).toMatchObject({ status: "archived", pathLocked: false });
+  });
+
+  it("applies schema defaults for keys absent from stored metadata", async () => {
+    mockExecute.mockResolvedValueOnce([pageRow({ metadata: {} })]);
+    const { items } = await listPageTree(db)();
+    expect(items[0]).toMatchObject({ menuOrder: 99, isMainMenu: false });
+  });
+
+  it("degrades malformed stored metadata to pure defaults", async () => {
+    mockExecute.mockResolvedValueOnce([
+      pageRow({ metadata: { menuOrder: "first", isMainMenu: "yes" } }),
+    ]);
+    const { items } = await listPageTree(db)();
+    expect(items[0]).toMatchObject({ menuOrder: 99, isMainMenu: false });
+  });
+
+  it("500s on a page with no path (data problem, not a request error)", async () => {
+    mockExecute.mockResolvedValueOnce([pageRow({ path: null })]);
+    await expect(listPageTree(db)()).rejects.toMatchObject({
+      statusCode: 500,
+    });
   });
 });
 

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -217,6 +217,66 @@ export function listContent(db: Kysely<DB>) {
   };
 }
 
+// ── Admin: page tree ────────────────────────────────────────────────────
+
+export function listPageTree(db: Kysely<DB>) {
+  return async () => {
+    // Every page regardless of status (the corpus is ~dozens of rows),
+    // ordered by path so ancestors precede their descendants and the
+    // order is stable; the client assembles the tree from parentId.
+    const rows = await db
+      .selectFrom("content_item")
+      .select([
+        "id",
+        "title",
+        "slug",
+        "path",
+        "parent_id",
+        "metadata",
+        "status",
+        "published_at",
+        "updated_at",
+      ])
+      .where("kind", "=", "page")
+      .orderBy("path", "asc")
+      .execute();
+
+    return {
+      items: rows.map((row) => {
+        if (row.path === null) {
+          // Set at create for every page (see the hierarchy helpers), so
+          // a NULL here is a data problem, not a normal state.
+          throwHttpError(500, "Page is missing its path");
+        }
+        // Parsing applies the schema defaults (menuOrder 99, flags
+        // false); a malformed stored row degrades to pure defaults
+        // rather than failing the whole tree (same stance as
+        // pageMenuOrder above).
+        const parsed = pageMetadataSchema.safeParse(row.metadata);
+        const metadata = parsed.success
+          ? parsed.data
+          : pageMetadataSchema.parse({});
+        return {
+          id: row.id,
+          title: row.title,
+          slug: row.slug,
+          path: row.path,
+          parentId: row.parent_id,
+          menuOrder: metadata.menuOrder,
+          isMainMenu: metadata.isMainMenu,
+          status: row.status as ContentStatus,
+          publishedAt: row.published_at?.toISOString() ?? null,
+          updatedAt: row.updated_at.toISOString(),
+          // The ever-published marker IS the slug/parent lock
+          // updateContent enforces; derived server-side so the UI never
+          // re-implements lock semantics.
+          pathLocked: row.published_at !== null,
+        };
+      }),
+    };
+  };
+}
+
 // ── Admin: get ──────────────────────────────────────────────────────────
 
 export function getContent(db: Kysely<DB>) {

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13385,6 +13385,56 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content/page-tree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                title: string;
+                                slug: string;
+                                path: string;
+                                parentId: string | null;
+                                menuOrder: number;
+                                isMainMenu: boolean;
+                                /** @enum {string} */
+                                status: "draft" | "published" | "archived";
+                                publishedAt: string | null;
+                                updatedAt: string;
+                                pathLocked: boolean;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/content/{contentId}": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -24132,6 +24132,92 @@
         }
       }
     },
+    "/api/admin/content/page-tree": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "parentId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "isMainMenu": {
+                            "type": "boolean"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "draft",
+                              "published",
+                              "archived"
+                            ]
+                          },
+                          "publishedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "pathLocked": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "slug",
+                          "path",
+                          "parentId",
+                          "menuOrder",
+                          "isMainMenu",
+                          "status",
+                          "publishedAt",
+                          "updatedAt",
+                          "pathLocked"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/content/{contentId}": {
       "get": {
         "parameters": [

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13385,6 +13385,56 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content/page-tree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                title: string;
+                                slug: string;
+                                path: string;
+                                parentId: string | null;
+                                menuOrder: number;
+                                isMainMenu: boolean;
+                                /** @enum {string} */
+                                status: "draft" | "published" | "archived";
+                                publishedAt: string | null;
+                                updatedAt: string;
+                                pathLocked: boolean;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/content/{contentId}": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -24132,6 +24132,92 @@
         }
       }
     },
+    "/api/admin/content/page-tree": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "parentId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "isMainMenu": {
+                            "type": "boolean"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "draft",
+                              "published",
+                              "archived"
+                            ]
+                          },
+                          "publishedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "pathLocked": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "slug",
+                          "path",
+                          "parentId",
+                          "menuOrder",
+                          "isMainMenu",
+                          "status",
+                          "publishedAt",
+                          "updatedAt",
+                          "pathLocked"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/content/{contentId}": {
       "get": {
         "parameters": [

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -20,6 +20,7 @@ import { LeadsTab } from "./leads-tab";
 import { MarketingOutboxTab } from "./marketing-outbox-tab";
 import { MatchFeesTab } from "./match-fees-tab";
 import { MembersTab } from "./members-tab";
+import { PagesTab } from "./pages-tab";
 import { RecordLinkingTab } from "./record-linking-tab";
 import { SponsorshipsTab } from "./sponsorships-tab";
 import { TreasurerTab } from "./treasurer-tab";
@@ -186,6 +187,15 @@ const SECTIONS: readonly SectionDef[] = [
         label: "Events",
         visible: (role) => checkPermission(role, "content_news", "view"),
         render: () => <ContentTab kind="event" />,
+      },
+      // Appended after the existing sub-tabs so the section's default
+      // (first visible) sub-tab - what a bare ?section=content deep link
+      // opens - doesn't change underneath existing links.
+      {
+        value: "pages",
+        label: "Pages",
+        visible: (role) => checkPermission(role, "content", "view"),
+        render: () => <PagesTab />,
       },
     ],
   },

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -867,7 +867,9 @@ function AuthorSelect({
 // a sentinel the slug grammar can never produce (no leading hyphens).
 const ROOT_PARENT = "--root--";
 
-const PATH_LOCKED_HINT = "Locked after publish - path and ordering are fixed";
+// menuOrder is deliberately NOT covered by this lock: it is presentation
+// only, so ordering stays editable after publish.
+const PATH_LOCKED_HINT = "Locked after publish - the page's address is fixed";
 
 function PageMetadataFields({
   form,

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -74,6 +74,7 @@ import {
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CONTENT_KIND_NOUNS } from "./content-kind-labels.js";
+import { buildPageTree, visibleNodes } from "./pages-tab.lib.js";
 
 // ── Custom blocks ───────────────────────────────────────────────────────
 //
@@ -433,6 +434,8 @@ function buildSlashItems(editor: Editor, startImageUpload: () => void) {
 interface EditorProps {
   kind: ContentKind;
   contentId: string | null;
+  /** Pages only: preset parent for a new child (?parent= URL param). */
+  newParentId?: string | null;
   onClose: () => void;
   onCreated: (id: string) => void;
 }
@@ -440,6 +443,7 @@ interface EditorProps {
 export default function ContentEditor({
   kind,
   contentId,
+  newParentId = null,
   onClose,
   onCreated,
 }: EditorProps) {
@@ -480,6 +484,7 @@ export default function ContentEditor({
       key={contentId ?? "new"}
       kind={kind}
       item={item ?? null}
+      newParentId={newParentId}
       onClose={onClose}
       onCreated={onCreated}
     />
@@ -497,6 +502,13 @@ interface FormState {
   description: string;
   // game_report
   playCricketId: string;
+  // page - menuOrder stays a string while typing; ldjson is the raw
+  // textarea value (validated/parsed only when building the payload)
+  menuOrder: string;
+  isMainMenu: boolean;
+  hideTitle: boolean;
+  ldjson: string;
+  parentId: string | null;
   // news
   tags: string[];
   authorSlug: string;
@@ -554,7 +566,10 @@ function formatUkTime(iso: string): string {
  * stored JSON may predate the current schema, so anything malformed
  * degrades to the field default rather than crashing the editor.
  */
-function initialForm(item: ContentItemDetail | null): FormState {
+function initialForm(
+  item: ContentItemDetail | null,
+  newParentId: string | null,
+): FormState {
   const metadata = item?.metadata ?? {};
   const location =
     typeof metadata.location === "object" && metadata.location !== null
@@ -565,6 +580,14 @@ function initialForm(item: ContentItemDetail | null): FormState {
     slug: item?.slug ?? "",
     description: item?.description ?? "",
     playCricketId: asString(metadata.playCricketId),
+    menuOrder: asNumberString(metadata.menuOrder) || "99",
+    isMainMenu: metadata.isMainMenu === true,
+    hideTitle: metadata.hideTitle === true,
+    ldjson:
+      typeof metadata.ldjson === "object" && metadata.ldjson !== null
+        ? JSON.stringify(metadata.ldjson, null, 2)
+        : "",
+    parentId: item !== null ? item.parentId : newParentId,
     tags: Array.isArray(metadata.tags)
       ? metadata.tags.filter(
           (tag): tag is string => typeof tag === "string" && tag !== "",
@@ -586,6 +609,19 @@ function initialForm(item: ContentItemDetail | null): FormState {
 const isBlankOrNumeric = (value: string) =>
   value.trim() === "" || !Number.isNaN(Number(value.trim()));
 
+/** Parsed ldjson object, or null when the textarea isn't a JSON object. */
+function parseLdjson(raw: string): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null;
+}
+
 /**
  * Client-side floor for per-kind metadata the API would 400 without
  * (the server revalidates everything). Returns the message shown on the
@@ -594,6 +630,20 @@ const isBlankOrNumeric = (value: string) =>
 function metadataProblem(kind: ContentKind, form: FormState): string | null {
   if (kind === "game_report" && !form.playCricketId) {
     return "Choose a Play-Cricket game first";
+  }
+  if (kind === "page") {
+    const menuOrder = Number(form.menuOrder.trim());
+    if (
+      form.menuOrder.trim() === "" ||
+      !Number.isInteger(menuOrder) ||
+      menuOrder < 0 ||
+      menuOrder > 999
+    ) {
+      return "Menu order must be a whole number from 0 to 999";
+    }
+    if (form.ldjson.trim() !== "" && parseLdjson(form.ldjson.trim()) === null) {
+      return "Structured data must be a valid JSON object (or left empty)";
+    }
   }
   if (kind === "event") {
     if (!form.when) return "Set the event start time first";
@@ -625,6 +675,16 @@ function buildMetadata(
   kind: ContentKind,
   form: FormState,
 ): Record<string, unknown> {
+  if (kind === "page") {
+    const ldjson = form.ldjson.trim();
+    return {
+      menuOrder: Number(form.menuOrder.trim()),
+      isMainMenu: form.isMainMenu,
+      hideTitle: form.hideTitle,
+      // Omitted entirely when empty - never an empty string for "no value".
+      ...(ldjson !== "" ? { ldjson: parseLdjson(ldjson) } : {}),
+    };
+  }
   if (kind === "news") {
     return {
       tags: form.tags,
@@ -803,15 +863,148 @@ function AuthorSelect({
   );
 }
 
+// Radix Select items can't have an empty value, so "top level" rides on
+// a sentinel the slug grammar can never produce (no leading hyphens).
+const ROOT_PARENT = "--root--";
+
+const PATH_LOCKED_HINT = "Locked after publish - path and ordering are fixed";
+
+function PageMetadataFields({
+  form,
+  itemId,
+  slugLocked,
+  onChange,
+}: {
+  form: FormState;
+  /** Editing target, or null when creating - excluded from the picker. */
+  itemId: string | null;
+  slugLocked: boolean;
+  onChange: (updates: Partial<FormState>) => void;
+}) {
+  // Same key as the Pages tab's tree query, so opening the editor from
+  // the tree hits the cache and the picker renders instantly.
+  const { data } = useQuery({
+    queryKey: ["admin", "content", "page-tree"],
+    queryFn: () => callApi(api.GET("/api/admin/content/page-tree")),
+  });
+  const items = useMemo(() => data?.items ?? [], [data]);
+
+  // Parent options: every page except this one and its descendants
+  // (descendants are exactly the rows whose path extends this page's -
+  // the same canonical-prefix rule the backend's cycle check uses).
+  const options = useMemo(() => {
+    const self = items.find((item) => item.id === itemId);
+    const eligible = items.filter(
+      (item) =>
+        item.id !== itemId &&
+        (self === undefined || !item.path.startsWith(`${self.path}/`)),
+    );
+    const allExpanded = new Set(eligible.map((item) => item.id));
+    return visibleNodes(buildPageTree(eligible), allExpanded);
+  }, [items, itemId]);
+
+  // While the tree query is still loading, the parent's path is unknown -
+  // show an ellipsis rather than implying the page sits at the root.
+  const parentPath =
+    form.parentId !== null
+      ? (items.find((item) => item.id === form.parentId)?.path ?? "/…")
+      : "";
+  const pathPreview = `${parentPath}/${form.slug || "…"}`;
+
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <Label>Parent page{slugLocked ? " (locked after publish)" : ""}</Label>
+        <Select
+          value={form.parentId ?? ROOT_PARENT}
+          disabled={slugLocked}
+          onValueChange={(next) => {
+            onChange({ parentId: next === ROOT_PARENT ? null : next });
+          }}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Top level" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ROOT_PARENT}>Top level (no parent)</SelectItem>
+            {options.map((node) => (
+              <SelectItem key={node.item.id} value={node.item.id}>
+                {"\u00A0".repeat(node.depth * 3)}
+                {node.item.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {slugLocked ? (
+          <span className="text-xs text-stone-500">{PATH_LOCKED_HINT}</span>
+        ) : (
+          <span className="text-xs text-stone-500">
+            Page address: <span className="font-mono">{pathPreview}</span>
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="page-menu-order">Menu order (0-999)</Label>
+        <Input
+          id="page-menu-order"
+          inputMode="numeric"
+          value={form.menuOrder}
+          onChange={(e) => {
+            onChange({ menuOrder: e.target.value });
+          }}
+        />
+        <span className="text-xs text-stone-500">
+          Lower numbers appear first among sibling pages.
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="page-is-main-menu"
+          checked={form.isMainMenu}
+          onCheckedChange={(value) => {
+            onChange({ isMainMenu: value === true });
+          }}
+        />
+        <Label htmlFor="page-is-main-menu">Show in the main menu</Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="page-hide-title"
+          checked={form.hideTitle}
+          onCheckedChange={(value) => {
+            onChange({ hideTitle: value === true });
+          }}
+        />
+        <Label htmlFor="page-hide-title">Hide the title heading</Label>
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="page-ldjson">Structured data (JSON-LD, optional)</Label>
+        <Textarea
+          id="page-ldjson"
+          rows={4}
+          className="font-mono text-xs"
+          placeholder='{"@context": "https://schema.org", …}'
+          value={form.ldjson}
+          onChange={(e) => {
+            onChange({ ldjson: e.target.value });
+          }}
+        />
+      </div>
+    </>
+  );
+}
+
 function MetadataFields({
   kind,
   form,
+  itemId,
   slugLocked,
   tagSuggestions,
   onChange,
 }: {
   kind: ContentKind;
   form: FormState;
+  itemId: string | null;
   slugLocked: boolean;
   tagSuggestions: string[];
   onChange: (updates: Partial<FormState>) => void;
@@ -852,6 +1045,14 @@ function MetadataFields({
           }}
         />
       </div>
+      {kind === "page" && (
+        <PageMetadataFields
+          form={form}
+          itemId={itemId}
+          slugLocked={slugLocked}
+          onChange={onChange}
+        />
+      )}
       {kind === "game_report" && (
         <div className="flex flex-col gap-1">
           <Label>Play-Cricket game</Label>
@@ -1417,11 +1618,13 @@ function EditorPane({
 function LoadedEditor({
   kind,
   item,
+  newParentId,
   onClose,
   onCreated,
 }: {
   kind: ContentKind;
   item: ContentItemDetail | null;
+  newParentId: string | null;
   onClose: () => void;
   onCreated: (id: string) => void;
 }) {
@@ -1435,7 +1638,9 @@ function LoadedEditor({
     "publish",
   );
 
-  const [form, setForm] = useState<FormState>(() => initialForm(item));
+  const [form, setForm] = useState<FormState>(() =>
+    initialForm(item, newParentId),
+  );
   const [consentConfirmed, setConsentConfirmed] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [lastSavedAt, setLastSavedAt] = useState<string | null>(
@@ -1488,6 +1693,9 @@ function LoadedEditor({
               description: form.description || null,
               body,
               metadata,
+              // Pages nest; every other kind is flat (the API rejects a
+              // parent on non-page kinds).
+              ...(kind === "page" ? { parentId: form.parentId } : {}),
             },
           }),
         );
@@ -1496,7 +1704,14 @@ function LoadedEditor({
         api.PUT("/api/admin/content/{contentId}", {
           params: { path: { contentId: item.id } },
           body: {
-            ...(slugLocked ? {} : { slug: form.slug }),
+            // Slug and (for pages) parent share the ever-published lock:
+            // path = parent path + slug, so neither is sent once locked.
+            ...(slugLocked
+              ? {}
+              : {
+                  slug: form.slug,
+                  ...(kind === "page" ? { parentId: form.parentId } : {}),
+                }),
             title: form.title,
             description: form.description || null,
             body,
@@ -1643,6 +1858,7 @@ function LoadedEditor({
           <MetadataFields
             kind={kind}
             form={form}
+            itemId={item?.id ?? null}
             slugLocked={slugLocked}
             tagSuggestions={tagSuggestions}
             onChange={onFormChange}

--- a/apps/web/src/pages/admin/content-state.ts
+++ b/apps/web/src/pages/admin/content-state.ts
@@ -1,0 +1,39 @@
+// Shared admin-content display helpers, used by the flat content list
+// (content-tab) and the page tree (pages-tab) so both render the same
+// badge treatment.
+
+/**
+ * What the row means editorially, not the raw status: a published item
+ * with a future published_at is Scheduled, not Live. The Live/Scheduled
+ * split is a client-side now() comparison - fine for the admin list; the
+ * public visibility decision stays server-side (publishedOnly()).
+ */
+export type DisplayState = "draft" | "scheduled" | "live" | "archived";
+
+export function displayState(item: {
+  status: string;
+  publishedAt: string | null;
+}): DisplayState {
+  if (item.status === "archived") return "archived";
+  if (item.status !== "published") return "draft";
+  return item.publishedAt !== null && Date.parse(item.publishedAt) > Date.now()
+    ? "scheduled"
+    : "live";
+}
+
+export const STATE_BADGES: Record<
+  DisplayState,
+  { label: string; variant: "default" | "secondary" | "outline" | "info" }
+> = {
+  live: { label: "Live", variant: "default" },
+  scheduled: { label: "Scheduled", variant: "info" },
+  draft: { label: "Draft", variant: "secondary" },
+  archived: { label: "Archived", variant: "outline" },
+};
+
+/**
+ * URL params are user input: anything that isn't a UUID degrades to the
+ * default rather than reaching the typed API call.
+ */
+export const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -30,44 +30,13 @@ import { lazy, Suspense } from "react";
 import { IoOpenOutline } from "react-icons/io5";
 import { useSearchParams } from "react-router";
 import { CONTENT_KIND_NOUNS } from "./content-kind-labels.js";
+import { displayState, STATE_BADGES, UUID_RE } from "./content-state.js";
 
 // The editor pulls in BlockNote (the single heaviest dependency in the
 // admin panel), so it loads as its own chunk only when an item is open.
 const ContentEditor = lazy(() => import("./content-editor.js"));
 
-/**
- * What the row means editorially, not the raw status: a published item
- * with a future published_at is Scheduled, not Live. The Live/Scheduled
- * split is a client-side now() comparison - fine for the admin list; the
- * public visibility decision stays server-side (publishedOnly()).
- */
-type DisplayState = "draft" | "scheduled" | "live" | "archived";
-
-function displayState(item: {
-  status: string;
-  publishedAt: string | null;
-}): DisplayState {
-  if (item.status === "archived") return "archived";
-  if (item.status !== "published") return "draft";
-  return item.publishedAt !== null && Date.parse(item.publishedAt) > Date.now()
-    ? "scheduled"
-    : "live";
-}
-
-const STATE_BADGES: Record<
-  DisplayState,
-  { label: string; variant: "default" | "secondary" | "outline" | "info" }
-> = {
-  live: { label: "Live", variant: "default" },
-  scheduled: { label: "Scheduled", variant: "info" },
-  draft: { label: "Draft", variant: "secondary" },
-  archived: { label: "Archived", variant: "outline" },
-};
-
 const PAGE_SIZE = 20;
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Public URL a published item is live at. Per-kind: game reports render

--- a/apps/web/src/pages/admin/pages-tab.lib.test.ts
+++ b/apps/web/src/pages/admin/pages-tab.lib.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPageTree,
+  reorderUpdates,
+  visibleNodes,
+  type PageTreeItem,
+} from "./pages-tab.lib.js";
+
+function item(
+  id: string,
+  path: string,
+  overrides: Partial<PageTreeItem> = {},
+): PageTreeItem {
+  return {
+    id,
+    title: id,
+    slug: path.split("/").filter(Boolean).pop() ?? id,
+    path,
+    parentId: null,
+    menuOrder: 99,
+    isMainMenu: false,
+    status: "draft",
+    publishedAt: null,
+    updatedAt: "2026-06-01T10:00:00.000Z",
+    pathLocked: false,
+    ...overrides,
+  };
+}
+
+describe("buildPageTree", () => {
+  it("nests children under parents with depths", () => {
+    const tree = buildPageTree([
+      item("club", "/club"),
+      item("history", "/club/history", { parentId: "club" }),
+      item("honours", "/club/history/honours", { parentId: "history" }),
+      item("cricket", "/cricket"),
+    ]);
+    expect(tree.map((n) => n.item.id)).toEqual(["club", "cricket"]);
+    expect(tree[0].depth).toBe(0);
+    expect(tree[0].children.map((n) => n.item.id)).toEqual(["history"]);
+    expect(tree[0].children[0].depth).toBe(1);
+    expect(tree[0].children[0].children.map((n) => n.item.id)).toEqual([
+      "honours",
+    ]);
+    expect(tree[0].children[0].children[0].depth).toBe(2);
+  });
+
+  it("promotes orphans (parent missing from the list) to root level", () => {
+    const tree = buildPageTree([
+      item("club", "/club"),
+      // Parent archived/missing - must not disappear from the admin view
+      item("lost", "/gone/lost", { parentId: "gone" }),
+    ]);
+    expect(tree.map((n) => n.item.id).toSorted()).toEqual(["club", "lost"]);
+    expect(tree.every((n) => n.depth === 0)).toBe(true);
+  });
+
+  it("sorts siblings by menuOrder, then title, then path", () => {
+    const tree = buildPageTree([
+      item("zeta", "/zeta", { menuOrder: 1, title: "Zeta" }),
+      item("beta", "/beta", { menuOrder: 5, title: "Same" }),
+      item("alpha", "/alpha", { menuOrder: 5, title: "Same" }),
+      item("mid", "/mid", { menuOrder: 2, title: "Mid" }),
+    ]);
+    // menuOrder wins; the equal-99 default pair falls to title (equal
+    // here) and then path
+    expect(tree.map((n) => n.item.id)).toEqual([
+      "zeta",
+      "mid",
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("returns an empty forest for no pages", () => {
+    expect(buildPageTree([])).toEqual([]);
+  });
+});
+
+describe("visibleNodes", () => {
+  const tree = buildPageTree([
+    item("club", "/club"),
+    item("history", "/club/history", { parentId: "club" }),
+    item("honours", "/club/history/honours", { parentId: "history" }),
+    item("cricket", "/cricket"),
+  ]);
+
+  it("shows only roots when nothing is expanded", () => {
+    expect(visibleNodes(tree, new Set()).map((n) => n.item.id)).toEqual([
+      "club",
+      "cricket",
+    ]);
+  });
+
+  it("reveals children of expanded nodes only, depth-first", () => {
+    expect(visibleNodes(tree, new Set(["club"])).map((n) => n.item.id)).toEqual(
+      ["club", "history", "cricket"],
+    );
+    expect(
+      visibleNodes(tree, new Set(["club", "history"])).map((n) => n.item.id),
+    ).toEqual(["club", "history", "honours", "cricket"]);
+  });
+
+  it("ignores expansion of a collapsed ancestor's descendants", () => {
+    // history is expanded but club is not - honours stays hidden
+    expect(
+      visibleNodes(tree, new Set(["history"])).map((n) => n.item.id),
+    ).toEqual(["club", "cricket"]);
+  });
+});
+
+describe("reorderUpdates", () => {
+  it("swaps the two adjacent pages when every menuOrder is distinct", () => {
+    const siblings = [
+      item("a", "/a", { menuOrder: 1 }),
+      item("b", "/b", { menuOrder: 5 }),
+      item("c", "/c", { menuOrder: 9 }),
+    ];
+    expect(reorderUpdates(siblings, "b", "up")).toEqual([
+      { id: "b", menuOrder: 1 },
+      { id: "a", menuOrder: 5 },
+    ]);
+    expect(reorderUpdates(siblings, "b", "down")).toEqual([
+      { id: "b", menuOrder: 9 },
+      { id: "c", menuOrder: 5 },
+    ]);
+  });
+
+  it("renumbers the whole group to spaced values when defaults collide", () => {
+    const siblings = [
+      item("a", "/a", { menuOrder: 99 }),
+      item("b", "/b", { menuOrder: 99 }),
+      item("c", "/c", { menuOrder: 99 }),
+    ];
+    // b moves up: new order is b, a, c at 10/20/30
+    expect(reorderUpdates(siblings, "b", "up")).toEqual([
+      { id: "b", menuOrder: 10 },
+      { id: "a", menuOrder: 20 },
+      { id: "c", menuOrder: 30 },
+    ]);
+  });
+
+  it("only emits updates for pages whose menuOrder actually changes", () => {
+    const siblings = [
+      item("a", "/a", { menuOrder: 10 }),
+      item("b", "/b", { menuOrder: 99 }),
+      item("c", "/c", { menuOrder: 99 }),
+    ];
+    // c moves up: renumber path (duplicates exist); a already sits at 10
+    expect(reorderUpdates(siblings, "c", "up")).toEqual([
+      { id: "c", menuOrder: 20 },
+      { id: "b", menuOrder: 30 },
+    ]);
+  });
+
+  it("is a no-op at the edges and for unknown ids", () => {
+    const siblings = [
+      item("a", "/a", { menuOrder: 1 }),
+      item("b", "/b", { menuOrder: 2 }),
+    ];
+    expect(reorderUpdates(siblings, "a", "up")).toEqual([]);
+    expect(reorderUpdates(siblings, "b", "down")).toEqual([]);
+    expect(reorderUpdates(siblings, "missing", "up")).toEqual([]);
+    expect(reorderUpdates([], "a", "up")).toEqual([]);
+  });
+
+  it("keeps renumbered values inside the schema cap for huge groups", () => {
+    const siblings = Array.from({ length: 120 }, (_, i) =>
+      item(`p${String(i)}`, `/p${String(i)}`, { menuOrder: 99 }),
+    );
+    const updates = reorderUpdates(siblings, "p1", "up");
+    expect(updates.length).toBeGreaterThan(0);
+    expect(Math.max(...updates.map((u) => u.menuOrder))).toBeLessThanOrEqual(
+      999,
+    );
+  });
+});

--- a/apps/web/src/pages/admin/pages-tab.lib.ts
+++ b/apps/web/src/pages/admin/pages-tab.lib.ts
@@ -1,0 +1,123 @@
+import type { paths } from "@/lib/api.gen.js";
+
+// Pure tree/reorder logic for the admin Pages tab, kept DOM-free so it is
+// unit-testable in plain vitest (same convention as the *-tab.reducer.ts
+// and *-tab.lib.ts siblings).
+
+/** One flat item from GET /api/admin/content/page-tree (OpenAPI-derived). */
+export type PageTreeItem =
+  paths["/api/admin/content/page-tree"]["get"]["responses"][200]["content"]["application/json"]["items"][number];
+
+export interface PageTreeNode {
+  item: PageTreeItem;
+  depth: number;
+  children: PageTreeNode[];
+}
+
+/**
+ * Sibling display order: menuOrder, then title, then path. The title
+ * tie-break keeps groups of default-99 pages alphabetical instead of
+ * insertion-ordered; path is the final total-order guarantee (titles can
+ * collide, sibling paths cannot).
+ */
+function compareSiblings(a: PageTreeItem, b: PageTreeItem): number {
+  if (a.menuOrder !== b.menuOrder) return a.menuOrder - b.menuOrder;
+  const byTitle = a.title.localeCompare(b.title);
+  if (byTitle !== 0) return byTitle;
+  return a.path.localeCompare(b.path);
+}
+
+/**
+ * Assemble the flat page list into a forest. Orphans - items whose
+ * parentId points at a page missing from the list (archived parent
+ * filtered out upstream, or genuinely gone) - are promoted to root level
+ * rather than silently disappearing from the admin view.
+ */
+export function buildPageTree(items: PageTreeItem[]): PageTreeNode[] {
+  const known = new Set(items.map((item) => item.id));
+  const childrenOf = new Map<string | null, PageTreeItem[]>();
+  for (const item of items) {
+    const key =
+      item.parentId !== null && known.has(item.parentId) ? item.parentId : null;
+    const bucket = childrenOf.get(key);
+    if (bucket) bucket.push(item);
+    else childrenOf.set(key, [item]);
+  }
+
+  const build = (item: PageTreeItem, depth: number): PageTreeNode => ({
+    item,
+    depth,
+    children: (childrenOf.get(item.id) ?? [])
+      .toSorted(compareSiblings)
+      .map((child) => build(child, depth + 1)),
+  });
+
+  return (childrenOf.get(null) ?? [])
+    .toSorted(compareSiblings)
+    .map((item) => build(item, 0));
+}
+
+/** Depth-first flatten of the subtrees whose parents are expanded. */
+export function visibleNodes(
+  nodes: PageTreeNode[],
+  expanded: ReadonlySet<string>,
+): PageTreeNode[] {
+  const out: PageTreeNode[] = [];
+  const walk = (node: PageTreeNode) => {
+    out.push(node);
+    if (expanded.has(node.item.id)) node.children.forEach(walk);
+  };
+  nodes.forEach(walk);
+  return out;
+}
+
+export interface MenuOrderUpdate {
+  id: string;
+  menuOrder: number;
+}
+
+/**
+ * The metadata updates needed to move `id` one position up or down among
+ * `siblings` (its display-ordered sibling group, the same order
+ * buildPageTree produced). Returns [] when the move is impossible
+ * (already at the edge, or not a sibling).
+ *
+ * When every sibling already has a distinct menuOrder, the two adjacent
+ * pages simply swap values. Any duplicate (typically several pages
+ * sharing the schema default 99) makes positions ambiguous, so the whole
+ * sibling group is renumbered to spaced values (10, 20, 30...) in the
+ * new order - one batch, deterministic ordering afterwards.
+ */
+export function reorderUpdates(
+  siblings: PageTreeItem[],
+  id: string,
+  direction: "up" | "down",
+): MenuOrderUpdate[] {
+  const from = siblings.findIndex((item) => item.id === id);
+  if (from === -1) return [];
+  const to = direction === "up" ? from - 1 : from + 1;
+  if (to < 0 || to >= siblings.length) return [];
+
+  const orders = siblings.map((item) => item.menuOrder);
+  const allDistinct = new Set(orders).size === orders.length;
+  if (allDistinct) {
+    return [
+      { id: siblings[from].id, menuOrder: siblings[to].menuOrder },
+      { id: siblings[to].id, menuOrder: siblings[from].menuOrder },
+    ];
+  }
+
+  const reordered = [...siblings];
+  [reordered[from], reordered[to]] = [reordered[to], reordered[from]];
+  // Spacing of 10 leaves room for manual insertion between neighbours;
+  // fall back to 1 if a group is ever so large that 10s would breach the
+  // schema's 999 cap.
+  const spacing = reordered.length * 10 > 999 ? 1 : 10;
+  const updates: MenuOrderUpdate[] = [];
+  reordered.forEach((item, index) => {
+    const menuOrder = (index + 1) * spacing;
+    // Pages already sitting on their spaced value need no write.
+    if (menuOrder !== item.menuOrder) updates.push({ id: item.id, menuOrder });
+  });
+  return updates;
+}

--- a/apps/web/src/pages/admin/pages-tab.tsx
+++ b/apps/web/src/pages/admin/pages-tab.tsx
@@ -34,8 +34,6 @@ import {
 // Same lazy split as content-tab: BlockNote only loads when an item opens.
 const ContentEditor = lazy(() => import("./content-editor.js"));
 
-const LOCKED_HINT = "Locked after publish - path and ordering are fixed";
-
 /** Sibling groups in display order, keyed by member id, for reordering. */
 function siblingGroups(roots: PageTreeNode[]): Map<string, PageTreeItem[]> {
   const groups = new Map<string, PageTreeItem[]>();
@@ -281,17 +279,12 @@ function PageRow({
   const state = displayState(item);
   const index = siblings.findIndex((s) => s.id === item.id);
 
-  // The backend deliberately still accepts menuOrder changes for
-  // ever-published pages (menuOrder is presentation, not part of the
-  // locked URL), so this reorder restriction is UI-only per the issue
-  // spec and trivially reversible if editors need it.
-  const reorderHint = item.pathLocked
-    ? LOCKED_HINT
-    : reordering
-      ? "Reordering…"
-      : null;
-  const canMoveUp = reorderHint === null && index > 0;
-  const canMoveDown = reorderHint === null && index < siblings.length - 1;
+  // menuOrder is presentation-only and deliberately NOT part of the
+  // publish lock (the backend accepts it for ever-published pages too),
+  // so reordering stays enabled regardless of pathLocked - only the
+  // sibling boundaries and an in-flight batch disable the moves.
+  const canMoveUp = !reordering && index > 0;
+  const canMoveDown = !reordering && index < siblings.length - 1;
 
   return (
     <li
@@ -372,14 +365,7 @@ function PageRow({
               }}
             >
               <IoArrowUpOutline className="size-4" />
-              <span>
-                Move up
-                {reorderHint !== null && (
-                  <span className="block text-xs text-stone-500">
-                    {reorderHint}
-                  </span>
-                )}
-              </span>
+              Move up
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={!canMoveDown}
@@ -388,14 +374,7 @@ function PageRow({
               }}
             >
               <IoArrowDownOutline className="size-4" />
-              <span>
-                Move down
-                {reorderHint !== null && (
-                  <span className="block text-xs text-stone-500">
-                    {reorderHint}
-                  </span>
-                )}
-              </span>
+              Move down
             </DropdownMenuItem>
             {state === "live" && (
               <DropdownMenuItem asChild>

--- a/apps/web/src/pages/admin/pages-tab.tsx
+++ b/apps/web/src/pages/admin/pages-tab.tsx
@@ -1,0 +1,413 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useHasPermission } from "@/hooks/use-has-permission";
+import { api, callApi } from "@/lib/api-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { formatInTimeZone } from "date-fns-tz";
+import { lazy, Suspense } from "react";
+import {
+  IoAddOutline,
+  IoArrowDownOutline,
+  IoArrowUpOutline,
+  IoChevronDownOutline,
+  IoChevronForwardOutline,
+  IoEllipsisVertical,
+  IoOpenOutline,
+} from "react-icons/io5";
+import { useSearchParams } from "react-router";
+import { displayState, STATE_BADGES, UUID_RE } from "./content-state.js";
+import {
+  buildPageTree,
+  reorderUpdates,
+  visibleNodes,
+  type MenuOrderUpdate,
+  type PageTreeItem,
+  type PageTreeNode,
+} from "./pages-tab.lib.js";
+
+// Same lazy split as content-tab: BlockNote only loads when an item opens.
+const ContentEditor = lazy(() => import("./content-editor.js"));
+
+const LOCKED_HINT = "Locked after publish - path and ordering are fixed";
+
+/** Sibling groups in display order, keyed by member id, for reordering. */
+function siblingGroups(roots: PageTreeNode[]): Map<string, PageTreeItem[]> {
+  const groups = new Map<string, PageTreeItem[]>();
+  const record = (nodes: PageTreeNode[]) => {
+    const items = nodes.map((n) => n.item);
+    for (const node of nodes) {
+      groups.set(node.item.id, items);
+      record(node.children);
+    }
+  };
+  record(roots);
+  return groups;
+}
+
+/**
+ * Page tree for the admin Content section. All UI state (open item,
+ * preset parent for a new child, expanded nodes) lives in the URL
+ * alongside the panel's section/sub params, so deep links restore the
+ * full view.
+ */
+export function PagesTab() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
+  const { allowed: canManage } = useHasPermission("content", "manage");
+
+  const itemParam = searchParams.get("item");
+  const openItem =
+    itemParam === "new" || (itemParam !== null && UUID_RE.test(itemParam))
+      ? itemParam
+      : null;
+  const parentParam = searchParams.get("parent");
+  const newParentId =
+    parentParam !== null && UUID_RE.test(parentParam) ? parentParam : null;
+  const expanded = new Set(
+    (searchParams.get("expanded") ?? "").split(",").filter(Boolean),
+  );
+
+  /**
+   * Navigation-like changes (open item, new child) push a history entry;
+   * expand/collapse replaces - like search refinement, expanding nodes
+   * must not spam history with one entry per chevron click.
+   */
+  const setParams = (
+    updates: Record<string, string | null>,
+    options: { replace?: boolean } = {},
+  ) => {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === null || value === "") params.delete(key);
+      else params.set(key, value);
+    }
+    setSearchParams(params, { replace: options.replace ?? false });
+  };
+
+  const { data, isLoading, error } = useQuery({
+    // Rooted under ["admin", "content"] so the editor's existing save/
+    // publish invalidations cover the tree without knowing about it.
+    queryKey: ["admin", "content", "page-tree"],
+    queryFn: () => callApi(api.GET("/api/admin/content/page-tree")),
+    enabled: openItem === null,
+  });
+
+  const reorderMutation = useMutation({
+    mutationFn: async (updates: MenuOrderUpdate[]) => {
+      // menuOrder lives inside the kind metadata and updates replace the
+      // whole metadata object, so merge over each page's current detail
+      // (the tree payload deliberately omits hideTitle/ldjson). Each
+      // page's read-then-write pair touches only its own row, so the
+      // batch runs in parallel.
+      await Promise.all(
+        updates.map(async (update) => {
+          const detail = await callApi(
+            api.GET("/api/admin/content/{contentId}", {
+              params: { path: { contentId: update.id } },
+            }),
+          );
+          await callApi(
+            api.PUT("/api/admin/content/{contentId}", {
+              params: { path: { contentId: update.id } },
+              body: {
+                metadata: { ...detail.metadata, menuOrder: update.menuOrder },
+              },
+            }),
+          );
+        }),
+      );
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
+      // menuOrder drives the public nav ordering; drop ["content", ...]
+      // (which includes ["content", "nav"]) so the live menu reorders too.
+      void queryClient.invalidateQueries({ queryKey: ["content"] });
+    },
+  });
+
+  if (openItem !== null) {
+    return (
+      <Suspense
+        fallback={
+          <p className="py-8 text-sm text-stone-500">Loading editor…</p>
+        }
+      >
+        <ContentEditor
+          kind="page"
+          contentId={openItem === "new" ? null : openItem}
+          newParentId={newParentId}
+          onClose={() => {
+            setParams(
+              { item: null, parent: null },
+              { replace: openItem === "new" },
+            );
+          }}
+          onCreated={(id) => {
+            // Swap "new" for the created id (and drop the parent preset):
+            // back must not return to the create form and spawn a duplicate.
+            setParams({ item: id, parent: null }, { replace: true });
+          }}
+        />
+      </Suspense>
+    );
+  }
+
+  const roots = buildPageTree(data?.items ?? []);
+  const rows = visibleNodes(roots, expanded);
+  const groups = siblingGroups(roots);
+
+  const toggleExpanded = (id: string) => {
+    const next = new Set(expanded);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setParams(
+      { expanded: Array.from(next).join(",") || null },
+      { replace: true },
+    );
+  };
+
+  const move = (item: PageTreeItem, direction: "up" | "down") => {
+    const updates = reorderUpdates(
+      groups.get(item.id) ?? [],
+      item.id,
+      direction,
+    );
+    if (updates.length > 0) reorderMutation.mutate(updates);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="max-w-xl text-xs text-stone-500">
+          Pages nest into sections. A section's landing page is the parent
+          page's own content - edit the parent to change what visitors see at
+          its address.
+        </p>
+        {canManage && (
+          <Button
+            onClick={() => {
+              setParams({ item: "new" });
+            }}
+          >
+            New page
+          </Button>
+        )}
+      </div>
+
+      {reorderMutation.error && (
+        <p className="text-sm text-red-600">
+          Couldn't reorder - {reorderMutation.error.message}
+        </p>
+      )}
+
+      {error ? (
+        <p className="py-8 text-sm text-red-600">
+          Couldn't load pages - {error.message}
+        </p>
+      ) : isLoading ? (
+        <p className="py-8 text-sm text-stone-500">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="py-8 text-sm text-stone-500">
+          No pages yet - create the first one. Pages added as children of an
+          existing page form a section, and the parent page itself is the
+          section's landing page.
+        </p>
+      ) : (
+        <ul className="divide-y divide-stone-200 rounded-lg border border-stone-200">
+          {rows.map((node) => (
+            <PageRow
+              key={node.item.id}
+              node={node}
+              expanded={expanded.has(node.item.id)}
+              canManage={canManage}
+              reordering={reorderMutation.isPending}
+              siblings={groups.get(node.item.id) ?? []}
+              onToggle={() => {
+                toggleExpanded(node.item.id);
+              }}
+              onOpen={() => {
+                setParams({ item: node.item.id });
+              }}
+              onNewChild={() => {
+                // Expand the parent too, so the new child is visible on
+                // return to the tree.
+                const nextExpanded = new Set(expanded);
+                nextExpanded.add(node.item.id);
+                setParams({
+                  item: "new",
+                  parent: node.item.id,
+                  expanded: Array.from(nextExpanded).join(","),
+                });
+              }}
+              onMove={(direction) => {
+                move(node.item, direction);
+              }}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function PageRow({
+  node,
+  expanded,
+  canManage,
+  reordering,
+  siblings,
+  onToggle,
+  onOpen,
+  onNewChild,
+  onMove,
+}: {
+  node: PageTreeNode;
+  expanded: boolean;
+  canManage: boolean;
+  reordering: boolean;
+  siblings: PageTreeItem[];
+  onToggle: () => void;
+  onOpen: () => void;
+  onNewChild: () => void;
+  onMove: (direction: "up" | "down") => void;
+}) {
+  const { item, depth, children } = node;
+  const state = displayState(item);
+  const index = siblings.findIndex((s) => s.id === item.id);
+
+  // The backend deliberately still accepts menuOrder changes for
+  // ever-published pages (menuOrder is presentation, not part of the
+  // locked URL), so this reorder restriction is UI-only per the issue
+  // spec and trivially reversible if editors need it.
+  const reorderHint = item.pathLocked
+    ? LOCKED_HINT
+    : reordering
+      ? "Reordering…"
+      : null;
+  const canMoveUp = reorderHint === null && index > 0;
+  const canMoveDown = reorderHint === null && index < siblings.length - 1;
+
+  return (
+    <li
+      className="flex items-center gap-2 py-2 pr-2"
+      style={{ paddingLeft: `${String(depth * 1.25 + 0.5)}rem` }}
+    >
+      {children.length > 0 ? (
+        <button
+          type="button"
+          aria-label={`${expanded ? "Collapse" : "Expand"} ${item.title}`}
+          aria-expanded={expanded}
+          className="flex size-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-100 hover:text-stone-900"
+          onClick={onToggle}
+        >
+          {expanded ? (
+            <IoChevronDownOutline className="size-4" />
+          ) : (
+            <IoChevronForwardOutline className="size-4" />
+          )}
+        </button>
+      ) : (
+        <span aria-hidden className="size-6 shrink-0" />
+      )}
+
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left"
+        onClick={onOpen}
+      >
+        <span className="truncate font-medium">
+          {item.title}
+          {children.length > 0 && (
+            <span className="ml-1 text-xs font-normal text-stone-400">
+              ({children.length})
+            </span>
+          )}
+        </span>
+        <span className="truncate text-xs text-stone-500">{item.path}</span>
+      </button>
+
+      <div className="flex shrink-0 flex-col items-end gap-0.5">
+        <Badge variant={STATE_BADGES[state].variant}>
+          {STATE_BADGES[state].label}
+        </Badge>
+        {state === "scheduled" && item.publishedAt !== null && (
+          <span className="text-xs text-stone-500">
+            {formatInTimeZone(
+              new Date(item.publishedAt),
+              "Europe/London",
+              "d MMM yyyy, HH:mm",
+            )}{" "}
+            UK time
+          </span>
+        )}
+      </div>
+
+      {canManage && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label={`Actions for ${item.title}`}
+              className="shrink-0 px-2"
+            >
+              <IoEllipsisVertical className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={onNewChild}>
+              <IoAddOutline className="size-4" />
+              New child page
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!canMoveUp}
+              onSelect={() => {
+                onMove("up");
+              }}
+            >
+              <IoArrowUpOutline className="size-4" />
+              <span>
+                Move up
+                {reorderHint !== null && (
+                  <span className="block text-xs text-stone-500">
+                    {reorderHint}
+                  </span>
+                )}
+              </span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!canMoveDown}
+              onSelect={() => {
+                onMove("down");
+              }}
+            >
+              <IoArrowDownOutline className="size-4" />
+              <span>
+                Move down
+                {reorderHint !== null && (
+                  <span className="block text-xs text-stone-500">
+                    {reorderHint}
+                  </span>
+                )}
+              </span>
+            </DropdownMenuItem>
+            {state === "live" && (
+              <DropdownMenuItem asChild>
+                <a href={item.path} target="_blank" rel="noopener noreferrer">
+                  <IoOpenOutline className="size-4" />
+                  View live page
+                </a>
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </li>
+  );
+}


### PR DESCRIPTION
Part of epic #492 (targets the epic branch). Closes #494.

## What

**Backend (small)**
- `GET /admin/content/page-tree`: every page regardless of status, path-ordered, with server-derived `pathLocked` (ever-published marker) and schema-defaulted `menuOrder`/`isMainMenu` - the UI never re-derives lock semantics.

**Admin UI**
- New Pages sub-tab in the Content section (resource `content`, appended last so existing deep links keep their default sub-tab).
- Tree view: indented rows (title + path), existing status badge treatment, chevron expand/collapse with `?expanded=` in the URL (replace-mode), selection via the existing `?item=` param. One-line tappable rows with a kebab menu, so it works on a phone.
- Create child: `?item=new&parent=<id>` presets the parent and auto-expands it; on create the URL swaps to the real id with replace so Back never respawns the form.
- Reorder: Move up/down swaps adjacent sibling menuOrders; if siblings share the 99 default the group is renumbered 10/20/30 in one batch (only changed rows written).
- Move/reorder disabled on path-locked pages with the hint "Locked after publish - path and ordering are fixed".
- Editor gains the page kind: menuOrder / isMainMenu / hideTitle / optional ldjson (JSON-validated, omitted when empty), parent picker (indented, excludes self + descendants), live path preview, existing slug-lock treatment.
- Empty state + caption explain that a section landing page is the parent item's own content (the `_index.mdx` equivalent).

## Notes for review
- menuOrder restriction on published pages is **UI-only** per the issue spec; the backend deliberately accepts it (code comment marks the spot) so flipping the rule later is trivial. Consequence: moving an unlocked sibling can renumber a locked sibling's menuOrder - position isn't part of the path lock.
- Reorder merges menuOrder over a fresh GET of each sibling's detail (PUT replaces whole metadata; the tree payload intentionally omits hideTitle/ldjson).
- Public nav invalidation covered: tree key lives under ["admin","content"], reorder also invalidates ["content"] which covers the nav query.

## Tests
api: 612 unit (+5), 466 integration (+1). web: 521 unit (+12: tree build, orphan promotion, visible-node flatten, reorder calc). typecheck/lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)