### PR TITLE
feat(content): migrate pages/** to the database, except legal (#496)

### DIFF
--- a/apps/api/scripts/image-pipeline.ts
+++ b/apps/api/scripts/image-pipeline.ts
@@ -1,0 +1,183 @@
+import type { DB } from "@percy-main/db";
+import { promises as fs } from "fs";
+import type { Kysely } from "kysely";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  processImage,
+  type ProcessedImage,
+} from "../src/features/content-images/service.ts";
+import {
+  CONTENT_IMAGES_PREFIX,
+  type ContentImageStore,
+} from "../src/lib/s3-content-images.ts";
+import type { MigrationBlock } from "./markdown-to-blocks.ts";
+import { imageIdForAsset, mdxToBlocks } from "./mdx-to-blocks.ts";
+
+// Shared <Image> handling for the MDX content migrations (#491 news +
+// events, #496 pages): every corpus references its images by public
+// "/images/..." path, which the web app's image-map resolves to files
+// under src/assets/images/. Each one goes through the same processing
+// pipeline as editor uploads (responsive WebP ladder + original-format
+// fallback in S3, registered in content_image), with UUIDv5 ids derived
+// from the source path so re-runs are idempotent.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ASSETS_DIR = path.resolve(__dirname, "../../web/src/assets/images");
+
+export class MissingImageError extends Error {
+  constructor(publicPath: string) {
+    super(`image file not found on disk for '${publicPath}'`);
+  }
+}
+
+export interface PendingImage {
+  imageId: string;
+  publicPath: string;
+  alt: string | null;
+  processed: ProcessedImage;
+  bytes: number;
+}
+
+export interface Converted {
+  blocks: MigrationBlock[];
+  images: PendingImage[];
+}
+
+/**
+ * Convert one MDX body, resolving each <Image> through the editor-upload
+ * processing pipeline (locally - nothing is written here, so --dry-run
+ * conversion is complete and writes can be deferred until after the
+ * skip/insert decision). The processed-image cache spans articles so a
+ * re-used asset is only decoded once.
+ */
+export async function convertBody(
+  body: string,
+  cache: Map<string, PendingImage>,
+): Promise<Converted> {
+  const images: PendingImage[] = [];
+  const blocks = await mdxToBlocks(body, async ({ src, alt, caption }) => {
+    const imageId = imageIdForAsset(src);
+    let pending = cache.get(imageId);
+    if (!pending) {
+      if (!src.startsWith("/images/")) {
+        throw new Error(`unexpected image src '${src}'`);
+      }
+      const assetPath = path.resolve(ASSETS_DIR, src.slice("/images/".length));
+      // A '..' segment in the src could otherwise resolve outside the
+      // bundled assets tree and upload an arbitrary readable file.
+      if (!assetPath.startsWith(ASSETS_DIR + path.sep)) {
+        throw new Error(`image src '${src}' escapes the assets directory`);
+      }
+      let original: Buffer;
+      try {
+        original = await fs.readFile(assetPath);
+      } catch {
+        throw new MissingImageError(src);
+      }
+      const processed = await processImage(
+        original,
+        imageId,
+        CONTENT_IMAGES_PREFIX,
+      );
+      pending = {
+        imageId,
+        publicPath: src,
+        alt: alt ?? null,
+        processed,
+        bytes: original.byteLength,
+      };
+      cache.set(imageId, pending);
+    }
+    images.push(pending);
+    // Exactly the prop set the editor inserts (content-editor.tsx): the
+    // plain src falls back to the ladder's largest original-format
+    // variant, picture carries the JSON-stringified PictureSource.
+    return {
+      src: pending.processed.picture.img.src,
+      alt: alt ?? "",
+      caption: caption ?? "",
+      picture: JSON.stringify(pending.processed.picture),
+    };
+  });
+  return { blocks, images };
+}
+
+/**
+ * Upload variants + register rows for an item's images (idempotent -
+ * existing content_image rows are reused). Returns the upload/reuse
+ * tallies for the run summary.
+ */
+export async function ensureImages(
+  db: Kysely<DB>,
+  store: ContentImageStore,
+  userId: string,
+  images: PendingImage[],
+): Promise<{ uploaded: number; reused: number }> {
+  let uploaded = 0;
+  let reused = 0;
+  for (const image of images) {
+    const existing = await db
+      .selectFrom("content_image")
+      .select("id")
+      .where("id", "=", image.imageId)
+      .executeTakeFirst();
+    if (existing) {
+      reused += 1;
+      continue;
+    }
+    for (const variant of image.processed.variants) {
+      await store.putVariant(variant.key, variant.body, variant.contentType);
+    }
+    await db
+      .insertInto("content_image")
+      .values({
+        id: image.imageId,
+        key_prefix: `${CONTENT_IMAGES_PREFIX}/${image.imageId}`,
+        original_format: image.processed.sourceFormat,
+        width: image.processed.width,
+        height: image.processed.height,
+        bytes: image.bytes,
+        picture: JSON.stringify(image.processed.picture),
+        alt: image.alt,
+        consent_confirmed: true,
+        uploaded_by: userId,
+      })
+      .onConflict((oc) => oc.column("id").doNothing())
+      .execute();
+    uploaded += 1;
+    console.log(
+      `    ^ uploaded ${image.publicPath} -> ${CONTENT_IMAGES_PREFIX}/${image.imageId}/ (${String(image.processed.variants.length)} variants)`,
+    );
+  }
+  return { uploaded, reused };
+}
+
+/**
+ * Dry-run counterpart of ensureImages: split an item's images into
+ * would-upload (new) and reused, deduplicating across items via the
+ * caller's plannedUploads set so a shared asset is only counted once.
+ */
+export async function planImageUploads(
+  db: Kysely<DB>,
+  images: PendingImage[],
+  plannedUploads: Set<string>,
+): Promise<{ newImages: PendingImage[]; reused: number }> {
+  const newImages: PendingImage[] = [];
+  let reused = 0;
+  for (const image of images) {
+    if (plannedUploads.has(image.imageId)) continue;
+    const row = await db
+      .selectFrom("content_image")
+      .select("id")
+      .where("id", "=", image.imageId)
+      .executeTakeFirst();
+    if (row) {
+      reused += 1;
+    } else {
+      newImages.push(image);
+      plannedUploads.add(image.imageId);
+    }
+  }
+  return { newImages, reused };
+}

--- a/apps/api/scripts/mdx-to-blocks.test.ts
+++ b/apps/api/scripts/mdx-to-blocks.test.ts
@@ -1,5 +1,6 @@
 import {
   contentBodySchema,
+  CUSTOM_BLOCK_TYPES,
   eventMetadataSchema,
 } from "@percy-main/shared/content";
 import { describe, expect, it, vi } from "vitest";
@@ -12,6 +13,7 @@ import {
   newsPublishedAt,
   parseEventSource,
   parseNewsSource,
+  parsePageSource,
   resolveLocation,
   segmentMdx,
   type ResolveContentImage,
@@ -131,6 +133,150 @@ describe("segmentMdx", () => {
       { kind: "markdown", text: "The away side, 9th in Division Three, lost." },
     ]);
   });
