### PR TITLE
feat(content): full editor-block + renderer coverage for all MDX components (#495)

### DIFF
--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -327,6 +327,26 @@ describe("ContentBody", () => {
     expect(html).toContain('href="/person/alex-slaven"');
   });
 
+  it("normalises personGrid slugs with spaces and empty segments", () => {
+    const html = renderBody([
+      block("personGrid", { props: { slugs: " alex-slaven , , bob ," } }),
+    ]);
+    // Trimmed slugs resolve; empty segments are dropped (no card with an
+    // empty profile link).
+    expect(html).toContain('href="/person/alex-slaven"');
+    expect(html).toContain('href="/person/bob"');
+    expect(html).not.toContain('href="/person/"');
+    // Exactly two person cards rendered.
+    expect(html.match(/class="person /g)).toHaveLength(2);
+  });
+
+  it("hides personGrid when slugs contains only separators and whitespace", () => {
+    const html = renderBody([
+      block("personGrid", { props: { slugs: " , ,, " } }),
+    ]);
+    expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
+  });
+
   it("hides leagueTable when divisionId is missing", () => {
     const html = renderBody([block("leagueTable", { props: {} })]);
     expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -11,10 +11,30 @@ vi.mock("@/lib/people.js", () => ({
     slug === "alex-slaven"
       ? { name: "Alex Slaven", photo: undefined, photoPicture: undefined }
       : undefined,
+  getAllPeople: () => [
+    {
+      slug: "alex-slaven",
+      name: "Alex Slaven",
+      photo: undefined,
+      photoPicture: undefined,
+    },
+  ],
 }));
 vi.mock("@/lib/image-map.js", () => ({
   getImageUrl: () => undefined,
   getPicture: () => undefined,
+}));
+// Stub network-dependent subcomponents so they render inert markup instead
+// of firing real API requests under renderToStaticMarkup.
+vi.mock("@/components/leaderboard-content.js", () => ({
+  LeaderboardContent: () => <div data-testid="leaderboard-stub" />,
+}));
+vi.mock("@/components/records-wall.js", () => ({
+  RecordsWall: () => <div data-testid="records-wall-stub" />,
+}));
+vi.mock("@/lib/marketing/consent.js", () => ({
+  CURRENT_CONSENT_VERSION: "v3",
+  requestConsentReopen: () => undefined,
 }));
 
 import { ContentBody } from "./content-body.js";
@@ -251,5 +271,111 @@ describe("ContentBody", () => {
     expect(html).not.toContain("javascript:");
     // Falls back to the plain (safe) src
     expect(html).toContain('src="/uploads/content/img-1/640.jpg"');
+  });
+
+  // ── New custom blocks ──────────────────────────────────────────────────
+
+  it("renders all custom block types in a fixture document without crashing", () => {
+    const picture = {
+      sources: {
+        avif: "/uploads/content/img-1/320.avif 320w",
+        webp: "/uploads/content/img-1/320.webp 320w",
+      },
+      img: { src: "/uploads/content/img-1/640.jpg", w: 640, h: 480 },
+    };
+    const html = renderBody([
+      block("person", { props: { slug: "alex-slaven", role: "Head Coach" } }),
+      block("personGrid", { props: { slugs: "alex-slaven" } }),
+      block("gamePreview", { props: { playCricketId: "123" } }),
+      block("eventPreview", {
+        props: { eventId: "1", name: "Quiz night", when: "2026-07-01" },
+      }),
+      block("contentImage", {
+        props: {
+          src: "/uploads/content/img-1/640.jpg",
+          alt: "A photo",
+          caption: "Caption",
+          picture: JSON.stringify(picture),
+        },
+      }),
+      block("leagueTable", {
+        props: { divisionId: "div-1", name: "Division 1" },
+      }),
+      block("leaderboard", {}),
+      block("recordsWall", {}),
+      block("contactForm", {
+        props: { title: "Get in touch", description: "We reply within 48h" },
+      }),
+      block("cookieSettingsLink", { props: { text: "Manage cookies" } }),
+      block("consentVersion", {}),
+    ]);
+    // Each custom block must produce some non-empty output (not null/empty).
+    expect(html.length).toBeGreaterThan(0);
+    // Spot-check a handful of expected fragments.
+    expect(html).toContain("Head Coach");
+    expect(html).toContain("Quiz night");
+    expect(html).toContain("Get in touch");
+    expect(html).toContain("Manage cookies");
+    expect(html).toContain("v3");
+  });
+
+  it("renders personGrid via the shared PersonGrid component", () => {
+    const html = renderBody([
+      block("personGrid", { props: { slugs: "alex-slaven" } }),
+    ]);
+    // PersonGrid renders Person cards, which include the profile link
+    expect(html).toContain('href="/person/alex-slaven"');
+  });
+
+  it("hides leagueTable when divisionId is missing", () => {
+    const html = renderBody([block("leagueTable", { props: {} })]);
+    expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
+  });
+
+  it("renders leagueTable when divisionId is provided", () => {
+    const html = renderBody([
+      block("leagueTable", { props: { divisionId: "12345", name: "Div 1" } }),
+    ]);
+    // leagueTable fires a query that is disabled in tests, renders nothing
+    // until data arrives - the component itself returns null when !data, so
+    // the outer block still produces some wrapper markup.
+    expect(html).toBeDefined();
+  });
+
+  it("renders leaderboard block", () => {
+    const html = renderBody([block("leaderboard", {})]);
+    expect(html).toContain("leaderboard-stub");
+  });
+
+  it("renders recordsWall block", () => {
+    const html = renderBody([block("recordsWall", {})]);
+    expect(html).toContain("records-wall-stub");
+  });
+
+  it("renders contactForm with title and description", () => {
+    const html = renderBody([
+      block("contactForm", {
+        props: { title: "Say hello", description: "We reply fast" },
+      }),
+    ]);
+    expect(html).toContain("Say hello");
+    expect(html).toContain("We reply fast");
+  });
+
+  it("renders cookieSettingsLink with custom text", () => {
+    const html = renderBody([
+      block("cookieSettingsLink", { props: { text: "Your cookie choices" } }),
+    ]);
+    expect(html).toContain("Your cookie choices");
+  });
+
+  it("renders cookieSettingsLink with default text when prop is missing", () => {
+    const html = renderBody([block("cookieSettingsLink", { props: {} })]);
+    expect(html).toContain("Cookie settings");
+  });
+
+  it("renders consentVersion as the current version string", () => {
+    const html = renderBody([block("consentVersion", {})]);
+    expect(html).toContain("v3");
   });
 });

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -332,9 +332,14 @@ function BlockView({ block }: { block: ContentBlock }) {
     case CUSTOM_BLOCK_TYPES.personGrid: {
       const slugs = stringProp(block, "slugs");
       if (!slugs) return null;
-      return (
-        <mdxComponents.PersonGrid slugs={slugs.split(",").filter(Boolean)} />
-      );
+      // Normalise the stored CSV: trim each segment, drop empties - so
+      // "alice, bob" and stray commas render correctly.
+      const parsed = slugs.split(",").flatMap((s) => {
+        const trimmed = s.trim();
+        return trimmed ? [trimmed] : [];
+      });
+      if (parsed.length === 0) return null;
+      return <mdxComponents.PersonGrid slugs={parsed} />;
     }
 
     case CUSTOM_BLOCK_TYPES.gamePreview: {

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -380,6 +380,44 @@ function BlockView({ block }: { block: ContentBlock }) {
       return <mdxComponents.Image src={src} alt={alt} caption={caption} />;
     }
 
+    case CUSTOM_BLOCK_TYPES.leagueTable: {
+      const divisionId = stringProp(block, "divisionId");
+      // Required prop: degrade silently when missing.
+      if (!divisionId) return null;
+      return (
+        <mdxComponents.LeagueTable
+          divisionId={divisionId}
+          name={stringProp(block, "name")}
+        />
+      );
+    }
+
+    case CUSTOM_BLOCK_TYPES.leaderboard:
+      return <mdxComponents.Leaderboard />;
+
+    case CUSTOM_BLOCK_TYPES.recordsWall:
+      return <mdxComponents.RecordsWall />;
+
+    case CUSTOM_BLOCK_TYPES.contactForm:
+      return (
+        <mdxComponents.ContactForm
+          title={stringProp(block, "title")}
+          description={stringProp(block, "description")}
+        />
+      );
+
+    case CUSTOM_BLOCK_TYPES.cookieSettingsLink: {
+      const text = stringProp(block, "text") ?? "Cookie settings";
+      return (
+        <mdxComponents.CookieSettingsLink>
+          {text}
+        </mdxComponents.CookieSettingsLink>
+      );
+    }
+
+    case CUSTOM_BLOCK_TYPES.consentVersion:
+      return <mdxComponents.ConsentVersion />;
+
     default:
       // Unknown / not-yet-supported block types degrade silently.
       return null;

--- a/apps/web/src/pages/admin/content-editor.schema.test.ts
+++ b/apps/web/src/pages/admin/content-editor.schema.test.ts
@@ -1,0 +1,102 @@
+import { CUSTOM_BLOCK_TYPES } from "@percy-main/shared/content";
+import { describe, expect, it, vi } from "vitest";
+
+// The editor schema is constructed at module load by createReactBlockSpec
+// calls that use @blocknote/react and @blocknote/shadcn. Neither package
+// functions outside a browser/JSDOM environment, so we stub the parts
+// that touch DOM APIs.  We only need the schema's blockSpecs keys - the
+// actual block render functions are irrelevant to this assertion.
+
+vi.mock("@blocknote/react", () => ({
+  createReactBlockSpec: (config: { type: string }) => () => ({
+    config,
+    implementation: {},
+  }),
+  getDefaultReactSlashMenuItems: () => [],
+  SuggestionMenuController: () => null,
+  useCreateBlockNote: () => ({}),
+}));
+
+vi.mock("@blocknote/core", () => ({
+  BlockNoteSchema: {
+    create: (opts: { blockSpecs: Record<string, unknown> }) => ({
+      blockSpecs: opts.blockSpecs,
+      BlockNoteEditor: null,
+      PartialBlock: null,
+    }),
+  },
+  defaultBlockSpecs: {
+    paragraph: {},
+    heading: {},
+    bulletListItem: {},
+    numberedListItem: {},
+    checkListItem: {},
+    table: {},
+    codeBlock: {},
+    quote: {},
+    image: {},
+    video: {},
+    audio: {},
+    file: {},
+  },
+  filterSuggestionItems: (_items: unknown[], _query: string) => [],
+  insertOrUpdateBlockForSlashMenu: () => undefined,
+}));
+
+vi.mock("@blocknote/shadcn", () => ({
+  BlockNoteView: () => null,
+}));
+
+vi.mock("@blocknote/core/fonts/inter.css", () => ({}));
+vi.mock("@blocknote/shadcn/style.css", () => ({}));
+
+// Stub all downstream imports that touch Vite-specific transforms or DOM.
+vi.mock("@/lib/people.js", () => ({
+  getAllPeople: () => [],
+  getPersonBySlug: () => undefined,
+}));
+vi.mock("@/lib/image-map.js", () => ({
+  getImageUrl: () => undefined,
+  getPicture: () => undefined,
+}));
+vi.mock("@/components/leaderboard-content.js", () => ({
+  LeaderboardContent: () => null,
+}));
+vi.mock("@/components/records-wall.js", () => ({
+  RecordsWall: () => null,
+}));
+vi.mock("@/lib/marketing/consent.js", () => ({
+  CURRENT_CONSENT_VERSION: "v3",
+  requestConsentReopen: () => undefined,
+}));
+vi.mock("@/lib/content-images.js", () => ({
+  uploadContentImage: () => Promise.resolve({}),
+}));
+vi.mock("@/lib/api-client.js", () => ({
+  api: {},
+  callApi: () => Promise.resolve({}),
+}));
+vi.mock("@/hooks/use-has-permission.js", () => ({
+  useHasPermission: () => ({ allowed: false }),
+}));
+vi.mock("./content-kind-labels.js", () => ({
+  CONTENT_KIND_NOUNS: {},
+}));
+vi.mock("./pages-tab.lib.js", () => ({
+  buildPageTree: () => [],
+  visibleNodes: () => [],
+}));
+
+// Dynamic import so vi.mock calls above are hoisted before module execution.
+const { schema } = await import("./content-editor.js");
+
+describe("content-editor schema", () => {
+  it("registers a blockSpec for every CUSTOM_BLOCK_TYPES value", () => {
+    const registeredKeys = new Set(Object.keys(schema.blockSpecs));
+    for (const blockType of Object.values(CUSTOM_BLOCK_TYPES)) {
+      expect(registeredKeys, `missing blockSpec for "${blockType}"`).toContain(
+        blockType,
+      );
+    }
+  });
+});

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -317,6 +317,238 @@ const contentImageBlock = createReactBlockSpec(
   },
 );
 
+const personGridBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.personGrid,
+    propSchema: {
+      // Comma-separated person slugs - same storage format as content-body
+      slugs: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const selected = block.props.slugs
+        ? block.props.slugs.split(",").filter(Boolean)
+        : [];
+      const allPeople = getAllPeople();
+      return (
+        <div className="my-2 flex w-full flex-col gap-2">
+          {selected.length > 0 ? (
+            <div className="pointer-events-none" aria-hidden>
+              <mdxComponents.PersonGrid slugs={selected} />
+            </div>
+          ) : (
+            <p className="text-sm text-stone-500">Choose people to display…</p>
+          )}
+          <div className="flex flex-col gap-1">
+            <p className="text-xs text-stone-500">
+              Select people (hold Ctrl/Cmd to pick multiple):
+            </p>
+            <select
+              aria-label="People"
+              multiple
+              size={Math.min(allPeople.length, 6)}
+              value={selected}
+              onChange={(e) => {
+                const chosen = Array.from(e.target.selectedOptions).map(
+                  (o) => o.value,
+                );
+                editor.updateBlock(block, {
+                  props: { ...block.props, slugs: chosen.join(",") },
+                });
+              }}
+              className="rounded border border-stone-300 bg-white p-1 text-sm"
+            >
+              {allPeople.map((p) => (
+                <option key={p.slug} value={p.slug}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      );
+    },
+  },
+);
+
+const leagueTableBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.leagueTable,
+    propSchema: {
+      divisionId: { default: "" },
+      name: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const set = (key: "divisionId" | "name", value: string) => {
+        editor.updateBlock(block, { props: { ...block.props, [key]: value } });
+      };
+      return (
+        <div className="my-2 flex w-full flex-col gap-2">
+          {block.props.divisionId ? (
+            <div className="pointer-events-none" aria-hidden>
+              <mdxComponents.LeagueTable
+                divisionId={block.props.divisionId}
+                name={block.props.name || undefined}
+              />
+            </div>
+          ) : (
+            <p className="text-sm text-stone-500">
+              Enter a division ID to preview…
+            </p>
+          )}
+          <input
+            aria-label="Division ID"
+            placeholder="Division ID (required)"
+            value={block.props.divisionId}
+            onChange={(e) => {
+              set("divisionId", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Table heading"
+            placeholder="Table heading (optional)"
+            value={block.props.name}
+            onChange={(e) => {
+              set("name", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+        </div>
+      );
+    },
+  },
+);
+
+const leaderboardBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.leaderboard,
+    propSchema: {},
+    content: "none",
+  },
+  {
+    render: () => (
+      <div className="pointer-events-none my-2 w-full" aria-hidden>
+        <mdxComponents.Leaderboard />
+      </div>
+    ),
+  },
+);
+
+const recordsWallBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.recordsWall,
+    propSchema: {},
+    content: "none",
+  },
+  {
+    render: () => (
+      <div className="pointer-events-none my-2 w-full" aria-hidden>
+        <mdxComponents.RecordsWall />
+      </div>
+    ),
+  },
+);
+
+const contactFormBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.contactForm,
+    propSchema: {
+      title: { default: "" },
+      description: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const set = (key: "title" | "description", value: string) => {
+        editor.updateBlock(block, { props: { ...block.props, [key]: value } });
+      };
+      return (
+        <div className="my-2 flex w-full flex-col gap-2">
+          {/* Wrap preview in pointer-events-none so the form can't be submitted inside the editor */}
+          <div className="pointer-events-none" aria-hidden>
+            <mdxComponents.ContactForm
+              title={block.props.title || undefined}
+              description={block.props.description || undefined}
+            />
+          </div>
+          <input
+            aria-label="Form title"
+            placeholder="Form title (optional)"
+            value={block.props.title}
+            onChange={(e) => {
+              set("title", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Form description"
+            placeholder="Description shown above the fields (optional)"
+            value={block.props.description}
+            onChange={(e) => {
+              set("description", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+        </div>
+      );
+    },
+  },
+);
+
+const cookieSettingsLinkBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.cookieSettingsLink,
+    propSchema: {
+      text: { default: "Cookie settings" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => (
+      <div className="my-2 flex w-full flex-col gap-2">
+        <div className="pointer-events-none" aria-hidden>
+          <mdxComponents.CookieSettingsLink>
+            {block.props.text || "Cookie settings"}
+          </mdxComponents.CookieSettingsLink>
+        </div>
+        <input
+          aria-label="Link text"
+          placeholder="Link text"
+          value={block.props.text}
+          onChange={(e) => {
+            editor.updateBlock(block, {
+              props: { ...block.props, text: e.target.value },
+            });
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        />
+      </div>
+    ),
+  },
+);
+
+const consentVersionBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.consentVersion,
+    propSchema: {},
+    content: "none",
+  },
+  {
+    render: () => (
+      <div className="pointer-events-none my-2" aria-hidden>
+        <mdxComponents.ConsentVersion />
+      </div>
+    ),
+  },
+);
+
 // BlockNote's built-in media blocks are removed: their URL-embed tab
 // would bypass the consent + EXIF-strip + responsive pipeline that the
 // contentImage block (slash menu "Upload photo") goes through.
@@ -328,13 +560,20 @@ const {
   ...allowedDefaultBlocks
 } = defaultBlockSpecs;
 
-const schema = BlockNoteSchema.create({
+export const schema = BlockNoteSchema.create({
   blockSpecs: {
     ...allowedDefaultBlocks,
     [CUSTOM_BLOCK_TYPES.person]: personBlock(),
+    [CUSTOM_BLOCK_TYPES.personGrid]: personGridBlock(),
     [CUSTOM_BLOCK_TYPES.gamePreview]: gamePreviewBlock(),
     [CUSTOM_BLOCK_TYPES.eventPreview]: eventPreviewBlock(),
     [CUSTOM_BLOCK_TYPES.contentImage]: contentImageBlock(),
+    [CUSTOM_BLOCK_TYPES.leagueTable]: leagueTableBlock(),
+    [CUSTOM_BLOCK_TYPES.leaderboard]: leaderboardBlock(),
+    [CUSTOM_BLOCK_TYPES.recordsWall]: recordsWallBlock(),
+    [CUSTOM_BLOCK_TYPES.contactForm]: contactFormBlock(),
+    [CUSTOM_BLOCK_TYPES.cookieSettingsLink]: cookieSettingsLinkBlock(),
+    [CUSTOM_BLOCK_TYPES.consentVersion]: consentVersionBlock(),
   },
 });
 
@@ -397,6 +636,18 @@ function buildSlashItems(editor: Editor, startImageUpload: () => void) {
       },
     },
     {
+      title: "Person grid",
+      subtext: "Show a grid of club member cards",
+      group: "Club content",
+      aliases: ["people", "grid", "team"],
+      icon: <span aria-hidden>👥</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.personGrid,
+        });
+      },
+    },
+    {
       title: "Game preview",
       subtext: "Link a Play-Cricket fixture or result",
       group: "Club content",
@@ -427,6 +678,78 @@ function buildSlashItems(editor: Editor, startImageUpload: () => void) {
       aliases: ["image", "photo", "picture"],
       icon: <span aria-hidden>📷</span>,
       onItemClick: startImageUpload,
+    },
+    {
+      title: "League table",
+      subtext: "Show a live Play-Cricket league standings table",
+      group: "Page widgets",
+      aliases: ["league", "table", "standings", "division"],
+      icon: <span aria-hidden>📊</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.leagueTable,
+        });
+      },
+    },
+    {
+      title: "Leaderboard",
+      subtext: "Show the club batting and bowling leaderboard",
+      group: "Page widgets",
+      aliases: ["leaderboard", "stats", "averages"],
+      icon: <span aria-hidden>🏆</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.leaderboard,
+        });
+      },
+    },
+    {
+      title: "Records wall",
+      subtext: "Show the club batting and bowling records",
+      group: "Page widgets",
+      aliases: ["records", "records wall"],
+      icon: <span aria-hidden>🎖️</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.recordsWall,
+        });
+      },
+    },
+    {
+      title: "Contact form",
+      subtext: "Embed a contact message form",
+      group: "Page widgets",
+      aliases: ["contact", "form", "message"],
+      icon: <span aria-hidden>✉️</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.contactForm,
+        });
+      },
+    },
+    {
+      title: "Cookie settings link",
+      subtext: "Inline link that reopens the cookie consent banner",
+      group: "Page widgets",
+      aliases: ["cookie", "consent", "gdpr", "privacy"],
+      icon: <span aria-hidden>🍪</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.cookieSettingsLink,
+        });
+      },
+    },
+    {
+      title: "Consent version",
+      subtext: "Display the current cookie consent policy version string",
+      group: "Page widgets",
+      aliases: ["consent version", "policy version"],
+      icon: <span aria-hidden>📋</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.consentVersion,
+        });
+      },
     },
   ];
 }

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -74,6 +74,7 @@ import {
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CONTENT_KIND_NOUNS } from "./content-kind-labels.js";
+import { EditorBlockPreview } from "./editor-block-preview.js";
 import { buildPageTree, visibleNodes } from "./pages-tab.lib.js";
 
 // ── Custom blocks ───────────────────────────────────────────────────────