+
+  it("lifts a bare markdown image paragraph into an Image segment", () => {
+    const segments = segmentMdx(
+      [
+        "##### Main Club Sponsor",
+        "",
+        "![The Crossling logo](/images/contentful/abc/logo.png)",
+        "",
+        "#### Weekly Schedule",
+      ].join("\n"),
+    );
+    expect(segments).toEqual([
+      { kind: "markdown", text: "##### Main Club Sponsor" },
+      {
+        kind: "component",
+        name: "Image",
+        attrs: {
+          src: "/images/contentful/abc/logo.png",
+          alt: "The Crossling logo",
+        },
+      },
+      { kind: "markdown", text: "#### Weekly Schedule" },
+    ]);
+  });
+
+  it("keeps an image inside a paragraph in the markdown segment", () => {
+    // Adjacent non-blank lines = one paragraph; lifting the image would
+    // split it, so it stays markdown (and markdownToBlocks rejects it).
+    const segments = segmentMdx(
+      ["Some text", "![alt](/images/x.png)", "more text"].join("\n"),
+    );
+    expect(segments).toEqual([
+      {
+        kind: "markdown",
+        text: "Some text\n![alt](/images/x.png)\nmore text",
+      },
+    ]);
+  });
+});
+
+describe("segmentMdx containers", () => {
+  it("parses PersonGrid children with slug + role fidelity", () => {
+    const segments = segmentMdx(
+      [
+        "### Captains",
+        "",
+        "<PersonGrid>",
+        '  <Person slug="alex-young" role="1st XI Captain" />',
+        '  <Person slug="john-allan" />',
+        "</PersonGrid>",
+      ].join("\n"),
+    );
+    expect(segments).toEqual([
+      { kind: "markdown", text: "### Captains" },
+      {
+        kind: "personGrid",
+        people: [
+          { slug: "alex-young", role: "1st XI Captain" },
+          { slug: "john-allan" },
+        ],
+      },
+    ]);
+  });
+
+  it("rejects a PersonGrid containing a non-Person element", () => {
+    expect(() =>
+      segmentMdx(
+        [
+          "<PersonGrid>",
+          '  <Person slug="a" />',
+          '  <Image src="/images/x.png" />',
+          "</PersonGrid>",
+        ].join("\n"),
+      ),
+    ).toThrow(/may only contain <Person \/> children/);
+  });
+
+  it("rejects a PersonGrid containing loose text", () => {
+    expect(() =>
+      segmentMdx(
+        [
+          "<PersonGrid>",
+          '  <Person slug="a" />',
+          "  hello",
+          "</PersonGrid>",
+        ].join("\n"),
+      ),
+    ).toThrow(/non-component content/);
+  });
+
+  it("rejects an empty PersonGrid", () => {
+    expect(() => segmentMdx("<PersonGrid>\n</PersonGrid>")).toThrow(
+      /no <Person> children/,
+    );
+  });
+
+  it("rejects a Person child without a slug", () => {
+    expect(() =>
+      segmentMdx('<PersonGrid>\n  <Person role="Coach" />\n</PersonGrid>'),
+    ).toThrow(/without slug/);
+  });
+
+  it("rejects the self-closing PersonGrid attribute form (corpus never uses it)", () => {
+    expect(() => segmentMdx('<PersonGrid slugs="a,b" />')).toThrow(
+      /without <Person> children/,
+    );
+  });
+
+  it("rejects an unclosed PersonGrid", () => {
+    expect(() => segmentMdx('<PersonGrid>\n  <Person slug="a" />')).toThrow(
+      /Unclosed <PersonGrid>/,
+    );
+  });
+
+  it("rejects an inline PersonGrid", () => {
+    expect(() =>
+      segmentMdx('Meet <PersonGrid>\n<Person slug="a" />\n</PersonGrid>'),
+    ).toThrow(/used inline/);
+  });
+
+  it("rejects a paired tag for a self-closing-only component", () => {
+    expect(() => segmentMdx("<Leaderboard></Leaderboard>")).toThrow(
+      /must be self-closing/,
+    );
+  });
+
+  it("takes paired CookieSettingsLink text from its children", () => {
+    const segments = segmentMdx(
+      "<CookieSettingsLink>Manage cookies</CookieSettingsLink>",
+    );
+    expect(segments).toEqual([
+      {
+        kind: "component",
+        name: "CookieSettingsLink",
+        attrs: { text: "Manage cookies" },
+      },
+    ]);
+  });
+
+  it("rejects CookieSettingsLink with tag-shaped children", () => {
+    expect(() =>
+      segmentMdx("<CookieSettingsLink><b>hi</b></CookieSettingsLink>"),
+    ).toThrow(/non-text children/);
+  });
 });
 
 describe("mdxToBlocks", () => {
@@ -212,10 +358,293 @@ describe("mdxToBlocks", () => {
     );
   });
 
-  it("still fails loudly on unsupported markdown constructs", async () => {
+  it("maps a bare markdown image through the contentImage pipeline", async () => {
+    const resolver = vi.fn(stubResolver);
+    const blocks = await mdxToBlocks(
+      "![The Crossling logo](/images/contentful/abc/logo.png)",
+      resolver,
+    );
+    expect(resolver).toHaveBeenCalledWith({
+      src: "/images/contentful/abc/logo.png",
+      alt: "The Crossling logo",
+      caption: undefined,
+    });
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ type: "contentImage" });
+  });
+
+  it("still fails loudly on an image inside a paragraph", async () => {
     await expect(
-      mdxToBlocks("![inline](/images/x.png)", stubResolver),
+      mdxToBlocks("An inline ![image](/images/x.png) here", stubResolver),
     ).rejects.toThrow(/Unsupported/);
+  });
+
+  it("still fails loudly on a linked image (the link would be dropped)", async () => {
+    await expect(
+      mdxToBlocks(
+        "[![VX3 Logo](/images/contentful/abc/vx3.webp)](https://kit.percymain.org)",
+        stubResolver,
+      ),
+    ).rejects.toThrow(/Unsupported/);
+  });
+});
+
+describe("mdxToBlocks page components", () => {
+  const single = async (body: string) => {
+    const blocks = await mdxToBlocks(body, stubResolver);
+    expect(blocks).toHaveLength(1);
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+    return blocks[0];
+  };
+
+  it("maps <Person> with the editor's prop set (role defaults empty)", async () => {
+    expect(
+      await single('<Person slug="paddy-rathbone" role="Welfare Officer" />'),
+    ).toMatchObject({
+      type: "person",
+      props: { slug: "paddy-rathbone", role: "Welfare Officer" },
+      children: [],
+    });
+    expect(await single('<Person slug="paddy-rathbone" />')).toMatchObject({
+      type: "person",
+      props: { slug: "paddy-rathbone", role: "" },
+    });
+  });
+
+  it("fails on a Person with no slug", async () => {
+    await expect(mdxToBlocks("<Person />", stubResolver)).rejects.toThrow(
+      /<Person> without slug/,
+    );
+  });
+
+  it("maps <EventPreview> id -> eventId (the block prop name)", async () => {
+    expect(
+      await single(
+        [
+          "<EventPreview",
+          '  id="refugee-week-celebration"',
+          '  name="Refugee Week Celebration"',
+          '  when="2025-06-22T13:00+01:00"',
+          "/>",
+        ].join("\n"),
+      ),
+    ).toMatchObject({
+      type: "eventPreview",
+      props: {
+        eventId: "refugee-week-celebration",
+        name: "Refugee Week Celebration",
+        when: "2025-06-22T13:00+01:00",
+      },
+    });
+  });
+
+  it("fails on an EventPreview missing a required prop", async () => {
+    await expect(
+      mdxToBlocks('<EventPreview id="x" name="y" />', stubResolver),
+    ).rejects.toThrow(/<EventPreview> without when/);
+  });
+
+  it("maps <LeagueTable> (name defaults empty)", async () => {
+    expect(
+      await single(
+        '<LeagueTable divisionId="135699" name="NTCL Division 4" />',
+      ),
+    ).toMatchObject({
+      type: "leagueTable",
+      props: { divisionId: "135699", name: "NTCL Division 4" },
+    });
+    expect(await single('<LeagueTable divisionId="135699" />')).toMatchObject({
+      type: "leagueTable",
+      props: { divisionId: "135699", name: "" },
+    });
+  });
+
+  it("fails on a LeagueTable with no divisionId", async () => {
+    await expect(mdxToBlocks("<LeagueTable />", stubResolver)).rejects.toThrow(
+      /<LeagueTable> without divisionId/,
+    );
+  });
+
+  it("maps the propless components to empty-prop blocks", async () => {
+    expect(await single("<Leaderboard />")).toMatchObject({
+      type: "leaderboard",
+      props: {},
+    });
+    expect(await single("<RecordsWall />")).toMatchObject({
+      type: "recordsWall",
+      props: {},
+    });
+    expect(await single("<ConsentVersion />")).toMatchObject({
+      type: "consentVersion",
+      props: {},
+    });
+  });
+
+  it("maps <ContactForm> with title/description defaulting empty", async () => {
+    expect(
+      await single(
+        '<ContactForm title="Get in Touch" description="Drop us a message." />',
+      ),
+    ).toMatchObject({
+      type: "contactForm",
+      props: { title: "Get in Touch", description: "Drop us a message." },
+    });
+    expect(await single("<ContactForm />")).toMatchObject({
+      type: "contactForm",
+      props: { title: "", description: "" },
+    });
+  });
+
+  it("maps <CookieSettingsLink>: children text when paired, default otherwise", async () => {
+    expect(
+      await single("<CookieSettingsLink>Manage cookies</CookieSettingsLink>"),
+    ).toMatchObject({
+      type: "cookieSettingsLink",
+      props: { text: "Manage cookies" },
+    });
+    expect(await single("<CookieSettingsLink />")).toMatchObject({
+      type: "cookieSettingsLink",
+      props: { text: "Cookie settings" },
+    });
+  });
+
+  it("maps <PersonGrid> children to role-preserving entries plus the slugs CSV", async () => {
+    expect(
+      await single(
+        [
+          "<PersonGrid>",
+          '  <Person slug="alex-young" role="1st XI Captain" />',
+          '  <Person slug="john-allan" />',
+          "</PersonGrid>",
+        ].join("\n"),
+      ),
+    ).toMatchObject({
+      type: "personGrid",
+      props: {
+        slugs: "alex-young,john-allan",
+        // Role kept on entries; the role-less child carries no role key
+        // (NULL-for-unset, matching what the editor writes).
+        entries: JSON.stringify([
+          { slug: "alex-young", role: "1st XI Captain" },
+          { slug: "john-allan" },
+        ]),
+      },
+    });
+  });
+
+  it("converts a kitchen-sink page body to schema-valid, known block types", async () => {
+    const blocks = await mdxToBlocks(
+      [
+        "Intro with a [link](/cricket).",
+        "",
+        "##### Captains",
+        "",
+        "<PersonGrid>",
+        '  <Person slug="alex-young" role="Captain" />',
+        "</PersonGrid>",
+        "",
+        '<Image src="/images/contentful/abc/p.jpg" alt="a" caption="c" />',
+        "",
+        '<LeagueTable divisionId="135699" name="Div 4" />',
+        "",
+        "<ContactForm />",
+        "",
+        "- one",
+        "- two",
+      ].join("\n"),
+      stubResolver,
+    );
+    expect(blocks.map((b) => b.type)).toEqual([
+      "paragraph",
+      "heading",
+      "personGrid",
+      "contentImage",
+      "leagueTable",
+      "contactForm",
+      "bulletListItem",
+      "bulletListItem",
+    ]);
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+    const knownTypes = new Set<string>([
+      "paragraph",
+      "heading",
+      "quote",
+      "codeBlock",
+      "table",
+      "bulletListItem",
+      "numberedListItem",
+      ...Object.values(CUSTOM_BLOCK_TYPES),
+    ]);
+    for (const block of blocks) {
+      expect(knownTypes.has(block.type)).toBe(true);
+    }
+  });
+});
+
+describe("parsePageSource", () => {
+  it("parses full frontmatter including ldjson passthrough", () => {
+    const parsed = parsePageSource(
+      [
+        "---",
+        "title: Cricket",
+        'description: "Percy Main Cricket Club."',
+        "menuOrder: 2",
+        "isMainMenu: true",
+        "hideTitle: true",
+        "ldjson:",
+        '  "@type": SportsClub',
+        "  name: Percy Main",
+        "---",
+        "",
+        "Body text.",
+      ].join("\n"),
+    );
+    expect(parsed).toEqual({
+      title: "Cricket",
+      description: "Percy Main Cricket Club.",
+      menuOrder: 2,
+      isMainMenu: true,
+      hideTitle: true,
+      ldjson: { "@type": "SportsClub", name: "Percy Main" },
+      body: "Body text.",
+    });
+  });
+
+  it("applies the defaults (menuOrder 99, flags false, no ldjson)", () => {
+    const parsed = parsePageSource(
+      ["---", "title: Boxing", "---", "", "Body."].join("\n"),
+    );
+    expect(parsed).toEqual({
+      title: "Boxing",
+      menuOrder: 99,
+      isMainMenu: false,
+      hideTitle: false,
+      body: "Body.",
+    });
+  });
+
+  it("rejects a missing title", () => {
+    expect(() =>
+      parsePageSource(["---", "menuOrder: 1", "---", "Body."].join("\n")),
+    ).toThrow();
+  });
+
+  it("rejects a non-object ldjson", () => {
+    expect(() =>
+      parsePageSource(
+        ["---", "title: X", 'ldjson: "not an object"', "---", "Body."].join(
+          "\n",
+        ),
+      ),
+    ).toThrow();
+  });
+
+  it("rejects a non-integer menuOrder", () => {
+    expect(() =>
+      parsePageSource(
+        ["---", "title: X", "menuOrder: 1.5", "---", "Body."].join("\n"),
+      ),
+    ).toThrow();
   });
 });
 

--- a/apps/api/scripts/mdx-to-blocks.ts
+++ b/apps/api/scripts/mdx-to-blocks.ts
@@ -5,36 +5,65 @@ import YAML from "yaml";
 import { z } from "zod";
 import { markdownToBlocks, type MigrationBlock } from "./markdown-to-blocks.ts";
 
-// One-time inbound migration converter (#491): the legacy MDX news +
-// events corpus -> the BlockNote-shaped block document the content API
-// stores (ADR 047). Unlike the game reports, this corpus embeds a small
-// fixed vocabulary of JSX components (<Image>, <GamePreview>) between
-// plain-markdown prose, so the body is segmented first: component
-// invocations are found with a regex over the raw source and everything
-// between them goes through markdownToBlocks() unchanged.
+// One-time inbound migration converter (#491, extended for pages in
+// #496): the legacy MDX news + events + pages corpus -> the
+// BlockNote-shaped block document the content API stores (ADR 047).
+// Unlike the game reports, these corpora embed a small fixed vocabulary
+// of JSX components between plain-markdown prose, so the body is
+// segmented first: component invocations are found with a regex over
+// the raw source and everything between them goes through
+// markdownToBlocks() unchanged.
 //
-// This is deliberately NOT a general MDX parser. The corpus is 17 files
-// written by a handful of people; a regex over the exact constructs they
-// used is simpler, auditable, and fails loudly on anything outside the
-// vocabulary - which is the correct behaviour for a one-time migration
-// (refusing beats silently dropping content).
+// This is deliberately NOT a general MDX parser. The corpus is a few
+// dozen files written by a handful of people; a regex over the exact
+// constructs they used is simpler, auditable, and fails loudly on
+// anything outside the vocabulary - which is the correct behaviour for
+// a one-time migration (refusing beats silently dropping content).
 
 // ── Segmentation ────────────────────────────────────────────────────────
 
 export type MdxSegment =
   | { kind: "markdown"; text: string }
-  | { kind: "component"; name: string; attrs: Record<string, string> };
-
-/** The only components the news/events corpus actually uses. */
-const KNOWN_COMPONENTS = new Set(["Image", "GamePreview"]);
+  | { kind: "component"; name: string; attrs: Record<string, string> }
+  // <PersonGrid> is the one container the corpus uses: paired tags
+  // wrapping self-closing <Person> children. Child roles are carried
+  // through so the converter can report when it has to drop them (the
+  // personGrid block type stores slugs only).
+  | { kind: "personGrid"; people: { slug: string; role?: string }[] };
 
 /**
- * A self-closing capitalised JSX invocation, possibly spanning lines
- * (the corpus writes <Image> with one attribute per line). The attr
- * chunk alternation permits ">" only inside quoted strings, so the
- * match cannot run past the closing "/>".
+ * Components the corpora write as self-closing invocations. Everything
+ * here maps 1:1 onto a custom block type from CUSTOM_BLOCK_TYPES (Image
+ * becomes contentImage via the upload pipeline).
  */
-const COMPONENT_RE = /<([A-Z][A-Za-z]*)((?:[^>"]|"[^"]*")*?)\/>/g;
+const SELF_CLOSING_COMPONENTS = new Set([
+  "Image",
+  "GamePreview",
+  "Person",
+  "EventPreview",
+  "LeagueTable",
+  "Leaderboard",
+  "RecordsWall",
+  "ContactForm",
+  "ConsentVersion",
+  "CookieSettingsLink",
+]);
+
+/**
+ * Components the corpora write as paired tags. PersonGrid wraps Person
+ * children (the slugs-attribute form is never used in the corpus, so it
+ * is deliberately unsupported); CookieSettingsLink's children are its
+ * link text.
+ */
+const CONTAINER_COMPONENTS = new Set(["PersonGrid", "CookieSettingsLink"]);
+
+/**
+ * A capitalised JSX tag - self-closing (capture 3 = "/") or opening -
+ * possibly spanning lines (the corpus writes <Image> with one attribute
+ * per line). The attr chunk alternation permits ">" only inside quoted
+ * strings, so the match cannot run past the tag's closing ">".
+ */
+const COMPONENT_RE = /<([A-Z][A-Za-z]*)((?:[^>"]|"[^"]*")*?)(\/)?>/g;
 
 /**
  * Attributes are exclusively string literals in this corpus
@@ -88,6 +117,95 @@ function assertNoLeftoverJsx(text: string): void {
 }
 
 /**
+ * A line that is exactly one markdown image. Only treated as a block
+ * when the surrounding lines are blank (i.e. it forms a paragraph of
+ * its own): the pages corpus writes one logo this way, and it maps to
+ * the same contentImage pipeline as <Image>. An image WITHIN a
+ * paragraph (or wrapped in a link) still fails the file - converting it
+ * would mean splitting a paragraph or dropping the link.
+ */
+const BARE_IMAGE_RE = /^!\[([^\]\n]*)\]\(([^)\s]+)\)$/;
+
+type ImageOrMarkdown =
+  | { kind: "markdown"; text: string }
+  | { kind: "component"; name: "Image"; attrs: Record<string, string> };
+
+/** Split a markdown chunk on bare-image paragraphs (see BARE_IMAGE_RE). */
+function splitBareImages(text: string): ImageOrMarkdown[] {
+  const lines = text.split("\n");
+  const parts: ImageOrMarkdown[] = [];
+  let pending: string[] = [];
+  const flush = () => {
+    const chunk = pending.join("\n").trim();
+    pending = [];
+    if (chunk !== "") parts.push({ kind: "markdown", text: chunk });
+  };
+  for (const [i, line] of lines.entries()) {
+    const match = BARE_IMAGE_RE.exec(line.trim());
+    const prevBlank = i === 0 || (lines[i - 1] ?? "").trim() === "";
+    const nextBlank =
+      i === lines.length - 1 || (lines[i + 1] ?? "").trim() === "";
+    if (match && prevBlank && nextBlank) {
+      flush();
+      const [, alt, src] = match;
+      parts.push({
+        kind: "component",
+        name: "Image",
+        attrs: {
+          src: src ?? "",
+          ...(alt !== undefined && alt !== "" && { alt }),
+        },
+      });
+      continue;
+    }
+    pending.push(line);
+  }
+  flush();
+  return parts;
+}
+
+/**
+ * Parse the children of a <PersonGrid> container: exclusively
+ * self-closing <Person> elements separated by whitespace, as the whole
+ * corpus writes them. Anything else fails the file.
+ */
+function parsePersonGridChildren(
+  inner: string,
+): { slug: string; role?: string }[] {
+  const people: { slug: string; role?: string }[] = [];
+  for (const match of inner.matchAll(COMPONENT_RE)) {
+    const [, name, rawAttrs, selfClosing] = match;
+    if (name !== "Person" || selfClosing !== "/") {
+      throw new Error(
+        `<PersonGrid> may only contain <Person /> children (found <${name ?? "?"}>) - migrate this file by hand`,
+      );
+    }
+    const attrs = parseComponentAttributes(rawAttrs ?? "");
+    if (!attrs.slug) {
+      throw new Error(
+        "<Person> inside <PersonGrid> without slug - migrate this file by hand",
+      );
+    }
+    people.push({
+      slug: attrs.slug,
+      ...(attrs.role !== undefined && { role: attrs.role }),
+    });
+  }
+  const leftover = inner.replace(COMPONENT_RE, "").trim();
+  if (leftover !== "") {
+    throw new Error(
+      `<PersonGrid> contains non-component content '${leftover.slice(0, 60)}' - migrate this file by hand`,
+    );
+  }
+  if (people.length === 0) {
+    throw new Error(
+      "<PersonGrid> with no <Person> children - migrate this file by hand",
+    );
+  }
+  return people;
+}
+
+/**
  * Split an MDX body into markdown segments and component invocations.
  * Components must be block-level (alone on their lines, as the whole
  * corpus writes them) - an inline invocation would force this code to
@@ -99,34 +217,83 @@ export function segmentMdx(body: string): MdxSegment[] {
   const pushMarkdown = (raw: string) => {
     const text = flattenSupTags(raw).trim();
     if (text === "") return;
-    assertNoLeftoverJsx(text);
-    segments.push({ kind: "markdown", text });
+    for (const part of splitBareImages(text)) {
+      if (part.kind === "markdown") assertNoLeftoverJsx(part.text);
+      segments.push(part);
+    }
   };
 
   let cursor = 0;
-  for (const match of body.matchAll(COMPONENT_RE)) {
-    const [full, name, rawAttrs] = match;
+  const re = new RegExp(COMPONENT_RE.source, "g");
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(body)) !== null) {
+    const [full, name, rawAttrs, selfClosing] = match;
     if (name === undefined || rawAttrs === undefined) continue;
-    if (!KNOWN_COMPONENTS.has(name)) {
-      throw new Error(
-        `Unknown component <${name}> - migrate this file by hand`,
-      );
-    }
     const start = match.index;
+    let end = start + full.length;
+
+    let segment: MdxSegment;
+    if (selfClosing === "/") {
+      if (!SELF_CLOSING_COMPONENTS.has(name)) {
+        throw new Error(
+          name === "PersonGrid"
+            ? "<PersonGrid /> without <Person> children (the slugs-attribute form is not used by the corpus) - migrate this file by hand"
+            : `Unknown component <${name}> - migrate this file by hand`,
+        );
+      }
+      segment = {
+        kind: "component",
+        name,
+        attrs: parseComponentAttributes(rawAttrs),
+      };
+    } else {
+      // Opening tag: only the two paired-tag containers are understood.
+      if (!CONTAINER_COMPONENTS.has(name)) {
+        throw new Error(
+          SELF_CLOSING_COMPONENTS.has(name)
+            ? `<${name}> must be self-closing - migrate this file by hand`
+            : `Unknown component <${name}> - migrate this file by hand`,
+        );
+      }
+      const closeTag = `</${name}>`;
+      const closeStart = body.indexOf(closeTag, end);
+      if (closeStart === -1) {
+        throw new Error(`Unclosed <${name}> - migrate this file by hand`);
+      }
+      const inner = body.slice(end, closeStart);
+      end = closeStart + closeTag.length;
+
+      if (name === "PersonGrid") {
+        segment = {
+          kind: "personGrid",
+          people: parsePersonGridChildren(inner),
+        };
+      } else {
+        // CookieSettingsLink: the children are the link text. Tag-shaped
+        // children mean vocabulary this converter does not understand.
+        if (/<[A-Za-z/]/.test(inner)) {
+          throw new Error(
+            "<CookieSettingsLink> with non-text children - migrate this file by hand",
+          );
+        }
+        const attrs = parseComponentAttributes(rawAttrs);
+        const text = inner.trim();
+        if (text !== "") attrs.text = text;
+        segment = { kind: "component", name, attrs };
+      }
+    }
+
     const before = body.slice(0, start);
-    const after = body.slice(start + full.length);
+    const after = body.slice(end);
     if (!/(^|\n)[ \t]*$/.test(before) || !/^[ \t]*(\n|$)/.test(after)) {
       throw new Error(
         `<${name}> used inline within other content - migrate this file by hand`,
       );
     }
     pushMarkdown(body.slice(cursor, start));
-    segments.push({
-      kind: "component",
-      name,
-      attrs: parseComponentAttributes(rawAttrs),
-    });
-    cursor = start + full.length;
+    segments.push(segment);
+    cursor = end;
+    re.lastIndex = end;
   }
   pushMarkdown(body.slice(cursor));
 
@@ -160,11 +327,23 @@ function customBlock(
   return { id: crypto.randomUUID(), type, props, children: [] };
 }
 
+/** A required string attribute, or a loud failure naming the component. */
+function requireAttr(
+  name: string,
+  attrs: Record<string, string>,
+  attr: string,
+): string {
+  const value = attrs[attr];
+  if (!value) throw new Error(`<${name}> without ${attr}`);
+  return value;
+}
+
 /**
- * Convert an MDX news/event body into the block array the content API
- * stores. Markdown segments reuse markdownToBlocks() (and inherit its
- * fail-loudly assertions); component segments map to the custom block
- * types the editor and public renderer share.
+ * Convert an MDX news/event/page body into the block array the content
+ * API stores. Markdown segments reuse markdownToBlocks() (and inherit
+ * its fail-loudly assertions); component segments map to the custom
+ * block types the editor and public renderer share, emitting exactly
+ * the prop set the editor's propSchema would (defaults filled in).
  */
 export async function mdxToBlocks(
   body: string,
@@ -176,22 +355,93 @@ export async function mdxToBlocks(
       blocks.push(...markdownToBlocks(segment.text));
       continue;
     }
-    if (segment.name === "GamePreview") {
-      const playCricketId = segment.attrs.playCricketId;
-      if (!playCricketId) {
-        throw new Error("<GamePreview> without playCricketId");
-      }
+    if (segment.kind === "personGrid") {
+      // entries (JSON-stringified [{slug, role?}]) is the canonical
+      // role-preserving prop the renderer and editor share; the slugs
+      // CSV is written alongside as the legacy fallback the renderer
+      // reads when entries is absent.
       blocks.push(
-        customBlock(CUSTOM_BLOCK_TYPES.gamePreview, { playCricketId }),
+        customBlock(CUSTOM_BLOCK_TYPES.personGrid, {
+          slugs: segment.people.map((p) => p.slug).join(","),
+          entries: JSON.stringify(segment.people),
+        }),
       );
       continue;
     }
-    // Image - the resolver returns the full prop set so the picture
-    // descriptor comes from the same pipeline as editor uploads.
-    const { src, alt, caption } = segment.attrs;
-    if (!src) throw new Error("<Image> without src");
-    const props = await resolveImage({ src, alt, caption });
-    blocks.push(customBlock(CUSTOM_BLOCK_TYPES.contentImage, props));
+    const { name, attrs } = segment;
+    switch (name) {
+      case "GamePreview":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.gamePreview, {
+            playCricketId: requireAttr(name, attrs, "playCricketId"),
+          }),
+        );
+        break;
+      case "Image": {
+        // The resolver returns the full prop set so the picture
+        // descriptor comes from the same pipeline as editor uploads.
+        const { src, alt, caption } = attrs;
+        if (!src) throw new Error("<Image> without src");
+        const props = await resolveImage({ src, alt, caption });
+        blocks.push(customBlock(CUSTOM_BLOCK_TYPES.contentImage, props));
+        break;
+      }
+      case "Person":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.person, {
+            slug: requireAttr(name, attrs, "slug"),
+            role: attrs.role ?? "",
+          }),
+        );
+        break;
+      case "EventPreview":
+        // The MDX prop is `id`; the block (and its editor propSchema)
+        // call it `eventId`.
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.eventPreview, {
+            eventId: requireAttr(name, attrs, "id"),
+            name: requireAttr(name, attrs, "name"),
+            when: requireAttr(name, attrs, "when"),
+          }),
+        );
+        break;
+      case "LeagueTable":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.leagueTable, {
+            divisionId: requireAttr(name, attrs, "divisionId"),
+            name: attrs.name ?? "",
+          }),
+        );
+        break;
+      case "Leaderboard":
+        blocks.push(customBlock(CUSTOM_BLOCK_TYPES.leaderboard, {}));
+        break;
+      case "RecordsWall":
+        blocks.push(customBlock(CUSTOM_BLOCK_TYPES.recordsWall, {}));
+        break;
+      case "ContactForm":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.contactForm, {
+            title: attrs.title ?? "",
+            description: attrs.description ?? "",
+          }),
+        );
+        break;
+      case "ConsentVersion":
+        blocks.push(customBlock(CUSTOM_BLOCK_TYPES.consentVersion, {}));
+        break;
+      case "CookieSettingsLink":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.cookieSettingsLink, {
+            text: attrs.text ?? "Cookie settings",
+          }),
+        );
+        break;
+      default:
+        // segmentMdx only emits known names; this guards drift between
+        // the two vocabularies.
+        throw new Error(`No block mapping for <${name}>`);
+    }
   }
   return blocks;
 }