@@ -95,10 +96,12 @@ const personBlock = createReactBlockSpec(
     render: ({ block, editor }) => (
       <div className="my-2 flex w-full max-w-xs flex-col gap-2">
         {block.props.slug ? (
-          <mdxComponents.Person
-            slug={block.props.slug}
-            role={block.props.role || undefined}
-          />
+          <EditorBlockPreview>
+            <mdxComponents.Person
+              slug={block.props.slug}
+              role={block.props.role || undefined}
+            />
+          </EditorBlockPreview>
         ) : (
           <p className="text-sm text-stone-500">Choose a person…</p>
         )}
@@ -147,9 +150,11 @@ const gamePreviewBlock = createReactBlockSpec(
     render: ({ block, editor }) => (
       <div className="my-2 w-full">
         {block.props.playCricketId ? (
-          <mdxComponents.GamePreview
-            playCricketId={block.props.playCricketId}
-          />
+          <EditorBlockPreview>
+            <mdxComponents.GamePreview
+              playCricketId={block.props.playCricketId}
+            />
+          </EditorBlockPreview>
         ) : (
           <p className="text-sm text-stone-500">Choose a game…</p>
         )}
@@ -188,11 +193,13 @@ const eventPreviewBlock = createReactBlockSpec(
       return (
         <div className="my-2 flex w-full max-w-sm flex-col gap-2">
           {complete ? (
-            <mdxComponents.EventPreview
-              id={block.props.eventId}
-              name={block.props.name}
-              when={block.props.when}
-            />
+            <EditorBlockPreview>
+              <mdxComponents.EventPreview
+                id={block.props.eventId}
+                name={block.props.name}
+                when={block.props.when}
+              />
+            </EditorBlockPreview>
           ) : (
             <p className="text-sm text-stone-500">Fill in the event details…</p>
           )}
@@ -273,22 +280,24 @@ const contentImageBlock = createReactBlockSpec(
       const picture = parsePictureProp(block.props.picture);
       return (
         <figure className="my-2 flex w-full max-w-lg flex-col gap-2">
-          {picture ? (
-            <OptimisedImage
-              picture={picture}
-              alt={block.props.alt}
-              className="h-auto max-w-full rounded-lg"
-              sizes="(max-width: 512px) 100vw, 512px"
-            />
-          ) : block.props.src ? (
-            <img
-              src={block.props.src}
-              alt={block.props.alt}
-              className="h-auto max-w-full rounded-lg"
-            />
-          ) : (
-            <p className="text-sm text-stone-500">Image uploading…</p>
-          )}
+          <EditorBlockPreview>
+            {picture ? (
+              <OptimisedImage
+                picture={picture}
+                alt={block.props.alt}
+                className="h-auto max-w-full rounded-lg"
+                sizes="(max-width: 512px) 100vw, 512px"
+              />
+            ) : block.props.src ? (
+              <img
+                src={block.props.src}
+                alt={block.props.alt}
+                className="h-auto max-w-full rounded-lg"
+              />
+            ) : (
+              <p className="text-sm text-stone-500">Image uploading…</p>
+            )}
+          </EditorBlockPreview>
           <input
             aria-label="Caption"
             placeholder="Caption (optional)"
@@ -328,16 +337,19 @@ const personGridBlock = createReactBlockSpec(
   },
   {
     render: ({ block, editor }) => {
-      const selected = block.props.slugs
-        ? block.props.slugs.split(",").filter(Boolean)
-        : [];
+      // Same CSV normalisation as the public renderer: trim each
+      // segment, drop empties - "alice, bob" works either side.
+      const selected = block.props.slugs.split(",").flatMap((s) => {
+        const trimmed = s.trim();
+        return trimmed ? [trimmed] : [];
+      });
       const allPeople = getAllPeople();
       return (
         <div className="my-2 flex w-full flex-col gap-2">
           {selected.length > 0 ? (
-            <div className="pointer-events-none" aria-hidden>
+            <EditorBlockPreview>
               <mdxComponents.PersonGrid slugs={selected} />
-            </div>
+            </EditorBlockPreview>
           ) : (
             <p className="text-sm text-stone-500">Choose people to display…</p>
           )}
@@ -390,12 +402,12 @@ const leagueTableBlock = createReactBlockSpec(
       return (
         <div className="my-2 flex w-full flex-col gap-2">
           {block.props.divisionId ? (
-            <div className="pointer-events-none" aria-hidden>
+            <EditorBlockPreview>
               <mdxComponents.LeagueTable
                 divisionId={block.props.divisionId}
                 name={block.props.name || undefined}
               />
-            </div>
+            </EditorBlockPreview>
           ) : (
             <p className="text-sm text-stone-500">
               Enter a division ID to preview…
@@ -433,9 +445,9 @@ const leaderboardBlock = createReactBlockSpec(
   },
   {
     render: () => (
-      <div className="pointer-events-none my-2 w-full" aria-hidden>
+      <EditorBlockPreview className="my-2 w-full">
         <mdxComponents.Leaderboard />
-      </div>
+      </EditorBlockPreview>
     ),
   },
 );
@@ -448,9 +460,9 @@ const recordsWallBlock = createReactBlockSpec(
   },
   {
     render: () => (
-      <div className="pointer-events-none my-2 w-full" aria-hidden>
+      <EditorBlockPreview className="my-2 w-full">
         <mdxComponents.RecordsWall />
-      </div>
+      </EditorBlockPreview>
     ),
   },
 );
@@ -471,13 +483,14 @@ const contactFormBlock = createReactBlockSpec(
       };
       return (
         <div className="my-2 flex w-full flex-col gap-2">
-          {/* Wrap preview in pointer-events-none so the form can't be submitted inside the editor */}
-          <div className="pointer-events-none" aria-hidden>
+          {/* Inert preview: the form must not be focusable or submittable
+              (mouse OR keyboard) inside the editor canvas */}
+          <EditorBlockPreview>
             <mdxComponents.ContactForm
               title={block.props.title || undefined}
               description={block.props.description || undefined}
             />
-          </div>
+          </EditorBlockPreview>
           <input
             aria-label="Form title"
             placeholder="Form title (optional)"
@@ -513,11 +526,11 @@ const cookieSettingsLinkBlock = createReactBlockSpec(
   {
     render: ({ block, editor }) => (
       <div className="my-2 flex w-full flex-col gap-2">
-        <div className="pointer-events-none" aria-hidden>
+        <EditorBlockPreview>
           <mdxComponents.CookieSettingsLink>
             {block.props.text || "Cookie settings"}
           </mdxComponents.CookieSettingsLink>
-        </div>
+        </EditorBlockPreview>
         <input
           aria-label="Link text"
           placeholder="Link text"
@@ -542,9 +555,9 @@ const consentVersionBlock = createReactBlockSpec(
   },
   {
     render: () => (
-      <div className="pointer-events-none my-2" aria-hidden>
+      <EditorBlockPreview className="my-2">
         <mdxComponents.ConsentVersion />
-      </div>
+      </EditorBlockPreview>
     ),
   },
 );

--- a/apps/web/src/pages/admin/editor-block-preview.test.tsx
+++ b/apps/web/src/pages/admin/editor-block-preview.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { EditorBlockPreview } from "./editor-block-preview.js";
+
+describe("EditorBlockPreview", () => {
+  it("marks the wrapper inert so nested controls are not focusable or activatable", () => {
+    const html = renderToStaticMarkup(
+      <EditorBlockPreview>
+        <button type="button">should be unreachable</button>
+      </EditorBlockPreview>,
+    );
+    // React 19 renders the boolean inert prop as a bare attribute. inert
+    // blocks focus, keyboard activation and pointer events, and carries
+    // aria-hidden semantics - the keyboard half of read-only previews.
+    expect(html).toMatch(/<div[^>]*\binert\b/);
+    // pointer-events-none stays as a fallback for partial inert support.
+    expect(html).toContain("pointer-events-none");
+    expect(html).toContain("should be unreachable");
+  });
+
+  it("merges extra classes onto the wrapper", () => {
+    const html = renderToStaticMarkup(
+      <EditorBlockPreview className="my-2 w-full">
+        <span>preview</span>
+      </EditorBlockPreview>,
+    );
+    expect(html).toContain("my-2");
+    expect(html).toContain("w-full");
+    expect(html).toContain("pointer-events-none");
+  });
+});

--- a/apps/web/src/pages/admin/editor-block-preview.tsx
+++ b/apps/web/src/pages/admin/editor-block-preview.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils.js";
+import type { ReactNode } from "react";
+
+/**
+ * Shared non-interactive wrapper for in-editor previews of custom
+ * blocks. The `inert` attribute (a React 19 boolean prop) blocks focus
+ * and keyboard activation as well as pointer interaction, and carries
+ * aria-hidden semantics - so nested forms, buttons and links (contact
+ * form submit, cookie-consent reopen, leaderboard URL state, profile
+ * links) can't be activated from inside the editor canvas.
+ * pointer-events-none stays as a belt-and-braces fallback for browsers
+ * with partial inert support.
+ */
+export function EditorBlockPreview({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div inert className={cn("pointer-events-none select-none", className)}>
+      {children}
+    </div>
+  );
+}

--- a/docs/content-blocks.md
+++ b/docs/content-blocks.md
@@ -1,0 +1,169 @@
+# Content blocks reference
+
+Every custom block available in the content editor. Use the `/` slash menu while editing to insert them.
+
+Blocks are stored as part of the page body and render identically whether the page was authored with the editor or migrated from an older MDX file.
+
+---
+
+## Person card
+
+**Slash menu:** Club content > Person card
+
+Displays a profile card for a single club member, including their photo, name, and a link to their full profile page.
+
+| Prop | Type   | Required | Default | Notes                                                     |
+| ---- | ------ | -------- | ------- | --------------------------------------------------------- |
+| slug | string | Yes      |         | The person's URL slug (e.g. `alex-slaven`)                |
+| role | string | No       |         | Optional label shown beneath the name (e.g. "Head Coach") |
+
+**Typical usage:** Introduce a committee member or coach on a team page.
+
+---
+
+## Person grid
+
+**Slash menu:** Club content > Person grid
+
+Displays a responsive grid of person cards. Choose one or more people using the multi-select control inside the editor (hold Ctrl or Cmd to pick more than one).
+
+| Prop  | Type   | Required | Default | Notes                                                                                         |
+| ----- | ------ | -------- | ------- | --------------------------------------------------------------------------------------------- |
+| slugs | string | Yes      |         | Comma-separated list of person slugs (stored and managed automatically by the editor control) |
+
+**Typical usage:** Show the full committee, a coaching team, or the playing squad on an "About" page.
+
+---
+
+## Game preview
+
+**Slash menu:** Club content > Game preview
+
+Shows a live fixture or result card, pulling data from Play-Cricket. Displays the teams, date, competition, home/away indicator, and the final score where available.
+
+| Prop          | Type   | Required | Default | Notes                                                                      |
+| ------------- | ------ | -------- | ------- | -------------------------------------------------------------------------- |
+| playCricketId | string | Yes      |         | The Play-Cricket match identifier (choose from the dropdown in the editor) |
+
+**Typical usage:** Highlight a recent result or upcoming fixture inside a news article or report.
+
+---
+
+## Event preview
+
+**Slash menu:** Club content > Event preview
+
+Shows a compact event card with the date, name, and a link to the full calendar entry.
+
+| Prop    | Type   | Required | Default | Notes                                 |
+| ------- | ------ | -------- | ------- | ------------------------------------- |
+| eventId | string | Yes      |         | The internal event identifier         |
+| name    | string | Yes      |         | The event display name                |
+| when    | string | Yes      |         | The event date (ISO date or datetime) |
+
+**Typical usage:** Promote an upcoming club event from within a page or news post.
+
+---
+
+## Upload photo
+
+**Slash menu:** Club content > Upload photo
+
+Uploads an image through the consent and processing pipeline and inserts a responsive photo block. You must tick the photo consent box in the left panel before uploading.
+
+| Prop    | Type   | Required | Default | Notes                                                             |
+| ------- | ------ | -------- | ------- | ----------------------------------------------------------------- |
+| src     | string | Yes      |         | Set automatically after upload                                    |
+| alt     | string | No       |         | Describe the photo for screen readers                             |
+| caption | string | No       |         | Short caption shown beneath the image                             |
+| picture | string | No       |         | JSON descriptor used for responsive rendering (set automatically) |
+
+**Typical usage:** Add match photos, venue images, or team photos to a page or article.
+
+---
+
+## League table
+
+**Slash menu:** Page widgets > League table
+
+Fetches and displays a live standings table from Play-Cricket for a given division.
+
+If `divisionId` is not set the block renders nothing (degrades silently). No division listing is currently available through the API, so you need to look up the division ID from Play-Cricket directly.
+
+| Prop       | Type   | Required | Default | Notes                                |
+| ---------- | ------ | -------- | ------- | ------------------------------------ |
+| divisionId | string | Yes      |         | The Play-Cricket division identifier |
+| name       | string | No       |         | Heading shown above the table        |
+
+**Typical usage:** Embed the current season standings on a teams or results page.
+
+---
+
+## Leaderboard
+
+**Slash menu:** Page widgets > Leaderboard
+
+Displays the club's batting and bowling leaderboard for the current season. No configuration required.
+
+| Prop   | Type | Required | Default | Notes |
+| ------ | ---- | -------- | ------- | ----- |
+| (none) |      |          |         |       |
+
+**Typical usage:** Add to a stats or season summary page.
+
+---
+
+## Records wall
+
+**Slash menu:** Page widgets > Records wall
+
+Displays the club's all-time batting and bowling records. No configuration required.
+
+| Prop   | Type | Required | Default | Notes |
+| ------ | ---- | -------- | ------- | ----- |
+| (none) |      |          |         |       |
+
+**Typical usage:** Add to a history or honours page.
+
+---
+
+## Contact form
+
+**Slash menu:** Page widgets > Contact form
+
+Embeds a contact message form. Submissions are sent by email to the club. The form cannot be submitted from inside the editor canvas (it is read-only there).
+
+| Prop        | Type   | Required | Default | Notes                                 |
+| ----------- | ------ | -------- | ------- | ------------------------------------- |
+| title       | string | No       |         | Heading shown above the form fields   |
+| description | string | No       |         | Short paragraph shown below the title |
+
+**Typical usage:** Add to a "Contact us" page or any page where you want people to be able to send the club a message.
+
+---
+
+## Cookie settings link
+
+**Slash menu:** Page widgets > Cookie settings link
+
+Renders an inline link that, when clicked, reopens the cookie consent banner so the visitor can change their preferences.
+
+| Prop | Type   | Required | Default         | Notes                 |
+| ---- | ------ | -------- | --------------- | --------------------- |
+| text | string | No       | Cookie settings | The visible link text |
+
+**Typical usage:** Add to a Privacy Policy or Cookie Policy page so readers can update their preferences without hunting for a button.
+
+---
+
+## Consent version
+
+**Slash menu:** Page widgets > Consent version
+
+Displays the current cookie consent policy version string inline in the text. Useful on policy pages where you want to reference which version of the policy is currently active.
+
+| Prop   | Type | Required | Default | Notes |
+| ------ | ---- | -------- | ------- | ----- |
+| (none) |      |          |         |       |
+
+**Typical usage:** Include in the cookie or privacy policy page body so the version number stays accurate without manual editing.

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -191,4 +191,10 @@ export const CUSTOM_BLOCK_TYPES = {
   // PictureSource descriptor from the upload API so public pages render
   // the responsive ladder without any lookup.
   contentImage: "contentImage",
+  leagueTable: "leagueTable",
+  leaderboard: "leaderboard",
+  recordsWall: "recordsWall",
+  contactForm: "contactForm",
+  cookieSettingsLink: "cookieSettingsLink",
+  consentVersion: "consentVersion",
 } as const;


### PR DESCRIPTION
Part of epic #492 (targets the epic branch). Closes #495.

## What
Every component in mdx-components.tsx is now insertable from the editor and renders through ContentBody (pre-release gate for Phase 3):

- New custom block types (shared constant + editor block + slash item + renderer mapping): leagueTable (divisionId, name?), leaderboard, recordsWall, contactForm (title?, description?), cookieSettingsLink (text, default "Cookie settings"), consentVersion.
- personGrid had a renderer mapping but no editor block - added the insert block (people multi-select stored as CSV slugs).
- In-editor rendering: all four API-backed/interactive blocks render LIVE read-only inside the canvas (pointer-events-none + aria-hidden), same pattern as gamePreview; the contact form cannot be submitted in-editor. No placeholder cards needed.
- Slash menu: new "Page widgets" group (League table, Leaderboard, Records wall, Contact form, Cookie settings link, Consent version); "Person grid" joins "Club content".
- docs/content-blocks.md: one-page block/props reference for editors covering all 11 custom blocks.
- leagueTable uses text inputs for divisionId (no divisions listing endpoint exists in the API spec to drive a picker).

## Tests
web 532 (+11: fixture doc with every block type renders, per-block render tests, required-prop degradation, blockSpecs-covers-CUSTOM_BLOCK_TYPES pin), api 612, typecheck/lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)