@@ -283,6 +533,43 @@ export function parseEventSource(source: string): EventSource {
     when: fm.when,
     ...(fm.finish !== undefined && { finish: fm.finish }),
     ...(fm.location !== undefined && { location: fm.location }),
+    body,
+  };
+}
+
+// Mirrors the static page loader's frontmatter handling (apps/web
+// lib/content.ts) and the defaults pageMetadataSchema applies: a
+// DB-backed page must come out indistinguishable from its static
+// version. ldjson is kept as-is (pasted structured data).
+const pageFrontmatterSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1).optional(),
+  menuOrder: z.number().int().default(99),
+  isMainMenu: z.boolean().default(false),
+  hideTitle: z.boolean().default(false),
+  ldjson: z.record(z.string(), z.unknown()).optional(),
+});
+
+export interface PageSource {
+  title: string;
+  description?: string;
+  menuOrder: number;
+  isMainMenu: boolean;
+  hideTitle: boolean;
+  ldjson?: Record<string, unknown>;
+  body: string;
+}
+
+export function parsePageSource(source: string): PageSource {
+  const { raw, body } = splitFrontmatter(source);
+  const fm = pageFrontmatterSchema.parse(raw);
+  return {
+    title: fm.title,
+    ...(fm.description !== undefined && { description: fm.description }),
+    menuOrder: fm.menuOrder,
+    isMainMenu: fm.isMainMenu,
+    hideTitle: fm.hideTitle,
+    ...(fm.ldjson !== undefined && { ldjson: fm.ldjson }),
     body,
   };
 }

--- a/apps/api/scripts/migrate-news-events.ts
+++ b/apps/api/scripts/migrate-news-events.ts
@@ -42,24 +42,22 @@ import path from "path";
 import { fileURLToPath } from "url";
 import YAML from "yaml";
 import {
-  processImage,
-  type ProcessedImage,
-} from "../src/features/content-images/service.ts";
-import {
   CONTENT_IMAGES_PREFIX,
   createContentImageStore,
   type ContentImageStore,
 } from "../src/lib/s3-content-images.ts";
 import {
-  blocksEqualIgnoringIds,
-  type MigrationBlock,
-} from "./markdown-to-blocks.ts";
+  convertBody,
+  ensureImages as ensureImagesShared,
+  planImageUploads,
+  type Converted,
+  type PendingImage,
+} from "./image-pipeline.ts";
+import { blocksEqualIgnoringIds } from "./markdown-to-blocks.ts";
 import {
   eventPublishedAt,
   findDuplicateLocationNames,
-  imageIdForAsset,
   jsonEqual,
-  mdxToBlocks,
   newsPublishedAt,
   parseEventSource,
   parseNewsSource,
@@ -74,9 +72,6 @@ const LOCATIONS_FILE = path.resolve(
   __dirname,
   "../../web/content/data/locations.yaml",
 );
-// Mirrors the web app's image-map: public "/images/..." paths resolve to
-// files under src/assets/images/.
-const ASSETS_DIR = path.resolve(__dirname, "../../web/src/assets/images");
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -91,84 +86,6 @@ function parseArgs() {
     process.exit(1);
   }
   return { userId, dryRun, force };
-}
-
-class MissingImageError extends Error {
-  constructor(publicPath: string) {
-    super(`image file not found on disk for '${publicPath}'`);
-  }
-}
-
-interface PendingImage {
-  imageId: string;
-  publicPath: string;
-  alt: string | null;
-  processed: ProcessedImage;
-  bytes: number;
-}
-
-interface Converted {
-  blocks: MigrationBlock[];
-  images: PendingImage[];
-}
-
-/**
- * Convert one MDX body, resolving each <Image> through the editor-upload
- * processing pipeline (locally - nothing is written here, so --dry-run
- * conversion is complete and writes can be deferred until after the
- * skip/insert decision). The processed-image cache spans articles so a
- * re-used asset is only decoded once.
- */
-async function convertBody(
-  body: string,
-  cache: Map<string, PendingImage>,
-): Promise<Converted> {
-  const images: PendingImage[] = [];
-  const blocks = await mdxToBlocks(body, async ({ src, alt, caption }) => {
-    const imageId = imageIdForAsset(src);
-    let pending = cache.get(imageId);
-    if (!pending) {
-      if (!src.startsWith("/images/")) {
-        throw new Error(`unexpected image src '${src}'`);
-      }
-      const assetPath = path.resolve(ASSETS_DIR, src.slice("/images/".length));
-      // A '..' segment in the src could otherwise resolve outside the
-      // bundled assets tree and upload an arbitrary readable file.
-      if (!assetPath.startsWith(ASSETS_DIR + path.sep)) {
-        throw new Error(`image src '${src}' escapes the assets directory`);
-      }
-      let original: Buffer;
-      try {
-        original = await fs.readFile(assetPath);
-      } catch {
-        throw new MissingImageError(src);
-      }
-      const processed = await processImage(
-        original,
-        imageId,
-        CONTENT_IMAGES_PREFIX,
-      );
-      pending = {
-        imageId,
-        publicPath: src,
-        alt: alt ?? null,
-        processed,
-        bytes: original.byteLength,
-      };
-      cache.set(imageId, pending);
-    }
-    images.push(pending);
-    // Exactly the prop set the editor inserts (content-editor.tsx): the
-    // plain src falls back to the ladder's largest original-format
-    // variant, picture carries the JSON-stringified PictureSource.
-    return {
-      src: pending.processed.picture.img.src,
-      alt: alt ?? "",
-      caption: caption ?? "",
-      picture: JSON.stringify(pending.processed.picture),
-    };
-  });
-  return { blocks, images };
 }
 
 interface MigrationItem {
@@ -351,40 +268,14 @@ async function main() {
   /** Upload variants + register rows for an article's images (idempotent). */
   const ensureImages = async (images: PendingImage[]) => {
     if (!store) throw new Error("store unavailable outside a real run");
-    for (const image of images) {
-      const existing = await db
-        .selectFrom("content_image")
-        .select("id")
-        .where("id", "=", image.imageId)
-        .executeTakeFirst();
-      if (existing) {
-        imagesReused += 1;
-        continue;
-      }
-      for (const variant of image.processed.variants) {
-        await store.putVariant(variant.key, variant.body, variant.contentType);
-      }
-      await db
-        .insertInto("content_image")
-        .values({
-          id: image.imageId,
-          key_prefix: `${CONTENT_IMAGES_PREFIX}/${image.imageId}`,
-          original_format: image.processed.sourceFormat,
-          width: image.processed.width,
-          height: image.processed.height,
-          bytes: image.bytes,
-          picture: JSON.stringify(image.processed.picture),
-          alt: image.alt,
-          consent_confirmed: true,
-          uploaded_by: userId,
-        })
-        .onConflict((oc) => oc.column("id").doNothing())
-        .execute();
-      imagesUploaded += 1;
-      console.log(
-        `    ^ uploaded ${image.publicPath} -> ${CONTENT_IMAGES_PREFIX}/${image.imageId}/ (${String(image.processed.variants.length)} variants)`,
-      );
-    }
+    const { uploaded, reused } = await ensureImagesShared(
+      db,
+      store,
+      userId,
+      images,
+    );
+    imagesUploaded += uploaded;
+    imagesReused += reused;
   };
 
   for (const item of items) {
@@ -440,21 +331,12 @@ async function main() {
     }
 
     if (dryRun) {
-      const newImages = [];
-      for (const image of images) {
-        if (plannedUploads.has(image.imageId)) continue;
-        const row = await db
-          .selectFrom("content_image")
-          .select("id")
-          .where("id", "=", image.imageId)
-          .executeTakeFirst();
-        if (row) {
-          imagesReused += 1;
-        } else {
-          newImages.push(image);
-          plannedUploads.add(image.imageId);
-        }
-      }
+      const { newImages, reused } = await planImageUploads(
+        db,
+        images,
+        plannedUploads,
+      );
+      imagesReused += reused;
       console.log(
         `  ~ ${item.file} would ${existing ? "update" : "insert"} '${item.title}' (${String(blocks.length)} blocks, ${String(images.length)} images, published_at ${item.publishedAt.toISOString()})`,
       );

--- a/apps/api/scripts/migrate-pages.ts
+++ b/apps/api/scripts/migrate-pages.ts
@@ -1,0 +1,547 @@
+/**
+ * One-off migration (#496): import the legacy MDX content pages into the
+ * content API's tables as published items, building parent_id/path from
+ * the directory layout (dir/_index.mdx IS the parent item) and pushing
+ * each embedded <Image> through the same processing pipeline as editor
+ * uploads. pages/legal/** is excluded by design (legal copy stays static
+ * and changes via PR review).
+ *
+ * The script inserts rows directly (like migrate-news-events.ts), so it
+ * upholds the page-hierarchy invariants itself rather than relying on
+ * the content service: path = parent path + /slug, parents inserted
+ * before children, and every page published with ONE shared
+ * published_at (script start) so the child-go-live >= parent gate holds
+ * trivially. A page that fails conversion stays static via the
+ * TRANSITION FALLBACK (#489) - and because a child row cannot exist
+ * without its parent row, a failed parent fails its whole subtree.
+ *
+ * Idempotent: upserts by page path. Unchanged items are skipped; image
+ * ids are UUIDv5-derived from the source asset path, so re-runs reuse
+ * the same S3 keys and content_image rows. Items that differ from the
+ * DB are skipped with a warning unless --force (the DB is canonical
+ * after cutover).
+ *
+ * Usage (local):
+ *   DATABASE_URL=postgres://percy:percy@localhost:5433/percy_main \
+ *     S3_BUCKET=percy-main-receipts-local \
+ *     S3_ENDPOINT=http://localhost:4566 \
+ *     AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+ *     pnpm exec tsx scripts/migrate-pages.ts --user <user-id> [--dry-run] [--force]
+ *
+ * Environment:
+ *   DATABASE_URL  required always (dry runs read existing rows).
+ *   S3_BUCKET     required unless --dry-run; the CloudFront uploads
+ *                 bucket (prod: see infra outputs; local: the
+ *                 percy-main-receipts-local LocalStack bucket).
+ *   S3_REGION     optional, defaults to eu-west-2.
+ *   S3_ENDPOINT   optional; set to http://localhost:4566 for LocalStack.
+ *   AWS credentials come from the SDK default chain - for a real prod
+ *   run set AWS_PROFILE=percy-main (matching the CLI profile rule).
+ *
+ * Against prod, run with the standard prod access pattern and the
+ * admin_rw URL - coordinate first; never point this at prod casually.
+ */
+import { createClient } from "@percy-main/db";
+import {
+  contentBodySchema,
+  pageMetadataSchema,
+  type ContentBody,
+  type PageMetadata,
+} from "@percy-main/shared/content";
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  createContentImageStore,
+  type ContentImageStore,
+} from "../src/lib/s3-content-images.ts";
+import {
+  convertBody,
+  ensureImages,
+  planImageUploads,
+  type PendingImage,
+} from "./image-pipeline.ts";
+import { blocksEqualIgnoringIds } from "./markdown-to-blocks.ts";
+import { jsonEqual, parsePageSource } from "./mdx-to-blocks.ts";
+import {
+  buildPageTree,
+  parentFailureReason,
+  type PageNode,
+} from "./page-tree.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PAGES_DIR = path.resolve(__dirname, "../../web/content/pages");
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const userFlag = args.indexOf("--user");
+  const userId = userFlag >= 0 ? args[userFlag + 1] : undefined;
+  const dryRun = args.includes("--dry-run");
+  const force = args.includes("--force");
+  if (!userId) {
+    console.error(
+      "Usage: tsx scripts/migrate-pages.ts --user <user-id> [--dry-run] [--force]",
+    );
+    process.exit(1);
+  }
+  return { userId, dryRun, force };
+}
+
+interface NavEntry {
+  path: string;
+  title: string;
+  menuOrder: number;
+  isMainMenu: boolean;
+}
+
+async function main() {
+  const { userId, dryRun, force } = parseArgs();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+
+  // The store is only needed for real runs - a dry run must not touch S3.
+  let store: ContentImageStore | null = null;
+  if (!dryRun) {
+    const bucket = process.env.S3_BUCKET;
+    if (!bucket) {
+      console.error("S3_BUCKET is required (omit only with --dry-run)");
+      process.exit(1);
+    }
+    store = createContentImageStore({
+      S3_BUCKET: bucket,
+      S3_REGION: process.env.S3_REGION ?? "eu-west-2",
+      S3_ENDPOINT: process.env.S3_ENDPOINT,
+      // Unused here (no presigned uploads) but part of the store config.
+      CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
+    });
+  }
+
+  const { client: db } = createClient(databaseUrl);
+
+  const attributedTo = await db
+    .selectFrom("user")
+    .select(["name", "email"])
+    .where("id", "=", userId)
+    .executeTakeFirst();
+  if (!attributedTo) {
+    console.error(`No user with id '${userId}'`);
+    await db.destroy();
+    process.exit(1);
+  }
+  console.log(
+    `Attributing imports to: ${attributedTo.name} <${attributedTo.email}>`,
+  );
+
+  const files = (await fs.readdir(PAGES_DIR, { recursive: true }))
+    .filter((f) => f.endsWith(".mdx"))
+    .map((f) => f.split(path.sep).join("/"))
+    .sort();
+  console.log(`Found ${String(files.length)} pages in ${PAGES_DIR}`);
+
+  const tree = buildPageTree(files);
+  for (const exclusion of tree.excluded) {
+    console.log(`  - ${exclusion.file}: ${exclusion.reason}`);
+  }
+
+  const counts = {
+    inserted: 0,
+    updated: 0,
+    unchanged: 0,
+    skipped: 0,
+    failed: 0,
+  };
+  let imagesUploaded = 0;
+  let imagesReused = 0;
+  const imageCache = new Map<string, PendingImage>();
+  // Dry-run only: ids already reported as "would upload", so an asset
+  // shared by two pages is not double-counted.
+  const plannedUploads = new Set<string>();
+
+  // ONE shared go-live instant for everything inserted this run: with
+  // parents inserted first, child published_at == parent published_at
+  // satisfies the child-go-live >= parent invariant trivially.
+  const publishedAt = new Date();
+
+  const failures: { file: string; reason: string }[] = [];
+  const skipped: { file: string; reason: string }[] = [];
+  const migrated: { path: string; action: string }[] = [];
+  const nav: NavEntry[] = [];
+
+  // Paths whose page failed this run - parentFailureReason() consults
+  // this to fail descendants (path order guarantees parents first).
+  const failedPaths = new Set<string>();
+  // Published parents available to attach children to: rows that exist
+  // (or, dry-run, would exist) as status=published after this run.
+  const publishedParents = new Map<
+    string,
+    { id: string | null; publishedAt: Date }
+  >();
+
+  const fail = (file: string, pagePath: string | undefined, reason: string) => {
+    counts.failed += 1;
+    failures.push({ file, reason });
+    if (pagePath !== undefined) failedPaths.add(pagePath);
+    console.warn(`  ! ${file}: ${reason}`);
+  };
+
+  for (const failure of tree.failed) {
+    fail(failure.file, failure.path, failure.reason);
+  }
+
+  const processNode = async (node: PageNode) => {
+    // ── Parent gates ──────────────────────────────────────────────────
+    const parentFailed = parentFailureReason(node, failedPaths);
+    if (parentFailed !== null) {
+      fail(node.file, node.path, parentFailed);
+      return;
+    }
+    let parentInfo: { id: string | null; publishedAt: Date } | null = null;
+    if (node.parentPath !== null) {
+      parentInfo = publishedParents.get(node.parentPath) ?? null;
+      if (!parentInfo) {
+        // The parent file processed without failing but did not yield a
+        // published row (an existing draft/archived row sits at its
+        // path) - a published child under it would break the hierarchy
+        // invariant.
+        fail(
+          node.file,
+          node.path,
+          `parent page at ${node.parentPath} is not published - resolve it and re-run`,
+        );
+        return;
+      }
+      // An existing parent scheduled for the future would put this
+      // child live before it - the exact invariant publishContent
+      // enforces top-down.
+      if (parentInfo.publishedAt.getTime() > publishedAt.getTime()) {
+        fail(
+          node.file,
+          node.path,
+          `parent page at ${node.parentPath} goes live in the future (${parentInfo.publishedAt.toISOString()}) - a child cannot publish before its parent`,
+        );
+        return;
+      }
+    }
+
+    // ── Parse + convert ───────────────────────────────────────────────
+    interface Prepared {
+      title: string;
+      description: string | null;
+      metadata: PageMetadata;
+      blocks: ContentBody;
+      images: PendingImage[];
+    }
+    const prepared: Prepared | null = await (async () => {
+      try {
+        const source = await fs.readFile(
+          path.join(PAGES_DIR, node.file),
+          "utf8",
+        );
+        const parsed = parsePageSource(source);
+        const metadata = pageMetadataSchema.parse({
+          menuOrder: parsed.menuOrder,
+          isMainMenu: parsed.isMainMenu,
+          hideTitle: parsed.hideTitle,
+          ...(parsed.ldjson !== undefined && { ldjson: parsed.ldjson }),
+        });
+        const converted = await convertBody(parsed.body, imageCache);
+        // The service validates bodies on every write; the script writes
+        // directly, so it runs the same gate.
+        const blocks = contentBodySchema.parse(converted.blocks);
+        return {
+          title: parsed.title,
+          description: parsed.description ?? null,
+          metadata,
+          blocks,
+          images: converted.images,
+        };
+      } catch (err) {
+        fail(
+          node.file,
+          node.path,
+          err instanceof Error ? err.message : String(err),
+        );
+        return null;
+      }
+    })();
+    if (prepared === null) return;
+    const { title, description, metadata, blocks, images } = prepared;
+
+    const navEntry: NavEntry = {
+      path: node.path,
+      title,
+      menuOrder: metadata.menuOrder,
+      isMainMenu: metadata.isMainMenu,
+    };
+
+    // ── Upsert ────────────────────────────────────────────────────────
+    const existing = await db
+      .selectFrom("content_item")
+      .select([
+        "id",
+        "body",
+        "title",
+        "description",
+        "metadata",
+        "status",
+        "published_at",
+      ])
+      .where("kind", "=", "page")
+      .where("path", "=", node.path)
+      .executeTakeFirst();
+
+    if (existing) {
+      // Same stance as the news migration: a non-published row would
+      // still 404 publicly, and a published row an editor may have
+      // touched is only overwritten under --force (post-cutover the DB
+      // is canonical and the MDX is the stale ancestor).
+      if (existing.status !== "published" || existing.published_at === null) {
+        counts.skipped += 1;
+        const reason = `a ${existing.status} item already exists at ${node.path} - the public endpoint will 404. Publish or remove it, then re-run.`;
+        skipped.push({ file: node.file, reason });
+        console.warn(`  ! ${node.file}: ${reason}`);
+        // Not added to failedPaths: descendants report the more precise
+        // "parent not published" via the publishedParents miss.
+        return;
+      }
+
+      // This path stays published whatever happens below, so children
+      // may attach to it; its real published_at drives their gate.
+      publishedParents.set(node.path, {
+        id: existing.id,
+        publishedAt: existing.published_at,
+      });
+
+      // published_at deliberately ignored: it is "script start" on
+      // every run, while the row keeps its original go-live.
+      const unchanged =
+        blocksEqualIgnoringIds(existing.body, blocks) &&
+        existing.title === title &&
+        existing.description === description &&
+        jsonEqual(existing.metadata, metadata);
+      if (unchanged) {
+        counts.unchanged += 1;
+        migrated.push({ path: node.path, action: "unchanged" });
+        nav.push(navEntry);
+        console.log(`  = ${node.file} unchanged (${existing.title})`);
+        return;
+      }
+      if (!force) {
+        counts.skipped += 1;
+        const reason = `published page '${existing.title}' differs from the MDX conversion (likely edited in the DB). Skipping - re-run with --force to overwrite.`;
+        skipped.push({ file: node.file, reason });
+        console.warn(`  ! ${node.file}: ${reason}`);
+        // The page is still live with the DB's values - those are what
+        // the nav actually serves.
+        const dbMetadata = pageMetadataSchema.safeParse(existing.metadata);
+        const effective = dbMetadata.success
+          ? dbMetadata.data
+          : pageMetadataSchema.parse({});
+        nav.push({
+          path: node.path,
+          title: existing.title,
+          menuOrder: effective.menuOrder,
+          isMainMenu: effective.isMainMenu,
+        });
+        return;
+      }
+
+      if (dryRun) {
+        const { newImages, reused } = await planImageUploads(
+          db,
+          images,
+          plannedUploads,
+        );
+        imagesReused += reused;
+        imagesUploaded += newImages.length;
+        console.log(
+          `  ~ ${node.file} would update '${title}' at ${node.path} (${String(blocks.length)} blocks, ${String(images.length)} images)`,
+        );
+        for (const image of newImages) {
+          console.log(`    ~ would upload ${image.publicPath}`);
+        }
+        counts.updated += 1;
+        migrated.push({ path: node.path, action: "updated" });
+        nav.push(navEntry);
+        return;
+      }
+
+      if (!store) throw new Error("store unavailable outside a real run");
+      const ensured = await ensureImages(db, store, userId, images);
+      imagesUploaded += ensured.uploaded;
+      imagesReused += ensured.reused;
+
+      // slug/parent_id/path/status/published_at untouched: the path
+      // matched, so the hierarchy is already right, and rewriting
+      // published_at would rewrite the page's go-live history.
+      await db.transaction().execute(async (tx) => {
+        await tx
+          .updateTable("content_item")
+          .set({
+            title,
+            description,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(metadata),
+            updated_by: userId,
+            updated_at: new Date(),
+          })
+          .where("id", "=", existing.id)
+          .execute();
+        await tx
+          .insertInto("content_revision")
+          .values({
+            content_id: existing.id,
+            title,
+            description,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(metadata),
+            saved_by: userId,
+          })
+          .execute();
+      });
+      counts.updated += 1;
+      migrated.push({ path: node.path, action: "updated" });
+      nav.push(navEntry);
+      console.log(`  ^ ${node.file} updated (${title})`);
+      return;
+    }
+
+    // ── Insert ────────────────────────────────────────────────────────
+    if (dryRun) {
+      const { newImages, reused } = await planImageUploads(
+        db,
+        images,
+        plannedUploads,
+      );
+      imagesReused += reused;
+      imagesUploaded += newImages.length;
+      console.log(
+        `  ~ ${node.file} would insert '${title}' at ${node.path} (${String(blocks.length)} blocks, ${String(images.length)} images, published_at ${publishedAt.toISOString()})`,
+      );
+      for (const image of newImages) {
+        console.log(`    ~ would upload ${image.publicPath}`);
+      }
+      counts.inserted += 1;
+      migrated.push({ path: node.path, action: "inserted" });
+      nav.push(navEntry);
+      publishedParents.set(node.path, { id: null, publishedAt });
+      return;
+    }
+
+    if (
+      node.parentPath !== null &&
+      (parentInfo === null || parentInfo.id === null)
+    ) {
+      // Real runs record real ids for every published parent; a miss
+      // here is a bug, not a data condition.
+      throw new Error(`no parent id recorded for ${node.parentPath}`);
+    }
+
+    if (!store) throw new Error("store unavailable outside a real run");
+    // Images first: like the editor flow, content_image rows + variants
+    // exist before any body referencing them is saved. Deferred to this
+    // point so skipped pages write nothing at all.
+    const ensured = await ensureImages(db, store, userId, images);
+    imagesUploaded += ensured.uploaded;
+    imagesReused += ensured.reused;
+
+    await db.transaction().execute(async (tx) => {
+      const inserted = await tx
+        .insertInto("content_item")
+        .values({
+          kind: "page",
+          slug: node.slug,
+          parent_id: parentInfo?.id ?? null,
+          path: node.path,
+          title,
+          description,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          status: "published",
+          published_at: publishedAt,
+          created_by: userId,
+          updated_by: userId,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      await tx
+        .insertInto("content_revision")
+        .values({
+          content_id: inserted.id,
+          title,
+          description,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          saved_by: userId,
+        })
+        .execute();
+      publishedParents.set(node.path, { id: inserted.id, publishedAt });
+    });
+    counts.inserted += 1;
+    migrated.push({ path: node.path, action: "inserted" });
+    nav.push(navEntry);
+    console.log(`  + ${node.file} inserted as '${title}' at ${node.path}`);
+  };
+
+  for (const node of tree.ordered) {
+    await processNode(node);
+  }
+
+  // ── Report ────────────────────────────────────────────────────────────
+
+  console.log("");
+  console.log("=== Migration report ===");
+  console.log(
+    `Pages: ${String(counts.inserted)} inserted, ${String(counts.updated)} updated, ${String(counts.unchanged)} unchanged, ${String(counts.skipped)} skipped, ${String(counts.failed)} failed, ${String(tree.excluded.length)} excluded`,
+  );
+  console.log(
+    `Images: ${String(imagesUploaded)} ${dryRun ? "would be uploaded" : "uploaded"}, ${String(imagesReused)} reused`,
+  );
+
+  console.log(`Migrated (${String(migrated.length)}):`);
+  for (const item of migrated) {
+    console.log(`  ${item.path} (${item.action})`);
+  }
+  console.log(`Failed (${String(failures.length)}):`);
+  for (const failure of failures) {
+    console.log(`  ${failure.file}: ${failure.reason}`);
+  }
+  console.log(`Skipped (${String(skipped.length)}):`);
+  for (const item of skipped) {
+    console.log(`  ${item.file}: ${item.reason}`);
+  }
+  console.log(`Excluded (${String(tree.excluded.length)}):`);
+  for (const exclusion of tree.excluded) {
+    console.log(`  ${exclusion.file}: ${exclusion.reason}`);
+  }
+
+  // The before/after nav snapshot artifact: what getPublishedNav would
+  // serve for this corpus after the run, in its path ordering. Compare
+  // against the static staticNavPages projection.
+  nav.sort((a, b) => a.path.localeCompare(b.path));
+  console.log("Nav payload (path-sorted):");
+  console.log(JSON.stringify(nav, null, 2));
+
+  console.log(
+    `Done with ${String(failures.length + skipped.length)} warnings${dryRun ? " (dry run)" : ""}`,
+  );
+  if (failures.length + skipped.length > 0) {
+    // Unlike news/events, pages have a per-path fallback: a page with no
+    // published DB row keeps rendering from the static bundle
+    // (TRANSITION FALLBACK #489), so a partial migration is safe - but
+    // the static MDX cleanup must not remove files listed above.
+    console.warn(
+      "NOTE: failed/skipped pages keep rendering from the static bundle " +
+        "via the per-path fallback. Do NOT delete their MDX in the " +
+        "cleanup PR until they are resolved and re-run.",
+    );
+    process.exitCode = 2;
+  }
+  await db.destroy();
+}
+
+await main();

--- a/apps/api/scripts/page-tree.test.ts
+++ b/apps/api/scripts/page-tree.test.ts
@@ -1,0 +1,205 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+import {
+  buildPageTree,
+  filePathToUrlPath,
+  LEGAL_EXCLUSION_REASON,
+  parentFailureReason,
+  type PageNode,
+} from "./page-tree.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PAGES_DIR = path.resolve(__dirname, "../../web/content/pages");
+
+describe("filePathToUrlPath", () => {
+  it("mirrors the web app's transform for plain files and _index", () => {
+    expect(filePathToUrlPath("boxing.mdx")).toBe("/boxing");
+    expect(filePathToUrlPath("charity/_index.mdx")).toBe("/charity");
+    expect(filePathToUrlPath("cricket/ground/_index.mdx")).toBe(
+      "/cricket/ground",
+    );
+    expect(filePathToUrlPath("cricket/ground/grounds-team.mdx")).toBe(
+      "/cricket/ground/grounds-team",
+    );
+  });
+});
+
+describe("buildPageTree", () => {
+  const fixture = [
+    "boxing.mdx",
+    "charity/_index.mdx",
+    "charity/agm-2025.mdx",
+    "cricket/_index.mdx",
+    "cricket/ground/_index.mdx",
+    "cricket/ground/grounds-team.mdx",
+    "legal/privacy.mdx",
+  ];
+
+  it("derives slug, path and parentPath from the directory layout", () => {
+    const tree = buildPageTree(fixture);
+    expect(tree.failed).toEqual([]);
+    expect(tree.ordered).toEqual([
+      { file: "boxing.mdx", slug: "boxing", path: "/boxing", parentPath: null },
+      {
+        file: "charity/_index.mdx",
+        slug: "charity",
+        path: "/charity",
+        parentPath: null,
+      },
+      {
+        file: "charity/agm-2025.mdx",
+        slug: "agm-2025",
+        path: "/charity/agm-2025",
+        parentPath: "/charity",
+      },
+      {
+        file: "cricket/_index.mdx",
+        slug: "cricket",
+        path: "/cricket",
+        parentPath: null,
+      },
+      {
+        file: "cricket/ground/_index.mdx",
+        slug: "ground",
+        path: "/cricket/ground",
+        parentPath: "/cricket",
+      },
+      {
+        file: "cricket/ground/grounds-team.mdx",
+        slug: "grounds-team",
+        path: "/cricket/ground/grounds-team",
+        parentPath: "/cricket/ground",
+      },
+    ]);
+  });
+
+  it("excludes legal/** by design", () => {
+    const tree = buildPageTree(fixture);
+    expect(tree.excluded).toEqual([
+      { file: "legal/privacy.mdx", reason: LEGAL_EXCLUSION_REASON },
+    ]);
+    expect(tree.ordered.some((n) => n.file.startsWith("legal/"))).toBe(false);
+  });
+
+  it("orders every parent before its children", () => {
+    const tree = buildPageTree(fixture);
+    const indexByPath = new Map(tree.ordered.map((n, i) => [n.path, i]));
+    for (const node of tree.ordered) {
+      if (node.parentPath === null) continue;
+      const parentIndex = indexByPath.get(node.parentPath);
+      expect(parentIndex).toBeDefined();
+      expect(parentIndex).toBeLessThan(indexByPath.get(node.path) ?? -1);
+    }
+  });
+
+  it("fails children of a directory with no _index.mdx, transitively", () => {
+    const tree = buildPageTree([
+      "cricket/senior/1st-xi.mdx",
+      "cricket/senior/_index.mdx",
+      // no cricket/_index.mdx
+    ]);
+    expect(tree.ordered).toEqual([]);
+    expect(tree.failed).toEqual([
+      {
+        file: "cricket/senior/_index.mdx",
+        path: "/cricket/senior",
+        reason: "parent page required: no _index.mdx provides '/cricket'",
+      },
+      {
+        file: "cricket/senior/1st-xi.mdx",
+        path: "/cricket/senior/1st-xi",
+        reason: "parent failed (/cricket/senior)",
+      },
+    ]);
+  });
+
+  it("fails a root _index.mdx (its path would be '/')", () => {
+    const tree = buildPageTree(["_index.mdx"]);
+    expect(tree.ordered).toEqual([]);
+    expect(tree.failed).toHaveLength(1);
+    expect(tree.failed[0]?.reason).toMatch(/root _index\.mdx/);
+  });
+
+  it("fails files whose slug is not a valid content slug", () => {
+    const tree = buildPageTree(["Has Space.mdx"]);
+    expect(tree.ordered).toEqual([]);
+    expect(tree.failed[0]?.reason).toMatch(/not a valid content slug/);
+  });
+});
+
+describe("parentFailureReason", () => {
+  const node = (path: string, parentPath: string | null): PageNode => ({
+    file: `${path.slice(1)}.mdx`,
+    slug: path.split("/").pop() ?? "",
+    path,
+    parentPath,
+  });
+
+  it("fails a child whose parent failed, transitively in path order", () => {
+    const failed = new Set<string>(["/cricket"]);
+    const ground = node("/cricket/ground", "/cricket");
+    expect(parentFailureReason(ground, failed)).toBe(
+      "parent failed (/cricket)",
+    );
+    // The script adds the failed child to the set before its children
+    // are processed - so the failure propagates down the whole subtree.
+    failed.add(ground.path);
+    expect(
+      parentFailureReason(
+        node("/cricket/ground/grounds-team", "/cricket/ground"),
+        failed,
+      ),
+    ).toBe("parent failed (/cricket/ground)");
+  });
+
+  it("does not fail unrelated subtrees or root pages", () => {
+    const failed = new Set<string>(["/cricket"]);
+    expect(
+      parentFailureReason(node("/charity/agm-2025", "/charity"), failed),
+    ).toBe(null);
+    expect(parentFailureReason(node("/boxing", null), failed)).toBe(null);
+  });
+});
+
+describe("real corpus parity", () => {
+  it("derives the same path as the web app's filePathToUrlPath for every page", async () => {
+    const files = (await fs.readdir(PAGES_DIR, { recursive: true }))
+      .filter((f) => f.endsWith(".mdx"))
+      .map((f) => f.split(path.sep).join("/"))
+      .sort();
+    expect(files.length).toBeGreaterThan(0);
+
+    const tree = buildPageTree(files);
+
+    // Structure: the real corpus must produce no structural failures -
+    // every non-legal file lands in ordered, legal is excluded.
+    expect(tree.failed).toEqual([]);
+    const nonLegal = files.filter((f) => !f.startsWith("legal/"));
+    expect(tree.ordered.map((n) => n.file).sort()).toEqual(nonLegal);
+    expect(tree.excluded.map((e) => e.file)).toEqual(
+      files.filter((f) => f.startsWith("legal/")),
+    );
+
+    // Paths: structural derivation (parent path + slug) agrees with the
+    // web app's file-path transform for every single page.
+    for (const node of tree.ordered) {
+      expect(node.path).toBe(filePathToUrlPath(node.file));
+      expect(node.path).toBe(
+        node.parentPath === null
+          ? `/${node.slug}`
+          : `${node.parentPath}/${node.slug}`,
+      );
+    }
+
+    // Ordering: parents always precede their children.
+    const seen = new Set<string>();
+    for (const node of tree.ordered) {
+      if (node.parentPath !== null) {
+        expect(seen.has(node.parentPath)).toBe(true);
+      }
+      seen.add(node.path);
+    }
+  });
+});

--- a/apps/api/scripts/page-tree.ts
+++ b/apps/api/scripts/page-tree.ts
@@ -1,0 +1,168 @@
+import {
+  contentPathSchema,
+  contentSlugSchema,
+} from "@percy-main/shared/content";
+
+// Page hierarchy derivation for the pages migration (#496): the static
+// corpus' directory layout IS the page tree. dir/_index.mdx is the
+// parent item for the directory (slug = dir name); every sibling file
+// is a child of that item. The derived URL paths must match the web
+// app's static routing (filePathToUrlPath in apps/web/src/lib/content.ts)
+// exactly, or migrated pages would come up at different URLs than their
+// static ancestors.
+
+export interface PageNode {
+  /** Path relative to content/pages, posix separators. */
+  file: string;
+  slug: string;
+  /** Materialised URL path, e.g. "/cricket/ground/grounds-team". */
+  path: string;
+  /** Parent page's URL path, or null for a root page. */
+  parentPath: string | null;
+}
+
+export interface PageTreeFailure {
+  file: string;
+  /** Derived URL path when derivable (used to fail descendants too). */
+  path?: string;
+  reason: string;
+}
+
+export interface PageTree {
+  /** Valid nodes, path-ordered: every ancestor precedes its descendants. */
+  ordered: PageNode[];
+  failed: PageTreeFailure[];
+  excluded: { file: string; reason: string }[];
+}
+
+export const LEGAL_EXCLUSION_REASON = "excluded by design (legal stays static)";
+
+/**
+ * Byte-for-byte mirror of the web app's transform (apps/web
+ * src/lib/content.ts) minus the Vite glob prefix: ".mdx" stripped,
+ * "_index" representing its directory. The migration derives paths
+ * structurally (parent path + slug); this is the independent
+ * cross-check.
+ */
+export function filePathToUrlPath(relPath: string): string {
+  let path = relPath.replace(/\.mdx$/, "");
+  path = path.replace(/\/_index$/, "").replace(/^_index$/, "");
+  return "/" + path;
+}
+
+function deriveNode(file: string): PageNode {
+  const segments = file.split("/");
+  const basename = segments.pop();
+  if (basename === undefined || !basename.endsWith(".mdx")) {
+    throw new Error("not an .mdx file");
+  }
+  const dirSegments = segments;
+
+  let slug: string;
+  let pathSegments: string[];
+  if (basename === "_index.mdx") {
+    const dirName = dirSegments[dirSegments.length - 1];
+    if (dirName === undefined) {
+      throw new Error("root _index.mdx has no slug (its path would be '/')");
+    }
+    slug = dirName;
+    pathSegments = dirSegments;
+  } else {
+    slug = basename.replace(/\.mdx$/, "");
+    pathSegments = [...dirSegments, slug];
+  }
+
+  if (!contentSlugSchema.safeParse(slug).success) {
+    throw new Error(
+      `slug '${slug}' is not a valid content slug (lowercase letters, numbers and hyphens)`,
+    );
+  }
+  const path = "/" + pathSegments.join("/");
+  if (!contentPathSchema.safeParse(path).success) {
+    throw new Error(`derived path '${path}' is not a valid page path`);
+  }
+
+  const parentPath =
+    pathSegments.length > 1 ? "/" + pathSegments.slice(0, -1).join("/") : null;
+
+  // Sanity check: the structural derivation (parent path + slug) must
+  // agree with the web app's file-path transform, segment for segment.
+  const expected = filePathToUrlPath(file);
+  if (path !== expected) {
+    throw new Error(
+      `derived path '${path}' does not match filePathToUrlPath '${expected}'`,
+    );
+  }
+  if (path !== (parentPath ?? "") + "/" + slug) {
+    throw new Error(`derived path '${path}' is not parent path + '/' + slug`);
+  }
+
+  return { file, slug, path, parentPath };
+}
+
+/**
+ * Build the page tree from the corpus file list. legal/** is excluded by
+ * design; structural failures (bad slug, missing parent _index.mdx, root
+ * _index.mdx) fail the file AND - because a page cannot be inserted
+ * without its parent row - every descendant of a failed file fails too.
+ */
+export function buildPageTree(files: string[]): PageTree {
+  const failed: PageTreeFailure[] = [];
+  const excluded: PageTree["excluded"] = [];
+
+  const candidates: PageNode[] = [];
+  for (const file of [...files].sort()) {
+    if (file.startsWith("legal/")) {
+      excluded.push({ file, reason: LEGAL_EXCLUSION_REASON });
+      continue;
+    }
+    try {
+      candidates.push(deriveNode(file));
+    } catch (err) {
+      failed.push({
+        file,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Path order: "/a" sorts before "/a/b", so every ancestor is processed
+  // (and inserted) before its descendants - the same ordering the admin
+  // page tree relies on.
+  candidates.sort((a, b) => a.path.localeCompare(b.path));
+
+  const okPaths = new Set<string>();
+  const failedPaths = new Set<string>();
+  const ordered: PageNode[] = [];
+  for (const node of candidates) {
+    if (node.parentPath !== null && !okPaths.has(node.parentPath)) {
+      const reason = failedPaths.has(node.parentPath)
+        ? `parent failed (${node.parentPath})`
+        : `parent page required: no _index.mdx provides '${node.parentPath}'`;
+      failed.push({ file: node.file, path: node.path, reason });
+      failedPaths.add(node.path);
+      continue;
+    }
+    okPaths.add(node.path);
+    ordered.push(node);
+  }
+
+  return { ordered, failed, excluded };
+}
+
+/**
+ * Runtime counterpart of buildPageTree's structural propagation: once a
+ * page fails conversion or upsert, every page under it must fail too
+ * (its row will not exist to parent them). Processing is path-ordered,
+ * so checking the direct parent propagates transitively as each failed
+ * child joins the set.
+ */
+export function parentFailureReason(
+  node: PageNode,
+  failedPaths: ReadonlySet<string>,
+): string | null {
+  if (node.parentPath !== null && failedPaths.has(node.parentPath)) {
+    return `parent failed (${node.parentPath})`;
+  }
+  return null;
+}

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -347,6 +347,61 @@ describe("ContentBody", () => {
     expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
   });
 
+  it("renders personGrid entries as Person children carrying their roles", () => {
+    const html = renderBody([
+      block("personGrid", {
+        props: {
+          slugs: "alex-slaven,bob",
+          entries: JSON.stringify([
+            { slug: "alex-slaven", role: "Head Coach" },
+            { slug: "bob" },
+          ]),
+        },
+      }),
+    ]);
+    expect(html).toContain('href="/person/alex-slaven"');
+    expect(html).toContain("Head Coach");
+    expect(html).toContain('href="/person/bob"');
+    // Exactly two person cards: same composition as the MDX corpus.
+    expect(html.match(/class="person /g)).toHaveLength(2);
+  });
+
+  it("prefers entries over the slugs CSV when both are present", () => {
+    const html = renderBody([
+      block("personGrid", {
+        props: {
+          slugs: "stale-slug",
+          entries: JSON.stringify([{ slug: "fresh-slug", role: "Captain" }]),
+        },
+      }),
+    ]);
+    expect(html).toContain('href="/person/fresh-slug"');
+    expect(html).toContain("Captain");
+    expect(html).not.toContain("stale-slug");
+  });
+
+  it("falls back to the slugs CSV when entries is malformed", () => {
+    for (const entries of [
+      "not json",
+      '{"slug":"x"}', // not an array
+      '[{"role":"Coach"}]', // entry without a slug
+      '[{"slug":""}]', // empty slug
+      '[{"slug":"x","role":5}]', // non-string role
+    ]) {
+      const html = renderBody([
+        block("personGrid", { props: { slugs: "alex-slaven", entries } }),
+      ]);
+      expect(html).toContain('href="/person/alex-slaven"');
+    }
+  });
+
+  it("falls back to the slugs CSV when entries is an empty array", () => {
+    const html = renderBody([
+      block("personGrid", { props: { slugs: "alex-slaven", entries: "[]" } }),
+    ]);
+    expect(html).toContain('href="/person/alex-slaven"');
+  });
+
   it("hides leagueTable when divisionId is missing", () => {
     const html = renderBody([block("leagueTable", { props: {} })]);
     expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -3,6 +3,7 @@ import {
   OptimisedImage,
   type PictureSource,
 } from "@/components/optimised-image.js";
+import { parsePersonGridEntries } from "@/lib/person-grid.js";
 import { cn } from "@/lib/utils.js";
 import {
   contentBodySchema,
@@ -330,6 +331,24 @@ function BlockView({ block }: { block: ContentBlock }) {
     }
 
     case CUSTOM_BLOCK_TYPES.personGrid: {
+      // Role-preserving entries prop (JSON-stringified [{slug, role?}],
+      // same precedent as contentImage's picture prop): compose
+      // PersonGrid with Person children exactly as the MDX corpus does.
+      // Absent or malformed entries degrade to the legacy slugs CSV.
+      const entries = parsePersonGridEntries(stringProp(block, "entries"));
+      if (entries !== null && entries.length > 0) {
+        return (
+          <mdxComponents.PersonGrid>
+            {entries.map((entry, i) => (
+              <mdxComponents.Person
+                key={`${entry.slug}-${String(i)}`}
+                slug={entry.slug}
+                role={entry.role}
+              />
+            ))}
+          </mdxComponents.PersonGrid>
+        );
+      }
       const slugs = stringProp(block, "slugs");
       if (!slugs) return null;
       // Normalise the stored CSV: trim each segment, drop empties - so

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -336,7 +336,7 @@ function BlockView({ block }: { block: ContentBlock }) {
       // PersonGrid with Person children exactly as the MDX corpus does.
       // Absent or malformed entries degrade to the legacy slugs CSV.
       const entries = parsePersonGridEntries(stringProp(block, "entries"));
-      if (entries !== null && entries.length > 0) {
+      if (entries !== null) {
         return (
           <mdxComponents.PersonGrid>
             {entries.map((entry, i) => (

--- a/apps/web/src/lib/person-grid.ts
+++ b/apps/web/src/lib/person-grid.ts
@@ -1,0 +1,47 @@
+// The personGrid block's role-preserving prop (#496): `entries` is a
+// JSON-stringified array of { slug, role? }, following the contentImage
+// `picture` JSON-string-prop precedent. The legacy `slugs` CSV prop is
+// kept as a fallback the renderer still reads when entries is absent or
+// malformed. Shared between the public renderer (content-body.tsx) and
+// the editor block (content-editor.tsx) so both parse identically.
+
+export interface PersonGridEntry {
+  slug: string;
+  role?: string;
+}
+
+/**
+ * Parse a JSON-stringified personGrid entries prop. Returns null for
+ * anything that is not a wholly valid array of { slug, role? } - the
+ * caller then falls back to the legacy slugs CSV (malformed stored
+ * content degrades, never crashes, per the renderer's conventions).
+ * Slugs are trimmed; empty roles are dropped (NULL-for-unset). Roles
+ * are otherwise kept verbatim: the editor round-trips entries through
+ * this parser on every keystroke, so trimming here would eat the
+ * trailing space while someone types a multi-word role.
+ */
+export function parsePersonGridEntries(
+  raw: string | undefined,
+): PersonGridEntry[] | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+
+  const entries: PersonGridEntry[] = [];
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null) return null;
+    const { slug, role } = item as { slug?: unknown; role?: unknown };
+    if (typeof slug !== "string" || slug.trim() === "") return null;
+    if (role !== undefined && typeof role !== "string") return null;
+    entries.push({
+      slug: slug.trim(),
+      ...(role ? { role } : {}),
+    });
+  }
+  return entries;
+}

--- a/apps/web/src/lib/person-grid.ts
+++ b/apps/web/src/lib/person-grid.ts
@@ -12,9 +12,11 @@ export interface PersonGridEntry {
 
 /**
  * Parse a JSON-stringified personGrid entries prop. Returns null for
- * anything that is not a wholly valid array of { slug, role? } - the
- * caller then falls back to the legacy slugs CSV (malformed stored
- * content degrades, never crashes, per the renderer's conventions).
+ * anything that is not a wholly valid, non-empty array of
+ * { slug, role? } - the caller then falls back to the legacy slugs CSV
+ * (malformed stored content degrades, never crashes, per the renderer's
+ * conventions). Empty arrays are null so the renderer and editor agree
+ * on when the fallback applies.
  * Slugs are trimmed; empty roles are dropped (NULL-for-unset). Roles
  * are otherwise kept verbatim: the editor round-trips entries through
  * this parser on every keystroke, so trimming here would eat the
@@ -43,5 +45,5 @@ export function parsePersonGridEntries(
       ...(role ? { role } : {}),
     });
   }
-  return entries;
+  return entries.length > 0 ? entries : null;
 }

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -60,6 +60,10 @@ import type { paths } from "@/lib/api.gen.js";
 import { uploadContentImage } from "@/lib/content-images.js";
 import { getAllPeople } from "@/lib/people.js";
 import {
+  parsePersonGridEntries,
+  type PersonGridEntry,
+} from "@/lib/person-grid.js";
+import {
   CONTENT_KIND_RESOURCES,
   contentBodySchema,
   CUSTOM_BLOCK_TYPES,
@@ -330,25 +334,52 @@ const personGridBlock = createReactBlockSpec(
   {
     type: CUSTOM_BLOCK_TYPES.personGrid,
     propSchema: {
-      // Comma-separated person slugs - same storage format as content-body
+      // Legacy fallback the public renderer still reads when entries is
+      // absent - kept in sync as the CSV of the selected slugs.
       slugs: { default: "" },
+      // Canonical role-preserving prop: JSON-stringified [{slug, role?}]
+      // (same precedent as contentImage's picture prop).
+      entries: { default: "" },
     },
     content: "none",
   },
   {
     render: ({ block, editor }) => {
-      // Same CSV normalisation as the public renderer: trim each
-      // segment, drop empties - "alice, bob" works either side.
-      const selected = block.props.slugs.split(",").flatMap((s) => {
-        const trimmed = s.trim();
-        return trimmed ? [trimmed] : [];
-      });
+      // entries is canonical; a block predating it (or with malformed
+      // JSON) degrades to the slugs CSV, role-less - exactly like the
+      // public renderer.
+      const entries: PersonGridEntry[] =
+        parsePersonGridEntries(block.props.entries) ??
+        block.props.slugs.split(",").flatMap((s) => {
+          const trimmed = s.trim();
+          return trimmed ? [{ slug: trimmed }] : [];
+        });
       const allPeople = getAllPeople();
+      const nameOf = (slug: string) =>
+        allPeople.find((p) => p.slug === slug)?.name ?? slug;
+      const write = (next: PersonGridEntry[]) => {
+        editor.updateBlock(block, {
+          props: {
+            ...block.props,
+            entries: JSON.stringify(next),
+            slugs: next.map((e) => e.slug).join(","),
+          },
+        });
+      };
       return (
         <div className="my-2 flex w-full flex-col gap-2">
-          {selected.length > 0 ? (
+          {entries.length > 0 ? (
             <EditorBlockPreview>
-              <mdxComponents.PersonGrid slugs={selected} />
+              {/* Same children composition as the public renderer. */}
+              <mdxComponents.PersonGrid>
+                {entries.map((entry, i) => (
+                  <mdxComponents.Person
+                    key={`${entry.slug}-${String(i)}`}
+                    slug={entry.slug}
+                    role={entry.role}
+                  />
+                ))}
+              </mdxComponents.PersonGrid>
             </EditorBlockPreview>
           ) : (
             <p className="text-sm text-stone-500">Choose people to display…</p>
@@ -361,14 +392,19 @@ const personGridBlock = createReactBlockSpec(
               aria-label="People"
               multiple
               size={Math.min(allPeople.length, 6)}
-              value={selected}
+              value={entries.map((e) => e.slug)}
               onChange={(e) => {
                 const chosen = Array.from(e.target.selectedOptions).map(
                   (o) => o.value,
                 );
-                editor.updateBlock(block, {
-                  props: { ...block.props, slugs: chosen.join(",") },
-                });
+                // People who stay selected keep their role; newly
+                // selected people start role-less.
+                write(
+                  chosen.map(
+                    (slug) =>
+                      entries.find((entry) => entry.slug === slug) ?? { slug },
+                  ),
+                );
               }}
               className="rounded border border-stone-300 bg-white p-1 text-sm"
             >
@@ -379,6 +415,25 @@ const personGridBlock = createReactBlockSpec(
               ))}
             </select>
           </div>
+          {entries.map((entry, i) => (
+            <input
+              key={`${entry.slug}-${String(i)}`}
+              aria-label={`Role shown for ${nameOf(entry.slug)}`}
+              placeholder={`Role for ${nameOf(entry.slug)} (optional)`}
+              value={entry.role ?? ""}
+              onChange={(e) => {
+                const role = e.target.value;
+                write(
+                  entries.map((current, j) =>
+                    j === i
+                      ? { slug: current.slug, ...(role !== "" && { role }) }
+                      : current,
+                  ),
+                );
+              }}
+              className="rounded border border-stone-300 bg-white p-1 text-sm"
+            />
+          ))}
         </div>
       );
     },


### PR DESCRIPTION
Part of epic #492 (targets the epic branch). Closes #496.

## What

**Migration script** (`apps/api/scripts/migrate-pages.ts` + shared machinery)
- Hierarchy from the directory layout: `dir/_index.mdx` IS the parent item; path derivation is a byte-for-byte mirror of the web `filePathToUrlPath`, asserted per page. Parents insert before children; one shared `published_at` (script start) keeps the child-go-live >= parent invariant trivially true.
- Idempotent upsert keyed by path (draft = skip+warn, published unchanged = skip, changed = skip unless `--force`); `--force` never touches slug/parent/path/status/published_at. Failed parent fails its subtree with logged reasons; legal/** excluded by design.
- End-of-run report prints migrated/failed/excluded lists plus the would-be nav payload `[{path,title,menuOrder,isMainMenu}]` - the before/after nav snapshot artifact.

**Converter** (`mdx-to-blocks.ts`)
- Full vocabulary: every mdx-component maps to its #495 block. PersonGrid parses the paired-container form with nested Person children. Bare block-level markdown images (`![..](..)` alone in a paragraph) lift through the contentImage pipeline - without this, one logo in `cricket/_index.mdx` failed the parent and gutted 21 descendant pages. Strictness otherwise unchanged: inline components, linked images, unknown JSX, imports all fail the file (each pinned by a test).
- **personGrid roles**: migration surfaced that the slugs-CSV block design dropped 60+ role labels (committee/captains/coaches), failing visual parity. The block now carries `entries` (JSON `[{slug, role?}]`, following the contentImage JSON-prop precedent); renderer composes `Person` children with roles, editor gains per-person role inputs, slugs CSV stays as a legacy fallback.

## Dry run against the real corpus (29 / 2 / 1 of 32 files)
- 29 migrate cleanly; nav payload spot-checks match frontmatter exactly.
- 2 stay static via the fallback, logged with reasons (by design per the issue): `cricket/kit-shop.mdx` (linked image - converting would drop the link), `cricket/safeguarding.mdx` (inline `<Person>` inside a heading).
- `legal/privacy.mdx` excluded permanently.
- Real-run verification on local Docker DB: correct parent_id chains, 1 distinct published_at, 29 revisions, image ladders to LocalStack with deterministic UUIDv5 reuse, re-run idempotent, draft-parent gate fails the subtree.

## Tests
api 653 (62 mdx-to-blocks, 10 page-tree), web 540 (+5 entries/fallback tests). typecheck/lint/build clean.

Post-merge (not this epic): run the prod migration before authoring, verify, then the cleanup PR prunes migrated MDX per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)