### PR TITLE
Epic: Live content editing - Phase 3: Hierarchical pages + full component coverage (#492)

### DIFF
--- a/apps/api/scripts/image-pipeline.ts
+++ b/apps/api/scripts/image-pipeline.ts
@@ -1,0 +1,183 @@
+import type { DB } from "@percy-main/db";
+import { promises as fs } from "fs";
+import type { Kysely } from "kysely";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  processImage,
+  type ProcessedImage,
+} from "../src/features/content-images/service.ts";
+import {
+  CONTENT_IMAGES_PREFIX,
+  type ContentImageStore,
+} from "../src/lib/s3-content-images.ts";
+import type { MigrationBlock } from "./markdown-to-blocks.ts";
+import { imageIdForAsset, mdxToBlocks } from "./mdx-to-blocks.ts";
+
+// Shared <Image> handling for the MDX content migrations (#491 news +
+// events, #496 pages): every corpus references its images by public
+// "/images/..." path, which the web app's image-map resolves to files
+// under src/assets/images/. Each one goes through the same processing
+// pipeline as editor uploads (responsive WebP ladder + original-format
+// fallback in S3, registered in content_image), with UUIDv5 ids derived
+// from the source path so re-runs are idempotent.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ASSETS_DIR = path.resolve(__dirname, "../../web/src/assets/images");
+
+export class MissingImageError extends Error {
+  constructor(publicPath: string) {
+    super(`image file not found on disk for '${publicPath}'`);
+  }
+}
+
+export interface PendingImage {
+  imageId: string;
+  publicPath: string;
+  alt: string | null;
+  processed: ProcessedImage;
+  bytes: number;
+}
+
+export interface Converted {
+  blocks: MigrationBlock[];
+  images: PendingImage[];
+}
+
+/**
+ * Convert one MDX body, resolving each <Image> through the editor-upload
+ * processing pipeline (locally - nothing is written here, so --dry-run
+ * conversion is complete and writes can be deferred until after the
+ * skip/insert decision). The processed-image cache spans articles so a
+ * re-used asset is only decoded once.
+ */
+export async function convertBody(
+  body: string,
+  cache: Map<string, PendingImage>,
+): Promise<Converted> {
+  const images: PendingImage[] = [];
+  const blocks = await mdxToBlocks(body, async ({ src, alt, caption }) => {
+    const imageId = imageIdForAsset(src);
+    let pending = cache.get(imageId);
+    if (!pending) {
+      if (!src.startsWith("/images/")) {
+        throw new Error(`unexpected image src '${src}'`);
+      }
+      const assetPath = path.resolve(ASSETS_DIR, src.slice("/images/".length));
+      // A '..' segment in the src could otherwise resolve outside the
+      // bundled assets tree and upload an arbitrary readable file.
+      if (!assetPath.startsWith(ASSETS_DIR + path.sep)) {
+        throw new Error(`image src '${src}' escapes the assets directory`);
+      }
+      let original: Buffer;
+      try {
+        original = await fs.readFile(assetPath);
+      } catch {
+        throw new MissingImageError(src);
+      }
+      const processed = await processImage(
+        original,
+        imageId,
+        CONTENT_IMAGES_PREFIX,
+      );
+      pending = {
+        imageId,
+        publicPath: src,
+        alt: alt ?? null,
+        processed,
+        bytes: original.byteLength,
+      };
+      cache.set(imageId, pending);
+    }
+    images.push(pending);
+    // Exactly the prop set the editor inserts (content-editor.tsx): the
+    // plain src falls back to the ladder's largest original-format
+    // variant, picture carries the JSON-stringified PictureSource.
+    return {
+      src: pending.processed.picture.img.src,
+      alt: alt ?? "",
+      caption: caption ?? "",
+      picture: JSON.stringify(pending.processed.picture),
+    };
+  });
+  return { blocks, images };
+}
+
+/**
+ * Upload variants + register rows for an item's images (idempotent -
+ * existing content_image rows are reused). Returns the upload/reuse
+ * tallies for the run summary.
+ */
+export async function ensureImages(
+  db: Kysely<DB>,
+  store: ContentImageStore,
+  userId: string,
+  images: PendingImage[],
+): Promise<{ uploaded: number; reused: number }> {
+  let uploaded = 0;
+  let reused = 0;
+  for (const image of images) {
+    const existing = await db
+      .selectFrom("content_image")
+      .select("id")
+      .where("id", "=", image.imageId)
+      .executeTakeFirst();
+    if (existing) {
+      reused += 1;
+      continue;
+    }
+    for (const variant of image.processed.variants) {
+      await store.putVariant(variant.key, variant.body, variant.contentType);
+    }
+    await db
+      .insertInto("content_image")
+      .values({
+        id: image.imageId,
+        key_prefix: `${CONTENT_IMAGES_PREFIX}/${image.imageId}`,
+        original_format: image.processed.sourceFormat,
+        width: image.processed.width,
+        height: image.processed.height,
+        bytes: image.bytes,
+        picture: JSON.stringify(image.processed.picture),
+        alt: image.alt,
+        consent_confirmed: true,
+        uploaded_by: userId,
+      })
+      .onConflict((oc) => oc.column("id").doNothing())
+      .execute();
+    uploaded += 1;
+    console.log(
+      `    ^ uploaded ${image.publicPath} -> ${CONTENT_IMAGES_PREFIX}/${image.imageId}/ (${String(image.processed.variants.length)} variants)`,
+    );
+  }
+  return { uploaded, reused };
+}
+
+/**
+ * Dry-run counterpart of ensureImages: split an item's images into
+ * would-upload (new) and reused, deduplicating across items via the
+ * caller's plannedUploads set so a shared asset is only counted once.
+ */
+export async function planImageUploads(
+  db: Kysely<DB>,
+  images: PendingImage[],
+  plannedUploads: Set<string>,
+): Promise<{ newImages: PendingImage[]; reused: number }> {
+  const newImages: PendingImage[] = [];
+  let reused = 0;
+  for (const image of images) {
+    if (plannedUploads.has(image.imageId)) continue;
+    const row = await db
+      .selectFrom("content_image")
+      .select("id")
+      .where("id", "=", image.imageId)
+      .executeTakeFirst();
+    if (row) {
+      reused += 1;
+    } else {
+      newImages.push(image);
+      plannedUploads.add(image.imageId);
+    }
+  }
+  return { newImages, reused };
+}

--- a/apps/api/scripts/mdx-to-blocks.test.ts
+++ b/apps/api/scripts/mdx-to-blocks.test.ts
@@ -1,5 +1,6 @@
 import {
   contentBodySchema,
+  CUSTOM_BLOCK_TYPES,
   eventMetadataSchema,
 } from "@percy-main/shared/content";
 import { describe, expect, it, vi } from "vitest";
@@ -12,6 +13,7 @@ import {
   newsPublishedAt,
   parseEventSource,
   parseNewsSource,
+  parsePageSource,
   resolveLocation,
   segmentMdx,
   type ResolveContentImage,
@@ -131,6 +133,150 @@ describe("segmentMdx", () => {
       { kind: "markdown", text: "The away side, 9th in Division Three, lost." },
     ]);
   });
+
+  it("lifts a bare markdown image paragraph into an Image segment", () => {
+    const segments = segmentMdx(
+      [
+        "##### Main Club Sponsor",
+        "",
+        "![The Crossling logo](/images/contentful/abc/logo.png)",
+        "",
+        "#### Weekly Schedule",
+      ].join("\n"),
+    );
+    expect(segments).toEqual([
+      { kind: "markdown", text: "##### Main Club Sponsor" },
+      {
+        kind: "component",
+        name: "Image",
+        attrs: {
+          src: "/images/contentful/abc/logo.png",
+          alt: "The Crossling logo",
+        },
+      },
+      { kind: "markdown", text: "#### Weekly Schedule" },
+    ]);
+  });
+
+  it("keeps an image inside a paragraph in the markdown segment", () => {
+    // Adjacent non-blank lines = one paragraph; lifting the image would
+    // split it, so it stays markdown (and markdownToBlocks rejects it).
+    const segments = segmentMdx(
+      ["Some text", "![alt](/images/x.png)", "more text"].join("\n"),
+    );
+    expect(segments).toEqual([
+      {
+        kind: "markdown",
+        text: "Some text\n![alt](/images/x.png)\nmore text",
+      },
+    ]);
+  });
+});
+
+describe("segmentMdx containers", () => {
+  it("parses PersonGrid children with slug + role fidelity", () => {
+    const segments = segmentMdx(
+      [
+        "### Captains",
+        "",
+        "<PersonGrid>",
+        '  <Person slug="alex-young" role="1st XI Captain" />',
+        '  <Person slug="john-allan" />',
+        "</PersonGrid>",
+      ].join("\n"),
+    );
+    expect(segments).toEqual([
+      { kind: "markdown", text: "### Captains" },
+      {
+        kind: "personGrid",
+        people: [
+          { slug: "alex-young", role: "1st XI Captain" },
+          { slug: "john-allan" },
+        ],
+      },
+    ]);
+  });
+
+  it("rejects a PersonGrid containing a non-Person element", () => {
+    expect(() =>
+      segmentMdx(
+        [
+          "<PersonGrid>",
+          '  <Person slug="a" />',
+          '  <Image src="/images/x.png" />',
+          "</PersonGrid>",
+        ].join("\n"),
+      ),
+    ).toThrow(/may only contain <Person \/> children/);
+  });
+
+  it("rejects a PersonGrid containing loose text", () => {
+    expect(() =>
+      segmentMdx(
+        [
+          "<PersonGrid>",
+          '  <Person slug="a" />',
+          "  hello",
+          "</PersonGrid>",
+        ].join("\n"),
+      ),
+    ).toThrow(/non-component content/);
+  });
+
+  it("rejects an empty PersonGrid", () => {
+    expect(() => segmentMdx("<PersonGrid>\n</PersonGrid>")).toThrow(
+      /no <Person> children/,
+    );
+  });
+
+  it("rejects a Person child without a slug", () => {
+    expect(() =>
+      segmentMdx('<PersonGrid>\n  <Person role="Coach" />\n</PersonGrid>'),
+    ).toThrow(/without slug/);
+  });
+
+  it("rejects the self-closing PersonGrid attribute form (corpus never uses it)", () => {
+    expect(() => segmentMdx('<PersonGrid slugs="a,b" />')).toThrow(
+      /without <Person> children/,
+    );
+  });
+
+  it("rejects an unclosed PersonGrid", () => {
+    expect(() => segmentMdx('<PersonGrid>\n  <Person slug="a" />')).toThrow(
+      /Unclosed <PersonGrid>/,
+    );
+  });
+
+  it("rejects an inline PersonGrid", () => {
+    expect(() =>
+      segmentMdx('Meet <PersonGrid>\n<Person slug="a" />\n</PersonGrid>'),
+    ).toThrow(/used inline/);
+  });
+
+  it("rejects a paired tag for a self-closing-only component", () => {
+    expect(() => segmentMdx("<Leaderboard></Leaderboard>")).toThrow(
+      /must be self-closing/,
+    );
+  });
+
+  it("takes paired CookieSettingsLink text from its children", () => {
+    const segments = segmentMdx(
+      "<CookieSettingsLink>Manage cookies</CookieSettingsLink>",
+    );
+    expect(segments).toEqual([
+      {
+        kind: "component",
+        name: "CookieSettingsLink",
+        attrs: { text: "Manage cookies" },
+      },
+    ]);
+  });
+
+  it("rejects CookieSettingsLink with tag-shaped children", () => {
+    expect(() =>
+      segmentMdx("<CookieSettingsLink><b>hi</b></CookieSettingsLink>"),
+    ).toThrow(/non-text children/);
+  });
 });
 
 describe("mdxToBlocks", () => {
@@ -212,10 +358,293 @@ describe("mdxToBlocks", () => {
     );
   });
 
-  it("still fails loudly on unsupported markdown constructs", async () => {
+  it("maps a bare markdown image through the contentImage pipeline", async () => {
+    const resolver = vi.fn(stubResolver);
+    const blocks = await mdxToBlocks(
+      "![The Crossling logo](/images/contentful/abc/logo.png)",
+      resolver,
+    );
+    expect(resolver).toHaveBeenCalledWith({
+      src: "/images/contentful/abc/logo.png",
+      alt: "The Crossling logo",
+      caption: undefined,
+    });
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ type: "contentImage" });
+  });
+
+  it("still fails loudly on an image inside a paragraph", async () => {
     await expect(
-      mdxToBlocks("![inline](/images/x.png)", stubResolver),
+      mdxToBlocks("An inline ![image](/images/x.png) here", stubResolver),
     ).rejects.toThrow(/Unsupported/);
+  });
+
+  it("still fails loudly on a linked image (the link would be dropped)", async () => {
+    await expect(
+      mdxToBlocks(
+        "[![VX3 Logo](/images/contentful/abc/vx3.webp)](https://kit.percymain.org)",
+        stubResolver,
+      ),
+    ).rejects.toThrow(/Unsupported/);
+  });
+});
+
+describe("mdxToBlocks page components", () => {
+  const single = async (body: string) => {
+    const blocks = await mdxToBlocks(body, stubResolver);
+    expect(blocks).toHaveLength(1);
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+    return blocks[0];
+  };
+
+  it("maps <Person> with the editor's prop set (role defaults empty)", async () => {
+    expect(
+      await single('<Person slug="paddy-rathbone" role="Welfare Officer" />'),
+    ).toMatchObject({
+      type: "person",
+      props: { slug: "paddy-rathbone", role: "Welfare Officer" },
+      children: [],
+    });
+    expect(await single('<Person slug="paddy-rathbone" />')).toMatchObject({
+      type: "person",
+      props: { slug: "paddy-rathbone", role: "" },
+    });
+  });
+
+  it("fails on a Person with no slug", async () => {
+    await expect(mdxToBlocks("<Person />", stubResolver)).rejects.toThrow(
+      /<Person> without slug/,
+    );
+  });
+
+  it("maps <EventPreview> id -> eventId (the block prop name)", async () => {
+    expect(
+      await single(
+        [
+          "<EventPreview",
+          '  id="refugee-week-celebration"',
+          '  name="Refugee Week Celebration"',
+          '  when="2025-06-22T13:00+01:00"',
+          "/>",
+        ].join("\n"),
+      ),
+    ).toMatchObject({
+      type: "eventPreview",
+      props: {
+        eventId: "refugee-week-celebration",
+        name: "Refugee Week Celebration",
+        when: "2025-06-22T13:00+01:00",
+      },
+    });
+  });
+
+  it("fails on an EventPreview missing a required prop", async () => {
+    await expect(
+      mdxToBlocks('<EventPreview id="x" name="y" />', stubResolver),
+    ).rejects.toThrow(/<EventPreview> without when/);
+  });
+
+  it("maps <LeagueTable> (name defaults empty)", async () => {
+    expect(
+      await single(
+        '<LeagueTable divisionId="135699" name="NTCL Division 4" />',
+      ),
+    ).toMatchObject({
+      type: "leagueTable",
+      props: { divisionId: "135699", name: "NTCL Division 4" },
+    });
+    expect(await single('<LeagueTable divisionId="135699" />')).toMatchObject({
+      type: "leagueTable",
+      props: { divisionId: "135699", name: "" },
+    });
+  });
+
+  it("fails on a LeagueTable with no divisionId", async () => {
+    await expect(mdxToBlocks("<LeagueTable />", stubResolver)).rejects.toThrow(
+      /<LeagueTable> without divisionId/,
+    );
+  });
+
+  it("maps the propless components to empty-prop blocks", async () => {
+    expect(await single("<Leaderboard />")).toMatchObject({
+      type: "leaderboard",
+      props: {},
+    });
+    expect(await single("<RecordsWall />")).toMatchObject({
+      type: "recordsWall",
+      props: {},
+    });
+    expect(await single("<ConsentVersion />")).toMatchObject({
+      type: "consentVersion",
+      props: {},
+    });
+  });
+
+  it("maps <ContactForm> with title/description defaulting empty", async () => {
+    expect(
+      await single(
+        '<ContactForm title="Get in Touch" description="Drop us a message." />',
+      ),
+    ).toMatchObject({
+      type: "contactForm",
+      props: { title: "Get in Touch", description: "Drop us a message." },
+    });
+    expect(await single("<ContactForm />")).toMatchObject({
+      type: "contactForm",
+      props: { title: "", description: "" },
+    });
+  });
+
+  it("maps <CookieSettingsLink>: children text when paired, default otherwise", async () => {
+    expect(
+      await single("<CookieSettingsLink>Manage cookies</CookieSettingsLink>"),
+    ).toMatchObject({
+      type: "cookieSettingsLink",
+      props: { text: "Manage cookies" },
+    });
+    expect(await single("<CookieSettingsLink />")).toMatchObject({
+      type: "cookieSettingsLink",
+      props: { text: "Cookie settings" },
+    });
+  });
+
+  it("maps <PersonGrid> children to role-preserving entries plus the slugs CSV", async () => {
+    expect(
+      await single(
+        [
+          "<PersonGrid>",
+          '  <Person slug="alex-young" role="1st XI Captain" />',
+          '  <Person slug="john-allan" />',
+          "</PersonGrid>",
+        ].join("\n"),
+      ),
+    ).toMatchObject({
+      type: "personGrid",
+      props: {
+        slugs: "alex-young,john-allan",
+        // Role kept on entries; the role-less child carries no role key
+        // (NULL-for-unset, matching what the editor writes).
+        entries: JSON.stringify([
+          { slug: "alex-young", role: "1st XI Captain" },
+          { slug: "john-allan" },
+        ]),
+      },
+    });
+  });
+
+  it("converts a kitchen-sink page body to schema-valid, known block types", async () => {
+    const blocks = await mdxToBlocks(
+      [
+        "Intro with a [link](/cricket).",
+        "",
+        "##### Captains",
+        "",
+        "<PersonGrid>",
+        '  <Person slug="alex-young" role="Captain" />',
+        "</PersonGrid>",
+        "",
+        '<Image src="/images/contentful/abc/p.jpg" alt="a" caption="c" />',
+        "",
+        '<LeagueTable divisionId="135699" name="Div 4" />',
+        "",
+        "<ContactForm />",
+        "",
+        "- one",
+        "- two",
+      ].join("\n"),
+      stubResolver,
+    );
+    expect(blocks.map((b) => b.type)).toEqual([
+      "paragraph",
+      "heading",
+      "personGrid",
+      "contentImage",
+      "leagueTable",
+      "contactForm",
+      "bulletListItem",
+      "bulletListItem",
+    ]);
+    expect(() => contentBodySchema.parse(blocks)).not.toThrow();
+    const knownTypes = new Set<string>([
+      "paragraph",
+      "heading",
+      "quote",
+      "codeBlock",
+      "table",
+      "bulletListItem",
+      "numberedListItem",
+      ...Object.values(CUSTOM_BLOCK_TYPES),
+    ]);
+    for (const block of blocks) {
+      expect(knownTypes.has(block.type)).toBe(true);
+    }
+  });
+});
+
+describe("parsePageSource", () => {
+  it("parses full frontmatter including ldjson passthrough", () => {
+    const parsed = parsePageSource(
+      [
+        "---",
+        "title: Cricket",
+        'description: "Percy Main Cricket Club."',
+        "menuOrder: 2",
+        "isMainMenu: true",
+        "hideTitle: true",
+        "ldjson:",
+        '  "@type": SportsClub',
+        "  name: Percy Main",
+        "---",
+        "",
+        "Body text.",
+      ].join("\n"),
+    );
+    expect(parsed).toEqual({
+      title: "Cricket",
+      description: "Percy Main Cricket Club.",
+      menuOrder: 2,
+      isMainMenu: true,
+      hideTitle: true,
+      ldjson: { "@type": "SportsClub", name: "Percy Main" },
+      body: "Body text.",
+    });
+  });
+
+  it("applies the defaults (menuOrder 99, flags false, no ldjson)", () => {
+    const parsed = parsePageSource(
+      ["---", "title: Boxing", "---", "", "Body."].join("\n"),
+    );
+    expect(parsed).toEqual({
+      title: "Boxing",
+      menuOrder: 99,
+      isMainMenu: false,
+      hideTitle: false,
+      body: "Body.",
+    });
+  });
+
+  it("rejects a missing title", () => {
+    expect(() =>
+      parsePageSource(["---", "menuOrder: 1", "---", "Body."].join("\n")),
+    ).toThrow();
+  });
+
+  it("rejects a non-object ldjson", () => {
+    expect(() =>
+      parsePageSource(
+        ["---", "title: X", 'ldjson: "not an object"', "---", "Body."].join(
+          "\n",
+        ),
+      ),
+    ).toThrow();
+  });
+
+  it("rejects a non-integer menuOrder", () => {
+    expect(() =>
+      parsePageSource(
+        ["---", "title: X", "menuOrder: 1.5", "---", "Body."].join("\n"),
+      ),
+    ).toThrow();
   });
 });
 

--- a/apps/api/scripts/mdx-to-blocks.ts
+++ b/apps/api/scripts/mdx-to-blocks.ts
@@ -5,36 +5,65 @@ import YAML from "yaml";
 import { z } from "zod";
 import { markdownToBlocks, type MigrationBlock } from "./markdown-to-blocks.ts";
 
-// One-time inbound migration converter (#491): the legacy MDX news +
-// events corpus -> the BlockNote-shaped block document the content API
-// stores (ADR 047). Unlike the game reports, this corpus embeds a small
-// fixed vocabulary of JSX components (<Image>, <GamePreview>) between
-// plain-markdown prose, so the body is segmented first: component
-// invocations are found with a regex over the raw source and everything
-// between them goes through markdownToBlocks() unchanged.
+// One-time inbound migration converter (#491, extended for pages in
+// #496): the legacy MDX news + events + pages corpus -> the
+// BlockNote-shaped block document the content API stores (ADR 047).
+// Unlike the game reports, these corpora embed a small fixed vocabulary
+// of JSX components between plain-markdown prose, so the body is
+// segmented first: component invocations are found with a regex over
+// the raw source and everything between them goes through
+// markdownToBlocks() unchanged.
 //
-// This is deliberately NOT a general MDX parser. The corpus is 17 files
-// written by a handful of people; a regex over the exact constructs they
-// used is simpler, auditable, and fails loudly on anything outside the
-// vocabulary - which is the correct behaviour for a one-time migration
-// (refusing beats silently dropping content).
+// This is deliberately NOT a general MDX parser. The corpus is a few
+// dozen files written by a handful of people; a regex over the exact
+// constructs they used is simpler, auditable, and fails loudly on
+// anything outside the vocabulary - which is the correct behaviour for
+// a one-time migration (refusing beats silently dropping content).
 
 // ── Segmentation ────────────────────────────────────────────────────────
 
 export type MdxSegment =
   | { kind: "markdown"; text: string }
-  | { kind: "component"; name: string; attrs: Record<string, string> };
-
-/** The only components the news/events corpus actually uses. */
-const KNOWN_COMPONENTS = new Set(["Image", "GamePreview"]);
+  | { kind: "component"; name: string; attrs: Record<string, string> }
+  // <PersonGrid> is the one container the corpus uses: paired tags
+  // wrapping self-closing <Person> children. Child roles are carried
+  // through so the converter can report when it has to drop them (the
+  // personGrid block type stores slugs only).
+  | { kind: "personGrid"; people: { slug: string; role?: string }[] };
 
 /**
- * A self-closing capitalised JSX invocation, possibly spanning lines
- * (the corpus writes <Image> with one attribute per line). The attr
- * chunk alternation permits ">" only inside quoted strings, so the
- * match cannot run past the closing "/>".
+ * Components the corpora write as self-closing invocations. Everything
+ * here maps 1:1 onto a custom block type from CUSTOM_BLOCK_TYPES (Image
+ * becomes contentImage via the upload pipeline).
  */
-const COMPONENT_RE = /<([A-Z][A-Za-z]*)((?:[^>"]|"[^"]*")*?)\/>/g;
+const SELF_CLOSING_COMPONENTS = new Set([
+  "Image",
+  "GamePreview",
+  "Person",
+  "EventPreview",
+  "LeagueTable",
+  "Leaderboard",
+  "RecordsWall",
+  "ContactForm",
+  "ConsentVersion",
+  "CookieSettingsLink",
+]);
+
+/**
+ * Components the corpora write as paired tags. PersonGrid wraps Person
+ * children (the slugs-attribute form is never used in the corpus, so it
+ * is deliberately unsupported); CookieSettingsLink's children are its
+ * link text.
+ */
+const CONTAINER_COMPONENTS = new Set(["PersonGrid", "CookieSettingsLink"]);
+
+/**
+ * A capitalised JSX tag - self-closing (capture 3 = "/") or opening -
+ * possibly spanning lines (the corpus writes <Image> with one attribute
+ * per line). The attr chunk alternation permits ">" only inside quoted
+ * strings, so the match cannot run past the tag's closing ">".
+ */
+const COMPONENT_RE = /<([A-Z][A-Za-z]*)((?:[^>"]|"[^"]*")*?)(\/)?>/g;
 
 /**
  * Attributes are exclusively string literals in this corpus
@@ -88,6 +117,95 @@ function assertNoLeftoverJsx(text: string): void {
 }
 
 /**
+ * A line that is exactly one markdown image. Only treated as a block
+ * when the surrounding lines are blank (i.e. it forms a paragraph of
+ * its own): the pages corpus writes one logo this way, and it maps to
+ * the same contentImage pipeline as <Image>. An image WITHIN a
+ * paragraph (or wrapped in a link) still fails the file - converting it
+ * would mean splitting a paragraph or dropping the link.
+ */
+const BARE_IMAGE_RE = /^!\[([^\]\n]*)\]\(([^)\s]+)\)$/;
+
+type ImageOrMarkdown =
+  | { kind: "markdown"; text: string }
+  | { kind: "component"; name: "Image"; attrs: Record<string, string> };
+
+/** Split a markdown chunk on bare-image paragraphs (see BARE_IMAGE_RE). */
+function splitBareImages(text: string): ImageOrMarkdown[] {
+  const lines = text.split("\n");
+  const parts: ImageOrMarkdown[] = [];
+  let pending: string[] = [];
+  const flush = () => {
+    const chunk = pending.join("\n").trim();
+    pending = [];
+    if (chunk !== "") parts.push({ kind: "markdown", text: chunk });
+  };
+  for (const [i, line] of lines.entries()) {
+    const match = BARE_IMAGE_RE.exec(line.trim());
+    const prevBlank = i === 0 || (lines[i - 1] ?? "").trim() === "";
+    const nextBlank =
+      i === lines.length - 1 || (lines[i + 1] ?? "").trim() === "";
+    if (match && prevBlank && nextBlank) {
+      flush();
+      const [, alt, src] = match;
+      parts.push({
+        kind: "component",
+        name: "Image",
+        attrs: {
+          src: src ?? "",
+          ...(alt !== undefined && alt !== "" && { alt }),
+        },
+      });
+      continue;
+    }
+    pending.push(line);
+  }
+  flush();
+  return parts;
+}
+
+/**
+ * Parse the children of a <PersonGrid> container: exclusively
+ * self-closing <Person> elements separated by whitespace, as the whole
+ * corpus writes them. Anything else fails the file.
+ */
+function parsePersonGridChildren(
+  inner: string,
+): { slug: string; role?: string }[] {
+  const people: { slug: string; role?: string }[] = [];
+  for (const match of inner.matchAll(COMPONENT_RE)) {
+    const [, name, rawAttrs, selfClosing] = match;
+    if (name !== "Person" || selfClosing !== "/") {
+      throw new Error(
+        `<PersonGrid> may only contain <Person /> children (found <${name ?? "?"}>) - migrate this file by hand`,
+      );
+    }
+    const attrs = parseComponentAttributes(rawAttrs ?? "");
+    if (!attrs.slug) {
+      throw new Error(
+        "<Person> inside <PersonGrid> without slug - migrate this file by hand",
+      );
+    }
+    people.push({
+      slug: attrs.slug,
+      ...(attrs.role !== undefined && { role: attrs.role }),
+    });
+  }
+  const leftover = inner.replace(COMPONENT_RE, "").trim();
+  if (leftover !== "") {
+    throw new Error(
+      `<PersonGrid> contains non-component content '${leftover.slice(0, 60)}' - migrate this file by hand`,
+    );
+  }
+  if (people.length === 0) {
+    throw new Error(
+      "<PersonGrid> with no <Person> children - migrate this file by hand",
+    );
+  }
+  return people;
+}
+
+/**
  * Split an MDX body into markdown segments and component invocations.
  * Components must be block-level (alone on their lines, as the whole
  * corpus writes them) - an inline invocation would force this code to
@@ -99,34 +217,83 @@ export function segmentMdx(body: string): MdxSegment[] {
   const pushMarkdown = (raw: string) => {
     const text = flattenSupTags(raw).trim();
     if (text === "") return;
-    assertNoLeftoverJsx(text);
-    segments.push({ kind: "markdown", text });
+    for (const part of splitBareImages(text)) {
+      if (part.kind === "markdown") assertNoLeftoverJsx(part.text);
+      segments.push(part);
+    }
   };
 
   let cursor = 0;
-  for (const match of body.matchAll(COMPONENT_RE)) {
-    const [full, name, rawAttrs] = match;
+  const re = new RegExp(COMPONENT_RE.source, "g");
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(body)) !== null) {
+    const [full, name, rawAttrs, selfClosing] = match;
     if (name === undefined || rawAttrs === undefined) continue;
-    if (!KNOWN_COMPONENTS.has(name)) {
-      throw new Error(
-        `Unknown component <${name}> - migrate this file by hand`,
-      );
-    }
     const start = match.index;
+    let end = start + full.length;
+
+    let segment: MdxSegment;
+    if (selfClosing === "/") {
+      if (!SELF_CLOSING_COMPONENTS.has(name)) {
+        throw new Error(
+          name === "PersonGrid"
+            ? "<PersonGrid /> without <Person> children (the slugs-attribute form is not used by the corpus) - migrate this file by hand"
+            : `Unknown component <${name}> - migrate this file by hand`,
+        );
+      }
+      segment = {
+        kind: "component",
+        name,
+        attrs: parseComponentAttributes(rawAttrs),
+      };
+    } else {
+      // Opening tag: only the two paired-tag containers are understood.
+      if (!CONTAINER_COMPONENTS.has(name)) {
+        throw new Error(
+          SELF_CLOSING_COMPONENTS.has(name)
+            ? `<${name}> must be self-closing - migrate this file by hand`
+            : `Unknown component <${name}> - migrate this file by hand`,
+        );
+      }
+      const closeTag = `</${name}>`;
+      const closeStart = body.indexOf(closeTag, end);
+      if (closeStart === -1) {
+        throw new Error(`Unclosed <${name}> - migrate this file by hand`);
+      }
+      const inner = body.slice(end, closeStart);
+      end = closeStart + closeTag.length;
+
+      if (name === "PersonGrid") {
+        segment = {
+          kind: "personGrid",
+          people: parsePersonGridChildren(inner),
+        };
+      } else {
+        // CookieSettingsLink: the children are the link text. Tag-shaped
+        // children mean vocabulary this converter does not understand.
+        if (/<[A-Za-z/]/.test(inner)) {
+          throw new Error(
+            "<CookieSettingsLink> with non-text children - migrate this file by hand",
+          );
+        }
+        const attrs = parseComponentAttributes(rawAttrs);
+        const text = inner.trim();
+        if (text !== "") attrs.text = text;
+        segment = { kind: "component", name, attrs };
+      }
+    }
+
     const before = body.slice(0, start);
-    const after = body.slice(start + full.length);
+    const after = body.slice(end);
     if (!/(^|\n)[ \t]*$/.test(before) || !/^[ \t]*(\n|$)/.test(after)) {
       throw new Error(
         `<${name}> used inline within other content - migrate this file by hand`,
       );
     }
     pushMarkdown(body.slice(cursor, start));
-    segments.push({
-      kind: "component",
-      name,
-      attrs: parseComponentAttributes(rawAttrs),
-    });
-    cursor = start + full.length;
+    segments.push(segment);
+    cursor = end;
+    re.lastIndex = end;
   }
   pushMarkdown(body.slice(cursor));
 
@@ -160,11 +327,23 @@ function customBlock(
   return { id: crypto.randomUUID(), type, props, children: [] };
 }
 
+/** A required string attribute, or a loud failure naming the component. */
+function requireAttr(
+  name: string,
+  attrs: Record<string, string>,
+  attr: string,
+): string {
+  const value = attrs[attr];
+  if (!value) throw new Error(`<${name}> without ${attr}`);
+  return value;
+}
+
 /**
- * Convert an MDX news/event body into the block array the content API
- * stores. Markdown segments reuse markdownToBlocks() (and inherit its
- * fail-loudly assertions); component segments map to the custom block
- * types the editor and public renderer share.
+ * Convert an MDX news/event/page body into the block array the content
+ * API stores. Markdown segments reuse markdownToBlocks() (and inherit
+ * its fail-loudly assertions); component segments map to the custom
+ * block types the editor and public renderer share, emitting exactly
+ * the prop set the editor's propSchema would (defaults filled in).
  */
 export async function mdxToBlocks(
   body: string,
@@ -176,22 +355,93 @@ export async function mdxToBlocks(
       blocks.push(...markdownToBlocks(segment.text));
       continue;
     }
-    if (segment.name === "GamePreview") {
-      const playCricketId = segment.attrs.playCricketId;
-      if (!playCricketId) {
-        throw new Error("<GamePreview> without playCricketId");
-      }
+    if (segment.kind === "personGrid") {
+      // entries (JSON-stringified [{slug, role?}]) is the canonical
+      // role-preserving prop the renderer and editor share; the slugs
+      // CSV is written alongside as the legacy fallback the renderer
+      // reads when entries is absent.
       blocks.push(
-        customBlock(CUSTOM_BLOCK_TYPES.gamePreview, { playCricketId }),
+        customBlock(CUSTOM_BLOCK_TYPES.personGrid, {
+          slugs: segment.people.map((p) => p.slug).join(","),
+          entries: JSON.stringify(segment.people),
+        }),
       );
       continue;
     }
-    // Image - the resolver returns the full prop set so the picture
-    // descriptor comes from the same pipeline as editor uploads.
-    const { src, alt, caption } = segment.attrs;
-    if (!src) throw new Error("<Image> without src");
-    const props = await resolveImage({ src, alt, caption });
-    blocks.push(customBlock(CUSTOM_BLOCK_TYPES.contentImage, props));
+    const { name, attrs } = segment;
+    switch (name) {
+      case "GamePreview":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.gamePreview, {
+            playCricketId: requireAttr(name, attrs, "playCricketId"),
+          }),
+        );
+        break;
+      case "Image": {
+        // The resolver returns the full prop set so the picture
+        // descriptor comes from the same pipeline as editor uploads.
+        const { src, alt, caption } = attrs;
+        if (!src) throw new Error("<Image> without src");
+        const props = await resolveImage({ src, alt, caption });
+        blocks.push(customBlock(CUSTOM_BLOCK_TYPES.contentImage, props));
+        break;
+      }
+      case "Person":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.person, {
+            slug: requireAttr(name, attrs, "slug"),
+            role: attrs.role ?? "",
+          }),
+        );
+        break;
+      case "EventPreview":
+        // The MDX prop is `id`; the block (and its editor propSchema)
+        // call it `eventId`.
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.eventPreview, {
+            eventId: requireAttr(name, attrs, "id"),
+            name: requireAttr(name, attrs, "name"),
+            when: requireAttr(name, attrs, "when"),
+          }),
+        );
+        break;
+      case "LeagueTable":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.leagueTable, {
+            divisionId: requireAttr(name, attrs, "divisionId"),
+            name: attrs.name ?? "",
+          }),
+        );
+        break;
+      case "Leaderboard":
+        blocks.push(customBlock(CUSTOM_BLOCK_TYPES.leaderboard, {}));
+        break;
+      case "RecordsWall":
+        blocks.push(customBlock(CUSTOM_BLOCK_TYPES.recordsWall, {}));
+        break;
+      case "ContactForm":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.contactForm, {
+            title: attrs.title ?? "",
+            description: attrs.description ?? "",
+          }),
+        );
+        break;
+      case "ConsentVersion":
+        blocks.push(customBlock(CUSTOM_BLOCK_TYPES.consentVersion, {}));
+        break;
+      case "CookieSettingsLink":
+        blocks.push(
+          customBlock(CUSTOM_BLOCK_TYPES.cookieSettingsLink, {
+            text: attrs.text ?? "Cookie settings",
+          }),
+        );
+        break;
+      default:
+        // segmentMdx only emits known names; this guards drift between
+        // the two vocabularies.
+        throw new Error(`No block mapping for <${name}>`);
+    }
   }
   return blocks;
 }
@@ -283,6 +533,43 @@ export function parseEventSource(source: string): EventSource {
     when: fm.when,
     ...(fm.finish !== undefined && { finish: fm.finish }),
     ...(fm.location !== undefined && { location: fm.location }),
+    body,
+  };
+}
+
+// Mirrors the static page loader's frontmatter handling (apps/web
+// lib/content.ts) and the defaults pageMetadataSchema applies: a
+// DB-backed page must come out indistinguishable from its static
+// version. ldjson is kept as-is (pasted structured data).
+const pageFrontmatterSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1).optional(),
+  menuOrder: z.number().int().default(99),
+  isMainMenu: z.boolean().default(false),
+  hideTitle: z.boolean().default(false),
+  ldjson: z.record(z.string(), z.unknown()).optional(),
+});
+
+export interface PageSource {
+  title: string;
+  description?: string;
+  menuOrder: number;
+  isMainMenu: boolean;
+  hideTitle: boolean;
+  ldjson?: Record<string, unknown>;
+  body: string;
+}
+
+export function parsePageSource(source: string): PageSource {
+  const { raw, body } = splitFrontmatter(source);
+  const fm = pageFrontmatterSchema.parse(raw);
+  return {
+    title: fm.title,
+    ...(fm.description !== undefined && { description: fm.description }),
+    menuOrder: fm.menuOrder,
+    isMainMenu: fm.isMainMenu,
+    hideTitle: fm.hideTitle,
+    ...(fm.ldjson !== undefined && { ldjson: fm.ldjson }),
     body,
   };
 }

--- a/apps/api/scripts/migrate-news-events.ts
+++ b/apps/api/scripts/migrate-news-events.ts
@@ -42,24 +42,22 @@ import path from "path";
 import { fileURLToPath } from "url";
 import YAML from "yaml";
 import {
-  processImage,
-  type ProcessedImage,
-} from "../src/features/content-images/service.ts";
-import {
   CONTENT_IMAGES_PREFIX,
   createContentImageStore,
   type ContentImageStore,
 } from "../src/lib/s3-content-images.ts";
 import {
-  blocksEqualIgnoringIds,
-  type MigrationBlock,
-} from "./markdown-to-blocks.ts";
+  convertBody,
+  ensureImages as ensureImagesShared,
+  planImageUploads,
+  type Converted,
+  type PendingImage,
+} from "./image-pipeline.ts";
+import { blocksEqualIgnoringIds } from "./markdown-to-blocks.ts";
 import {
   eventPublishedAt,
   findDuplicateLocationNames,
-  imageIdForAsset,
   jsonEqual,
-  mdxToBlocks,
   newsPublishedAt,
   parseEventSource,
   parseNewsSource,
@@ -74,9 +72,6 @@ const LOCATIONS_FILE = path.resolve(
   __dirname,
   "../../web/content/data/locations.yaml",
 );
-// Mirrors the web app's image-map: public "/images/..." paths resolve to
-// files under src/assets/images/.
-const ASSETS_DIR = path.resolve(__dirname, "../../web/src/assets/images");
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -91,84 +86,6 @@ function parseArgs() {
     process.exit(1);
   }
   return { userId, dryRun, force };
-}
-
-class MissingImageError extends Error {
-  constructor(publicPath: string) {
-    super(`image file not found on disk for '${publicPath}'`);
-  }
-}
-
-interface PendingImage {
-  imageId: string;
-  publicPath: string;
-  alt: string | null;
-  processed: ProcessedImage;
-  bytes: number;
-}
-
-interface Converted {
-  blocks: MigrationBlock[];
-  images: PendingImage[];
-}
-
-/**
- * Convert one MDX body, resolving each <Image> through the editor-upload
- * processing pipeline (locally - nothing is written here, so --dry-run
- * conversion is complete and writes can be deferred until after the
- * skip/insert decision). The processed-image cache spans articles so a
- * re-used asset is only decoded once.
- */
-async function convertBody(
-  body: string,
-  cache: Map<string, PendingImage>,
-): Promise<Converted> {
-  const images: PendingImage[] = [];
-  const blocks = await mdxToBlocks(body, async ({ src, alt, caption }) => {
-    const imageId = imageIdForAsset(src);
-    let pending = cache.get(imageId);
-    if (!pending) {
-      if (!src.startsWith("/images/")) {
-        throw new Error(`unexpected image src '${src}'`);
-      }
-      const assetPath = path.resolve(ASSETS_DIR, src.slice("/images/".length));
-      // A '..' segment in the src could otherwise resolve outside the
-      // bundled assets tree and upload an arbitrary readable file.
-      if (!assetPath.startsWith(ASSETS_DIR + path.sep)) {
-        throw new Error(`image src '${src}' escapes the assets directory`);
-      }
-      let original: Buffer;
-      try {
-        original = await fs.readFile(assetPath);
-      } catch {
-        throw new MissingImageError(src);
-      }
-      const processed = await processImage(
-        original,
-        imageId,
-        CONTENT_IMAGES_PREFIX,
-      );
-      pending = {
-        imageId,
-        publicPath: src,
-        alt: alt ?? null,
-        processed,
-        bytes: original.byteLength,
-      };
-      cache.set(imageId, pending);
-    }
-    images.push(pending);
-    // Exactly the prop set the editor inserts (content-editor.tsx): the
-    // plain src falls back to the ladder's largest original-format
-    // variant, picture carries the JSON-stringified PictureSource.
-    return {
-      src: pending.processed.picture.img.src,
-      alt: alt ?? "",
-      caption: caption ?? "",
-      picture: JSON.stringify(pending.processed.picture),
-    };
-  });
-  return { blocks, images };
 }
 
 interface MigrationItem {
@@ -351,40 +268,14 @@ async function main() {
   /** Upload variants + register rows for an article's images (idempotent). */
   const ensureImages = async (images: PendingImage[]) => {
     if (!store) throw new Error("store unavailable outside a real run");
-    for (const image of images) {
-      const existing = await db
-        .selectFrom("content_image")
-        .select("id")
-        .where("id", "=", image.imageId)
-        .executeTakeFirst();
-      if (existing) {
-        imagesReused += 1;
-        continue;
-      }
-      for (const variant of image.processed.variants) {
-        await store.putVariant(variant.key, variant.body, variant.contentType);
-      }
-      await db
-        .insertInto("content_image")
-        .values({
-          id: image.imageId,
-          key_prefix: `${CONTENT_IMAGES_PREFIX}/${image.imageId}`,
-          original_format: image.processed.sourceFormat,
-          width: image.processed.width,
-          height: image.processed.height,
-          bytes: image.bytes,
-          picture: JSON.stringify(image.processed.picture),
-          alt: image.alt,
-          consent_confirmed: true,
-          uploaded_by: userId,
-        })
-        .onConflict((oc) => oc.column("id").doNothing())
-        .execute();
-      imagesUploaded += 1;
-      console.log(
-        `    ^ uploaded ${image.publicPath} -> ${CONTENT_IMAGES_PREFIX}/${image.imageId}/ (${String(image.processed.variants.length)} variants)`,
-      );
-    }
+    const { uploaded, reused } = await ensureImagesShared(
+      db,
+      store,
+      userId,
+      images,
+    );
+    imagesUploaded += uploaded;
+    imagesReused += reused;
   };
 
   for (const item of items) {
@@ -440,21 +331,12 @@ async function main() {
     }
 
     if (dryRun) {
-      const newImages = [];
-      for (const image of images) {
-        if (plannedUploads.has(image.imageId)) continue;
-        const row = await db
-          .selectFrom("content_image")
-          .select("id")
-          .where("id", "=", image.imageId)
-          .executeTakeFirst();
-        if (row) {
-          imagesReused += 1;
-        } else {
-          newImages.push(image);
-          plannedUploads.add(image.imageId);
-        }
-      }
+      const { newImages, reused } = await planImageUploads(
+        db,
+        images,
+        plannedUploads,
+      );
+      imagesReused += reused;
       console.log(
         `  ~ ${item.file} would ${existing ? "update" : "insert"} '${item.title}' (${String(blocks.length)} blocks, ${String(images.length)} images, published_at ${item.publishedAt.toISOString()})`,
       );

--- a/apps/api/scripts/migrate-pages.ts
+++ b/apps/api/scripts/migrate-pages.ts
@@ -1,0 +1,547 @@
+/**
+ * One-off migration (#496): import the legacy MDX content pages into the
+ * content API's tables as published items, building parent_id/path from
+ * the directory layout (dir/_index.mdx IS the parent item) and pushing
+ * each embedded <Image> through the same processing pipeline as editor
+ * uploads. pages/legal/** is excluded by design (legal copy stays static
+ * and changes via PR review).
+ *
+ * The script inserts rows directly (like migrate-news-events.ts), so it
+ * upholds the page-hierarchy invariants itself rather than relying on
+ * the content service: path = parent path + /slug, parents inserted
+ * before children, and every page published with ONE shared
+ * published_at (script start) so the child-go-live >= parent gate holds
+ * trivially. A page that fails conversion stays static via the
+ * TRANSITION FALLBACK (#489) - and because a child row cannot exist
+ * without its parent row, a failed parent fails its whole subtree.
+ *
+ * Idempotent: upserts by page path. Unchanged items are skipped; image
+ * ids are UUIDv5-derived from the source asset path, so re-runs reuse
+ * the same S3 keys and content_image rows. Items that differ from the
+ * DB are skipped with a warning unless --force (the DB is canonical
+ * after cutover).
+ *
+ * Usage (local):
+ *   DATABASE_URL=postgres://percy:percy@localhost:5433/percy_main \
+ *     S3_BUCKET=percy-main-receipts-local \
+ *     S3_ENDPOINT=http://localhost:4566 \
+ *     AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+ *     pnpm exec tsx scripts/migrate-pages.ts --user <user-id> [--dry-run] [--force]
+ *
+ * Environment:
+ *   DATABASE_URL  required always (dry runs read existing rows).
+ *   S3_BUCKET     required unless --dry-run; the CloudFront uploads
+ *                 bucket (prod: see infra outputs; local: the
+ *                 percy-main-receipts-local LocalStack bucket).
+ *   S3_REGION     optional, defaults to eu-west-2.
+ *   S3_ENDPOINT   optional; set to http://localhost:4566 for LocalStack.
+ *   AWS credentials come from the SDK default chain - for a real prod
+ *   run set AWS_PROFILE=percy-main (matching the CLI profile rule).
+ *
+ * Against prod, run with the standard prod access pattern and the
+ * admin_rw URL - coordinate first; never point this at prod casually.
+ */
+import { createClient } from "@percy-main/db";
+import {
+  contentBodySchema,
+  pageMetadataSchema,
+  type ContentBody,
+  type PageMetadata,
+} from "@percy-main/shared/content";
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  createContentImageStore,
+  type ContentImageStore,
+} from "../src/lib/s3-content-images.ts";
+import {
+  convertBody,
+  ensureImages,
+  planImageUploads,
+  type PendingImage,
+} from "./image-pipeline.ts";
+import { blocksEqualIgnoringIds } from "./markdown-to-blocks.ts";
+import { jsonEqual, parsePageSource } from "./mdx-to-blocks.ts";
+import {
+  buildPageTree,
+  parentFailureReason,
+  type PageNode,
+} from "./page-tree.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PAGES_DIR = path.resolve(__dirname, "../../web/content/pages");
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const userFlag = args.indexOf("--user");
+  const userId = userFlag >= 0 ? args[userFlag + 1] : undefined;
+  const dryRun = args.includes("--dry-run");
+  const force = args.includes("--force");
+  if (!userId) {
+    console.error(
+      "Usage: tsx scripts/migrate-pages.ts --user <user-id> [--dry-run] [--force]",
+    );
+    process.exit(1);
+  }
+  return { userId, dryRun, force };
+}
+
+interface NavEntry {
+  path: string;
+  title: string;
+  menuOrder: number;
+  isMainMenu: boolean;
+}
+
+async function main() {
+  const { userId, dryRun, force } = parseArgs();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+
+  // The store is only needed for real runs - a dry run must not touch S3.
+  let store: ContentImageStore | null = null;
+  if (!dryRun) {
+    const bucket = process.env.S3_BUCKET;
+    if (!bucket) {
+      console.error("S3_BUCKET is required (omit only with --dry-run)");
+      process.exit(1);
+    }
+    store = createContentImageStore({
+      S3_BUCKET: bucket,
+      S3_REGION: process.env.S3_REGION ?? "eu-west-2",
+      S3_ENDPOINT: process.env.S3_ENDPOINT,
+      // Unused here (no presigned uploads) but part of the store config.
+      CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
+    });
+  }
+
+  const { client: db } = createClient(databaseUrl);
+
+  const attributedTo = await db
+    .selectFrom("user")
+    .select(["name", "email"])
+    .where("id", "=", userId)
+    .executeTakeFirst();
+  if (!attributedTo) {
+    console.error(`No user with id '${userId}'`);
+    await db.destroy();
+    process.exit(1);
+  }
+  console.log(
+    `Attributing imports to: ${attributedTo.name} <${attributedTo.email}>`,
+  );
+
+  const files = (await fs.readdir(PAGES_DIR, { recursive: true }))
+    .filter((f) => f.endsWith(".mdx"))
+    .map((f) => f.split(path.sep).join("/"))
+    .sort();
+  console.log(`Found ${String(files.length)} pages in ${PAGES_DIR}`);
+
+  const tree = buildPageTree(files);
+  for (const exclusion of tree.excluded) {
+    console.log(`  - ${exclusion.file}: ${exclusion.reason}`);
+  }
+
+  const counts = {
+    inserted: 0,
+    updated: 0,
+    unchanged: 0,
+    skipped: 0,
+    failed: 0,
+  };
+  let imagesUploaded = 0;
+  let imagesReused = 0;
+  const imageCache = new Map<string, PendingImage>();
+  // Dry-run only: ids already reported as "would upload", so an asset
+  // shared by two pages is not double-counted.
+  const plannedUploads = new Set<string>();
+
+  // ONE shared go-live instant for everything inserted this run: with
+  // parents inserted first, child published_at == parent published_at
+  // satisfies the child-go-live >= parent invariant trivially.
+  const publishedAt = new Date();
+
+  const failures: { file: string; reason: string }[] = [];
+  const skipped: { file: string; reason: string }[] = [];
+  const migrated: { path: string; action: string }[] = [];
+  const nav: NavEntry[] = [];
+
+  // Paths whose page failed this run - parentFailureReason() consults
+  // this to fail descendants (path order guarantees parents first).
+  const failedPaths = new Set<string>();
+  // Published parents available to attach children to: rows that exist
+  // (or, dry-run, would exist) as status=published after this run.
+  const publishedParents = new Map<
+    string,
+    { id: string | null; publishedAt: Date }
+  >();
+
+  const fail = (file: string, pagePath: string | undefined, reason: string) => {
+    counts.failed += 1;
+    failures.push({ file, reason });
+    if (pagePath !== undefined) failedPaths.add(pagePath);
+    console.warn(`  ! ${file}: ${reason}`);
+  };
+
+  for (const failure of tree.failed) {
+    fail(failure.file, failure.path, failure.reason);
+  }
+
+  const processNode = async (node: PageNode) => {
+    // ── Parent gates ──────────────────────────────────────────────────
+    const parentFailed = parentFailureReason(node, failedPaths);
+    if (parentFailed !== null) {
+      fail(node.file, node.path, parentFailed);
+      return;
+    }
+    let parentInfo: { id: string | null; publishedAt: Date } | null = null;
+    if (node.parentPath !== null) {
+      parentInfo = publishedParents.get(node.parentPath) ?? null;
+      if (!parentInfo) {
+        // The parent file processed without failing but did not yield a
+        // published row (an existing draft/archived row sits at its
+        // path) - a published child under it would break the hierarchy
+        // invariant.
+        fail(
+          node.file,
+          node.path,
+          `parent page at ${node.parentPath} is not published - resolve it and re-run`,
+        );
+        return;
+      }
+      // An existing parent scheduled for the future would put this
+      // child live before it - the exact invariant publishContent
+      // enforces top-down.
+      if (parentInfo.publishedAt.getTime() > publishedAt.getTime()) {
+        fail(
+          node.file,
+          node.path,
+          `parent page at ${node.parentPath} goes live in the future (${parentInfo.publishedAt.toISOString()}) - a child cannot publish before its parent`,
+        );
+        return;
+      }
+    }
+
+    // ── Parse + convert ───────────────────────────────────────────────
+    interface Prepared {
+      title: string;
+      description: string | null;
+      metadata: PageMetadata;
+      blocks: ContentBody;
+      images: PendingImage[];
+    }
+    const prepared: Prepared | null = await (async () => {
+      try {
+        const source = await fs.readFile(
+          path.join(PAGES_DIR, node.file),
+          "utf8",
+        );
+        const parsed = parsePageSource(source);
+        const metadata = pageMetadataSchema.parse({
+          menuOrder: parsed.menuOrder,
+          isMainMenu: parsed.isMainMenu,
+          hideTitle: parsed.hideTitle,
+          ...(parsed.ldjson !== undefined && { ldjson: parsed.ldjson }),
+        });
+        const converted = await convertBody(parsed.body, imageCache);
+        // The service validates bodies on every write; the script writes
+        // directly, so it runs the same gate.
+        const blocks = contentBodySchema.parse(converted.blocks);
+        return {
+          title: parsed.title,
+          description: parsed.description ?? null,
+          metadata,
+          blocks,
+          images: converted.images,
+        };
+      } catch (err) {
+        fail(
+          node.file,
+          node.path,
+          err instanceof Error ? err.message : String(err),
+        );
+        return null;
+      }
+    })();
+    if (prepared === null) return;
+    const { title, description, metadata, blocks, images } = prepared;
+
+    const navEntry: NavEntry = {
+      path: node.path,
+      title,
+      menuOrder: metadata.menuOrder,
+      isMainMenu: metadata.isMainMenu,
+    };
+
+    // ── Upsert ────────────────────────────────────────────────────────
+    const existing = await db
+      .selectFrom("content_item")
+      .select([
+        "id",
+        "body",
+        "title",
+        "description",
+        "metadata",
+        "status",
+        "published_at",
+      ])
+      .where("kind", "=", "page")
+      .where("path", "=", node.path)
+      .executeTakeFirst();
+
+    if (existing) {
+      // Same stance as the news migration: a non-published row would
+      // still 404 publicly, and a published row an editor may have
+      // touched is only overwritten under --force (post-cutover the DB
+      // is canonical and the MDX is the stale ancestor).
+      if (existing.status !== "published" || existing.published_at === null) {
+        counts.skipped += 1;
+        const reason = `a ${existing.status} item already exists at ${node.path} - the public endpoint will 404. Publish or remove it, then re-run.`;
+        skipped.push({ file: node.file, reason });
+        console.warn(`  ! ${node.file}: ${reason}`);
+        // Not added to failedPaths: descendants report the more precise
+        // "parent not published" via the publishedParents miss.
+        return;
+      }
+
+      // This path stays published whatever happens below, so children
+      // may attach to it; its real published_at drives their gate.
+      publishedParents.set(node.path, {
+        id: existing.id,
+        publishedAt: existing.published_at,
+      });
+
+      // published_at deliberately ignored: it is "script start" on
+      // every run, while the row keeps its original go-live.
+      const unchanged =
+        blocksEqualIgnoringIds(existing.body, blocks) &&
+        existing.title === title &&
+        existing.description === description &&
+        jsonEqual(existing.metadata, metadata);
+      if (unchanged) {
+        counts.unchanged += 1;
+        migrated.push({ path: node.path, action: "unchanged" });
+        nav.push(navEntry);
+        console.log(`  = ${node.file} unchanged (${existing.title})`);
+        return;
+      }
+      if (!force) {
+        counts.skipped += 1;
+        const reason = `published page '${existing.title}' differs from the MDX conversion (likely edited in the DB). Skipping - re-run with --force to overwrite.`;
+        skipped.push({ file: node.file, reason });
+        console.warn(`  ! ${node.file}: ${reason}`);
+        // The page is still live with the DB's values - those are what
+        // the nav actually serves.
+        const dbMetadata = pageMetadataSchema.safeParse(existing.metadata);
+        const effective = dbMetadata.success
+          ? dbMetadata.data
+          : pageMetadataSchema.parse({});
+        nav.push({
+          path: node.path,
+          title: existing.title,
+          menuOrder: effective.menuOrder,
+          isMainMenu: effective.isMainMenu,
+        });
+        return;
+      }
+
+      if (dryRun) {
+        const { newImages, reused } = await planImageUploads(
+          db,
+          images,
+          plannedUploads,
+        );
+        imagesReused += reused;
+        imagesUploaded += newImages.length;
+        console.log(
+          `  ~ ${node.file} would update '${title}' at ${node.path} (${String(blocks.length)} blocks, ${String(images.length)} images)`,
+        );
+        for (const image of newImages) {
+          console.log(`    ~ would upload ${image.publicPath}`);
+        }
+        counts.updated += 1;
+        migrated.push({ path: node.path, action: "updated" });
+        nav.push(navEntry);
+        return;
+      }
+
+      if (!store) throw new Error("store unavailable outside a real run");
+      const ensured = await ensureImages(db, store, userId, images);
+      imagesUploaded += ensured.uploaded;
+      imagesReused += ensured.reused;
+
+      // slug/parent_id/path/status/published_at untouched: the path
+      // matched, so the hierarchy is already right, and rewriting
+      // published_at would rewrite the page's go-live history.
+      await db.transaction().execute(async (tx) => {
+        await tx
+          .updateTable("content_item")
+          .set({
+            title,
+            description,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(metadata),
+            updated_by: userId,
+            updated_at: new Date(),
+          })
+          .where("id", "=", existing.id)
+          .execute();
+        await tx
+          .insertInto("content_revision")
+          .values({
+            content_id: existing.id,
+            title,
+            description,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(metadata),
+            saved_by: userId,
+          })
+          .execute();
+      });
+      counts.updated += 1;
+      migrated.push({ path: node.path, action: "updated" });
+      nav.push(navEntry);
+      console.log(`  ^ ${node.file} updated (${title})`);
+      return;
+    }
+
+    // ── Insert ────────────────────────────────────────────────────────
+    if (dryRun) {
+      const { newImages, reused } = await planImageUploads(
+        db,
+        images,
+        plannedUploads,
+      );
+      imagesReused += reused;
+      imagesUploaded += newImages.length;
+      console.log(
+        `  ~ ${node.file} would insert '${title}' at ${node.path} (${String(blocks.length)} blocks, ${String(images.length)} images, published_at ${publishedAt.toISOString()})`,
+      );
+      for (const image of newImages) {
+        console.log(`    ~ would upload ${image.publicPath}`);
+      }
+      counts.inserted += 1;
+      migrated.push({ path: node.path, action: "inserted" });
+      nav.push(navEntry);
+      publishedParents.set(node.path, { id: null, publishedAt });
+      return;
+    }
+
+    if (
+      node.parentPath !== null &&
+      (parentInfo === null || parentInfo.id === null)
+    ) {
+      // Real runs record real ids for every published parent; a miss
+      // here is a bug, not a data condition.
+      throw new Error(`no parent id recorded for ${node.parentPath}`);
+    }
+
+    if (!store) throw new Error("store unavailable outside a real run");
+    // Images first: like the editor flow, content_image rows + variants
+    // exist before any body referencing them is saved. Deferred to this
+    // point so skipped pages write nothing at all.
+    const ensured = await ensureImages(db, store, userId, images);
+    imagesUploaded += ensured.uploaded;
+    imagesReused += ensured.reused;
+
+    await db.transaction().execute(async (tx) => {
+      const inserted = await tx
+        .insertInto("content_item")
+        .values({
+          kind: "page",
+          slug: node.slug,
+          parent_id: parentInfo?.id ?? null,
+          path: node.path,
+          title,
+          description,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          status: "published",
+          published_at: publishedAt,
+          created_by: userId,
+          updated_by: userId,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      await tx
+        .insertInto("content_revision")
+        .values({
+          content_id: inserted.id,
+          title,
+          description,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          saved_by: userId,
+        })
+        .execute();
+      publishedParents.set(node.path, { id: inserted.id, publishedAt });
+    });
+    counts.inserted += 1;
+    migrated.push({ path: node.path, action: "inserted" });
+    nav.push(navEntry);
+    console.log(`  + ${node.file} inserted as '${title}' at ${node.path}`);
+  };
+
+  for (const node of tree.ordered) {
+    await processNode(node);
+  }
+
+  // ── Report ────────────────────────────────────────────────────────────
+
+  console.log("");
+  console.log("=== Migration report ===");
+  console.log(
+    `Pages: ${String(counts.inserted)} inserted, ${String(counts.updated)} updated, ${String(counts.unchanged)} unchanged, ${String(counts.skipped)} skipped, ${String(counts.failed)} failed, ${String(tree.excluded.length)} excluded`,
+  );
+  console.log(
+    `Images: ${String(imagesUploaded)} ${dryRun ? "would be uploaded" : "uploaded"}, ${String(imagesReused)} reused`,
+  );
+
+  console.log(`Migrated (${String(migrated.length)}):`);
+  for (const item of migrated) {
+    console.log(`  ${item.path} (${item.action})`);
+  }
+  console.log(`Failed (${String(failures.length)}):`);
+  for (const failure of failures) {
+    console.log(`  ${failure.file}: ${failure.reason}`);
+  }
+  console.log(`Skipped (${String(skipped.length)}):`);
+  for (const item of skipped) {
+    console.log(`  ${item.file}: ${item.reason}`);
+  }
+  console.log(`Excluded (${String(tree.excluded.length)}):`);
+  for (const exclusion of tree.excluded) {
+    console.log(`  ${exclusion.file}: ${exclusion.reason}`);
+  }
+
+  // The before/after nav snapshot artifact: what getPublishedNav would
+  // serve for this corpus after the run, in its path ordering. Compare
+  // against the static staticNavPages projection.
+  nav.sort((a, b) => a.path.localeCompare(b.path));
+  console.log("Nav payload (path-sorted):");
+  console.log(JSON.stringify(nav, null, 2));
+
+  console.log(
+    `Done with ${String(failures.length + skipped.length)} warnings${dryRun ? " (dry run)" : ""}`,
+  );
+  if (failures.length + skipped.length > 0) {
+    // Unlike news/events, pages have a per-path fallback: a page with no
+    // published DB row keeps rendering from the static bundle
+    // (TRANSITION FALLBACK #489), so a partial migration is safe - but
+    // the static MDX cleanup must not remove files listed above.
+    console.warn(
+      "NOTE: failed/skipped pages keep rendering from the static bundle " +
+        "via the per-path fallback. Do NOT delete their MDX in the " +
+        "cleanup PR until they are resolved and re-run.",
+    );
+    process.exitCode = 2;
+  }
+  await db.destroy();
+}
+
+await main();

--- a/apps/api/scripts/page-tree.test.ts
+++ b/apps/api/scripts/page-tree.test.ts
@@ -1,0 +1,205 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+import {
+  buildPageTree,
+  filePathToUrlPath,
+  LEGAL_EXCLUSION_REASON,
+  parentFailureReason,
+  type PageNode,
+} from "./page-tree.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PAGES_DIR = path.resolve(__dirname, "../../web/content/pages");
+
+describe("filePathToUrlPath", () => {
+  it("mirrors the web app's transform for plain files and _index", () => {
+    expect(filePathToUrlPath("boxing.mdx")).toBe("/boxing");
+    expect(filePathToUrlPath("charity/_index.mdx")).toBe("/charity");
+    expect(filePathToUrlPath("cricket/ground/_index.mdx")).toBe(
+      "/cricket/ground",
+    );
+    expect(filePathToUrlPath("cricket/ground/grounds-team.mdx")).toBe(
+      "/cricket/ground/grounds-team",
+    );
+  });
+});
+
+describe("buildPageTree", () => {
+  const fixture = [
+    "boxing.mdx",
+    "charity/_index.mdx",
+    "charity/agm-2025.mdx",
+    "cricket/_index.mdx",
+    "cricket/ground/_index.mdx",
+    "cricket/ground/grounds-team.mdx",
+    "legal/privacy.mdx",
+  ];
+
+  it("derives slug, path and parentPath from the directory layout", () => {
+    const tree = buildPageTree(fixture);
+    expect(tree.failed).toEqual([]);
+    expect(tree.ordered).toEqual([
+      { file: "boxing.mdx", slug: "boxing", path: "/boxing", parentPath: null },
+      {
+        file: "charity/_index.mdx",
+        slug: "charity",
+        path: "/charity",
+        parentPath: null,
+      },
+      {
+        file: "charity/agm-2025.mdx",
+        slug: "agm-2025",
+        path: "/charity/agm-2025",
+        parentPath: "/charity",
+      },
+      {
+        file: "cricket/_index.mdx",
+        slug: "cricket",
+        path: "/cricket",
+        parentPath: null,
+      },
+      {
+        file: "cricket/ground/_index.mdx",
+        slug: "ground",
+        path: "/cricket/ground",
+        parentPath: "/cricket",
+      },
+      {
+        file: "cricket/ground/grounds-team.mdx",
+        slug: "grounds-team",
+        path: "/cricket/ground/grounds-team",
+        parentPath: "/cricket/ground",
+      },
+    ]);
+  });
+
+  it("excludes legal/** by design", () => {
+    const tree = buildPageTree(fixture);
+    expect(tree.excluded).toEqual([
+      { file: "legal/privacy.mdx", reason: LEGAL_EXCLUSION_REASON },
+    ]);
+    expect(tree.ordered.some((n) => n.file.startsWith("legal/"))).toBe(false);
+  });
+
+  it("orders every parent before its children", () => {
+    const tree = buildPageTree(fixture);
+    const indexByPath = new Map(tree.ordered.map((n, i) => [n.path, i]));
+    for (const node of tree.ordered) {
+      if (node.parentPath === null) continue;
+      const parentIndex = indexByPath.get(node.parentPath);
+      expect(parentIndex).toBeDefined();
+      expect(parentIndex).toBeLessThan(indexByPath.get(node.path) ?? -1);
+    }
+  });
+
+  it("fails children of a directory with no _index.mdx, transitively", () => {
+    const tree = buildPageTree([
+      "cricket/senior/1st-xi.mdx",
+      "cricket/senior/_index.mdx",
+      // no cricket/_index.mdx
+    ]);
+    expect(tree.ordered).toEqual([]);
+    expect(tree.failed).toEqual([
+      {
+        file: "cricket/senior/_index.mdx",
+        path: "/cricket/senior",
+        reason: "parent page required: no _index.mdx provides '/cricket'",
+      },
+      {
+        file: "cricket/senior/1st-xi.mdx",
+        path: "/cricket/senior/1st-xi",
+        reason: "parent failed (/cricket/senior)",
+      },
+    ]);
+  });
+
+  it("fails a root _index.mdx (its path would be '/')", () => {
+    const tree = buildPageTree(["_index.mdx"]);
+    expect(tree.ordered).toEqual([]);
+    expect(tree.failed).toHaveLength(1);
+    expect(tree.failed[0]?.reason).toMatch(/root _index\.mdx/);
+  });
+
+  it("fails files whose slug is not a valid content slug", () => {
+    const tree = buildPageTree(["Has Space.mdx"]);
+    expect(tree.ordered).toEqual([]);
+    expect(tree.failed[0]?.reason).toMatch(/not a valid content slug/);
+  });
+});
+
+describe("parentFailureReason", () => {
+  const node = (path: string, parentPath: string | null): PageNode => ({
+    file: `${path.slice(1)}.mdx`,
+    slug: path.split("/").pop() ?? "",
+    path,
+    parentPath,
+  });
+
+  it("fails a child whose parent failed, transitively in path order", () => {
+    const failed = new Set<string>(["/cricket"]);
+    const ground = node("/cricket/ground", "/cricket");
+    expect(parentFailureReason(ground, failed)).toBe(
+      "parent failed (/cricket)",
+    );
+    // The script adds the failed child to the set before its children
+    // are processed - so the failure propagates down the whole subtree.
+    failed.add(ground.path);
+    expect(
+      parentFailureReason(
+        node("/cricket/ground/grounds-team", "/cricket/ground"),
+        failed,
+      ),
+    ).toBe("parent failed (/cricket/ground)");
+  });
+
+  it("does not fail unrelated subtrees or root pages", () => {
+    const failed = new Set<string>(["/cricket"]);
+    expect(
+      parentFailureReason(node("/charity/agm-2025", "/charity"), failed),
+    ).toBe(null);
+    expect(parentFailureReason(node("/boxing", null), failed)).toBe(null);
+  });
+});
+
+describe("real corpus parity", () => {
+  it("derives the same path as the web app's filePathToUrlPath for every page", async () => {
+    const files = (await fs.readdir(PAGES_DIR, { recursive: true }))
+      .filter((f) => f.endsWith(".mdx"))
+      .map((f) => f.split(path.sep).join("/"))
+      .sort();
+    expect(files.length).toBeGreaterThan(0);
+
+    const tree = buildPageTree(files);
+
+    // Structure: the real corpus must produce no structural failures -
+    // every non-legal file lands in ordered, legal is excluded.
+    expect(tree.failed).toEqual([]);
+    const nonLegal = files.filter((f) => !f.startsWith("legal/"));
+    expect(tree.ordered.map((n) => n.file).sort()).toEqual(nonLegal);
+    expect(tree.excluded.map((e) => e.file)).toEqual(
+      files.filter((f) => f.startsWith("legal/")),
+    );
+
+    // Paths: structural derivation (parent path + slug) agrees with the
+    // web app's file-path transform for every single page.
+    for (const node of tree.ordered) {
+      expect(node.path).toBe(filePathToUrlPath(node.file));
+      expect(node.path).toBe(
+        node.parentPath === null
+          ? `/${node.slug}`
+          : `${node.parentPath}/${node.slug}`,
+      );
+    }
+
+    // Ordering: parents always precede their children.
+    const seen = new Set<string>();
+    for (const node of tree.ordered) {
+      if (node.parentPath !== null) {
+        expect(seen.has(node.parentPath)).toBe(true);
+      }
+      seen.add(node.path);
+    }
+  });
+});

--- a/apps/api/scripts/page-tree.ts
+++ b/apps/api/scripts/page-tree.ts
@@ -1,0 +1,168 @@
+import {
+  contentPathSchema,
+  contentSlugSchema,
+} from "@percy-main/shared/content";
+
+// Page hierarchy derivation for the pages migration (#496): the static
+// corpus' directory layout IS the page tree. dir/_index.mdx is the
+// parent item for the directory (slug = dir name); every sibling file
+// is a child of that item. The derived URL paths must match the web
+// app's static routing (filePathToUrlPath in apps/web/src/lib/content.ts)
+// exactly, or migrated pages would come up at different URLs than their
+// static ancestors.
+
+export interface PageNode {
+  /** Path relative to content/pages, posix separators. */
+  file: string;
+  slug: string;
+  /** Materialised URL path, e.g. "/cricket/ground/grounds-team". */
+  path: string;
+  /** Parent page's URL path, or null for a root page. */
+  parentPath: string | null;
+}
+
+export interface PageTreeFailure {
+  file: string;
+  /** Derived URL path when derivable (used to fail descendants too). */
+  path?: string;
+  reason: string;
+}
+
+export interface PageTree {
+  /** Valid nodes, path-ordered: every ancestor precedes its descendants. */
+  ordered: PageNode[];
+  failed: PageTreeFailure[];
+  excluded: { file: string; reason: string }[];
+}
+
+export const LEGAL_EXCLUSION_REASON = "excluded by design (legal stays static)";
+
+/**
+ * Byte-for-byte mirror of the web app's transform (apps/web
+ * src/lib/content.ts) minus the Vite glob prefix: ".mdx" stripped,
+ * "_index" representing its directory. The migration derives paths
+ * structurally (parent path + slug); this is the independent
+ * cross-check.
+ */
+export function filePathToUrlPath(relPath: string): string {
+  let path = relPath.replace(/\.mdx$/, "");
+  path = path.replace(/\/_index$/, "").replace(/^_index$/, "");
+  return "/" + path;
+}
+
+function deriveNode(file: string): PageNode {
+  const segments = file.split("/");
+  const basename = segments.pop();
+  if (basename === undefined || !basename.endsWith(".mdx")) {
+    throw new Error("not an .mdx file");
+  }
+  const dirSegments = segments;
+
+  let slug: string;
+  let pathSegments: string[];
+  if (basename === "_index.mdx") {
+    const dirName = dirSegments[dirSegments.length - 1];
+    if (dirName === undefined) {
+      throw new Error("root _index.mdx has no slug (its path would be '/')");
+    }
+    slug = dirName;
+    pathSegments = dirSegments;
+  } else {
+    slug = basename.replace(/\.mdx$/, "");
+    pathSegments = [...dirSegments, slug];
+  }
+
+  if (!contentSlugSchema.safeParse(slug).success) {
+    throw new Error(
+      `slug '${slug}' is not a valid content slug (lowercase letters, numbers and hyphens)`,
+    );
+  }
+  const path = "/" + pathSegments.join("/");
+  if (!contentPathSchema.safeParse(path).success) {
+    throw new Error(`derived path '${path}' is not a valid page path`);
+  }
+
+  const parentPath =
+    pathSegments.length > 1 ? "/" + pathSegments.slice(0, -1).join("/") : null;
+
+  // Sanity check: the structural derivation (parent path + slug) must
+  // agree with the web app's file-path transform, segment for segment.
+  const expected = filePathToUrlPath(file);
+  if (path !== expected) {
+    throw new Error(
+      `derived path '${path}' does not match filePathToUrlPath '${expected}'`,
+    );
+  }
+  if (path !== (parentPath ?? "") + "/" + slug) {
+    throw new Error(`derived path '${path}' is not parent path + '/' + slug`);
+  }
+
+  return { file, slug, path, parentPath };
+}
+
+/**
+ * Build the page tree from the corpus file list. legal/** is excluded by
+ * design; structural failures (bad slug, missing parent _index.mdx, root
+ * _index.mdx) fail the file AND - because a page cannot be inserted
+ * without its parent row - every descendant of a failed file fails too.
+ */
+export function buildPageTree(files: string[]): PageTree {
+  const failed: PageTreeFailure[] = [];
+  const excluded: PageTree["excluded"] = [];
+
+  const candidates: PageNode[] = [];
+  for (const file of [...files].sort()) {
+    if (file.startsWith("legal/")) {
+      excluded.push({ file, reason: LEGAL_EXCLUSION_REASON });
+      continue;
+    }
+    try {
+      candidates.push(deriveNode(file));
+    } catch (err) {
+      failed.push({
+        file,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Path order: "/a" sorts before "/a/b", so every ancestor is processed
+  // (and inserted) before its descendants - the same ordering the admin
+  // page tree relies on.
+  candidates.sort((a, b) => a.path.localeCompare(b.path));
+
+  const okPaths = new Set<string>();
+  const failedPaths = new Set<string>();
+  const ordered: PageNode[] = [];
+  for (const node of candidates) {
+    if (node.parentPath !== null && !okPaths.has(node.parentPath)) {
+      const reason = failedPaths.has(node.parentPath)
+        ? `parent failed (${node.parentPath})`
+        : `parent page required: no _index.mdx provides '${node.parentPath}'`;
+      failed.push({ file: node.file, path: node.path, reason });
+      failedPaths.add(node.path);
+      continue;
+    }
+    okPaths.add(node.path);
+    ordered.push(node);
+  }
+
+  return { ordered, failed, excluded };
+}
+
+/**
+ * Runtime counterpart of buildPageTree's structural propagation: once a
+ * page fails conversion or upsert, every page under it must fail too
+ * (its row will not exist to parent them). Processing is path-ordered,
+ * so checking the direct parent propagates transitively as each failed
+ * child joins the set.
+ */
+export function parentFailureReason(
+  node: PageNode,
+  failedPaths: ReadonlySet<string>,
+): string | null {
+  if (node.parentPath !== null && failedPaths.has(node.parentPath)) {
+    return `parent failed (${node.parentPath})`;
+  }
+  return null;
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,7 +5,7 @@ import swaggerUi from "@fastify/swagger-ui";
 import type { Tracer } from "@opentelemetry/api";
 import { createClient as createDbClient, type DB } from "@percy-main/db";
 import { createSend, type Email } from "@percy-main/email";
-import Fastify, { type FastifyError } from "fastify";
+import Fastify from "fastify";
 import {
   jsonSchemaTransform,
   serializerCompiler,
@@ -14,6 +14,7 @@ import {
 import type { Kysely, PostgresDialect } from "kysely";
 import type { Config } from "./config.ts";
 import { createAuth, type Auth } from "./features/auth/auth.ts";
+import { errorHandler } from "./lib/error-handler.ts";
 import { createPhoenixTracer } from "./lib/phoenix-tracer.ts";
 import { createPushSender, type SendPush } from "./lib/push-sender.ts";
 import {
@@ -280,30 +281,9 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   });
   await app.register(cookie);
 
-  // Custom error handler. Reasons over Fastify's default:
-  //  - Stops 4xx (deliberately thrown via Object.assign(new Error,
-  //    { statusCode: 4xx })) from polluting NR's error-rate alarm.
-  //    400/401/403/404 log at warn with kind=http_client_error.
-  //  - 5xx and unknown statuses log at error with kind=http_error.
-  //  - Pino redact (#171) handles PII in the err object;
-  //    setErrorHandler doesn't need to re-redact.
-  //  - Reply body keeps the existing { error: message } shape so
-  //    clients aren't broken.
-  app.setErrorHandler((err: FastifyError, request, reply) => {
-    const status = err.statusCode ?? 500;
-    if (status >= 500) {
-      request.log.error(
-        { err, event: "http_error", status },
-        err.message || "internal_server_error",
-      );
-    } else {
-      request.log.warn(
-        { err, event: "http_client_error", status },
-        err.message,
-      );
-    }
-    return reply.status(status).send({ error: err.message });
-  });
+  // Custom error handler - see lib/error-handler.ts for the rationale
+  // (4xx vs 5xx log levels, NR alarm hygiene, { error } body shape).
+  app.setErrorHandler(errorHandler);
 
   // Register all feature routes
   await app.register(healthRoutes);

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -19,6 +19,7 @@ import {
   getPublishedContent,
   getPublishedGameReport,
   listContent,
+  listPageTree,
   listPublishedEvents,
   listPublishedNews,
   listRevisions,
@@ -1016,6 +1017,69 @@ describe("content service (integration)", () => {
       } finally {
         await app.close();
       }
+    });
+
+    it("lists every page for the admin tree: all statuses, path-ordered, lock and defaults derived", async () => {
+      // Pages from earlier tests share the container, so assertions
+      // filter to this test's own pages; path ordering is preserved
+      // under filtering (a subsequence of an ordered list stays ordered).
+      const root = await mkPage("tree-root", {
+        metadata: { menuOrder: 2, isMainMenu: true },
+      });
+      const childBeta = await mkPage("beta", { parentId: root });
+      const childAlpha = await mkPage("alpha", { parentId: root });
+      const archived = await mkPage("tree-archived");
+      await archiveContent(ctx.db)({ contentId: archived, userId });
+      await publishContent(ctx.db)({ contentId: root, userId });
+
+      const { items } = await listPageTree(ctx.db)();
+      const mine = (id: string, list = items) => list.find((i) => i.id === id);
+      const ids = new Set([root, childAlpha, childBeta, archived]);
+      const ours = items.filter((i) => ids.has(i.id));
+
+      // Ordered by path: ancestors before descendants, siblings lexicographic
+      expect(ours.map((i) => i.path)).toEqual([
+        "/tree-archived",
+        "/tree-root",
+        "/tree-root/alpha",
+        "/tree-root/beta",
+      ]);
+
+      // Published root: explicit metadata surfaces, lock derived
+      expect(mine(root)).toMatchObject({
+        slug: "tree-root",
+        parentId: null,
+        status: "published",
+        menuOrder: 2,
+        isMainMenu: true,
+        pathLocked: true,
+      });
+      expect(mine(root)?.publishedAt).not.toBeNull();
+
+      // Draft child: schema defaults applied, no lock
+      expect(mine(childAlpha)).toMatchObject({
+        slug: "alpha",
+        parentId: root,
+        status: "draft",
+        menuOrder: 99,
+        isMainMenu: false,
+        publishedAt: null,
+        pathLocked: false,
+      });
+
+      // Archived pages stay in the tree (never published → unlocked)
+      expect(mine(archived)).toMatchObject({
+        status: "archived",
+        pathLocked: false,
+      });
+
+      // Unpublish keeps the ever-published marker: still locked as draft
+      await unpublishContent(ctx.db)({ contentId: root, userId });
+      const after = await listPageTree(ctx.db)();
+      expect(mine(root, after.items)).toMatchObject({
+        status: "draft",
+        pathLocked: true,
+      });
     });
   });
 });

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -680,4 +680,342 @@ describe("content service (integration)", () => {
       }
     });
   });
+
+  describe("page hierarchy", () => {
+    const mkPage = async (
+      slug: string,
+      opts: {
+        parentId?: string | null;
+        metadata?: Record<string, unknown>;
+      } = {},
+    ) => {
+      const { id } = await createContent(ctx.db)({
+        kind: "page",
+        slug,
+        title: `Page ${slug}`,
+        description: null,
+        body: body(slug),
+        metadata: opts.metadata ?? {},
+        parentId: opts.parentId ?? null,
+        userId,
+      });
+      return id;
+    };
+
+    const pathOf = async (id: string) => (await getContent(ctx.db)(id)).path;
+
+    it("computes materialised paths and cascades pre-publish renames and moves", async () => {
+      const parent = await mkPage("cricket");
+      const child = await mkPage("juniors", { parentId: parent });
+      const grandchild = await mkPage("coaches", { parentId: child });
+
+      expect(await pathOf(parent)).toBe("/cricket");
+      expect(await pathOf(child)).toBe("/cricket/juniors");
+      expect(await pathOf(grandchild)).toBe("/cricket/juniors/coaches");
+
+      // Hierarchy fields surface in the admin detail/summary shape
+      const detail = await getContent(ctx.db)(child);
+      expect(detail.parentId).toBe(parent);
+      expect(detail.menuOrder).toBe(99);
+
+      // A pre-publish rename cascades through every descendant
+      await updateContent(ctx.db)({
+        contentId: parent,
+        slug: "playing",
+        userId,
+      });
+      expect(await pathOf(parent)).toBe("/playing");
+      expect(await pathOf(child)).toBe("/playing/juniors");
+      expect(await pathOf(grandchild)).toBe("/playing/juniors/coaches");
+
+      // Reparent: move the grandchild up a level, then to the site root
+      await updateContent(ctx.db)({
+        contentId: grandchild,
+        parentId: parent,
+        userId,
+      });
+      expect(await pathOf(grandchild)).toBe("/playing/coaches");
+      await updateContent(ctx.db)({
+        contentId: grandchild,
+        parentId: null,
+        userId,
+      });
+      expect(await pathOf(grandchild)).toBe("/coaches");
+
+      // Cycle prevention: self and descendant parents are rejected
+      await expect(
+        updateContent(ctx.db)({ contentId: parent, parentId: parent, userId }),
+      ).rejects.toMatchObject({ statusCode: 400, message: /own parent/ });
+      await expect(
+        updateContent(ctx.db)({ contentId: parent, parentId: child, userId }),
+      ).rejects.toMatchObject({ statusCode: 400, message: /descendant/ });
+
+      // Sibling slug uniqueness: among one parent's children...
+      await expect(
+        mkPage("juniors", { parentId: parent }),
+      ).rejects.toMatchObject({ statusCode: 409 });
+      // ...and among root pages (the grandchild now owns /coaches)
+      await expect(mkPage("coaches")).rejects.toMatchObject({
+        statusCode: 409,
+      });
+    });
+
+    it("rejects a parent on non-page kinds", async () => {
+      await expect(
+        createContent(ctx.db)({
+          kind: "news",
+          slug: "hierarchy-news",
+          title: "Hierarchy news",
+          description: null,
+          body: body("No parents for news."),
+          metadata: { tags: [] },
+          parentId: crypto.randomUUID(),
+          userId,
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Only pages can have a parent page",
+      });
+    });
+
+    it("publishes top-down, unpublishes bottom-up, and locks live paths", async () => {
+      const parent = await mkPage("rules");
+      const child = await mkPage("code-of-conduct", { parentId: parent });
+
+      // Child first → blocked until the parent is published
+      await expect(
+        publishContent(ctx.db)({ contentId: child, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Cannot publish this page until its parent page is published",
+      });
+      await publishContent(ctx.db)({ contentId: parent, userId });
+      await publishContent(ctx.db)({ contentId: child, userId });
+
+      // Both ever-published: slug AND parent are locked
+      await expect(
+        updateContent(ctx.db)({ contentId: parent, slug: "renamed", userId }),
+      ).rejects.toMatchObject({ statusCode: 409, message: /locked/ });
+      await expect(
+        updateContent(ctx.db)({ contentId: child, parentId: null, userId }),
+      ).rejects.toMatchObject({ statusCode: 409, message: /locked/ });
+
+      // The parent cannot be unpublished over a live child
+      await expect(
+        unpublishContent(ctx.db)({ contentId: parent, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: /published child pages/,
+      });
+
+      // Bottom-up works (also returns this test's pages to draft so the
+      // nav test below can assert an exact payload)
+      await unpublishContent(ctx.db)({ contentId: child, userId });
+      await unpublishContent(ctx.db)({ contentId: parent, userId });
+    });
+
+    it("pins a draft ancestor's slug via an ever-published descendant", async () => {
+      // Under the publish-ordering rules a descendant can only have gone
+      // live if its ancestors did too, so a never-published ancestor
+      // with an ever-published child needs the ancestor's own marker
+      // cleared by hand (ops-level intervention; same direct-flip
+      // technique as the visibility-boundary test). The descendant lock
+      // is defense in depth for exactly such states.
+      const parent = await mkPage("sections");
+      const child = await mkPage("alpha", { parentId: parent });
+
+      await publishContent(ctx.db)({ contentId: parent, userId });
+      await publishContent(ctx.db)({ contentId: child, userId });
+      await unpublishContent(ctx.db)({ contentId: child, userId });
+      await unpublishContent(ctx.db)({ contentId: parent, userId });
+      await ctx.db
+        .updateTable("content_item")
+        .set({ published_at: null })
+        .where("id", "=", parent)
+        .execute();
+
+      // The parent's own ever-published marker is gone...
+      expect((await getContent(ctx.db)(parent)).publishedAt).toBeNull();
+      // ...but the ever-published child still pins its slug and parent.
+      await expect(
+        updateContent(ctx.db)({ contentId: parent, slug: "chapters", userId }),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: /descendant page '\/sections\/alpha' has been published/,
+      });
+    });
+
+    it("keeps a child's go-live at or after its parent's", async () => {
+      const parent = await mkPage("season");
+      const child = await mkPage("fixtures", { parentId: parent });
+      const parentAt = new Date(Date.now() + 60 * 60 * 1000);
+      await publishContent(ctx.db)({
+        contentId: parent,
+        publishedAt: parentAt.toISOString(),
+        userId,
+      });
+
+      const tooEarly = `Parent page goes live at ${parentAt.toISOString()}; schedule this page for that time or later`;
+
+      // Publish-now while the parent is still scheduled: the child would
+      // be live on a URL prefix the public cannot see yet
+      await expect(
+        publishContent(ctx.db)({ contentId: child, userId }),
+      ).rejects.toMatchObject({ statusCode: 400, message: tooEarly });
+
+      // Scheduling before the parent's go-live is equally rejected...
+      await expect(
+        publishContent(ctx.db)({
+          contentId: child,
+          publishedAt: new Date(
+            parentAt.getTime() - 30 * 60 * 1000,
+          ).toISOString(),
+          userId,
+        }),
+      ).rejects.toMatchObject({ statusCode: 400, message: tooEarly });
+
+      // ...as is backdating the child into the past
+      await expect(
+        publishContent(ctx.db)({
+          contentId: child,
+          publishedAt: new Date(Date.now() - 1000).toISOString(),
+          userId,
+        }),
+      ).rejects.toMatchObject({ statusCode: 400, message: tooEarly });
+
+      // The parent's exact go-live instant works: a whole section can be
+      // scheduled together, top-down
+      const scheduled = await publishContent(ctx.db)({
+        contentId: child,
+        publishedAt: parentAt.toISOString(),
+        userId,
+      });
+      expect(scheduled.publishedAt).toBe(parentAt.toISOString());
+
+      // Unwind bottom-up (never live, so the markers clear and the nav
+      // test below keeps its exact payload)
+      await unpublishContent(ctx.db)({ contentId: child, userId });
+      await unpublishContent(ctx.db)({ contentId: parent, userId });
+    });
+
+    it("archives a page only after its children are unpublished", async () => {
+      const parent = await mkPage("vault");
+      const child = await mkPage("records", { parentId: parent });
+      await publishContent(ctx.db)({ contentId: parent, userId });
+      await publishContent(ctx.db)({ contentId: child, userId });
+
+      await expect(
+        archiveContent(ctx.db)({ contentId: parent, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: /published child pages/,
+      });
+
+      await unpublishContent(ctx.db)({ contentId: child, userId });
+      // A draft child under an archived parent is acceptable...
+      await archiveContent(ctx.db)({ contentId: parent, userId });
+      expect((await getContent(ctx.db)(parent)).status).toBe("archived");
+      // ...it just cannot be published (parent-not-published gate)
+      await expect(
+        publishContent(ctx.db)({ contentId: child, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Cannot publish this page until its parent page is published",
+      });
+    });
+
+    it("serves nav and page-by-path for exactly the published pages (HTTP)", async () => {
+      const navA = await mkPage("nav-a", {
+        metadata: { menuOrder: 1, isMainMenu: true },
+      });
+      const navB = await mkPage("nav-b", { parentId: navA });
+      await mkPage("nav-draft");
+      const navSched = await mkPage("nav-sched");
+
+      await publishContent(ctx.db)({ contentId: navA, userId });
+      await publishContent(ctx.db)({ contentId: navB, userId });
+      await publishContent(ctx.db)({
+        contentId: navSched,
+        publishedAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        userId,
+      });
+
+      // Root pages stay resolvable through the generic kind+slug route
+      const rootBySlug = await getPublishedContent(ctx.db)({
+        kind: "page",
+        slug: "nav-a",
+      });
+      expect(rootBySlug.id).toBe(navA);
+
+      const logger = createTestLogger();
+      const app = Fastify({ logger: { level: "info", stream: logger.stream } });
+      app.setValidatorCompiler(validatorCompiler);
+      app.setSerializerCompiler(serializerCompiler);
+      app.decorate("db", ctx.db);
+      await app.register(contentRoutes);
+      try {
+        // Nav: exactly the live pages (no draft, no still-future
+        // schedule), ordered by path, defaults applied from the schema.
+        const nav = await app.inject({ method: "GET", url: "/content/nav" });
+        expect(nav.statusCode).toBe(200);
+        expect(nav.json()).toEqual({
+          items: [
+            {
+              path: "/nav-a",
+              title: "Page nav-a",
+              menuOrder: 1,
+              isMainMenu: true,
+            },
+            {
+              path: "/nav-a/nav-b",
+              title: "Page nav-b",
+              menuOrder: 99,
+              isMainMenu: false,
+            },
+          ],
+        });
+
+        // by-path serves the nested page with an ETag + 304 revalidation
+        const byPath = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=/nav-a/nav-b",
+        });
+        expect(byPath.statusCode).toBe(200);
+        expect(byPath.json<{ kind: string; slug: string }>()).toMatchObject({
+          kind: "page",
+          slug: "nav-b",
+        });
+        const etag = byPath.headers.etag;
+        expect(etag).toBeDefined();
+        const revalidated = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=/nav-a/nav-b",
+          headers: { "if-none-match": etag ?? "" },
+        });
+        expect(revalidated.statusCode).toBe(304);
+
+        // Drafts and scheduled pages 404 (and never leak an ETag)
+        const draft = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=/nav-draft",
+        });
+        expect(draft.statusCode).toBe(404);
+        expect(draft.headers.etag).toBeUndefined();
+        const sched = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=/nav-sched",
+        });
+        expect(sched.statusCode).toBe(404);
+
+        // Path shape is validated at the route: no leading slash → 400
+        const bad = await app.inject({
+          method: "GET",
+          url: "/content/page/by-path?path=nav-a",
+        });
+        expect(bad.statusCode).toBe(400);
+      } finally {
+        await app.close();
+      }
+    });
+  });
 });

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -4,6 +4,7 @@ import {
   validatorCompiler,
 } from "fastify-type-provider-zod";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { errorHandler } from "../../lib/error-handler.ts";
 import {
   seedTestUser,
   startTestContainer,
@@ -893,6 +894,32 @@ describe("content service (integration)", () => {
       });
       expect(scheduled.publishedAt).toBe(parentAt.toISOString());
 
+      // The mirror gate: re-scheduling the PARENT later than the child's
+      // go-live would leave the child publicly live under a 404ing
+      // parent between the two instants
+      await expect(
+        publishContent(ctx.db)({
+          contentId: parent,
+          publishedAt: new Date(
+            parentAt.getTime() + 30 * 60 * 1000,
+          ).toISOString(),
+          userId,
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message:
+          "Children are scheduled before this go-live - reschedule them first",
+      });
+
+      // Re-scheduling the parent to the SAME instant stays allowed
+      // (equal go-lives, the invariant the child gate permits)
+      const reScheduled = await publishContent(ctx.db)({
+        contentId: parent,
+        publishedAt: parentAt.toISOString(),
+        userId,
+      });
+      expect(reScheduled.publishedAt).toBe(parentAt.toISOString());
+
       // Unwind bottom-up (never live, so the markers clear and the nav
       // test below keeps its exact payload)
       await unpublishContent(ctx.db)({ contentId: child, userId });
@@ -957,6 +984,9 @@ describe("content service (integration)", () => {
       try {
         // Nav: exactly the live pages (no draft, no still-future
         // schedule), ordered by path, defaults applied from the schema.
+        // removed[] lists every ever-live page no longer visible -
+        // exactly the tombstones earlier tests in this describe minted
+        // (unpublish-after-live and archive-after-live), path-ordered.
         const nav = await app.inject({ method: "GET", url: "/content/nav" });
         expect(nav.statusCode).toBe(200);
         expect(nav.json()).toEqual({
@@ -973,6 +1003,13 @@ describe("content service (integration)", () => {
               menuOrder: 99,
               isMainMenu: false,
             },
+          ],
+          removed: [
+            "/rules",
+            "/rules/code-of-conduct",
+            "/sections/alpha",
+            "/vault",
+            "/vault/records",
           ],
         });
 
@@ -1080,6 +1117,132 @@ describe("content service (integration)", () => {
         status: "draft",
         pathLocked: true,
       });
+    });
+
+    it("rejects reserved root slugs but allows them on children", async () => {
+      // The SPA router owns these first segments; a root page there
+      // could never be reached past the router.
+      await expect(mkPage("news")).rejects.toMatchObject({
+        statusCode: 400,
+        message: "This address is reserved by the site",
+      });
+
+      const parent = await mkPage("reserved-host");
+      // Only the first path segment routes, so children may reuse them
+      const child = await mkPage("news", { parentId: parent });
+      expect((await getContent(ctx.db)(child)).path).toBe(
+        "/reserved-host/news",
+      );
+
+      // Renaming a root page onto a reserved slug is equally blocked...
+      await expect(
+        updateContent(ctx.db)({ contentId: parent, slug: "admin", userId }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "This address is reserved by the site",
+      });
+      // ...as is moving a reserved-slugged child up to the root
+      await expect(
+        updateContent(ctx.db)({ contentId: child, parentId: null, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "This address is reserved by the site",
+      });
+    });
+
+    it("rejects creating or moving pages under an archived parent", async () => {
+      const attic = await mkPage("attic");
+      await archiveContent(ctx.db)({ contentId: attic, userId });
+
+      await expect(mkPage("boxes", { parentId: attic })).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Cannot create a page under an archived page",
+      });
+
+      const loft = await mkPage("loft");
+      await expect(
+        updateContent(ctx.db)({ contentId: loft, parentId: attic, userId }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Cannot move a page under an archived page",
+      });
+    });
+
+    it("rejects computed paths that exceed the path schema bounds", async () => {
+      // Four 200-char segments fit (804 chars); the fifth would push the
+      // materialised path to 1005, past contentPathSchema's 1000 cap -
+      // the same rule the by-path querystring validates, so a deeper
+      // page could never be fetched.
+      const segment = "x".repeat(200);
+      let parentId: string | null = null;
+      for (let depth = 0; depth < 4; depth++) {
+        parentId = await mkPage(segment, { parentId });
+      }
+      await expect(mkPage(segment, { parentId })).rejects.toMatchObject({
+        statusCode: 400,
+        message: /too long or too deep/,
+      });
+    });
+
+    it("tombstones taken-down pages: by-path 410 vs 404 matrix + nav removed[] (HTTP)", async () => {
+      // The SPA falls back to bundled static MDX on 404, so a takedown
+      // (unpublish/archive after going live) must be distinguishable
+      // from "never existed" - 410, plus a nav removed[] entry to drop
+      // resurrected static nav items.
+      await mkPage("tomb-draft"); // created, never published
+      const tombUnpub = await mkPage("tomb-unpub");
+      const tombArch = await mkPage("tomb-arch");
+      const tombSched = await mkPage("tomb-sched");
+
+      await publishContent(ctx.db)({ contentId: tombUnpub, userId });
+      await unpublishContent(ctx.db)({ contentId: tombUnpub, userId });
+      await publishContent(ctx.db)({ contentId: tombArch, userId });
+      await archiveContent(ctx.db)({ contentId: tombArch, userId });
+      await publishContent(ctx.db)({
+        contentId: tombSched,
+        publishedAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        userId,
+      });
+
+      const logger = createTestLogger();
+      const app = Fastify({ logger: { level: "info", stream: logger.stream } });
+      app.setValidatorCompiler(validatorCompiler);
+      app.setSerializerCompiler(serializerCompiler);
+      // The production error handler, so the 410 body assertion below
+      // exercises the real { error } contract, not Fastify's default.
+      app.setErrorHandler(errorHandler);
+      app.decorate("db", ctx.db);
+      await app.register(contentRoutes);
+      try {
+        const get = (path: string) =>
+          app.inject({
+            method: "GET",
+            url: `/content/page/by-path?path=${path}`,
+          });
+
+        // Never live: drafts and future schedules leak nothing - 404
+        expect((await get("/tomb-draft")).statusCode).toBe(404);
+        expect((await get("/tomb-sched")).statusCode).toBe(404);
+
+        // Ever-live but taken down: 410 Gone with the documented body
+        const unpub = await get("/tomb-unpub");
+        expect(unpub.statusCode).toBe(410);
+        expect(unpub.json()).toEqual({ error: "This page has been removed" });
+        expect(unpub.headers.etag).toBeUndefined();
+        expect((await get("/tomb-arch")).statusCode).toBe(410);
+
+        // nav removed[]: exactly the ever-live-but-hidden paths (other
+        // tests minted tombstones of their own, so containment only)
+        const nav = await app
+          .inject({ method: "GET", url: "/content/nav" })
+          .then((res) => res.json<{ items: unknown[]; removed: string[] }>());
+        expect(nav.removed).toContain("/tomb-unpub");
+        expect(nav.removed).toContain("/tomb-arch");
+        expect(nav.removed).not.toContain("/tomb-draft");
+        expect(nav.removed).not.toContain("/tomb-sched");
+      } finally {
+        await app.close();
+      }
     });
   });
 });

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -20,6 +20,8 @@ import {
   listNewsQuerySchema,
   listNewsResponseSchema,
   listRevisionsResponseSchema,
+  navResponseSchema,
+  pageByPathQuerySchema,
   playCricketIdParamSchema,
   publicContentParamsSchema,
   publicContentResponseSchema,
@@ -33,6 +35,8 @@ import {
   getContentMeta,
   getPublishedContent,
   getPublishedGameReport,
+  getPublishedNav,
+  getPublishedPageByPath,
   listContent,
   listPublishedEvents,
   listPublishedNews,
@@ -81,6 +85,8 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const publicGameReport = getPublishedGameReport(app.db);
   const publicNews = listPublishedNews(app.db);
   const publicEvents = listPublishedEvents(app.db);
+  const publicNav = getPublishedNav(app.db);
+  const publicPageByPath = getPublishedPageByPath(app.db);
 
   // ── Admin ──
 
@@ -287,6 +293,28 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   );
 
+  // Page lookup by full materialised path - the canonical public page
+  // route (nested page slugs are only unique among siblings). Static
+  // segments, so find-my-way prefers it over /content/:kind/:slug.
+  app.get(
+    "/content/page/by-path",
+    {
+      schema: {
+        querystring: pageByPathQuerySchema,
+        response: { 200: publicContentResponseSchema, 304: z.null() },
+      },
+    },
+    async (request, reply) => {
+      const item = await publicPageByPath(request.query.path);
+      const etag = etagFor(item);
+      void reply.header("etag", etag);
+      if (request.headers["if-none-match"] === etag) {
+        return await reply.code(304).send(null);
+      }
+      return item;
+    },
+  );
+
   // List endpoints. One static segment, so no clash with the two-segment
   // /content/:kind/:slug above. No ETag here: any item edit, publish or
   // scheduled publish crossing now() would have to invalidate it.
@@ -313,6 +341,18 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async () => {
       return await publicEvents();
+    },
+  );
+
+  app.get(
+    "/content/nav",
+    {
+      schema: {
+        response: { 200: navResponseSchema },
+      },
+    },
+    async () => {
+      return await publicNav();
     },
   );
 };

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -14,6 +14,7 @@ import {
   contentDetailResponseSchema,
   contentIdParamSchema,
   createContentSchema,
+  goneResponseSchema,
   listContentQuerySchema,
   listContentResponseSchema,
   listEventsResponseSchema,
@@ -316,12 +317,19 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   // Page lookup by full materialised path - the canonical public page
   // route (nested page slugs are only unique among siblings). Static
   // segments, so find-my-way prefers it over /content/:kind/:slug.
+  // 410 = tombstone: the page WAS live here but has been taken down;
+  // the SPA must not fall back to its bundled static version (404 keeps
+  // that fallback for never-live paths).
   app.get(
     "/content/page/by-path",
     {
       schema: {
         querystring: pageByPathQuerySchema,
-        response: { 200: publicContentResponseSchema, 304: z.null() },
+        response: {
+          200: publicContentResponseSchema,
+          304: z.null(),
+          410: goneResponseSchema,
+        },
       },
     },
     async (request, reply) => {

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -22,6 +22,7 @@ import {
   listRevisionsResponseSchema,
   navResponseSchema,
   pageByPathQuerySchema,
+  pageTreeResponseSchema,
   playCricketIdParamSchema,
   publicContentParamsSchema,
   publicContentResponseSchema,
@@ -38,6 +39,7 @@ import {
   getPublishedNav,
   getPublishedPageByPath,
   listContent,
+  listPageTree,
   listPublishedEvents,
   listPublishedNews,
   listRevisions,
@@ -73,6 +75,7 @@ const publishResponseSchema = z.object({
 // eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
 export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const list = listContent(app.db);
+  const pageTree = listPageTree(app.db);
   const get = getContent(app.db);
   const metaOf = getContentMeta(app.db);
   const create = createContent(app.db);
@@ -102,6 +105,23 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       assertContentPermission(request, request.query.kind, "view");
       return await list(request.query);
+    },
+  );
+
+  // Static segment, so find-my-way prefers it over /admin/content/:contentId.
+  // Same permission treatment as the admin list for kind=page (resource
+  // "content", action "view").
+  app.get(
+    "/admin/content/page-tree",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        response: { 200: pageTreeResponseSchema },
+      },
+    },
+    async (request) => {
+      assertContentPermission(request, "page", "view");
+      return await pageTree();
     },
   );
 

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -75,6 +75,32 @@ export const listContentResponseSchema = z.object({
   total: z.number().int().nonnegative(),
 });
 
+// ── Admin: page tree ────────────────────────────────────────────────────
+
+/**
+ * Every page regardless of status, ordered by path - the single source
+ * for the admin tree view. pathLocked is the server-derived
+ * ever-published lock (published_at non-null, the same marker
+ * updateContent enforces) so the UI never re-derives lock semantics.
+ */
+export const pageTreeResponseSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      slug: z.string(),
+      path: z.string(),
+      parentId: z.string().nullable(),
+      menuOrder: z.number().int(),
+      isMainMenu: z.boolean(),
+      status: contentStatusSchema,
+      publishedAt: z.string().nullable(),
+      updatedAt: z.string(),
+      pathLocked: z.boolean(),
+    }),
+  ),
+});
+
 // ── Admin: get / create / update ────────────────────────────────────────
 
 export const contentIdParamSchema = z.object({

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -1,6 +1,7 @@
 import {
   blockPropValueSchema,
   contentKindSchema,
+  contentPathSchema,
   contentSlugSchema,
   contentStatusSchema,
   newsTagSchema,
@@ -42,6 +43,12 @@ export const contentSummarySchema = z.object({
   description: z.string().nullable(),
   status: contentStatusSchema,
   metadata: contentMetadataSchema,
+  // Hierarchy fields: populated for pages, null for every other kind.
+  // menuOrder is hoisted out of metadata so the admin tree view can sort
+  // without re-parsing the metadata jsonb.
+  parentId: z.string().nullable(),
+  path: z.string().nullable(),
+  menuOrder: z.number().int().nullable(),
   publishedAt: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
@@ -81,6 +88,8 @@ export const createContentSchema = z.object({
   description: z.string().min(1).max(1000).nullish(),
   body: contentBodyTransportSchema,
   metadata: contentMetadataSchema,
+  /** Pages only: parent page id (omit/null for a root page). */
+  parentId: z.uuid().nullish(),
 });
 
 export const updateContentSchema = z.object({
@@ -89,6 +98,11 @@ export const updateContentSchema = z.object({
   description: z.string().min(1).max(1000).nullish(),
   body: contentBodyTransportSchema.optional(),
   metadata: contentMetadataSchema.optional(),
+  /**
+   * Pages only: omit to leave the parent unchanged, null to move to the
+   * root, an id to move under that page. Locked once ever published.
+   */
+  parentId: z.uuid().nullish(),
 });
 
 export const contentDetailResponseSchema = contentDetailSchema;
@@ -183,4 +197,27 @@ export const listNewsResponseSchema = z.object({
 
 export const listEventsResponseSchema = z.object({
   items: z.array(publicListItemSchema),
+});
+
+// ── Public: pages (nav + by-path) ───────────────────────────────────────
+
+/**
+ * Every published page's nav fields, ordered by path. A few KB for the
+ * whole site, so no pagination; tree assembly stays client-side
+ * (replaces the build-time getNavigationTree/getBreadcrumbs/
+ * getMainMenuItems over static frontmatter).
+ */
+export const navResponseSchema = z.object({
+  items: z.array(
+    z.object({
+      path: z.string(),
+      title: z.string(),
+      menuOrder: z.number().int(),
+      isMainMenu: z.boolean(),
+    }),
+  ),
+});
+
+export const pageByPathQuerySchema = z.object({
+  path: contentPathSchema,
 });

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -242,8 +242,24 @@ export const navResponseSchema = z.object({
       isMainMenu: z.boolean(),
     }),
   ),
+  /**
+   * Tombstoned paths: pages that were publicly live but are no longer
+   * visible (unpublished/archived after going live). The SPA drops
+   * matching entries from its bundled static nav so a takedown does not
+   * resurrect the stale static page in menus.
+   */
+  removed: z.array(z.string()),
 });
 
 export const pageByPathQuerySchema = z.object({
   path: contentPathSchema,
+});
+
+/**
+ * Tombstone body for by-path lookups of ever-live pages that are no
+ * longer visible (410 Gone). Shape matches the global error handler's
+ * `{ error }` reply.
+ */
+export const goneResponseSchema = z.object({
+  error: z.string(),
 });

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -50,6 +50,7 @@ import {
   archiveContent,
   createContent,
   getPublishedGameReport,
+  listPageTree,
   publishContent,
   unpublishContent,
   updateContent,
@@ -917,6 +918,101 @@ describe("unpublishContent", () => {
       userId: "user-1",
     });
     expect(result).toEqual({ id: "content-1" });
+  });
+});
+
+describe("listPageTree", () => {
+  const pageRow = (overrides: Record<string, unknown> = {}) => ({
+    id: "page-1",
+    title: "Cricket",
+    slug: "cricket",
+    path: "/cricket",
+    parent_id: null,
+    metadata: { menuOrder: 1, isMainMenu: true, hideTitle: false },
+    status: "draft",
+    published_at: null,
+    updated_at: new Date("2026-06-02T10:00:00Z"),
+    ...overrides,
+  });
+
+  it("maps rows: hierarchy fields, metadata values and timestamps", async () => {
+    mockExecute.mockResolvedValueOnce([
+      pageRow(),
+      pageRow({
+        id: "page-2",
+        title: "Juniors",
+        slug: "juniors",
+        path: "/cricket/juniors",
+        parent_id: "page-1",
+        status: "published",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      }),
+    ]);
+    const { items } = await listPageTree(db)();
+    expect(items).toEqual([
+      {
+        id: "page-1",
+        title: "Cricket",
+        slug: "cricket",
+        path: "/cricket",
+        parentId: null,
+        menuOrder: 1,
+        isMainMenu: true,
+        status: "draft",
+        publishedAt: null,
+        updatedAt: "2026-06-02T10:00:00.000Z",
+        pathLocked: false,
+      },
+      {
+        id: "page-2",
+        title: "Juniors",
+        slug: "juniors",
+        path: "/cricket/juniors",
+        parentId: "page-1",
+        menuOrder: 1,
+        isMainMenu: true,
+        status: "published",
+        publishedAt: "2026-06-01T10:00:00.000Z",
+        updatedAt: "2026-06-02T10:00:00.000Z",
+        pathLocked: true,
+      },
+    ]);
+  });
+
+  it("derives pathLocked from the ever-published marker, not status", async () => {
+    // Unpublish retains a past published_at (the item WAS live), so a
+    // draft can still be locked; archive never touches the marker.
+    mockExecute.mockResolvedValueOnce([
+      pageRow({
+        status: "draft",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      }),
+      pageRow({ id: "page-2", path: "/club", status: "archived" }),
+    ]);
+    const { items } = await listPageTree(db)();
+    expect(items[0]).toMatchObject({ status: "draft", pathLocked: true });
+    expect(items[1]).toMatchObject({ status: "archived", pathLocked: false });
+  });
+
+  it("applies schema defaults for keys absent from stored metadata", async () => {
+    mockExecute.mockResolvedValueOnce([pageRow({ metadata: {} })]);
+    const { items } = await listPageTree(db)();
+    expect(items[0]).toMatchObject({ menuOrder: 99, isMainMenu: false });
+  });
+
+  it("degrades malformed stored metadata to pure defaults", async () => {
+    mockExecute.mockResolvedValueOnce([
+      pageRow({ metadata: { menuOrder: "first", isMainMenu: "yes" } }),
+    ]);
+    const { items } = await listPageTree(db)();
+    expect(items[0]).toMatchObject({ menuOrder: 99, isMainMenu: false });
+  });
+
+  it("500s on a page with no path (data problem, not a request error)", async () => {
+    mockExecute.mockResolvedValueOnce([pageRow({ path: null })]);
+    await expect(listPageTree(db)()).rejects.toMatchObject({
+      statusCode: 500,
+    });
   });
 });
 

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -9,37 +9,42 @@ import {
 } from "kysely";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockExecuteTakeFirst, mockExecuteTakeFirstOrThrow, mockQueryBuilder } =
-  vi.hoisted(() => {
-    const mockExecuteTakeFirst = vi.fn();
-    const mockExecuteTakeFirstOrThrow = vi.fn();
-    const mockExecute = vi.fn();
+const {
+  mockExecuteTakeFirst,
+  mockExecuteTakeFirstOrThrow,
+  mockExecute,
+  mockQueryBuilder,
+} = vi.hoisted(() => {
+  const mockExecuteTakeFirst = vi.fn();
+  const mockExecuteTakeFirstOrThrow = vi.fn();
+  const mockExecute = vi.fn();
 
-    const mockQueryBuilder: Record<string, unknown> = {
-      selectFrom: vi.fn().mockReturnThis(),
-      updateTable: vi.fn().mockReturnThis(),
-      insertInto: vi.fn().mockReturnThis(),
-      leftJoin: vi.fn().mockReturnThis(),
-      where: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      set: vi.fn().mockReturnThis(),
-      values: vi.fn().mockReturnThis(),
-      returning: vi.fn().mockReturnThis(),
-      orderBy: vi.fn().mockReturnThis(),
-      limit: vi.fn().mockReturnThis(),
-      offset: vi.fn().mockReturnThis(),
-      executeTakeFirst: mockExecuteTakeFirst,
-      executeTakeFirstOrThrow: mockExecuteTakeFirstOrThrow,
-      execute: mockExecute,
-    };
+  const mockQueryBuilder: Record<string, unknown> = {
+    selectFrom: vi.fn().mockReturnThis(),
+    updateTable: vi.fn().mockReturnThis(),
+    insertInto: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockReturnThis(),
+    forUpdate: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
+    executeTakeFirst: mockExecuteTakeFirst,
+    executeTakeFirstOrThrow: mockExecuteTakeFirstOrThrow,
+    execute: mockExecute,
+  };
 
-    return {
-      mockExecuteTakeFirst,
-      mockExecuteTakeFirstOrThrow,
-      mockExecute,
-      mockQueryBuilder,
-    };
-  });
+  return {
+    mockExecuteTakeFirst,
+    mockExecuteTakeFirstOrThrow,
+    mockExecute,
+    mockQueryBuilder,
+  };
+});
 
 import {
   archiveContent,
@@ -63,13 +68,32 @@ const compilerDb = new Kysely<DB>({
   },
 });
 
-/** SQL text (whitespace-normalised) of a column's value in the first .set() call. */
-function setSqlFor(column: string): string {
-  const setArg = (mockQueryBuilder.set as ReturnType<typeof vi.fn>).mock
-    .calls[0]?.[0] as Record<string, RawBuilder<unknown>>;
+/** SQL text (whitespace-normalised) of a column's value in the nth .set() call. */
+function setSqlFor(column: string, callIndex = 0): string {
+  const setArg = (mockQueryBuilder.set as ReturnType<typeof vi.fn>).mock.calls[
+    callIndex
+  ]?.[0] as Record<string, RawBuilder<unknown>>;
   const builder = setArg[column];
   if (!builder) throw new Error(`.set() did not include ${column}`);
   return builder.compile(compilerDb).sql.replace(/\s+/g, " ").trim();
+}
+
+/** The argument object of the nth .set() call (for plain, non-SQL values). */
+function setArgFor(callIndex = 0): Record<string, unknown> {
+  const setArg = (mockQueryBuilder.set as ReturnType<typeof vi.fn>).mock.calls[
+    callIndex
+  ]?.[0] as Record<string, unknown> | undefined;
+  if (!setArg) throw new Error(`.set() was not called ${callIndex + 1} times`);
+  return setArg;
+}
+
+/** The argument object of the nth .values() call. */
+function valuesArgFor(callIndex = 0): Record<string, unknown> {
+  const arg = (mockQueryBuilder.values as ReturnType<typeof vi.fn>).mock.calls[
+    callIndex
+  ]?.[0] as Record<string, unknown> | undefined;
+  if (!arg) throw new Error(`.values() was not called ${callIndex + 1} times`);
+  return arg;
 }
 
 /**
@@ -313,13 +337,261 @@ describe("updateContent", () => {
     });
     expect(result).toEqual({ id: "content-1" });
   });
+
+  it("rejects a parentId on non-page kinds", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(currentRow); // game_report
+    await expect(
+      updateContent(db)({
+        contentId: "content-1",
+        userId: "user-1",
+        parentId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Only pages can have a parent page",
+    });
+  });
+});
+
+describe("page hierarchy: createContent", () => {
+  const pageCreate = (overrides: Record<string, unknown> = {}) =>
+    validCreate({
+      kind: "page" as const,
+      slug: "about",
+      title: "About",
+      metadata: {},
+      ...overrides,
+    });
+
+  it("rejects a parentId on non-page kinds", async () => {
+    await expect(
+      createContent(db)(validCreate({ parentId: "parent-1" })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Only pages can have a parent page",
+    });
+  });
+
+  it("computes a root page's path and applies metadata defaults", async () => {
+    const result = await createContent(db)(pageCreate());
+    expect(result).toEqual({ id: "content-1" });
+    const inserted = valuesArgFor() as { metadata: string };
+    expect(valuesArgFor()).toMatchObject({
+      parent_id: null,
+      path: "/about",
+    });
+    expect(JSON.parse(inserted.metadata)).toEqual({
+      menuOrder: 99,
+      isMainMenu: false,
+      hideTitle: false,
+    });
+  });
+
+  it("computes a child page's path from its parent's", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ id: "parent-1", kind: "page", path: "/cricket" }) // parent fetch
+      .mockResolvedValueOnce(undefined); // sibling slug check
+    const result = await createContent(db)(
+      pageCreate({ slug: "juniors", parentId: "parent-1" }),
+    );
+    expect(result).toEqual({ id: "content-1" });
+    expect(valuesArgFor()).toMatchObject({
+      parent_id: "parent-1",
+      path: "/cricket/juniors",
+    });
+  });
+
+  it("rejects a parent that does not exist", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // parent fetch
+    await expect(
+      createContent(db)(pageCreate({ parentId: "missing" })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Parent page not found",
+    });
+  });
+
+  it("rejects a parent that is not a page", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "news-1",
+      kind: "news",
+      path: null,
+    });
+    await expect(
+      createContent(db)(pageCreate({ parentId: "news-1" })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Parent page not found",
+    });
+  });
+
+  it("keeps parent_id and path NULL for non-page kinds", async () => {
+    await createContent(db)(validCreate());
+    expect(valuesArgFor()).toMatchObject({ parent_id: null, path: null });
+  });
+});
+
+describe("page hierarchy: updateContent", () => {
+  const pageRow = {
+    id: "page-1",
+    kind: "page",
+    slug: "cricket",
+    parent_id: null,
+    path: "/cricket",
+    title: "Cricket",
+    description: null,
+    body: validBody,
+    metadata: { menuOrder: 1, isMainMenu: true, hideTitle: false },
+    published_at: null,
+  };
+
+  it("recomputes the path on slug change and cascades to descendants", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pageRow) // fetch current
+      .mockResolvedValueOnce(undefined); // sibling slug check
+    mockExecute.mockResolvedValueOnce([
+      { id: "child-1", path: "/cricket/juniors", published_at: null },
+      {
+        id: "grandchild-1",
+        path: "/cricket/juniors/coaches",
+        published_at: null,
+      },
+    ]); // descendants
+    const result = await updateContent(db)({
+      contentId: "page-1",
+      userId: "user-1",
+      slug: "playing",
+    });
+    expect(result).toEqual({ id: "page-1" });
+    // Main update rewrites the page's own path...
+    expect(setArgFor(0)).toMatchObject({
+      slug: "playing",
+      parent_id: null,
+      path: "/playing",
+    });
+    // ...and the cascade re-prefixes every descendant in one statement:
+    // new prefix ($1) + the tail of the old path (substr past '/cricket').
+    expect(setSqlFor("path", 1)).toBe("$1 || substr(path, 9)");
+    const cascadeWhere = (
+      mockQueryBuilder.where as ReturnType<typeof vi.fn>
+    ).mock.calls.find((call) => call[1] === "in");
+    expect(cascadeWhere?.[2]).toEqual(["child-1", "grandchild-1"]);
+  });
+
+  it("recomputes the path on parent change", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pageRow) // fetch current
+      .mockResolvedValueOnce({ id: "parent-2", kind: "page", path: "/club" }) // new parent
+      .mockResolvedValueOnce(undefined); // sibling slug check
+    mockExecute.mockResolvedValueOnce([]); // no descendants
+    await updateContent(db)({
+      contentId: "page-1",
+      userId: "user-1",
+      parentId: "parent-2",
+    });
+    expect(setArgFor(0)).toMatchObject({
+      slug: "cricket",
+      parent_id: "parent-2",
+      path: "/club/cricket",
+    });
+  });
+
+  it("locks slug and parent once the page has ever been published", async () => {
+    const published = {
+      ...pageRow,
+      published_at: new Date("2026-06-01T10:00:00Z"),
+    };
+    mockExecuteTakeFirst.mockResolvedValueOnce(published);
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        slug: "playing",
+      }),
+    ).rejects.toMatchObject({ statusCode: 409, message: /locked/ });
+
+    mockExecuteTakeFirst.mockResolvedValueOnce(published);
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        parentId: "parent-2",
+      }),
+    ).rejects.toMatchObject({ statusCode: 409, message: /locked/ });
+  });
+
+  it("rejects a slug change that would move an ever-published descendant", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(pageRow);
+    mockExecute.mockResolvedValueOnce([
+      {
+        id: "child-1",
+        path: "/cricket/juniors",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      },
+    ]);
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        slug: "playing",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message: /descendant page '\/cricket\/juniors' has been published/,
+    });
+  });
+
+  it("rejects making a page its own parent", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(pageRow);
+    mockExecute.mockResolvedValueOnce([]); // descendants
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        parentId: "page-1",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "A page cannot be its own parent",
+    });
+  });
+
+  it("rejects moving a page under one of its own descendants", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(pageRow).mockResolvedValueOnce({
+      id: "child-1",
+      kind: "page",
+      path: "/cricket/juniors",
+    }); // new parent = descendant
+    mockExecute.mockResolvedValueOnce([
+      { id: "child-1", path: "/cricket/juniors", published_at: null },
+    ]);
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        parentId: "child-1",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "A page cannot be moved under one of its own descendants",
+    });
+  });
 });
 
 describe("publishContent", () => {
+  // Call order inside the transaction: 1. unlocked peek (kind/parent_id)
+  // 2. [pages with a parent] parent row FOR UPDATE 3. item row FOR
+  // UPDATE 4. the UPDATE itself.
+  const peeked = { kind: "game_report", status: "draft", parent_id: null };
+  const pagePeek = { kind: "page", status: "draft", parent_id: "p1" };
+  const liveParent = {
+    status: "published",
+    published_at: new Date("2026-06-01T10:00:00Z"),
+    live_now: true,
+  };
+
   it("404s when the item does not exist", async () => {
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update returning nothing
-      .mockResolvedValueOnce(undefined); // existence check
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // peek
     await expect(
       publishContent(db)({ contentId: "missing", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 404 });
@@ -327,8 +599,8 @@ describe("publishContent", () => {
 
   it("409s when the item is archived", async () => {
     mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update skipped archived row
-      .mockResolvedValueOnce({ status: "archived" }); // but it exists
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce({ ...peeked, status: "archived" }); // locked item
     await expect(
       publishContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({
@@ -339,10 +611,10 @@ describe("publishContent", () => {
 
   it("returns the effective publishedAt", async () => {
     const at = new Date("2026-07-01T10:00:00Z");
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      id: "content-1",
-      published_at: at,
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce(peeked) // locked item
+      .mockResolvedValueOnce({ id: "content-1", published_at: at });
     const result = await publishContent(db)({
       contentId: "content-1",
       publishedAt: at.toISOString(),
@@ -356,25 +628,26 @@ describe("publishContent", () => {
 
   it("passes an explicit publishedAt through as a concrete date", async () => {
     const at = new Date("2026-07-01T10:00:00Z");
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      id: "content-1",
-      published_at: at,
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce(peeked) // locked item
+      .mockResolvedValueOnce({ id: "content-1", published_at: at });
     await publishContent(db)({
       contentId: "content-1",
       publishedAt: at.toISOString(),
       userId: "user-1",
     });
-    const setArg = (mockQueryBuilder.set as ReturnType<typeof vi.fn>).mock
-      .calls[0]?.[0] as { published_at: unknown };
-    expect(setArg.published_at).toEqual(at);
+    expect(setArgFor().published_at).toEqual(at);
   });
 
   it("publish-now keeps published_at only when already past (DB-clock CASE)", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      id: "content-1",
-      published_at: new Date("2026-06-01T10:00:00Z"),
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce(peeked) // locked item
+      .mockResolvedValueOnce({
+        id: "content-1",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      });
     await publishContent(db)({ contentId: "content-1", userId: "user-1" });
     // NULL or a still-future schedule must fall through to now(); only a
     // past live-from date survives a dateless publish.
@@ -387,10 +660,13 @@ describe("publishContent", () => {
   });
 
   it("guards the ever-live invariant in the UPDATE's WHERE (DB clock)", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      id: "content-1",
-      published_at: new Date("2027-01-01T10:00:00Z"),
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(peeked)
+      .mockResolvedValueOnce(peeked) // locked item
+      .mockResolvedValueOnce({
+        id: "content-1",
+        published_at: new Date("2027-01-01T10:00:00Z"),
+      });
     await publishContent(db)({
       contentId: "content-1",
       publishedAt: "2027-01-01T10:00:00Z",
@@ -405,8 +681,9 @@ describe("publishContent", () => {
 
   it("409s when scheduling an item that has already been live", async () => {
     mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // ever-live guard excluded the row
-      .mockResolvedValueOnce({ status: "published" }); // exists, not archived
+      .mockResolvedValueOnce({ ...peeked, status: "published" }) // peek
+      .mockResolvedValueOnce({ ...peeked, status: "published" }) // locked item
+      .mockResolvedValueOnce(undefined); // ever-live guard excluded the row
     await expect(
       publishContent(db)({
         contentId: "content-1",
@@ -419,13 +696,117 @@ describe("publishContent", () => {
         "This item has already been live - it can only be published immediately",
     });
   });
+
+  it("400s when publishing a page whose parent is not published", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce({
+        status: "draft",
+        published_at: null,
+        live_now: null,
+      }) // locked parent
+      .mockResolvedValueOnce(pagePeek); // locked item
+    await expect(
+      publishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Cannot publish this page until its parent page is published",
+    });
+  });
+
+  it("publishes a page under a live parent", async () => {
+    const at = new Date("2026-06-02T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce(liveParent) // locked parent
+      .mockResolvedValueOnce(pagePeek) // locked item
+      .mockResolvedValueOnce({ id: "content-1", published_at: at }); // update
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1", publishedAt: at.toISOString() });
+  });
+
+  it("publishes a root page without any parent check", async () => {
+    const at = new Date("2026-06-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: null })
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: null })
+      .mockResolvedValueOnce({ id: "content-1", published_at: at }); // update
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1", publishedAt: at.toISOString() });
+  });
+
+  it("rejects publish-now while the parent is still scheduled", async () => {
+    const parentAt = new Date("2027-01-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce({
+        status: "published",
+        published_at: parentAt,
+        live_now: false, // scheduled: not yet live on the DB clock
+      })
+      .mockResolvedValueOnce(pagePeek); // locked item
+    await expect(
+      publishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: `Parent page goes live at ${parentAt.toISOString()}; schedule this page for that time or later`,
+    });
+  });
+
+  it("rejects scheduling (or backdating) a child before the parent's go-live", async () => {
+    const parentAt = new Date("2027-01-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce({
+        status: "published",
+        published_at: parentAt,
+        live_now: false,
+      })
+      .mockResolvedValueOnce(pagePeek); // locked item
+    await expect(
+      publishContent(db)({
+        contentId: "content-1",
+        publishedAt: "2026-12-31T10:00:00Z",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: `Parent page goes live at ${parentAt.toISOString()}; schedule this page for that time or later`,
+    });
+  });
+
+  it("allows scheduling a child at the parent's exact go-live time", async () => {
+    const parentAt = new Date("2027-01-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(pagePeek)
+      .mockResolvedValueOnce({
+        status: "published",
+        published_at: parentAt,
+        live_now: false,
+      })
+      .mockResolvedValueOnce(pagePeek) // locked item
+      .mockResolvedValueOnce({ id: "content-1", published_at: parentAt });
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      publishedAt: parentAt.toISOString(),
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      id: "content-1",
+      publishedAt: parentAt.toISOString(),
+    });
+  });
 });
 
 describe("archiveContent", () => {
   it("404s when the item does not exist", async () => {
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update matched nothing
-      .mockResolvedValueOnce(undefined); // and it does not exist
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // locked item
     await expect(
       archiveContent(db)({ contentId: "missing", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 404 });
@@ -433,9 +814,10 @@ describe("archiveContent", () => {
 
   it("409s when the item is already archived", async () => {
     // Re-archiving must not silently bump updated_at/updated_by.
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update skipped the archived row
-      .mockResolvedValueOnce({ id: "content-1" }); // but it exists
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      kind: "game_report",
+      status: "archived",
+    });
     await expect(
       archiveContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({
@@ -445,7 +827,34 @@ describe("archiveContent", () => {
   });
 
   it("archives a non-archived item", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({ id: "content-1" });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "game_report", status: "draft" })
+      .mockResolvedValueOnce({ id: "content-1" }); // update
+    const result = await archiveContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1" });
+  });
+
+  it("409s when archiving a page that has published children", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // locked item
+      .mockResolvedValueOnce({ id: "child-1" }); // published-child probe
+    await expect(
+      archiveContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message:
+        "Cannot archive a page that has published child pages - unpublish or archive the children first",
+    });
+  });
+
+  it("archives a page whose children are all drafts", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // locked item
+      .mockResolvedValueOnce(undefined) // no published child
+      .mockResolvedValueOnce({ id: "content-1" }); // update
     const result = await archiveContent(db)({
       contentId: "content-1",
       userId: "user-1",
@@ -456,25 +865,26 @@ describe("archiveContent", () => {
 
 describe("unpublishContent", () => {
   it("409s when the item is not currently published", async () => {
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined) // update matched nothing
-      .mockResolvedValueOnce({ id: "content-1" }); // but it exists
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      kind: "game_report",
+      status: "draft",
+    }); // prefetch
     await expect(
       unpublishContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 409 });
   });
 
   it("404s when the item does not exist", async () => {
-    mockExecuteTakeFirst
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined);
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // prefetch
     await expect(
       unpublishContent(db)({ contentId: "missing", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 404 });
   });
 
   it("clears published_at only while it is still in the future (DB-clock CASE)", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({ id: "content-1" });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "game_report", status: "published" })
+      .mockResolvedValueOnce({ id: "content-1" }); // update
     await unpublishContent(db)({ contentId: "content-1", userId: "user-1" });
     // Cancelling a schedule that never went live clears the
     // ever-published marker (unlocking the slug); a past published_at -
@@ -482,6 +892,31 @@ describe("unpublishContent", () => {
     expect(setSqlFor("published_at")).toBe(
       "CASE WHEN published_at > CURRENT_TIMESTAMP THEN NULL ELSE published_at END",
     );
+  });
+
+  it("400s when unpublishing a page that has published children", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // prefetch
+      .mockResolvedValueOnce({ id: "child-1" }); // published-child probe
+    await expect(
+      unpublishContent(db)({ contentId: "content-1", userId: "user-1" }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message:
+        "Cannot unpublish a page that has published child pages - unpublish the children first",
+    });
+  });
+
+  it("unpublishes a page whose children are all unpublished", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // prefetch
+      .mockResolvedValueOnce(undefined) // no published child
+      .mockResolvedValueOnce({ id: "content-1" }); // update
+    const result = await unpublishContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1" });
   });
 });
 

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -5,6 +5,7 @@ import {
   PostgresAdapter,
   PostgresIntrospector,
   PostgresQueryCompiler,
+  type AliasedRawBuilder,
   type RawBuilder,
 } from "kysely";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,6 +22,7 @@ const {
 
   const mockQueryBuilder: Record<string, unknown> = {
     selectFrom: vi.fn().mockReturnThis(),
+    selectNoFrom: vi.fn().mockReturnThis(),
     updateTable: vi.fn().mockReturnThis(),
     insertInto: vi.fn().mockReturnThis(),
     leftJoin: vi.fn().mockReturnThis(),
@@ -50,6 +52,8 @@ import {
   archiveContent,
   createContent,
   getPublishedGameReport,
+  getPublishedNav,
+  getPublishedPageByPath,
   listPageTree,
   publishContent,
   unpublishContent,
@@ -96,6 +100,26 @@ function valuesArgFor(callIndex = 0): Record<string, unknown> {
   if (!arg) throw new Error(`.values() was not called ${callIndex + 1} times`);
   return arg;
 }
+
+/**
+ * SQL text of every .selectNoFrom() call - the form lockPageTree's
+ * advisory lock uses. Compiling through the DummyDriver Kysely proves
+ * the exact statement the service would execute.
+ */
+function selectNoFromSql(): string[] {
+  return (
+    mockQueryBuilder.selectNoFrom as ReturnType<typeof vi.fn>
+  ).mock.calls.map((call) =>
+    compilerDb
+      .selectNoFrom(call[0] as AliasedRawBuilder<unknown, "page_tree_lock">)
+      .compile()
+      .sql.replace(/\s+/g, " ")
+      .trim(),
+  );
+}
+
+const PAGE_TREE_LOCK_SQL =
+  "select pg_advisory_xact_lock(hashtext('content-page-tree')) as \"page_tree_lock\"";
 
 /**
  * SQL text (whitespace-normalised) of every raw single-argument .where()
@@ -430,6 +454,57 @@ describe("page hierarchy: createContent", () => {
     await createContent(db)(validCreate());
     expect(valuesArgFor()).toMatchObject({ parent_id: null, path: null });
   });
+
+  it("rejects a ROOT page on a reserved slug", async () => {
+    await expect(
+      createContent(db)(pageCreate({ slug: "news" })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "This address is reserved by the site",
+    });
+  });
+
+  it("allows a reserved slug on a CHILD page (only the first segment routes)", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ id: "parent-1", kind: "page", path: "/cricket" }) // parent fetch
+      .mockResolvedValueOnce(undefined); // sibling slug check
+    const result = await createContent(db)(
+      pageCreate({ slug: "news", parentId: "parent-1" }),
+    );
+    expect(result).toEqual({ id: "content-1" });
+    expect(valuesArgFor()).toMatchObject({ path: "/cricket/news" });
+  });
+
+  it("rejects creating a page under an archived parent", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "parent-1",
+      kind: "page",
+      path: "/cricket",
+      status: "archived",
+    });
+    await expect(
+      createContent(db)(pageCreate({ parentId: "parent-1" })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Cannot create a page under an archived page",
+    });
+  });
+
+  it("rejects a computed path that exceeds the path schema bounds", async () => {
+    // Parent path of 997 chars + "/" + 4-char slug = 1002 > the schema's
+    // 1000-char cap.
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "parent-1",
+      kind: "page",
+      path: `/${"a".repeat(996)}`,
+    });
+    await expect(
+      createContent(db)(pageCreate({ slug: "team", parentId: "parent-1" })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: /too long or too deep/,
+    });
+  });
 });
 
 describe("page hierarchy: updateContent", () => {
@@ -450,14 +525,16 @@ describe("page hierarchy: updateContent", () => {
     mockExecuteTakeFirst
       .mockResolvedValueOnce(pageRow) // fetch current
       .mockResolvedValueOnce(undefined); // sibling slug check
-    mockExecute.mockResolvedValueOnce([
-      { id: "child-1", path: "/cricket/juniors", published_at: null },
-      {
-        id: "grandchild-1",
-        path: "/cricket/juniors/coaches",
-        published_at: null,
-      },
-    ]); // descendants
+    mockExecute
+      .mockResolvedValueOnce(undefined) // page-tree advisory lock
+      .mockResolvedValueOnce([
+        { id: "child-1", path: "/cricket/juniors", published_at: null },
+        {
+          id: "grandchild-1",
+          path: "/cricket/juniors/coaches",
+          published_at: null,
+        },
+      ]); // descendants
     const result = await updateContent(db)({
       contentId: "page-1",
       userId: "user-1",
@@ -484,7 +561,9 @@ describe("page hierarchy: updateContent", () => {
       .mockResolvedValueOnce(pageRow) // fetch current
       .mockResolvedValueOnce({ id: "parent-2", kind: "page", path: "/club" }) // new parent
       .mockResolvedValueOnce(undefined); // sibling slug check
-    mockExecute.mockResolvedValueOnce([]); // no descendants
+    mockExecute
+      .mockResolvedValueOnce(undefined) // page-tree advisory lock
+      .mockResolvedValueOnce([]); // no descendants
     await updateContent(db)({
       contentId: "page-1",
       userId: "user-1",
@@ -523,13 +602,15 @@ describe("page hierarchy: updateContent", () => {
 
   it("rejects a slug change that would move an ever-published descendant", async () => {
     mockExecuteTakeFirst.mockResolvedValueOnce(pageRow);
-    mockExecute.mockResolvedValueOnce([
-      {
-        id: "child-1",
-        path: "/cricket/juniors",
-        published_at: new Date("2026-06-01T10:00:00Z"),
-      },
-    ]);
+    mockExecute
+      .mockResolvedValueOnce(undefined) // page-tree advisory lock
+      .mockResolvedValueOnce([
+        {
+          id: "child-1",
+          path: "/cricket/juniors",
+          published_at: new Date("2026-06-01T10:00:00Z"),
+        },
+      ]);
     await expect(
       updateContent(db)({
         contentId: "page-1",
@@ -544,7 +625,9 @@ describe("page hierarchy: updateContent", () => {
 
   it("rejects making a page its own parent", async () => {
     mockExecuteTakeFirst.mockResolvedValueOnce(pageRow);
-    mockExecute.mockResolvedValueOnce([]); // descendants
+    mockExecute
+      .mockResolvedValueOnce(undefined) // page-tree advisory lock
+      .mockResolvedValueOnce([]); // descendants
     await expect(
       updateContent(db)({
         contentId: "page-1",
@@ -563,9 +646,11 @@ describe("page hierarchy: updateContent", () => {
       kind: "page",
       path: "/cricket/juniors",
     }); // new parent = descendant
-    mockExecute.mockResolvedValueOnce([
-      { id: "child-1", path: "/cricket/juniors", published_at: null },
-    ]);
+    mockExecute
+      .mockResolvedValueOnce(undefined) // page-tree advisory lock
+      .mockResolvedValueOnce([
+        { id: "child-1", path: "/cricket/juniors", published_at: null },
+      ]);
     await expect(
       updateContent(db)({
         contentId: "page-1",
@@ -575,6 +660,71 @@ describe("page hierarchy: updateContent", () => {
     ).rejects.toMatchObject({
       statusCode: 400,
       message: "A page cannot be moved under one of its own descendants",
+    });
+  });
+
+  it("rejects renaming a root page to a reserved slug", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(pageRow);
+    mockExecute
+      .mockResolvedValueOnce(undefined) // page-tree advisory lock
+      .mockResolvedValueOnce([]); // descendants
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        slug: "admin",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "This address is reserved by the site",
+    });
+  });
+
+  it("rejects moving a page under an archived parent", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce(pageRow).mockResolvedValueOnce({
+      id: "parent-2",
+      kind: "page",
+      path: "/club",
+      status: "archived",
+    });
+    mockExecute
+      .mockResolvedValueOnce(undefined) // page-tree advisory lock
+      .mockResolvedValueOnce([]); // descendants
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        parentId: "parent-2",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Cannot move a page under an archived page",
+    });
+  });
+
+  it("rejects a rename that would push a descendant's path over the bounds", async () => {
+    // New root path: "/" + 200 chars = 201. The descendant keeps its
+    // 801-char tail, so its cascaded path would be 1002 > the 1000 cap -
+    // rejected even though the page's own new path is fine.
+    mockExecuteTakeFirst.mockResolvedValueOnce(pageRow);
+    mockExecute
+      .mockResolvedValueOnce(undefined) // page-tree advisory lock
+      .mockResolvedValueOnce([
+        {
+          id: "child-1",
+          path: `/cricket/${"b".repeat(800)}`,
+          published_at: null,
+        },
+      ]);
+    await expect(
+      updateContent(db)({
+        contentId: "page-1",
+        userId: "user-1",
+        slug: "a".repeat(200),
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: /too long or too deep/,
     });
   });
 });
@@ -792,6 +942,7 @@ describe("publishContent", () => {
         live_now: false,
       })
       .mockResolvedValueOnce(pagePeek) // locked item
+      .mockResolvedValueOnce(undefined) // stranded-children probe: none
       .mockResolvedValueOnce({ id: "content-1", published_at: parentAt });
     const result = await publishContent(db)({
       contentId: "content-1",
@@ -803,11 +954,83 @@ describe("publishContent", () => {
       publishedAt: parentAt.toISOString(),
     });
   });
+
+  it("rejects re-scheduling a page later than a published child's go-live", async () => {
+    // Root page (no parent gate), explicit later date: the probe finds a
+    // published child whose published_at precedes the new go-live.
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({
+        kind: "page",
+        status: "published",
+        parent_id: null,
+      })
+      .mockResolvedValueOnce({
+        kind: "page",
+        status: "published",
+        parent_id: null,
+      }) // locked item
+      .mockResolvedValueOnce({ id: "child-1" }); // stranded child found
+    await expect(
+      publishContent(db)({
+        contentId: "content-1",
+        publishedAt: "2027-06-01T10:00:00Z",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message:
+        "Children are scheduled before this go-live - reschedule them first",
+    });
+  });
+
+  it("allows re-scheduling when every published child shares the new go-live", async () => {
+    // Equal instants pass: the probe's published_at < newGoLive predicate
+    // is strict, mirroring the child-side gate.
+    const at = new Date("2027-06-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({
+        kind: "page",
+        status: "published",
+        parent_id: null,
+      })
+      .mockResolvedValueOnce({
+        kind: "page",
+        status: "published",
+        parent_id: null,
+      }) // locked item
+      .mockResolvedValueOnce(undefined) // no child precedes the new go-live
+      .mockResolvedValueOnce({ id: "content-1", published_at: at }); // update
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      publishedAt: at.toISOString(),
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1", publishedAt: at.toISOString() });
+  });
+
+  it("skips the stranded-children probe on publish-now", async () => {
+    // Publish-now can only move the go-live earlier (or keep it), so the
+    // probe never runs - the sequence is peek, locked item, update.
+    const at = new Date("2026-06-01T10:00:00Z");
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: null })
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: null })
+      .mockResolvedValueOnce({ id: "content-1", published_at: at }); // update
+    const result = await publishContent(db)({
+      contentId: "content-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "content-1", publishedAt: at.toISOString() });
+    // Three executeTakeFirst calls and no fourth probe.
+    expect(mockExecuteTakeFirst).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe("archiveContent", () => {
+  // Call order: 1. unlocked kind peek (advisory-lock targeting) 2. item
+  // row FOR UPDATE 3. [pages] published-child probe 4. the UPDATE.
   it("404s when the item does not exist", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // locked item
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // peek
     await expect(
       archiveContent(db)({ contentId: "missing", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 404 });
@@ -815,10 +1038,9 @@ describe("archiveContent", () => {
 
   it("409s when the item is already archived", async () => {
     // Re-archiving must not silently bump updated_at/updated_by.
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      kind: "game_report",
-      status: "archived",
-    });
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "game_report" }) // peek
+      .mockResolvedValueOnce({ kind: "game_report", status: "archived" });
     await expect(
       archiveContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({
@@ -829,6 +1051,7 @@ describe("archiveContent", () => {
 
   it("archives a non-archived item", async () => {
     mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "game_report" }) // peek
       .mockResolvedValueOnce({ kind: "game_report", status: "draft" })
       .mockResolvedValueOnce({ id: "content-1" }); // update
     const result = await archiveContent(db)({
@@ -840,6 +1063,7 @@ describe("archiveContent", () => {
 
   it("409s when archiving a page that has published children", async () => {
     mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page" }) // peek
       .mockResolvedValueOnce({ kind: "page", status: "published" }) // locked item
       .mockResolvedValueOnce({ id: "child-1" }); // published-child probe
     await expect(
@@ -853,6 +1077,7 @@ describe("archiveContent", () => {
 
   it("archives a page whose children are all drafts", async () => {
     mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page" }) // peek
       .mockResolvedValueOnce({ kind: "page", status: "published" }) // locked item
       .mockResolvedValueOnce(undefined) // no published child
       .mockResolvedValueOnce({ id: "content-1" }); // update
@@ -865,18 +1090,19 @@ describe("archiveContent", () => {
 });
 
 describe("unpublishContent", () => {
+  // Call order: 1. unlocked kind peek (advisory-lock targeting) 2. item
+  // row FOR UPDATE 3. [pages] published-child probe 4. the UPDATE.
   it("409s when the item is not currently published", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce({
-      kind: "game_report",
-      status: "draft",
-    }); // prefetch
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "game_report" }) // peek
+      .mockResolvedValueOnce({ kind: "game_report", status: "draft" });
     await expect(
       unpublishContent(db)({ contentId: "content-1", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 409 });
   });
 
   it("404s when the item does not exist", async () => {
-    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // prefetch
+    mockExecuteTakeFirst.mockResolvedValueOnce(undefined); // peek
     await expect(
       unpublishContent(db)({ contentId: "missing", userId: "user-1" }),
     ).rejects.toMatchObject({ statusCode: 404 });
@@ -884,6 +1110,7 @@ describe("unpublishContent", () => {
 
   it("clears published_at only while it is still in the future (DB-clock CASE)", async () => {
     mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "game_report" }) // peek
       .mockResolvedValueOnce({ kind: "game_report", status: "published" })
       .mockResolvedValueOnce({ id: "content-1" }); // update
     await unpublishContent(db)({ contentId: "content-1", userId: "user-1" });
@@ -897,7 +1124,8 @@ describe("unpublishContent", () => {
 
   it("400s when unpublishing a page that has published children", async () => {
     mockExecuteTakeFirst
-      .mockResolvedValueOnce({ kind: "page", status: "published" }) // prefetch
+      .mockResolvedValueOnce({ kind: "page" }) // peek
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // locked item
       .mockResolvedValueOnce({ id: "child-1" }); // published-child probe
     await expect(
       unpublishContent(db)({ contentId: "content-1", userId: "user-1" }),
@@ -910,7 +1138,8 @@ describe("unpublishContent", () => {
 
   it("unpublishes a page whose children are all unpublished", async () => {
     mockExecuteTakeFirst
-      .mockResolvedValueOnce({ kind: "page", status: "published" }) // prefetch
+      .mockResolvedValueOnce({ kind: "page" }) // peek
+      .mockResolvedValueOnce({ kind: "page", status: "published" }) // locked item
       .mockResolvedValueOnce(undefined) // no published child
       .mockResolvedValueOnce({ id: "content-1" }); // update
     const result = await unpublishContent(db)({
@@ -918,6 +1147,130 @@ describe("unpublishContent", () => {
       userId: "user-1",
     });
     expect(result).toEqual({ id: "content-1" });
+  });
+});
+
+describe("page-tree advisory lock", () => {
+  // The multi-row tree invariants (cycles, path cascades, publish
+  // ordering, the ever-published lock) cannot be protected by per-row
+  // FOR UPDATE locks alone, so every page mutation must serialise on
+  // pg_advisory_xact_lock(hashtext('content-page-tree')). These tests
+  // pin the exact statement and that non-page flows skip it.
+  const pagePublishMocks = () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: null })
+      .mockResolvedValueOnce({ kind: "page", status: "draft", parent_id: null })
+      .mockResolvedValueOnce({
+        id: "content-1",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      });
+  };
+
+  it("is taken for page creates, with the exact statement", async () => {
+    await createContent(db)(
+      validCreate({
+        kind: "page",
+        slug: "about",
+        title: "About",
+        metadata: {},
+      }),
+    );
+    expect(selectNoFromSql()).toEqual([PAGE_TREE_LOCK_SQL]);
+  });
+
+  it("is not taken for non-page creates", async () => {
+    await createContent(db)(validCreate());
+    expect(selectNoFromSql()).toEqual([]);
+  });
+
+  it("is taken for updates that change slug or parent", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "page-1",
+      kind: "page",
+      slug: "cricket",
+      parent_id: null,
+      path: "/cricket",
+      title: "Cricket",
+      description: null,
+      body: validBody,
+      metadata: {},
+      published_at: null,
+    });
+    mockExecute
+      .mockResolvedValueOnce(undefined) // the advisory lock itself
+      .mockResolvedValueOnce([]); // descendants
+    await updateContent(db)({
+      contentId: "page-1",
+      userId: "user-1",
+      slug: "playing",
+    });
+    expect(selectNoFromSql()).toEqual([PAGE_TREE_LOCK_SQL]);
+  });
+
+  it("is not taken for title-only updates", async () => {
+    mockExecuteTakeFirst.mockResolvedValueOnce({
+      id: "page-1",
+      kind: "page",
+      slug: "cricket",
+      parent_id: null,
+      path: "/cricket",
+      title: "Cricket",
+      description: null,
+      body: validBody,
+      metadata: {},
+      published_at: null,
+    });
+    await updateContent(db)({
+      contentId: "page-1",
+      userId: "user-1",
+      title: "New title",
+    });
+    expect(selectNoFromSql()).toEqual([]);
+  });
+
+  it("is taken for page publish, unpublish and archive", async () => {
+    pagePublishMocks();
+    await publishContent(db)({ contentId: "content-1", userId: "user-1" });
+
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page" }) // peek
+      .mockResolvedValueOnce({ kind: "page", status: "published" })
+      .mockResolvedValueOnce(undefined) // no published child
+      .mockResolvedValueOnce({ id: "content-1" });
+    await unpublishContent(db)({ contentId: "content-1", userId: "user-1" });
+
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({ kind: "page" }) // peek
+      .mockResolvedValueOnce({ kind: "page", status: "draft" })
+      .mockResolvedValueOnce(undefined) // no published child
+      .mockResolvedValueOnce({ id: "content-1" });
+    await archiveContent(db)({ contentId: "content-1", userId: "user-1" });
+
+    expect(selectNoFromSql()).toEqual([
+      PAGE_TREE_LOCK_SQL,
+      PAGE_TREE_LOCK_SQL,
+      PAGE_TREE_LOCK_SQL,
+    ]);
+  });
+
+  it("is not taken for non-page status transitions", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce({
+        kind: "game_report",
+        status: "draft",
+        parent_id: null,
+      })
+      .mockResolvedValueOnce({
+        kind: "game_report",
+        status: "draft",
+        parent_id: null,
+      })
+      .mockResolvedValueOnce({
+        id: "content-1",
+        published_at: new Date("2026-06-01T10:00:00Z"),
+      });
+    await publishContent(db)({ contentId: "content-1", userId: "user-1" });
+    expect(selectNoFromSql()).toEqual([]);
   });
 });
 
@@ -1012,6 +1365,42 @@ describe("listPageTree", () => {
     mockExecute.mockResolvedValueOnce([pageRow({ path: null })]);
     await expect(listPageTree(db)()).rejects.toMatchObject({
       statusCode: 500,
+    });
+  });
+});
+
+describe("getPublishedPageByPath", () => {
+  it("410s (tombstone) for an ever-live page that is no longer visible", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined) // no publicly visible row
+      .mockResolvedValueOnce({ id: "page-1" }); // ever-live row at the path
+    await expect(getPublishedPageByPath(db)("/club")).rejects.toMatchObject({
+      statusCode: 410,
+      message: "This page has been removed",
+    });
+  });
+
+  it("404s when the path has never been publicly live", async () => {
+    mockExecuteTakeFirst
+      .mockResolvedValueOnce(undefined) // no publicly visible row
+      .mockResolvedValueOnce(undefined); // no ever-live row either
+    await expect(getPublishedPageByPath(db)("/club")).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+});
+
+describe("getPublishedNav", () => {
+  it("returns visible items plus tombstoned paths in removed[]", async () => {
+    mockExecute
+      .mockResolvedValueOnce([{ path: "/club", title: "Club", metadata: {} }]) // visible
+      .mockResolvedValueOnce([{ path: "/old-section" }]); // ever-live, hidden
+    const nav = await getPublishedNav(db)();
+    expect(nav).toEqual({
+      items: [
+        { path: "/club", title: "Club", menuOrder: 99, isMainMenu: false },
+      ],
+      removed: ["/old-section"],
     });
   });
 });

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -217,6 +217,66 @@ export function listContent(db: Kysely<DB>) {
   };
 }
 
+// ── Admin: page tree ────────────────────────────────────────────────────
+
+export function listPageTree(db: Kysely<DB>) {
+  return async () => {
+    // Every page regardless of status (the corpus is ~dozens of rows),
+    // ordered by path so ancestors precede their descendants and the
+    // order is stable; the client assembles the tree from parentId.
+    const rows = await db
+      .selectFrom("content_item")
+      .select([
+        "id",
+        "title",
+        "slug",
+        "path",
+        "parent_id",
+        "metadata",
+        "status",
+        "published_at",
+        "updated_at",
+      ])
+      .where("kind", "=", "page")
+      .orderBy("path", "asc")
+      .execute();
+
+    return {
+      items: rows.map((row) => {
+        if (row.path === null) {
+          // Set at create for every page (see the hierarchy helpers), so
+          // a NULL here is a data problem, not a normal state.
+          throwHttpError(500, "Page is missing its path");
+        }
+        // Parsing applies the schema defaults (menuOrder 99, flags
+        // false); a malformed stored row degrades to pure defaults
+        // rather than failing the whole tree (same stance as
+        // pageMenuOrder above).
+        const parsed = pageMetadataSchema.safeParse(row.metadata);
+        const metadata = parsed.success
+          ? parsed.data
+          : pageMetadataSchema.parse({});
+        return {
+          id: row.id,
+          title: row.title,
+          slug: row.slug,
+          path: row.path,
+          parentId: row.parent_id,
+          menuOrder: metadata.menuOrder,
+          isMainMenu: metadata.isMainMenu,
+          status: row.status as ContentStatus,
+          publishedAt: row.published_at?.toISOString() ?? null,
+          updatedAt: row.updated_at.toISOString(),
+          // The ever-published marker IS the slug/parent lock
+          // updateContent enforces; derived server-side so the UI never
+          // re-implements lock semantics.
+          pathLocked: row.published_at !== null,
+        };
+      }),
+    };
+  };
+}
+
 // ── Admin: get ──────────────────────────────────────────────────────────
 
 export function getContent(db: Kysely<DB>) {

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -2,9 +2,11 @@ import type { DB } from "@percy-main/db";
 import {
   CONTENT_METADATA_SCHEMAS,
   contentBodySchema,
+  contentPathSchema,
   eventMetadataSchema,
   newsMetadataSchema,
   pageMetadataSchema,
+  RESERVED_ROOT_SLUGS,
   type ContentKind,
   type ContentStatus,
 } from "@percy-main/shared/content";
@@ -327,19 +329,82 @@ export function getContentMeta(db: Kysely<DB>) {
 // the rows whose path extends its own.
 
 /**
- * Resolve a prospective parent: must exist and be a page. Returns its
+ * Serialise every page-tree mutation on one transaction-scoped advisory
+ * lock (released automatically at commit/rollback).
+ *
+ * The tree invariants - no parent_id cycles, materialised path = parent
+ * path + slug for every descendant, publish ordering, the
+ * ever-published lock - span MULTIPLE rows, so the per-row FOR UPDATE
+ * locks cannot exclude write-skew: two concurrent moves (A under B, B
+ * under A) each pass their cycle check and commit a cycle; a
+ * create-under-parent racing an ancestor rename lands with a stale path
+ * prefix the rename's cascade never saw; a slug change racing a publish
+ * bypasses the ever-published lock. Taking this lock first makes every
+ * page mutation fully serial. The page corpus is ~30 rows with a
+ * handful of edits a day, so the serialisation cost is irrelevant. The
+ * FOR UPDATE row locks stay as belt-and-braces (and for the non-page
+ * flows that share these code paths).
+ */
+async function lockPageTree(tx: Transaction<DB>) {
+  await tx
+    .selectNoFrom(
+      sql`pg_advisory_xact_lock(hashtext('content-page-tree'))`.as(
+        "page_tree_lock",
+      ),
+    )
+    .execute();
+}
+
+/**
+ * Computed paths (on create and for every cascaded descendant on
+ * rename/move) must stay within contentPathSchema's bounds - the same
+ * rule the pages migration enforces - or the public by-path lookup
+ * (whose querystring is validated by that schema) could never reach
+ * the page.
+ */
+function assertValidPath(path: string) {
+  if (!contentPathSchema.safeParse(path).success) {
+    throwHttpError(
+      400,
+      `The resulting page path '${path}' is too long or too deep - use a shorter slug or move the page higher up the tree`,
+    );
+  }
+}
+
+/**
+ * A ROOT page may not occupy a slug the SPA router or infra owns (only
+ * the first path segment routes, so children are unaffected).
+ */
+function assertRootSlugAllowed(slug: string) {
+  if (RESERVED_ROOT_SLUGS.has(slug)) {
+    throwHttpError(400, "This address is reserved by the site");
+  }
+}
+
+/**
+ * Resolve a prospective parent: must exist, be a page, and not be
+ * archived (an archived page is a retired URL prefix - nothing new
+ * grows under it; the publish gate would block the child anyway, so
+ * fail at authoring time with a message that says why). Returns its
  * path (set at create for every page, so non-null - a NULL here means
  * the row predates hierarchy support, which cannot happen: pages were
  * not editable through the API before it).
  */
-async function resolveParentPage(tx: Transaction<DB>, parentId: string) {
+async function resolveParentPage(
+  tx: Transaction<DB>,
+  parentId: string,
+  archivedMessage: string,
+) {
   const parent = await tx
     .selectFrom("content_item")
-    .select(["id", "kind", "path"])
+    .select(["id", "kind", "path", "status"])
     .where("id", "=", parentId)
     .executeTakeFirst();
   if (parent?.kind !== "page") {
     throwHttpError(400, "Parent page not found");
+  }
+  if (parent.status === "archived") {
+    throwHttpError(400, archivedMessage);
   }
   if (parent.path === null) {
     throwHttpError(500, "Parent page is missing its path");
@@ -391,16 +456,30 @@ export function createContent(db: Kysely<DB>) {
     if (parentId !== null && params.kind !== "page") {
       throwHttpError(400, "Only pages can have a parent page");
     }
+    if (params.kind === "page" && parentId === null) {
+      assertRootSlugAllowed(params.slug);
+    }
 
     return await db.transaction().execute(async (tx) => {
+      // Page creates mutate the tree (their path embeds the parent
+      // chain), so they serialise on the advisory lock before any read.
+      if (params.kind === "page") {
+        await lockPageTree(tx);
+      }
+
       let path: string | null = null;
       if (params.kind === "page") {
         if (parentId !== null) {
-          const parent = await resolveParentPage(tx, parentId);
+          const parent = await resolveParentPage(
+            tx,
+            parentId,
+            "Cannot create a page under an archived page",
+          );
           path = `${parent.path}/${params.slug}`;
         } else {
           path = `/${params.slug}`;
         }
+        assertValidPath(path);
       }
 
       // Sibling-slug uniqueness implies path uniqueness too (a path is
@@ -455,6 +534,17 @@ export function updateContent(db: Kysely<DB>) {
     },
   ) => {
     return await db.transaction().execute(async (tx) => {
+      // Slug/parent changes mutate the page tree (path recompute +
+      // descendant cascade), so they serialise on the advisory lock
+      // BEFORE any read - every check below (including the
+      // ever-published lock on published_at) then runs on post-lock
+      // state, closing the change-vs-publish race. Taken whenever the
+      // params are present: the kind isn't known until the row is read,
+      // and over-locking a non-page slug change is harmless.
+      if (params.slug !== undefined || params.parentId !== undefined) {
+        await lockPageTree(tx);
+      }
+
       const current = await tx
         .selectFrom("content_item")
         .select([
@@ -552,12 +642,17 @@ export function updateContent(db: Kysely<DB>) {
 
         let newPath: string;
         if (parentId === null) {
+          assertRootSlugAllowed(slug);
           newPath = `/${slug}`;
         } else {
           if (parentId === current.id) {
             throwHttpError(400, "A page cannot be its own parent");
           }
-          const parent = await resolveParentPage(tx, parentId);
+          const parent = await resolveParentPage(
+            tx,
+            parentId,
+            "Cannot move a page under an archived page",
+          );
           if (parent.path.startsWith(`${oldPath}/`)) {
             throwHttpError(
               400,
@@ -565,6 +660,16 @@ export function updateContent(db: Kysely<DB>) {
             );
           }
           newPath = `${parent.path}/${slug}`;
+        }
+        // The new path AND every cascaded descendant path must stay
+        // within contentPathSchema's bounds (a move deeper can push a
+        // deep subtree over the limit even when this page's own path
+        // is fine).
+        assertValidPath(newPath);
+        for (const d of descendants) {
+          if (d.path !== null) {
+            assertValidPath(newPath + d.path.slice(oldPath.length));
+          }
         }
         path = newPath;
 
@@ -591,12 +696,17 @@ export function updateContent(db: Kysely<DB>) {
         await assertPlayCricketIdAvailable(tx, kind, metadata, current.id);
       }
 
+      // parent_id/path are only written when the hierarchy actually
+      // changed: writing back the values read at the top would clobber
+      // a concurrent ancestor-rename cascade (which bumps this row's
+      // path) from an unrelated edit. Hierarchy changes themselves are
+      // serialised by the advisory lock above.
+      const hierarchyChanged = isPage && (slugChanged || parentChanged);
       await tx
         .updateTable("content_item")
         .set({
           slug,
-          parent_id: parentId,
-          path,
+          ...(hierarchyChanged ? { parent_id: parentId, path } : {}),
           title,
           description,
           body: JSON.stringify(body),
@@ -654,6 +764,14 @@ export function publishContent(db: Kysely<DB>) {
         .where("id", "=", params.contentId)
         .executeTakeFirst();
       if (!peek) throwHttpError(404, "Content not found");
+
+      // Page status transitions participate in the tree invariants
+      // (publish ordering vs slug/parent changes), so they serialise on
+      // the same advisory lock as create/update. Taken before any row
+      // lock; all gates below re-read under it.
+      if (peek.kind === "page") {
+        await lockPageTree(tx);
+      }
 
       const lockParent = (parentId: string) =>
         tx
@@ -717,6 +835,31 @@ export function publishContent(db: Kysely<DB>) {
           throwHttpError(
             400,
             `Parent page goes live at ${parent.published_at.toISOString()}; schedule this page for that time or later`,
+          );
+        }
+      }
+
+      // The mirror gate, parent's side: re-scheduling (or backdating)
+      // this page's go-live must not strand an already-published child
+      // whose go-live precedes it - between the two instants the child
+      // would be publicly live under a 404ing parent. Direct children
+      // suffice: the child gate above guarantees grandchildren never
+      // precede their own parent. Only an explicit publishedAt can move
+      // the go-live later (publish-now never produces a future date).
+      // Equal instants stay allowed, matching the child gate.
+      if (item.kind === "page" && params.publishedAt !== undefined) {
+        const stranded = await tx
+          .selectFrom("content_item")
+          .select("id")
+          .where("parent_id", "=", params.contentId)
+          .where("status", "=", "published")
+          .where("published_at", "<", new Date(params.publishedAt))
+          .forUpdate()
+          .executeTakeFirst();
+        if (stranded) {
+          throwHttpError(
+            400,
+            "Children are scheduled before this go-live - reschedule them first",
           );
         }
       }
@@ -791,6 +934,19 @@ export function unpublishContent(db: Kysely<DB>) {
     // race a concurrent child publish. Lock order parent -> child (the
     // item IS the parent here), consistent with publishContent.
     return await db.transaction().execute(async (tx) => {
+      // Unlocked peek for lock targeting only: page status transitions
+      // serialise on the page-tree advisory lock, which must precede
+      // every row lock. All gates re-read under the locks below.
+      const peek = await tx
+        .selectFrom("content_item")
+        .select("kind")
+        .where("id", "=", params.contentId)
+        .executeTakeFirst();
+      if (!peek) throwHttpError(404, "Content not found");
+      if (peek.kind === "page") {
+        await lockPageTree(tx);
+      }
+
       const item = await tx
         .selectFrom("content_item")
         .select(["kind", "status"])
@@ -861,6 +1017,17 @@ export function archiveContent(db: Kysely<DB>) {
     // Same transaction + lock pattern as unpublishContent: the
     // published-children gate must not race a concurrent child publish.
     return await db.transaction().execute(async (tx) => {
+      // Unlocked peek for lock targeting only (see unpublishContent).
+      const peek = await tx
+        .selectFrom("content_item")
+        .select("kind")
+        .where("id", "=", params.contentId)
+        .executeTakeFirst();
+      if (!peek) throwHttpError(404, "Content not found");
+      if (peek.kind === "page") {
+        await lockPageTree(tx);
+      }
+
       const item = await tx
         .selectFrom("content_item")
         .select(["kind", "status"])
@@ -1048,7 +1215,25 @@ export function getPublishedPageByPath(db: Kysely<DB>) {
       .where("path", "=", path)
       .executeTakeFirst();
 
-    if (!row) throwHttpError(404, "Content not found");
+    if (!row) {
+      // Tombstone: the SPA falls back to its bundled static MDX on 404,
+      // so an urgent takedown (unpublish/archive of a migrated page)
+      // must not read as "missing" and resurrect the stale static
+      // version. A row at this path that has EVER been publicly live
+      // (past published_at - the same marker as the slug lock) but is
+      // not visible now is 410 Gone. Never-live paths (drafts, future
+      // schedules, cancelled schedules) stay 404 and leak nothing.
+      const tombstone = await db
+        .selectFrom("content_item")
+        .select("id")
+        .where("kind", "=", "page")
+        .where("path", "=", path)
+        .where("published_at", "is not", null)
+        .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`)
+        .executeTakeFirst();
+      if (tombstone) throwHttpError(410, "This page has been removed");
+      throwHttpError(404, "Content not found");
+    }
     return toPublic(row);
   };
 }
@@ -1208,6 +1393,23 @@ export function getPublishedNav(db: Kysely<DB>) {
       .orderBy("path", "asc")
       .execute();
 
+    // Tombstoned paths (same ever-live test as the by-path 410): pages
+    // that WERE publicly live but are not visible now. The SPA uses
+    // these to drop matching entries from its bundled static nav, so a
+    // takedown doesn't resurrect the stale static page in menus. The
+    // status partition makes the two queries consistent without a
+    // transaction: a row is either published (items candidate) or not
+    // (removed candidate), never both.
+    const removedRows = await db
+      .selectFrom("content_item")
+      .select("path")
+      .where("kind", "=", "page")
+      .where("status", "!=", "published")
+      .where("published_at", "is not", null)
+      .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`)
+      .orderBy("path", "asc")
+      .execute();
+
     return {
       items: rows.map((row) => {
         if (row.path === null) {
@@ -1226,6 +1428,9 @@ export function getPublishedNav(db: Kysely<DB>) {
           isMainMenu: metadata.data.isMainMenu,
         };
       }),
+      removed: removedRows.flatMap((row) =>
+        row.path === null ? [] : [row.path],
+      ),
     };
   };
 }

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -4,6 +4,7 @@ import {
   contentBodySchema,
   eventMetadataSchema,
   newsMetadataSchema,
+  pageMetadataSchema,
   type ContentKind,
   type ContentStatus,
 } from "@percy-main/shared/content";
@@ -93,11 +94,27 @@ interface ContentItemRow {
   description: string | null;
   status: string;
   metadata: unknown;
+  parent_id: string | null;
+  path: string | null;
   published_at: Date | null;
   created_at: Date;
   updated_at: Date;
   updated_by: string;
   updated_by_name: string | null;
+}
+
+/**
+ * menuOrder hoisted out of a page's metadata for the admin tree view
+ * (null for every other kind). Falls back to the schema default rather
+ * than failing the whole list if a stored row somehow predates the page
+ * metadata schema.
+ */
+function pageMenuOrder(kind: string, metadata: unknown): number | null {
+  if (kind !== "page") return null;
+  const parsed = pageMetadataSchema.safeParse(metadata);
+  return parsed.success
+    ? parsed.data.menuOrder
+    : pageMetadataSchema.parse({}).menuOrder;
 }
 
 function toSummary(row: ContentItemRow) {
@@ -109,6 +126,9 @@ function toSummary(row: ContentItemRow) {
     description: row.description,
     status: row.status as ContentStatus,
     metadata: row.metadata as Record<string, unknown>,
+    parentId: row.parent_id,
+    path: row.path,
+    menuOrder: pageMenuOrder(row.kind, row.metadata),
     publishedAt: row.published_at?.toISOString() ?? null,
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
@@ -125,6 +145,8 @@ const summaryColumns = [
   "content_item.description",
   "content_item.status",
   "content_item.metadata",
+  "content_item.parent_id",
+  "content_item.path",
   "content_item.published_at",
   "content_item.created_at",
   "content_item.updated_at",
@@ -236,6 +258,65 @@ export function getContentMeta(db: Kysely<DB>) {
   };
 }
 
+// ── Hierarchy helpers (pages only) ──────────────────────────────────────
+//
+// Pages form an adjacency list via parent_id with a materialised URL
+// path; every other kind keeps both NULL. A page's path is computed on
+// every create and on slug/parent changes (never client-supplied), so a
+// path is canonical by construction: descendants of a page are exactly
+// the rows whose path extends its own.
+
+/**
+ * Resolve a prospective parent: must exist and be a page. Returns its
+ * path (set at create for every page, so non-null - a NULL here means
+ * the row predates hierarchy support, which cannot happen: pages were
+ * not editable through the API before it).
+ */
+async function resolveParentPage(tx: Transaction<DB>, parentId: string) {
+  const parent = await tx
+    .selectFrom("content_item")
+    .select(["id", "kind", "path"])
+    .where("id", "=", parentId)
+    .executeTakeFirst();
+  if (parent?.kind !== "page") {
+    throwHttpError(400, "Parent page not found");
+  }
+  if (parent.path === null) {
+    throwHttpError(500, "Parent page is missing its path");
+  }
+  return { id: parent.id, path: parent.path };
+}
+
+/**
+ * Friendly 409 for a slug clash among siblings (root pages and flat
+ * kinds: per-kind among parentless rows; child pages: among the
+ * parent's children). The partial unique indexes are the backstop.
+ */
+async function assertSlugAvailable(
+  tx: Transaction<DB>,
+  kind: ContentKind,
+  slug: string,
+  parentId: string | null,
+  excludeId?: string,
+) {
+  let query = tx
+    .selectFrom("content_item")
+    .select("id")
+    .where("kind", "=", kind)
+    .where("slug", "=", slug);
+  query =
+    parentId === null
+      ? query.where("parent_id", "is", null)
+      : query.where("parent_id", "=", parentId);
+  if (excludeId !== undefined) {
+    query = query.where("id", "!=", excludeId);
+  }
+  const clash = await query.executeTakeFirst();
+  if (clash) {
+    throwHttpError(409, `A ${kind} item with slug '${slug}' already exists`);
+  }
+}
+
 // ── Admin: create ───────────────────────────────────────────────────────
 
 export function createContent(db: Kysely<DB>) {
@@ -245,21 +326,27 @@ export function createContent(db: Kysely<DB>) {
     const metadata = parseMetadata(params.kind, params.metadata);
     const body = parseBody(params.body);
     const description = params.description ?? null;
+    const parentId = params.parentId ?? null;
+
+    if (parentId !== null && params.kind !== "page") {
+      throwHttpError(400, "Only pages can have a parent page");
+    }
 
     return await db.transaction().execute(async (tx) => {
-      const existing = await tx
-        .selectFrom("content_item")
-        .select("id")
-        .where("kind", "=", params.kind)
-        .where("slug", "=", params.slug)
-        .where("parent_id", "is", null)
-        .executeTakeFirst();
-      if (existing) {
-        throwHttpError(
-          409,
-          `A ${params.kind} item with slug '${params.slug}' already exists`,
-        );
+      let path: string | null = null;
+      if (params.kind === "page") {
+        if (parentId !== null) {
+          const parent = await resolveParentPage(tx, parentId);
+          path = `${parent.path}/${params.slug}`;
+        } else {
+          path = `/${params.slug}`;
+        }
       }
+
+      // Sibling-slug uniqueness implies path uniqueness too (a path is
+      // parent path + slug, and parent paths are unique), so this is the
+      // friendly 409 for both; the unique indexes catch races.
+      await assertSlugAvailable(tx, params.kind, params.slug, parentId);
 
       await assertPlayCricketIdAvailable(tx, params.kind, metadata);
 
@@ -268,6 +355,8 @@ export function createContent(db: Kysely<DB>) {
         .values({
           kind: params.kind,
           slug: params.slug,
+          parent_id: parentId,
+          path,
           title: params.title,
           description,
           body: JSON.stringify(body),
@@ -312,6 +401,8 @@ export function updateContent(db: Kysely<DB>) {
           "id",
           "kind",
           "slug",
+          "parent_id",
+          "path",
           "title",
           "description",
           "body",
@@ -324,18 +415,32 @@ export function updateContent(db: Kysely<DB>) {
       if (!current) throwHttpError(404, "Content not found");
 
       const kind = current.kind as ContentKind;
+      const isPage = kind === "page";
 
-      // Slug locks once the item has ever been publicly visible.
+      if (!isPage && params.parentId != null) {
+        throwHttpError(400, "Only pages can have a parent page");
+      }
+
+      const slug = params.slug ?? current.slug;
+      const slugChanged = slug !== current.slug;
+      // undefined = unchanged, null = move to root, id = move under it.
+      const parentId =
+        params.parentId !== undefined ? params.parentId : current.parent_id;
+      const parentChanged = parentId !== current.parent_id;
+
+      // The slug - and for pages the parent too, since path = parent path
+      // + slug - locks once the item has ever been publicly visible.
       // published_at is the ever-published marker: unpublish keeps it for
       // items that went live, and clears it when cancelling a schedule
       // that never did - which re-unlocks the slug, deliberately. No
       // redirect handling exists anywhere.
-      if (
-        params.slug !== undefined &&
-        params.slug !== current.slug &&
-        current.published_at !== null
-      ) {
-        throwHttpError(409, "Slug is locked once an item has been published");
+      if ((slugChanged || parentChanged) && current.published_at !== null) {
+        throwHttpError(
+          409,
+          isPage
+            ? "Slug and parent are locked once a page has been published - its path is its public URL"
+            : "Slug is locked once an item has been published",
+        );
       }
 
       const title = params.title ?? current.title;
@@ -351,23 +456,75 @@ export function updateContent(db: Kysely<DB>) {
         params.metadata !== undefined
           ? parseMetadata(kind, params.metadata)
           : parseMetadata(kind, current.metadata as Record<string, unknown>);
-      const slug = params.slug ?? current.slug;
 
-      if (slug !== current.slug) {
-        const clash = await tx
+      // Pages: a slug or parent change recomputes this page's path and
+      // every descendant's. Descendants are exactly the rows whose path
+      // extends this page's (paths are materialised from the parent
+      // chain, so the prefix relation is canonical).
+      let path = current.path;
+      let cascade: {
+        ids: string[];
+        newPrefix: string;
+        oldPrefixLength: number;
+      } | null = null;
+
+      if (isPage && (slugChanged || parentChanged)) {
+        const oldPath = current.path;
+        if (oldPath === null) {
+          throwHttpError(500, "Page is missing its path");
+        }
+
+        const descendants = await tx
           .selectFrom("content_item")
-          .select("id")
-          .where("kind", "=", kind)
-          .where("slug", "=", slug)
-          .where("parent_id", "is", null)
-          .where("id", "!=", current.id)
-          .executeTakeFirst();
-        if (clash) {
+          .select(["id", "path", "published_at"])
+          .where("path", "like", `${oldPath}/%`)
+          .execute();
+
+        // An ever-published descendant's URL is (or was) live, which pins
+        // every ancestor slug on its path - same lock as its own.
+        const locked = descendants.find((d) => d.published_at !== null);
+        if (locked) {
           throwHttpError(
             409,
-            `A ${kind} item with slug '${slug}' already exists`,
+            `Cannot change this page's slug or parent: descendant page '${locked.path ?? locked.id}' has been published, which pins its ancestors' slugs`,
           );
         }
+
+        let newPath: string;
+        if (parentId === null) {
+          newPath = `/${slug}`;
+        } else {
+          if (parentId === current.id) {
+            throwHttpError(400, "A page cannot be its own parent");
+          }
+          const parent = await resolveParentPage(tx, parentId);
+          if (parent.path.startsWith(`${oldPath}/`)) {
+            throwHttpError(
+              400,
+              "A page cannot be moved under one of its own descendants",
+            );
+          }
+          newPath = `${parent.path}/${slug}`;
+        }
+        path = newPath;
+
+        if (descendants.length > 0) {
+          cascade = {
+            ids: descendants.map((d) => d.id),
+            newPrefix: newPath,
+            oldPrefixLength: oldPath.length,
+          };
+        }
+      }
+
+      if (slugChanged || parentChanged) {
+        await assertSlugAvailable(
+          tx,
+          kind,
+          slug,
+          isPage ? parentId : null,
+          current.id,
+        );
       }
 
       if (params.metadata !== undefined) {
@@ -378,6 +535,8 @@ export function updateContent(db: Kysely<DB>) {
         .updateTable("content_item")
         .set({
           slug,
+          parent_id: parentId,
+          path,
           title,
           description,
           body: JSON.stringify(body),
@@ -387,6 +546,22 @@ export function updateContent(db: Kysely<DB>) {
         })
         .where("id", "=", current.id)
         .execute();
+
+      if (cascade !== null) {
+        // Re-prefix every descendant path in one statement. Paths only
+        // contain [a-z0-9-/], so the LIKE above and the substr here need
+        // no escaping. Bump updated_at/updated_by: the row's public URL
+        // changed, and admin list ordering + ETags key off updated_at.
+        await tx
+          .updateTable("content_item")
+          .set({
+            path: sql`${cascade.newPrefix} || substr(path, ${sql.lit(cascade.oldPrefixLength + 1)})`,
+            updated_by: params.userId,
+            updated_at: sql`CURRENT_TIMESTAMP`,
+          })
+          .where("id", "in", cascade.ids)
+          .execute();
+      }
 
       await writeRevision(
         tx,
@@ -407,152 +582,277 @@ export function publishContent(db: Kysely<DB>) {
     publishedAt?: string;
     userId: string;
   }) => {
-    let query = db
-      .updateTable("content_item")
-      .set({
-        status: "published",
-        // No explicit date: keep the original "live from" time only when
-        // it is already in the past (re-publish after unpublish must not
-        // rewrite history). NULL (first publish) or a still-future
-        // schedule (the editor pressed "Publish now" on a scheduled
-        // item) becomes now(). NULL <= now() is NULL, so both fall to
-        // the ELSE branch. Expressed in SQL so the comparison uses the
-        // DB clock, consistent with publishedOnly().
-        published_at: params.publishedAt
-          ? new Date(params.publishedAt)
-          : sql`CASE
+    // The hierarchy gates are check-then-update, so they run in a
+    // transaction over FOR UPDATE row locks. Lock order is parent ->
+    // child everywhere (unpublish/archive lock the item, then its
+    // children), so the parent row must be locked before the item; the
+    // unlocked peek only discovers which parent that is.
+    return await db.transaction().execute(async (tx) => {
+      const peek = await tx
+        .selectFrom("content_item")
+        .select(["kind", "parent_id"])
+        .where("id", "=", params.contentId)
+        .executeTakeFirst();
+      if (!peek) throwHttpError(404, "Content not found");
+
+      const lockParent = (parentId: string) =>
+        tx
+          .selectFrom("content_item")
+          .select([
+            "status",
+            "published_at",
+            // DB-clock liveness, consistent with publishedOnly().
+            // NULL published_at propagates: live_now is then NULL too.
+            sql<boolean | null>`published_at <= CURRENT_TIMESTAMP`.as(
+              "live_now",
+            ),
+          ])
+          .where("id", "=", parentId)
+          .forUpdate()
+          .executeTakeFirst();
+
+      let parent =
+        peek.kind === "page" && peek.parent_id !== null
+          ? await lockParent(peek.parent_id)
+          : undefined;
+
+      const item = await tx
+        .selectFrom("content_item")
+        .select(["kind", "status", "parent_id"])
+        .where("id", "=", params.contentId)
+        .forUpdate()
+        .executeTakeFirst();
+      if (!item) throwHttpError(404, "Content not found");
+      if (item.status === "archived") {
+        throwHttpError(409, "Archived content cannot be published");
+      }
+
+      // A page goes live at parent path + slug, so a child must never be
+      // publicly visible while its parent is not (dead URL prefix,
+      // broken breadcrumbs/nav). Publish top-down...
+      if (item.kind === "page" && item.parent_id !== null) {
+        if (item.parent_id !== peek.parent_id) {
+          // Reparented between the peek and the item lock: lock the
+          // actual parent. Out of lock order, but the race is
+          // vanishingly rare and PostgreSQL resolves any deadlock by
+          // aborting one transaction.
+          parent = await lockParent(item.parent_id);
+        }
+        if (parent?.status !== "published" || parent.published_at === null) {
+          throwHttpError(
+            400,
+            "Cannot publish this page until its parent page is published",
+          );
+        }
+        // ...and never ahead of the parent: the child's effective
+        // go-live (the explicit date, or now) may not precede the
+        // parent's published_at. Scheduling a whole section for one
+        // instant stays allowed; backdating a child before its parent
+        // is not.
+        const beforeParent =
+          params.publishedAt !== undefined
+            ? new Date(params.publishedAt) < parent.published_at
+            : parent.live_now !== true;
+        if (beforeParent) {
+          throwHttpError(
+            400,
+            `Parent page goes live at ${parent.published_at.toISOString()}; schedule this page for that time or later`,
+          );
+        }
+      }
+
+      let query = tx
+        .updateTable("content_item")
+        .set({
+          status: "published",
+          // No explicit date: keep the original "live from" time only when
+          // it is already in the past (re-publish after unpublish must not
+          // rewrite history). NULL (first publish) or a still-future
+          // schedule (the editor pressed "Publish now" on a scheduled
+          // item) becomes now(). NULL <= now() is NULL, so both fall to
+          // the ELSE branch. Expressed in SQL so the comparison uses the
+          // DB clock, consistent with publishedOnly().
+          published_at: params.publishedAt
+            ? new Date(params.publishedAt)
+            : sql`CASE
               WHEN published_at <= CURRENT_TIMESTAMP THEN published_at
               ELSE CURRENT_TIMESTAMP
             END`,
-        updated_by: params.userId,
-        updated_at: sql`CURRENT_TIMESTAMP`,
-      })
-      .where("id", "=", params.contentId)
-      .where("status", "!=", "archived");
+          updated_by: params.userId,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", params.contentId)
+        .where("status", "!=", "archived");
 
-    if (params.publishedAt !== undefined) {
-      // Invariant: published_at in the past <=> the item has been
-      // publicly visible. An explicit FUTURE date on an item whose
-      // published_at is already past would silently pull a page that WAS
-      // public - and a later cancel-schedule would see a future
-      // published_at, clear it, and unlock the slug of a page whose URL
-      // was live. Guarded inside the UPDATE's WHERE on the DB clock so
-      // it cannot race the publish boundary; the IS NOT NULL keeps a
-      // first publish (NULL published_at) out of the NULL-propagating
-      // comparison. Explicit past/current dates stay allowed (idempotent
-      // re-publish, migration-style backdating).
-      query = query.where(
-        sql<boolean>`NOT (
+      if (params.publishedAt !== undefined) {
+        // Invariant: published_at in the past <=> the item has been
+        // publicly visible. An explicit FUTURE date on an item whose
+        // published_at is already past would silently pull a page that WAS
+        // public - and a later cancel-schedule would see a future
+        // published_at, clear it, and unlock the slug of a page whose URL
+        // was live. Guarded inside the UPDATE's WHERE on the DB clock so
+        // it cannot race the publish boundary; the IS NOT NULL keeps a
+        // first publish (NULL published_at) out of the NULL-propagating
+        // comparison. Explicit past/current dates stay allowed (idempotent
+        // re-publish, migration-style backdating).
+        query = query.where(
+          sql<boolean>`NOT (
           published_at IS NOT NULL
           AND published_at <= CURRENT_TIMESTAMP
           AND ${new Date(params.publishedAt)}::timestamptz > CURRENT_TIMESTAMP
         )`,
-      );
-    }
-
-    const result = await query
-      .returning(["id", "published_at"])
-      .executeTakeFirst();
-
-    if (!result) {
-      // Missing, archived, or scheduling an ever-live item; disambiguate
-      // for a useful error.
-      const existing = await db
-        .selectFrom("content_item")
-        .select("status")
-        .where("id", "=", params.contentId)
-        .executeTakeFirst();
-      if (!existing) throwHttpError(404, "Content not found");
-      if (existing.status === "archived") {
-        throwHttpError(409, "Archived content cannot be published");
+        );
       }
-      throwHttpError(
-        409,
-        "This item has already been live - it can only be published immediately",
-      );
-    }
 
-    return {
-      id: result.id,
-      publishedAt: result.published_at?.toISOString() ?? null,
-    };
+      const result = await query
+        .returning(["id", "published_at"])
+        .executeTakeFirst();
+
+      if (!result) {
+        // The item row is locked and passed the archived check, so the
+        // only remaining exclusion is the ever-live scheduling guard.
+        throwHttpError(
+          409,
+          "This item has already been live - it can only be published immediately",
+        );
+      }
+
+      return {
+        id: result.id,
+        publishedAt: result.published_at?.toISOString() ?? null,
+      };
+    });
   };
 }
 
 export function unpublishContent(db: Kysely<DB>) {
   return async (params: { contentId: string; userId: string }) => {
-    // A past published_at is deliberately retained: it marks "ever
-    // published", which locks the slug. A still-future published_at means
-    // a schedule being cancelled before the public ever saw the item, so
-    // the ever-published marker is cleared and the slug unlocks.
-    // Visibility is otherwise governed by status alone.
-    // Only a published item can be unpublished - in particular this must
-    // not offer a back door out of 'archived' (archive -> unpublish ->
-    // publish would resurrect archived content past the manage-only
-    // archive control).
-    const result = await db
-      .updateTable("content_item")
-      .set({
-        status: "draft",
-        published_at: sql`CASE
-          WHEN published_at > CURRENT_TIMESTAMP THEN NULL
-          ELSE published_at
-        END`,
-        updated_by: params.userId,
-        updated_at: sql`CURRENT_TIMESTAMP`,
-      })
-      .where("id", "=", params.contentId)
-      .where("status", "=", "published")
-      .returning("id")
-      .executeTakeFirst();
-
-    if (!result) {
-      const exists = await db
+    // Transaction + FOR UPDATE: the published-children gate must not
+    // race a concurrent child publish. Lock order parent -> child (the
+    // item IS the parent here), consistent with publishContent.
+    return await db.transaction().execute(async (tx) => {
+      const item = await tx
         .selectFrom("content_item")
-        .select("id")
+        .select(["kind", "status"])
         .where("id", "=", params.contentId)
+        .forUpdate()
         .executeTakeFirst();
-      throwHttpError(
-        exists ? 409 : 404,
-        exists
-          ? "Only published content can be unpublished"
-          : "Content not found",
-      );
-    }
-    return { id: result.id };
+      if (!item) throwHttpError(404, "Content not found");
+      if (item.status !== "published") {
+        // Only a published item can be unpublished - in particular this
+        // must not offer a back door out of 'archived' (archive ->
+        // unpublish -> publish would resurrect archived content past the
+        // manage-only archive control).
+        throwHttpError(409, "Only published content can be unpublished");
+      }
+
+      // Mirror of the publish rule: pulling a page out from under a
+      // published (or scheduled) child would leave live URLs on a dead
+      // prefix. Unpublish bottom-up. (A child publish locks this row
+      // before its own, so holding it already serialises the gate; the
+      // child lock makes the pattern uniform.)
+      if (item.kind === "page") {
+        const publishedChild = await tx
+          .selectFrom("content_item")
+          .select("id")
+          .where("parent_id", "=", params.contentId)
+          .where("status", "=", "published")
+          .forUpdate()
+          .executeTakeFirst();
+        if (publishedChild) {
+          throwHttpError(
+            400,
+            "Cannot unpublish a page that has published child pages - unpublish the children first",
+          );
+        }
+      }
+
+      // A past published_at is deliberately retained: it marks "ever
+      // published", which locks the slug. A still-future published_at
+      // means a schedule being cancelled before the public ever saw the
+      // item, so the ever-published marker is cleared and the slug
+      // unlocks. Visibility is otherwise governed by status alone.
+      const result = await tx
+        .updateTable("content_item")
+        .set({
+          status: "draft",
+          published_at: sql`CASE
+            WHEN published_at > CURRENT_TIMESTAMP THEN NULL
+            ELSE published_at
+          END`,
+          updated_by: params.userId,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", params.contentId)
+        .where("status", "=", "published")
+        .returning("id")
+        .executeTakeFirst();
+
+      if (!result) {
+        throwHttpError(409, "Only published content can be unpublished");
+      }
+      return { id: result.id };
+    });
   };
 }
 
 export function archiveContent(db: Kysely<DB>) {
   return async (params: { contentId: string; userId: string }) => {
-    // Re-archiving must not silently succeed: it would bump
-    // updated_at/updated_by for a no-op, misattributing the archive.
-    const result = await db
-      .updateTable("content_item")
-      .set({
-        status: "archived",
-        updated_by: params.userId,
-        updated_at: sql`CURRENT_TIMESTAMP`,
-      })
-      .where("id", "=", params.contentId)
-      .where("status", "!=", "archived")
-      .returning("id")
-      .executeTakeFirst();
-
-    if (!result) {
-      // Either missing or already archived; disambiguate for a useful
-      // error (same pattern as publishContent).
-      const exists = await db
+    // Same transaction + lock pattern as unpublishContent: the
+    // published-children gate must not race a concurrent child publish.
+    return await db.transaction().execute(async (tx) => {
+      const item = await tx
         .selectFrom("content_item")
-        .select("id")
+        .select(["kind", "status"])
         .where("id", "=", params.contentId)
+        .forUpdate()
         .executeTakeFirst();
-      throwHttpError(
-        exists ? 409 : 404,
-        exists ? "Content is already archived" : "Content not found",
-      );
-    }
-    return { id: result.id };
+      if (!item) throwHttpError(404, "Content not found");
+      if (item.status === "archived") {
+        // Re-archiving must not silently succeed: it would bump
+        // updated_at/updated_by for a no-op, misattributing the archive.
+        throwHttpError(409, "Content is already archived");
+      }
+
+      // Archiving a page over a live child is the unpublish hole in a
+      // different coat: the child's URL would sit on a dead prefix.
+      // Direct children suffice - the publish gate guarantees a
+      // published grandchild implies a published middle page. A DRAFT
+      // child under an archived parent is fine; it just cannot publish
+      // (parent-not-published gate).
+      if (item.kind === "page") {
+        const publishedChild = await tx
+          .selectFrom("content_item")
+          .select("id")
+          .where("parent_id", "=", params.contentId)
+          .where("status", "=", "published")
+          .forUpdate()
+          .executeTakeFirst();
+        if (publishedChild) {
+          throwHttpError(
+            409,
+            "Cannot archive a page that has published child pages - unpublish or archive the children first",
+          );
+        }
+      }
+
+      const result = await tx
+        .updateTable("content_item")
+        .set({
+          status: "archived",
+          updated_by: params.userId,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", params.contentId)
+        .where("status", "!=", "archived")
+        .returning("id")
+        .executeTakeFirst();
+
+      if (!result) {
+        throwHttpError(409, "Content is already archived");
+      }
+      return { id: result.id };
+    });
   };
 }
 
@@ -660,10 +960,32 @@ function publishedOnly(db: Kysely<DB>) {
 
 export function getPublishedContent(db: Kysely<DB>) {
   return async (params: { kind: ContentKind; slug: string }) => {
-    const row = await publishedOnly(db)
+    let query = publishedOnly(db)
       .select(publicColumns)
       .where("kind", "=", params.kind)
-      .where("slug", "=", params.slug)
+      .where("slug", "=", params.slug);
+
+    // Page slugs are only unique among siblings, so a bare kind+slug
+    // lookup is ambiguous for nested pages. Root pages stay resolvable
+    // here (kind+slug is unique where parent_id is null); everything
+    // deeper goes through getPublishedPageByPath.
+    if (params.kind === "page") {
+      query = query.where("parent_id", "is", null);
+    }
+
+    const row = await query.executeTakeFirst();
+
+    if (!row) throwHttpError(404, "Content not found");
+    return toPublic(row);
+  };
+}
+
+export function getPublishedPageByPath(db: Kysely<DB>) {
+  return async (path: string) => {
+    const row = await publishedOnly(db)
+      .select(publicColumns)
+      .where("kind", "=", "page")
+      .where("path", "=", path)
       .executeTakeFirst();
 
     if (!row) throwHttpError(404, "Content not found");
@@ -811,6 +1133,40 @@ export function listPublishedNews(db: Kysely<DB>) {
         authorCount: Number(authorRow.authors),
       };
     });
+  };
+}
+
+export function getPublishedNav(db: Kysely<DB>) {
+  return async () => {
+    // Every published page's nav fields in one small payload (~30 rows
+    // sitewide); the client assembles the tree, breadcrumbs and main
+    // menu from the path prefixes. Ordered by path so the order is
+    // stable and ancestors precede their descendants.
+    const rows = await publishedOnly(db)
+      .select(["path", "title", "metadata"])
+      .where("kind", "=", "page")
+      .orderBy("path", "asc")
+      .execute();
+
+    return {
+      items: rows.map((row) => {
+        if (row.path === null) {
+          throwHttpError(500, "Published page missing its path");
+        }
+        // Parsing applies the schema defaults (menuOrder 99, flags
+        // false) for any keys absent from the stored metadata.
+        const metadata = pageMetadataSchema.safeParse(row.metadata);
+        if (!metadata.success) {
+          throwHttpError(500, "Stored metadata does not match its kind schema");
+        }
+        return {
+          path: row.path,
+          title: row.title,
+          menuOrder: metadata.data.menuOrder,
+          isMainMenu: metadata.data.isMainMenu,
+        };
+      }),
+    };
   };
 }
 

--- a/apps/api/src/lib/error-handler.ts
+++ b/apps/api/src/lib/error-handler.ts
@@ -1,0 +1,33 @@
+import type { FastifyError, FastifyReply, FastifyRequest } from "fastify";
+
+/**
+ * Custom error handler. Reasons over Fastify's default:
+ *  - Stops 4xx (deliberately thrown via Object.assign(new Error,
+ *    { statusCode: 4xx })) from polluting NR's error-rate alarm.
+ *    400/401/403/404 log at warn with kind=http_client_error.
+ *  - 5xx and unknown statuses log at error with kind=http_error.
+ *  - Pino redact (#171) handles PII in the err object; the handler
+ *    doesn't need to re-redact.
+ *  - Reply body keeps the existing { error: message } shape so clients
+ *    aren't broken.
+ *
+ * Exported standalone so integration tests can register the SAME
+ * handler on their minimal apps - error-body assertions (e.g. the
+ * by-path 410 tombstone) then exercise the production contract.
+ */
+export function errorHandler(
+  err: FastifyError,
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  const status = err.statusCode ?? 500;
+  if (status >= 500) {
+    request.log.error(
+      { err, event: "http_error", status },
+      err.message || "internal_server_error",
+    );
+  } else {
+    request.log.warn({ err, event: "http_client_error", status }, err.message);
+  }
+  return reply.status(status).send({ error: err.message });
+}

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13317,6 +13317,9 @@ export interface paths {
                                 metadata: {
                                     [key: string]: unknown;
                                 };
+                                parentId: string | null;
+                                path: string | null;
+                                menuOrder: number | null;
                                 publishedAt: string | null;
                                 createdAt: string;
                                 updatedAt: string;
@@ -13357,6 +13360,8 @@ export interface paths {
                         metadata: {
                             [key: string]: unknown;
                         };
+                        /** Format: uuid */
+                        parentId?: string | null;
                     };
                 };
             };
@@ -13416,6 +13421,9 @@ export interface paths {
                             metadata: {
                                 [key: string]: unknown;
                             };
+                            parentId: string | null;
+                            path: string | null;
+                            menuOrder: number | null;
                             publishedAt: string | null;
                             createdAt: string;
                             updatedAt: string;
@@ -13462,6 +13470,8 @@ export interface paths {
                         metadata?: {
                             [key: string]: unknown;
                         };
+                        /** Format: uuid */
+                        parentId?: string | null;
                     };
                 };
             };
@@ -13791,6 +13801,73 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/content/page/by-path": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    path: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/news": {
         parameters: {
             query?: never;
@@ -13885,6 +13962,48 @@ export interface paths {
                                 };
                                 publishedAt: string;
                                 updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/nav": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                path: string;
+                                title: string;
+                                menuOrder: number;
+                                isMainMenu: boolean;
                             }[];
                         };
                     };

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13385,6 +13385,56 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content/page-tree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                title: string;
+                                slug: string;
+                                path: string;
+                                parentId: string | null;
+                                menuOrder: number;
+                                isMainMenu: boolean;
+                                /** @enum {string} */
+                                status: "draft" | "published" | "archived";
+                                publishedAt: string | null;
+                                updatedAt: string;
+                                pathLocked: boolean;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/content/{contentId}": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13908,6 +13908,17 @@ export interface paths {
                         "application/json": null;
                     };
                 };
+                /** @description Default Response */
+                410: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         put?: never;
@@ -14055,6 +14066,7 @@ export interface paths {
                                 menuOrder: number;
                                 isMainMenu: boolean;
                             }[];
+                            removed: string[];
                         };
                     };
                 };

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -23940,6 +23940,20 @@
                             "type": "object",
                             "additionalProperties": {}
                           },
+                          "parentId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "path": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
                           "publishedAt": {
                             "nullable": true,
                             "type": "string"
@@ -23966,6 +23980,9 @@
                           "description",
                           "status",
                           "metadata",
+                          "parentId",
+                          "path",
+                          "menuOrder",
                           "publishedAt",
                           "createdAt",
                           "updatedAt",
@@ -24073,6 +24090,12 @@
                   "metadata": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "parentId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   }
                 },
                 "required": [
@@ -24166,6 +24189,20 @@
                       "type": "object",
                       "additionalProperties": {}
                     },
+                    "parentId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "path": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "menuOrder": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
                     "publishedAt": {
                       "nullable": true,
                       "type": "string"
@@ -24236,6 +24273,9 @@
                     "description",
                     "status",
                     "metadata",
+                    "parentId",
+                    "path",
+                    "menuOrder",
                     "publishedAt",
                     "createdAt",
                     "updatedAt",
@@ -24321,6 +24361,12 @@
                   "metadata": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "parentId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   }
                 }
               }
@@ -24843,6 +24889,140 @@
         }
       }
     },
+    "/api/content/page/by-path": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 1000,
+              "pattern": "^(?:\\/[a-z0-9]+(?:-[a-z0-9]+)*)+$"
+            },
+            "in": "query",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/news": {
       "get": {
         "parameters": [
@@ -25045,6 +25225,57 @@
                           "metadata",
                           "publishedAt",
                           "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/nav": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "isMainMenu": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "title",
+                          "menuOrder",
+                          "isMainMenu"
                         ],
                         "additionalProperties": false
                       }

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -24132,6 +24132,92 @@
         }
       }
     },
+    "/api/admin/content/page-tree": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "parentId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "isMainMenu": {
+                            "type": "boolean"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "draft",
+                              "published",
+                              "archived"
+                            ]
+                          },
+                          "publishedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "pathLocked": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "slug",
+                          "path",
+                          "parentId",
+                          "menuOrder",
+                          "isMainMenu",
+                          "status",
+                          "publishedAt",
+                          "updatedAt",
+                          "pathLocked"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/content/{contentId}": {
       "get": {
         "parameters": [

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -25105,6 +25105,25 @@
                 }
               }
             }
+          },
+          "410": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }
@@ -25365,10 +25384,17 @@
                         ],
                         "additionalProperties": false
                       }
+                    },
+                    "removed": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
-                    "items"
+                    "items",
+                    "removed"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/content/pages/cricket/kit-shop.mdx
+++ b/apps/web/content/pages/cricket/kit-shop.mdx
@@ -4,6 +4,6 @@ description: "Official Percy Main Cricket Club kit and teamwear supplied by VX3.
 menuOrder: 7
 ---
 
-Our cricket kit is supplied by VX3. Click on their logo to visit the online shop.
+Our cricket kit is supplied by VX3 via [our online shop](https://kit.percymain.org).
 
-[![VX3 Logo](/images/contentful/6c1c149d47d8e8f43243f8a1ec48696e/vx3_logo.webp)](https://kit.percymain.org)
+![VX3 Logo](/images/contentful/6c1c149d47d8e8f43243f8a1ec48696e/vx3_logo.webp)

--- a/apps/web/content/pages/cricket/safeguarding.mdx
+++ b/apps/web/content/pages/cricket/safeguarding.mdx
@@ -25,4 +25,5 @@ We will do this by:
 - Ensuring all suspicions concerns and allegations are taken seriously and dealt with swiftly and appropriately
 - Ensuring access to confidential information relating to child safeguarding matters is restricted to those who need to know in order to safeguard children – including the Club Welfare Officer and the appropriate external authorities, such as the Local Authority Designated Officer (LADO), as specified within ECB child safeguarding procedures
 
-##### <Person slug="paddy-rathbone" />
+<Person slug="paddy-rathbone" />
+<Person slug="alex-young" />

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -347,6 +347,61 @@ describe("ContentBody", () => {
     expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
   });
 
+  it("renders personGrid entries as Person children carrying their roles", () => {
+    const html = renderBody([
+      block("personGrid", {
+        props: {
+          slugs: "alex-slaven,bob",
+          entries: JSON.stringify([
+            { slug: "alex-slaven", role: "Head Coach" },
+            { slug: "bob" },
+          ]),
+        },
+      }),
+    ]);
+    expect(html).toContain('href="/person/alex-slaven"');
+    expect(html).toContain("Head Coach");
+    expect(html).toContain('href="/person/bob"');
+    // Exactly two person cards: same composition as the MDX corpus.
+    expect(html.match(/class="person /g)).toHaveLength(2);
+  });
+
+  it("prefers entries over the slugs CSV when both are present", () => {
+    const html = renderBody([
+      block("personGrid", {
+        props: {
+          slugs: "stale-slug",
+          entries: JSON.stringify([{ slug: "fresh-slug", role: "Captain" }]),
+        },
+      }),
+    ]);
+    expect(html).toContain('href="/person/fresh-slug"');
+    expect(html).toContain("Captain");
+    expect(html).not.toContain("stale-slug");
+  });
+
+  it("falls back to the slugs CSV when entries is malformed", () => {
+    for (const entries of [
+      "not json",
+      '{"slug":"x"}', // not an array
+      '[{"role":"Coach"}]', // entry without a slug
+      '[{"slug":""}]', // empty slug
+      '[{"slug":"x","role":5}]', // non-string role
+    ]) {
+      const html = renderBody([
+        block("personGrid", { props: { slugs: "alex-slaven", entries } }),
+      ]);
+      expect(html).toContain('href="/person/alex-slaven"');
+    }
+  });
+
+  it("falls back to the slugs CSV when entries is an empty array", () => {
+    const html = renderBody([
+      block("personGrid", { props: { slugs: "alex-slaven", entries: "[]" } }),
+    ]);
+    expect(html).toContain('href="/person/alex-slaven"');
+  });
+
   it("hides leagueTable when divisionId is missing", () => {
     const html = renderBody([block("leagueTable", { props: {} })]);
     expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -11,10 +11,30 @@ vi.mock("@/lib/people.js", () => ({
     slug === "alex-slaven"
       ? { name: "Alex Slaven", photo: undefined, photoPicture: undefined }
       : undefined,
+  getAllPeople: () => [
+    {
+      slug: "alex-slaven",
+      name: "Alex Slaven",
+      photo: undefined,
+      photoPicture: undefined,
+    },
+  ],
 }));
 vi.mock("@/lib/image-map.js", () => ({
   getImageUrl: () => undefined,
   getPicture: () => undefined,
+}));
+// Stub network-dependent subcomponents so they render inert markup instead
+// of firing real API requests under renderToStaticMarkup.
+vi.mock("@/components/leaderboard-content.js", () => ({
+  LeaderboardContent: () => <div data-testid="leaderboard-stub" />,
+}));
+vi.mock("@/components/records-wall.js", () => ({
+  RecordsWall: () => <div data-testid="records-wall-stub" />,
+}));
+vi.mock("@/lib/marketing/consent.js", () => ({
+  CURRENT_CONSENT_VERSION: "v3",
+  requestConsentReopen: () => undefined,
 }));
 
 import { ContentBody } from "./content-body.js";
@@ -251,5 +271,131 @@ describe("ContentBody", () => {
     expect(html).not.toContain("javascript:");
     // Falls back to the plain (safe) src
     expect(html).toContain('src="/uploads/content/img-1/640.jpg"');
+  });
+
+  // ── New custom blocks ──────────────────────────────────────────────────
+
+  it("renders all custom block types in a fixture document without crashing", () => {
+    const picture = {
+      sources: {
+        avif: "/uploads/content/img-1/320.avif 320w",
+        webp: "/uploads/content/img-1/320.webp 320w",
+      },
+      img: { src: "/uploads/content/img-1/640.jpg", w: 640, h: 480 },
+    };
+    const html = renderBody([
+      block("person", { props: { slug: "alex-slaven", role: "Head Coach" } }),
+      block("personGrid", { props: { slugs: "alex-slaven" } }),
+      block("gamePreview", { props: { playCricketId: "123" } }),
+      block("eventPreview", {
+        props: { eventId: "1", name: "Quiz night", when: "2026-07-01" },
+      }),
+      block("contentImage", {
+        props: {
+          src: "/uploads/content/img-1/640.jpg",
+          alt: "A photo",
+          caption: "Caption",
+          picture: JSON.stringify(picture),
+        },
+      }),
+      block("leagueTable", {
+        props: { divisionId: "div-1", name: "Division 1" },
+      }),
+      block("leaderboard", {}),
+      block("recordsWall", {}),
+      block("contactForm", {
+        props: { title: "Get in touch", description: "We reply within 48h" },
+      }),
+      block("cookieSettingsLink", { props: { text: "Manage cookies" } }),
+      block("consentVersion", {}),
+    ]);
+    // Each custom block must produce some non-empty output (not null/empty).
+    expect(html.length).toBeGreaterThan(0);
+    // Spot-check a handful of expected fragments.
+    expect(html).toContain("Head Coach");
+    expect(html).toContain("Quiz night");
+    expect(html).toContain("Get in touch");
+    expect(html).toContain("Manage cookies");
+    expect(html).toContain("v3");
+  });
+
+  it("renders personGrid via the shared PersonGrid component", () => {
+    const html = renderBody([
+      block("personGrid", { props: { slugs: "alex-slaven" } }),
+    ]);
+    // PersonGrid renders Person cards, which include the profile link
+    expect(html).toContain('href="/person/alex-slaven"');
+  });
+
+  it("normalises personGrid slugs with spaces and empty segments", () => {
+    const html = renderBody([
+      block("personGrid", { props: { slugs: " alex-slaven , , bob ," } }),
+    ]);
+    // Trimmed slugs resolve; empty segments are dropped (no card with an
+    // empty profile link).
+    expect(html).toContain('href="/person/alex-slaven"');
+    expect(html).toContain('href="/person/bob"');
+    expect(html).not.toContain('href="/person/"');
+    // Exactly two person cards rendered.
+    expect(html.match(/class="person /g)).toHaveLength(2);
+  });
+
+  it("hides personGrid when slugs contains only separators and whitespace", () => {
+    const html = renderBody([
+      block("personGrid", { props: { slugs: " , ,, " } }),
+    ]);
+    expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
+  });
+
+  it("hides leagueTable when divisionId is missing", () => {
+    const html = renderBody([block("leagueTable", { props: {} })]);
+    expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
+  });
+
+  it("renders leagueTable when divisionId is provided", () => {
+    const html = renderBody([
+      block("leagueTable", { props: { divisionId: "12345", name: "Div 1" } }),
+    ]);
+    // leagueTable fires a query that is disabled in tests, renders nothing
+    // until data arrives - the component itself returns null when !data, so
+    // the outer block still produces some wrapper markup.
+    expect(html).toBeDefined();
+  });
+
+  it("renders leaderboard block", () => {
+    const html = renderBody([block("leaderboard", {})]);
+    expect(html).toContain("leaderboard-stub");
+  });
+
+  it("renders recordsWall block", () => {
+    const html = renderBody([block("recordsWall", {})]);
+    expect(html).toContain("records-wall-stub");
+  });
+
+  it("renders contactForm with title and description", () => {
+    const html = renderBody([
+      block("contactForm", {
+        props: { title: "Say hello", description: "We reply fast" },
+      }),
+    ]);
+    expect(html).toContain("Say hello");
+    expect(html).toContain("We reply fast");
+  });
+
+  it("renders cookieSettingsLink with custom text", () => {
+    const html = renderBody([
+      block("cookieSettingsLink", { props: { text: "Your cookie choices" } }),
+    ]);
+    expect(html).toContain("Your cookie choices");
+  });
+
+  it("renders cookieSettingsLink with default text when prop is missing", () => {
+    const html = renderBody([block("cookieSettingsLink", { props: {} })]);
+    expect(html).toContain("Cookie settings");
+  });
+
+  it("renders consentVersion as the current version string", () => {
+    const html = renderBody([block("consentVersion", {})]);
+    expect(html).toContain("v3");
   });
 });

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -3,6 +3,7 @@ import {
   OptimisedImage,
   type PictureSource,
 } from "@/components/optimised-image.js";
+import { parsePersonGridEntries } from "@/lib/person-grid.js";
 import { cn } from "@/lib/utils.js";
 import {
   contentBodySchema,
@@ -330,6 +331,24 @@ function BlockView({ block }: { block: ContentBlock }) {
     }
 
     case CUSTOM_BLOCK_TYPES.personGrid: {
+      // Role-preserving entries prop (JSON-stringified [{slug, role?}],
+      // same precedent as contentImage's picture prop): compose
+      // PersonGrid with Person children exactly as the MDX corpus does.
+      // Absent or malformed entries degrade to the legacy slugs CSV.
+      const entries = parsePersonGridEntries(stringProp(block, "entries"));
+      if (entries !== null) {
+        return (
+          <mdxComponents.PersonGrid>
+            {entries.map((entry, i) => (
+              <mdxComponents.Person
+                key={`${entry.slug}-${String(i)}`}
+                slug={entry.slug}
+                role={entry.role}
+              />
+            ))}
+          </mdxComponents.PersonGrid>
+        );
+      }
       const slugs = stringProp(block, "slugs");
       if (!slugs) return null;
       // Normalise the stored CSV: trim each segment, drop empties - so

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -332,9 +332,14 @@ function BlockView({ block }: { block: ContentBlock }) {
     case CUSTOM_BLOCK_TYPES.personGrid: {
       const slugs = stringProp(block, "slugs");
       if (!slugs) return null;
-      return (
-        <mdxComponents.PersonGrid slugs={slugs.split(",").filter(Boolean)} />
-      );
+      // Normalise the stored CSV: trim each segment, drop empties - so
+      // "alice, bob" and stray commas render correctly.
+      const parsed = slugs.split(",").flatMap((s) => {
+        const trimmed = s.trim();
+        return trimmed ? [trimmed] : [];
+      });
+      if (parsed.length === 0) return null;
+      return <mdxComponents.PersonGrid slugs={parsed} />;
     }
 
     case CUSTOM_BLOCK_TYPES.gamePreview: {
@@ -379,6 +384,44 @@ function BlockView({ block }: { block: ContentBlock }) {
       if (!src || !isSafeImageSrc(src)) return null;
       return <mdxComponents.Image src={src} alt={alt} caption={caption} />;
     }
+
+    case CUSTOM_BLOCK_TYPES.leagueTable: {
+      const divisionId = stringProp(block, "divisionId");
+      // Required prop: degrade silently when missing.
+      if (!divisionId) return null;
+      return (
+        <mdxComponents.LeagueTable
+          divisionId={divisionId}
+          name={stringProp(block, "name")}
+        />
+      );
+    }
+
+    case CUSTOM_BLOCK_TYPES.leaderboard:
+      return <mdxComponents.Leaderboard />;
+
+    case CUSTOM_BLOCK_TYPES.recordsWall:
+      return <mdxComponents.RecordsWall />;
+
+    case CUSTOM_BLOCK_TYPES.contactForm:
+      return (
+        <mdxComponents.ContactForm
+          title={stringProp(block, "title")}
+          description={stringProp(block, "description")}
+        />
+      );
+
+    case CUSTOM_BLOCK_TYPES.cookieSettingsLink: {
+      const text = stringProp(block, "text") ?? "Cookie settings";
+      return (
+        <mdxComponents.CookieSettingsLink>
+          {text}
+        </mdxComponents.CookieSettingsLink>
+      );
+    }
+
+    case CUSTOM_BLOCK_TYPES.consentVersion:
+      return <mdxComponents.ConsentVersion />;
 
     default:
       // Unknown / not-yet-supported block types degrade silently.

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -1,8 +1,10 @@
+import { useSiteNav } from "@/hooks/use-site-nav.js";
 import { useSession } from "@/lib/auth-client.js";
-import { getMainMenuItems } from "@/lib/content.js";
+import { getMainMenuItems } from "@/lib/nav.js";
 import { getPriceId } from "@/lib/stripe-env.js";
 import {
   useEffect,
+  useMemo,
   useRef,
   useState,
   type FC,
@@ -28,18 +30,29 @@ const fixedMenuEnd: MenuItem[] = [
   { name: "Fantasy", url: "/fantasy", match: { start: "/fantasy" } },
 ];
 
-/** Content pages with isMainMenu: true, sorted by menuOrder */
-const contentMenuItems: MenuItem[] = getMainMenuItems().map((page) => ({
-  name: page.title,
-  url: page.path,
-  match: { start: page.path },
-}));
-
-const menu: MenuItem[] = [
-  ...fixedMenuStart,
-  ...contentMenuItems,
-  ...fixedMenuEnd,
-];
+/**
+ * Fixed items wrapped around the merged nav's main-menu pages (#493):
+ * isMainMenu pages sorted by menuOrder, DB pages overriding static ones
+ * at the same path. useSiteNav's static placeholder means the first
+ * render already shows the full static menu - no flash or jump while the
+ * nav query is in flight, and pre-migration (empty API list) the menu is
+ * identical to the old module-level static assembly.
+ */
+function useMenu(): MenuItem[] {
+  const navPages = useSiteNav();
+  return useMemo<MenuItem[]>(
+    () => [
+      ...fixedMenuStart,
+      ...getMainMenuItems(navPages).map((page) => ({
+        name: page.title,
+        url: page.path,
+        match: { start: page.path },
+      })),
+      ...fixedMenuEnd,
+    ],
+    [navPages],
+  );
+}
 
 function isActive(pathname: string, item: MenuItem): boolean {
   if (item.match === "exact") return pathname === item.url;
@@ -128,6 +141,7 @@ const NavItem: FC<{
 
 export const SiteHeader: FC = () => {
   const location = useLocation();
+  const menu = useMenu();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [stickyVisible, setStickyVisible] = useState(false);
   const mastheadRef = useRef<HTMLDivElement>(null);

--- a/apps/web/src/hooks/use-site-nav.ts
+++ b/apps/web/src/hooks/use-site-nav.ts
@@ -1,0 +1,28 @@
+import { navQueryOptions } from "@/lib/content-queries.js";
+import { staticNavPages } from "@/lib/content.js";
+import { mergeNavPages, type NavPage } from "@/lib/nav.js";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+// While the nav query is in flight the placeholder stands in: an empty
+// API list merges to the static-only nav, so headers and sidebars render
+// immediately with no flash - pre-migration (DB holds no published
+// pages) the settled output is byte-identical to the placeholder, so
+// nothing ever jumps. Module-level constant for referential stability.
+const EMPTY_NAV: { items: NavPage[] } = { items: [] };
+
+/**
+ * The merged site nav (#493): published DB pages from the API plus
+ * static MDX pages not shadowed by a DB page at the same path. On API
+ * error the query data stays unset and this degrades to the static-only
+ * list - nav never breaks.
+ */
+export function useSiteNav(): NavPage[] {
+  const { data } = useQuery({
+    ...navQueryOptions(),
+    placeholderData: EMPTY_NAV,
+  });
+
+  const items = data?.items;
+  return useMemo(() => mergeNavPages(items ?? [], staticNavPages), [items]);
+}

--- a/apps/web/src/hooks/use-site-nav.ts
+++ b/apps/web/src/hooks/use-site-nav.ts
@@ -5,17 +5,23 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 // While the nav query is in flight the placeholder stands in: an empty
-// API list merges to the static-only nav, so headers and sidebars render
-// immediately with no flash - pre-migration (DB holds no published
-// pages) the settled output is byte-identical to the placeholder, so
-// nothing ever jumps. Module-level constant for referential stability.
-const EMPTY_NAV: { items: NavPage[] } = { items: [] };
+// API list (and no tombstones) merges to the static-only nav, so headers
+// and sidebars render immediately with no flash - pre-migration (DB holds
+// no published pages) the settled output is byte-identical to the
+// placeholder, so nothing ever jumps. Module-level constant for
+// referential stability.
+const EMPTY_NAV: { items: NavPage[]; removed: string[] } = {
+  items: [],
+  removed: [],
+};
 
 /**
  * The merged site nav (#493): published DB pages from the API plus
- * static MDX pages not shadowed by a DB page at the same path. On API
- * error the query data stays unset and this degrades to the static-only
- * list - nav never breaks.
+ * static MDX pages not shadowed by a DB page at the same path, minus
+ * static pages tombstoned by the API's removed[] list (ever-live pages
+ * since unpublished/archived - takedowns must not resurrect the bundled
+ * MDX entry). On API error the query data stays unset and this degrades
+ * to the static-only list - nav never breaks.
  */
 export function useSiteNav(): NavPage[] {
   const { data } = useQuery({
@@ -24,5 +30,9 @@ export function useSiteNav(): NavPage[] {
   });
 
   const items = data?.items;
-  return useMemo(() => mergeNavPages(items ?? [], staticNavPages), [items]);
+  const removed = data?.removed;
+  return useMemo(
+    () => mergeNavPages(items ?? [], staticNavPages, removed ?? []),
+    [items, removed],
+  );
 }

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13317,6 +13317,9 @@ export interface paths {
                                 metadata: {
                                     [key: string]: unknown;
                                 };
+                                parentId: string | null;
+                                path: string | null;
+                                menuOrder: number | null;
                                 publishedAt: string | null;
                                 createdAt: string;
                                 updatedAt: string;
@@ -13357,6 +13360,8 @@ export interface paths {
                         metadata: {
                             [key: string]: unknown;
                         };
+                        /** Format: uuid */
+                        parentId?: string | null;
                     };
                 };
             };
@@ -13416,6 +13421,9 @@ export interface paths {
                             metadata: {
                                 [key: string]: unknown;
                             };
+                            parentId: string | null;
+                            path: string | null;
+                            menuOrder: number | null;
                             publishedAt: string | null;
                             createdAt: string;
                             updatedAt: string;
@@ -13462,6 +13470,8 @@ export interface paths {
                         metadata?: {
                             [key: string]: unknown;
                         };
+                        /** Format: uuid */
+                        parentId?: string | null;
                     };
                 };
             };
@@ -13791,6 +13801,73 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/content/page/by-path": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query: {
+                    path: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "page" | "news" | "event" | "game_report" | "person";
+                            slug: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            publishedAt: string;
+                            updatedAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                304: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": null;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/news": {
         parameters: {
             query?: never;
@@ -13885,6 +13962,48 @@ export interface paths {
                                 };
                                 publishedAt: string;
                                 updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/nav": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                path: string;
+                                title: string;
+                                menuOrder: number;
+                                isMainMenu: boolean;
                             }[];
                         };
                     };

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13385,6 +13385,56 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content/page-tree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                title: string;
+                                slug: string;
+                                path: string;
+                                parentId: string | null;
+                                menuOrder: number;
+                                isMainMenu: boolean;
+                                /** @enum {string} */
+                                status: "draft" | "published" | "archived";
+                                publishedAt: string | null;
+                                updatedAt: string;
+                                pathLocked: boolean;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/content/{contentId}": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13908,6 +13908,17 @@ export interface paths {
                         "application/json": null;
                     };
                 };
+                /** @description Default Response */
+                410: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         put?: never;
@@ -14055,6 +14066,7 @@ export interface paths {
                                 menuOrder: number;
                                 isMainMenu: boolean;
                             }[];
+                            removed: string[];
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -23940,6 +23940,20 @@
                             "type": "object",
                             "additionalProperties": {}
                           },
+                          "parentId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "path": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
                           "publishedAt": {
                             "nullable": true,
                             "type": "string"
@@ -23966,6 +23980,9 @@
                           "description",
                           "status",
                           "metadata",
+                          "parentId",
+                          "path",
+                          "menuOrder",
                           "publishedAt",
                           "createdAt",
                           "updatedAt",
@@ -24073,6 +24090,12 @@
                   "metadata": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "parentId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   }
                 },
                 "required": [
@@ -24166,6 +24189,20 @@
                       "type": "object",
                       "additionalProperties": {}
                     },
+                    "parentId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "path": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "menuOrder": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
                     "publishedAt": {
                       "nullable": true,
                       "type": "string"
@@ -24236,6 +24273,9 @@
                     "description",
                     "status",
                     "metadata",
+                    "parentId",
+                    "path",
+                    "menuOrder",
                     "publishedAt",
                     "createdAt",
                     "updatedAt",
@@ -24321,6 +24361,12 @@
                   "metadata": {
                     "type": "object",
                     "additionalProperties": {}
+                  },
+                  "parentId": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
                   }
                 }
               }
@@ -24843,6 +24889,140 @@
         }
       }
     },
+    "/api/content/page/by-path": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 1000,
+              "pattern": "^(?:\\/[a-z0-9]+(?:-[a-z0-9]+)*)+$"
+            },
+            "in": "query",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "page",
+                        "news",
+                        "event",
+                        "game_report",
+                        "person"
+                      ]
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "publishedAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "kind",
+                    "slug",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "publishedAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/news": {
       "get": {
         "parameters": [
@@ -25045,6 +25225,57 @@
                           "metadata",
                           "publishedAt",
                           "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/nav": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "isMainMenu": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "title",
+                          "menuOrder",
+                          "isMainMenu"
                         ],
                         "additionalProperties": false
                       }

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -24132,6 +24132,92 @@
         }
       }
     },
+    "/api/admin/content/page-tree": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "parentId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "menuOrder": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "isMainMenu": {
+                            "type": "boolean"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "draft",
+                              "published",
+                              "archived"
+                            ]
+                          },
+                          "publishedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "pathLocked": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "slug",
+                          "path",
+                          "parentId",
+                          "menuOrder",
+                          "isMainMenu",
+                          "status",
+                          "publishedAt",
+                          "updatedAt",
+                          "pathLocked"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/content/{contentId}": {
       "get": {
         "parameters": [

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -25105,6 +25105,25 @@
                 }
               }
             }
+          },
+          "410": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }
@@ -25365,10 +25384,17 @@
                         ],
                         "additionalProperties": false
                       }
+                    },
+                    "removed": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
-                    "items"
+                    "items",
+                    "removed"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/lib/content-queries.test.ts
+++ b/apps/web/src/lib/content-queries.test.ts
@@ -1,0 +1,68 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+// The queryFn's terminal-state mapping (404 -> null, 410 -> PAGE_GONE,
+// anything else -> error) is what keeps an API incident from rendering
+// as a 404 and spiking the route_not_found metric - lock it down at the
+// lib level. The HTTP layer is mocked; callApi's throw shape (an Error
+// carrying `status`) is simulated directly.
+const callApi = vi.hoisted(() => vi.fn());
+vi.mock("./api-client.js", () => ({
+  api: { GET: vi.fn() },
+  callApi,
+}));
+
+import {
+  isPageGone,
+  PAGE_GONE,
+  pageByPathQueryOptions,
+} from "./content-queries.js";
+
+const apiError = (status: number) =>
+  Object.assign(new Error(`HTTP ${status}`), { status });
+
+function runQueryFn(path: string) {
+  const opts = pageByPathQueryOptions(path);
+  const { queryFn } = opts;
+  if (typeof queryFn !== "function") {
+    throw new Error("expected pageByPathQueryOptions to define a queryFn");
+  }
+  return queryFn({
+    client: new QueryClient(),
+    queryKey: opts.queryKey,
+    signal: new AbortController().signal,
+    meta: undefined,
+  });
+}
+
+describe("pageByPathQueryOptions queryFn", () => {
+  it("returns the page payload on success", async () => {
+    const payload = { id: "1", title: "Club" };
+    callApi.mockResolvedValueOnce(payload);
+    await expect(runQueryFn("/club")).resolves.toBe(payload);
+  });
+
+  it("maps 404 to null - never published, static fallback applies", async () => {
+    callApi.mockRejectedValueOnce(apiError(404));
+    await expect(runQueryFn("/club")).resolves.toBeNull();
+  });
+
+  it("maps 410 to the PAGE_GONE sentinel - takedown, no fallback", async () => {
+    callApi.mockRejectedValueOnce(apiError(410));
+    await expect(runQueryFn("/club")).resolves.toBe(PAGE_GONE);
+  });
+
+  it("rethrows other failures so callers see an error, not a miss", async () => {
+    callApi.mockRejectedValueOnce(apiError(500));
+    await expect(runQueryFn("/club")).rejects.toThrow("HTTP 500");
+  });
+});
+
+describe("isPageGone", () => {
+  it("matches only the gone sentinel shape", () => {
+    expect(isPageGone(PAGE_GONE)).toBe(true);
+    expect(isPageGone(null)).toBe(false);
+    expect(isPageGone(undefined)).toBe(false);
+    expect(isPageGone({ id: "1", title: "Club" })).toBe(false);
+  });
+});

--- a/apps/web/src/lib/content-queries.ts
+++ b/apps/web/src/lib/content-queries.ts
@@ -1,8 +1,10 @@
 import {
   eventMetadataSchema,
   newsMetadataSchema,
+  pageMetadataSchema,
   type EventMetadata,
   type NewsMetadata,
+  type PageMetadata,
 } from "@percy-main/shared/content";
 import { queryOptions } from "@tanstack/react-query";
 import { api, callApi } from "./api-client.js";
@@ -70,6 +72,45 @@ export function eventQueryOptions(slug: string) {
   });
 }
 
+export function pageByPathQueryOptions(path: string) {
+  return queryOptions({
+    queryKey: ["content", "page", path],
+    queryFn: async () => {
+      try {
+        return await callApi(
+          api.GET("/api/content/page/by-path", {
+            params: { query: { path } },
+          }),
+        );
+      } catch (err) {
+        // Not published in the DB - callers fall back to the bundled MDX.
+        if ((err as { status?: number }).status === 404) return null;
+        throw err;
+      }
+    },
+    staleTime: detailStaleTime,
+    retry: false,
+  });
+}
+
+// The nav list backs the site header and every content-page sidebar, so
+// it is cached aggressively: the shared STALE_TIME bounds visible
+// staleness, while a generous gcTime keeps the last good list around for
+// instant SPA navigations long after the query unmounts. Retries stay at
+// the react-query default (like the list queries above) - consumers
+// degrade to the static-only nav while the query is pending or failed,
+// so nav never breaks on API trouble.
+const NAV_GC_TIME = 24 * 60 * 60 * 1000;
+
+export function navQueryOptions() {
+  return queryOptions({
+    queryKey: ["content", "nav"],
+    queryFn: () => callApi(api.GET("/api/content/nav")),
+    staleTime: STALE_TIME,
+    gcTime: NAV_GC_TIME,
+  });
+}
+
 export function newsListQueryOptions(params: { tag?: string; page: number }) {
   return queryOptions({
     queryKey: ["content", "news-list", params.tag ?? null, params.page],
@@ -110,5 +151,10 @@ export function parseEventMetadata(
   metadata: unknown,
 ): EventMetadata | undefined {
   const parsed = eventMetadataSchema.safeParse(metadata);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function parsePageMetadata(metadata: unknown): PageMetadata | undefined {
+  const parsed = pageMetadataSchema.safeParse(metadata);
   return parsed.success ? parsed.data : undefined;
 }

--- a/apps/web/src/lib/content-queries.ts
+++ b/apps/web/src/lib/content-queries.ts
@@ -25,8 +25,26 @@ const STALE_TIME = 5 * 60 * 1000;
 // 5 minutes - bounded staleness there is accepted.
 const NOT_FOUND_STALE_TIME = 30 * 1000;
 
+/**
+ * Sentinel for a 410 Gone page: an ever-live page deliberately taken
+ * down (unpublished or archived). Distinct from the 404 `null` so
+ * callers can suppress the static fallback - a takedown must not
+ * resurrect the bundled MDX version of the page.
+ */
+export const PAGE_GONE = { gone: true } as const;
+export type PageGone = typeof PAGE_GONE;
+
+export function isPageGone(value: unknown): value is PageGone {
+  return typeof value === "object" && value !== null && "gone" in value;
+}
+
+// Both miss states go stale fast: `null` so a scheduled publish shows up
+// promptly (see above), PAGE_GONE so reverting a mistaken takedown
+// propagates just as quickly.
 const detailStaleTime = (query: { state: { data: unknown } }) =>
-  query.state.data === null ? NOT_FOUND_STALE_TIME : STALE_TIME;
+  query.state.data === null || isPageGone(query.state.data)
+    ? NOT_FOUND_STALE_TIME
+    : STALE_TIME;
 
 export const NEWS_PAGE_SIZE = 5;
 
@@ -83,8 +101,16 @@ export function pageByPathQueryOptions(path: string) {
           }),
         );
       } catch (err) {
-        // Not published in the DB - callers fall back to the bundled MDX.
-        if ((err as { status?: number }).status === 404) return null;
+        const status = (err as { status?: number }).status;
+        // Never published in the DB - callers fall back to the bundled
+        // MDX.
+        if (status === 404) return null;
+        // Ever-live page taken down (unpublished/archived). A terminal
+        // data state, not an error: callers render "not found" without
+        // the static fallback and without a route_not_found report.
+        if (status === 410) return PAGE_GONE;
+        // Anything else (5xx, network) surfaces as a query error so
+        // callers can tell an API incident apart from a real miss.
         throw err;
       }
     },

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -1,11 +1,12 @@
 import type { FC } from "react";
+import type { NavPage } from "./nav.js";
 
 interface MdxModule {
   default: FC;
   frontmatter: Record<string, unknown>;
 }
 
-interface ContentPage {
+export interface ContentPage {
   /** URL path, e.g. "/club/history/honours" */
   path: string;
   /** MDX frontmatter */
@@ -17,11 +18,6 @@ interface ContentPage {
   ldjson?: unknown;
   /** The React component that renders the MDX content */
   Component: FC;
-}
-
-export interface ContentNode {
-  page: ContentPage;
-  children: ContentNode[];
 }
 
 /**
@@ -72,71 +68,14 @@ const contentPages: ContentPage[] = loadPages().sort((a, b) =>
 export const contentPageMap = new Map(contentPages.map((p) => [p.path, p]));
 
 /**
- * Get the parent path of a given path.
- * "/club/history/honours" → "/club/history"
- * "/club" → null (top-level)
+ * Static pages projected to the lightweight NavPage shape, ready to merge
+ * with the API nav list (lib/nav.ts, #493). Path-sorted because
+ * contentPages is - mergeNavPages relies on that ordering for the
+ * static-only case to match the old behaviour exactly.
  */
-function parentPath(path: string): string | null {
-  const lastSlash = path.lastIndexOf("/");
-  if (lastSlash <= 0) return null;
-  return path.substring(0, lastSlash);
-}
-
-/**
- * Build a tree of ContentNodes for sidebar navigation.
- * Given a page path, finds the top-level ancestor and returns
- * the full subtree under that ancestor.
- */
-export function getNavigationTree(currentPath: string): ContentNode | null {
-  // Find the top-level section (e.g. "/club" from "/club/history/honours")
-  const segments = currentPath.split("/").filter(Boolean);
-  if (segments.length === 0) return null;
-
-  const sectionPath = "/" + segments[0];
-  const sectionPage = contentPageMap.get(sectionPath);
-  if (!sectionPage) return null;
-
-  // Build the subtree
-  function buildNode(page: ContentPage): ContentNode {
-    const children = contentPages
-      .filter((p) => parentPath(p.path) === page.path)
-      .sort((a, b) => a.menuOrder - b.menuOrder);
-
-    return {
-      page,
-      children: children.map(buildNode),
-    };
-  }
-
-  return buildNode(sectionPage);
-}
-
-/**
- * Build breadcrumb trail from root to current page.
- * Returns array of { title, path } from ancestor to current.
- */
-export function getBreadcrumbs(
-  currentPath: string,
-): Array<{ title: string; path: string }> {
-  const crumbs: Array<{ title: string; path: string }> = [];
-  let path: string | null = currentPath;
-
-  while (path) {
-    const page = contentPageMap.get(path);
-    if (page) {
-      crumbs.unshift({ title: page.title, path: page.path });
-    }
-    path = parentPath(path);
-  }
-
-  return crumbs;
-}
-
-/**
- * Get the top-level content sections that should appear in the main menu.
- */
-export function getMainMenuItems(): ContentPage[] {
-  return contentPages
-    .filter((p) => p.isMainMenu)
-    .sort((a, b) => a.menuOrder - b.menuOrder);
-}
+export const staticNavPages: NavPage[] = contentPages.map((p) => ({
+  path: p.path,
+  title: p.title,
+  menuOrder: p.menuOrder,
+  isMainMenu: p.isMainMenu,
+}));

--- a/apps/web/src/lib/nav.test.ts
+++ b/apps/web/src/lib/nav.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBreadcrumbs,
+  getMainMenuItems,
+  getNavigationTree,
+  mergeNavPages,
+  type NavPage,
+} from "./nav";
+
+function page(path: string, overrides: Partial<NavPage> = {}): NavPage {
+  return {
+    path,
+    title: path.split("/").filter(Boolean).join(" "),
+    menuOrder: 99,
+    isMainMenu: false,
+    ...overrides,
+  };
+}
+
+// A static corpus mirroring the real content layout: a section root with
+// ordered children and one grandchild level. Path-sorted, like
+// content.ts's contentPages / staticNavPages.
+const staticPages: NavPage[] = [
+  page("/club", { title: "Club", isMainMenu: true, menuOrder: 1 }),
+  page("/club/committee", { title: "Committee", menuOrder: 2 }),
+  page("/club/history", { title: "History", menuOrder: 1 }),
+  page("/club/history/honours", { title: "Honours", menuOrder: 1 }),
+  page("/cricket", { title: "Cricket", isMainMenu: true, menuOrder: 2 }),
+  page("/legal", { title: "Legal" }),
+  page("/legal/privacy", { title: "Privacy Policy" }),
+];
+
+describe("mergeNavPages", () => {
+  it("returns the static list unchanged when the API list is empty (pre-migration)", () => {
+    expect(mergeNavPages([], staticPages)).toEqual(staticPages);
+  });
+
+  it("API page overrides the static page at the same path", () => {
+    const merged = mergeNavPages(
+      [page("/club", { title: "The Club", isMainMenu: true, menuOrder: 5 })],
+      staticPages,
+    );
+    const club = merged.find((p) => p.path === "/club");
+    expect(club).toEqual({
+      path: "/club",
+      title: "The Club",
+      isMainMenu: true,
+      menuOrder: 5,
+    });
+    // No duplicate entry for the shadowed static page
+    expect(merged.filter((p) => p.path === "/club")).toHaveLength(1);
+    expect(merged).toHaveLength(staticPages.length);
+  });
+
+  it("keeps static pages not shadowed by an API path", () => {
+    const merged = mergeNavPages([page("/club")], staticPages);
+    expect(merged.map((p) => p.path)).toContain("/legal/privacy");
+    expect(merged.map((p) => p.path)).toContain("/club/history/honours");
+  });
+
+  it("sorts the merged list by path", () => {
+    const merged = mergeNavPages(
+      [page("/cricket/juniors"), page("/boxing")],
+      staticPages,
+    );
+    expect(merged.map((p) => p.path)).toEqual(
+      [...merged.map((p) => p.path)].sort((a, b) => a.localeCompare(b)),
+    );
+    expect(merged[0]?.path).toBe("/boxing");
+  });
+});
+
+describe("getNavigationTree", () => {
+  it("returns the section subtree for a nested current path", () => {
+    const tree = getNavigationTree(staticPages, "/club/history/honours");
+    expect(tree?.page.path).toBe("/club");
+    expect(tree?.children.map((c) => c.page.path)).toEqual([
+      "/club/history",
+      "/club/committee",
+    ]);
+    expect(tree?.children[0]?.children.map((c) => c.page.path)).toEqual([
+      "/club/history/honours",
+    ]);
+  });
+
+  it("sorts children by menuOrder", () => {
+    // History (menuOrder 1) before Committee (menuOrder 2) despite
+    // "committee" sorting first by path.
+    const tree = getNavigationTree(staticPages, "/club");
+    expect(tree?.children.map((c) => c.page.title)).toEqual([
+      "History",
+      "Committee",
+    ]);
+  });
+
+  it("breaks menuOrder ties by path order (stable sort)", () => {
+    const tree = getNavigationTree(staticPages, "/legal");
+    // Both legal children default to menuOrder 99... there is only one;
+    // build a tie explicitly instead.
+    expect(tree?.children).toHaveLength(1);
+
+    const tied = [
+      page("/a"),
+      page("/a/x", { menuOrder: 5 }),
+      page("/a/y", { menuOrder: 5 }),
+    ];
+    const tiedTree = getNavigationTree(tied, "/a");
+    expect(tiedTree?.children.map((c) => c.page.path)).toEqual([
+      "/a/x",
+      "/a/y",
+    ]);
+  });
+
+  it("returns null when the section root is not in the list", () => {
+    expect(getNavigationTree(staticPages, "/news/some-article")).toBeNull();
+  });
+
+  it("returns null for the root path", () => {
+    expect(getNavigationTree(staticPages, "/")).toBeNull();
+  });
+
+  it("includes DB pages merged into a static section", () => {
+    const merged = mergeNavPages(
+      [page("/club/grounds", { title: "Grounds", menuOrder: 0 })],
+      staticPages,
+    );
+    const tree = getNavigationTree(merged, "/club");
+    expect(tree?.children.map((c) => c.page.title)).toEqual([
+      "Grounds",
+      "History",
+      "Committee",
+    ]);
+  });
+});
+
+describe("getBreadcrumbs", () => {
+  it("walks ancestors from root to the current page", () => {
+    expect(getBreadcrumbs(staticPages, "/club/history/honours")).toEqual([
+      { title: "Club", path: "/club" },
+      { title: "History", path: "/club/history" },
+      { title: "Honours", path: "/club/history/honours" },
+    ]);
+  });
+
+  it("skips ancestors missing from the merged list", () => {
+    // A DB page can be published deeper than any published ancestor.
+    const pages = [page("/club/teams/firsts", { title: "First XI" })];
+    expect(getBreadcrumbs(pages, "/club/teams/firsts")).toEqual([
+      { title: "First XI", path: "/club/teams/firsts" },
+    ]);
+  });
+
+  it("returns known ancestors even when the current page is unknown", () => {
+    expect(getBreadcrumbs(staticPages, "/club/history/missing")).toEqual([
+      { title: "Club", path: "/club" },
+      { title: "History", path: "/club/history" },
+    ]);
+  });
+
+  it("returns an empty trail when nothing on the path is known", () => {
+    expect(getBreadcrumbs(staticPages, "/nowhere/at/all")).toEqual([]);
+  });
+});
+
+describe("getMainMenuItems", () => {
+  it("filters to isMainMenu pages and sorts by menuOrder", () => {
+    const items = getMainMenuItems([
+      ...staticPages,
+      page("/boxing", { title: "Boxing", isMainMenu: true, menuOrder: 0 }),
+    ]);
+    expect(items.map((p) => p.title)).toEqual(["Boxing", "Club", "Cricket"]);
+  });
+
+  it("returns an empty list when no page is flagged for the main menu", () => {
+    expect(getMainMenuItems([page("/legal")])).toEqual([]);
+  });
+
+  it("lets a DB override pull a page out of the main menu", () => {
+    const merged = mergeNavPages(
+      [page("/cricket", { title: "Cricket", isMainMenu: false })],
+      staticPages,
+    );
+    expect(getMainMenuItems(merged).map((p) => p.title)).toEqual(["Club"]);
+  });
+});

--- a/apps/web/src/lib/nav.test.ts
+++ b/apps/web/src/lib/nav.test.ts
@@ -68,6 +68,42 @@ describe("mergeNavPages", () => {
     );
     expect(merged[0]?.path).toBe("/boxing");
   });
+
+  it("drops a static page tombstoned by removed[] - a takedown sticks", () => {
+    const merged = mergeNavPages([], staticPages, ["/club/committee"]);
+    expect(merged.map((p) => p.path)).not.toContain("/club/committee");
+    expect(merged).toHaveLength(staticPages.length - 1);
+  });
+
+  it("treats tombstones with no static twin as no-ops", () => {
+    expect(mergeNavPages([], staticPages, ["/never-existed"])).toEqual(
+      staticPages,
+    );
+  });
+
+  it("lets an API item at a tombstoned path win over the tombstone", () => {
+    // The API only tombstones paths it is not serving, but a stale
+    // removed[] entry must not hide a page the API is publishing.
+    const merged = mergeNavPages(
+      [page("/club/committee", { title: "Committee (DB)" })],
+      staticPages,
+      ["/club/committee"],
+    );
+    expect(merged.find((p) => p.path === "/club/committee")?.title).toBe(
+      "Committee (DB)",
+    );
+  });
+
+  it("removes a tombstoned static page from the main menu", () => {
+    const merged = mergeNavPages([], staticPages, ["/cricket"]);
+    expect(getMainMenuItems(merged).map((p) => p.title)).toEqual(["Club"]);
+  });
+
+  it("defaults to no tombstones when removed[] is omitted", () => {
+    expect(mergeNavPages([], staticPages)).toEqual(
+      mergeNavPages([], staticPages, []),
+    );
+  });
 });
 
 describe("getNavigationTree", () => {

--- a/apps/web/src/lib/nav.ts
+++ b/apps/web/src/lib/nav.ts
@@ -29,13 +29,24 @@ export interface NavNode {
  * sorted by path, mirroring the static pipeline's contentPages ordering -
  * with an empty API list (pre-migration) the output is identical to the
  * old static-only list.
+ *
+ * `removedPaths` are tombstones: paths of ever-live DB pages that have
+ * since been unpublished or archived. Static pages at those paths are
+ * dropped instead of resurrecting - an urgent takedown must stick even
+ * where a bundled MDX twin exists. Tombstones with no static twin are
+ * simply no-ops, and an API item at a tombstoned path still wins (the
+ * API only tombstones paths it is not serving).
  */
 export function mergeNavPages(
   apiPages: NavPage[],
   staticPages: NavPage[],
+  removedPaths: readonly string[] = [],
 ): NavPage[] {
+  const removed = new Set(removedPaths);
   const byPath = new Map<string, NavPage>();
-  for (const page of staticPages) byPath.set(page.path, page);
+  for (const page of staticPages) {
+    if (!removed.has(page.path)) byPath.set(page.path, page);
+  }
   for (const page of apiPages) byPath.set(page.path, page);
   return Array.from(byPath.values()).toSorted((a, b) =>
     a.path.localeCompare(b.path),

--- a/apps/web/src/lib/nav.ts
+++ b/apps/web/src/lib/nav.ts
@@ -1,0 +1,123 @@
+// Pure nav-model functions for the merged page hierarchy (#493): DB-backed
+// pages from GET /api/content/nav plus the bundled static MDX pages. Kept
+// free of Vite-only dependencies (content.ts needs import.meta.glob) so
+// the tree/breadcrumb/menu logic is unit-testable in plain vitest.
+
+/**
+ * Lightweight nav shape shared by API nav items and static content pages.
+ * Nav trees, breadcrumbs and menus only need these fields - only the page
+ * renderer needs the full static ContentPage (with its Component).
+ */
+export interface NavPage {
+  /** URL path, e.g. "/club/history/honours" */
+  path: string;
+  title: string;
+  menuOrder: number;
+  isMainMenu: boolean;
+}
+
+export interface NavNode {
+  page: NavPage;
+  children: NavNode[];
+}
+
+/**
+ * Merge API nav items with the static page list. The API wins on a path
+ * collision (a migrated page's DB title/menu placement replaces its
+ * bundled MDX ancestor); static pages without a DB counterpart pass
+ * through unchanged, so sections migrate one at a time. The result is
+ * sorted by path, mirroring the static pipeline's contentPages ordering -
+ * with an empty API list (pre-migration) the output is identical to the
+ * old static-only list.
+ */
+export function mergeNavPages(
+  apiPages: NavPage[],
+  staticPages: NavPage[],
+): NavPage[] {
+  const byPath = new Map<string, NavPage>();
+  for (const page of staticPages) byPath.set(page.path, page);
+  for (const page of apiPages) byPath.set(page.path, page);
+  return Array.from(byPath.values()).toSorted((a, b) =>
+    a.path.localeCompare(b.path),
+  );
+}
+
+/**
+ * Get the parent path of a given path.
+ * "/club/history/honours" → "/club/history"
+ * "/club" → null (top-level)
+ */
+function parentPath(path: string): string | null {
+  const lastSlash = path.lastIndexOf("/");
+  if (lastSlash <= 0) return null;
+  return path.substring(0, lastSlash);
+}
+
+/**
+ * Build a tree of NavNodes for sidebar navigation.
+ * Given a page path, finds the top-level ancestor and returns
+ * the full subtree under that ancestor.
+ *
+ * Children sort by menuOrder; the sort is stable, so equal menuOrders
+ * keep the input (path) order - same tie-break as the old static-only
+ * implementation.
+ */
+export function getNavigationTree(
+  pages: NavPage[],
+  currentPath: string,
+): NavNode | null {
+  // Find the top-level section (e.g. "/club" from "/club/history/honours")
+  const segments = currentPath.split("/").filter(Boolean);
+  if (segments.length === 0) return null;
+
+  const sectionPath = "/" + segments[0];
+  const sectionPage = pages.find((p) => p.path === sectionPath);
+  if (!sectionPage) return null;
+
+  // Build the subtree
+  function buildNode(page: NavPage): NavNode {
+    const children = pages
+      .filter((p) => parentPath(p.path) === page.path)
+      .sort((a, b) => a.menuOrder - b.menuOrder);
+
+    return {
+      page,
+      children: children.map(buildNode),
+    };
+  }
+
+  return buildNode(sectionPage);
+}
+
+/**
+ * Build breadcrumb trail from root to current page.
+ * Returns array of { title, path } from ancestor to current.
+ * Ancestors missing from the page list are skipped.
+ */
+export function getBreadcrumbs(
+  pages: NavPage[],
+  currentPath: string,
+): Array<{ title: string; path: string }> {
+  const byPath = new Map(pages.map((p) => [p.path, p]));
+  const crumbs: Array<{ title: string; path: string }> = [];
+  let path: string | null = currentPath;
+
+  while (path) {
+    const page = byPath.get(path);
+    if (page) {
+      crumbs.unshift({ title: page.title, path: page.path });
+    }
+    path = parentPath(path);
+  }
+
+  return crumbs;
+}
+
+/**
+ * Get the top-level content sections that should appear in the main menu.
+ */
+export function getMainMenuItems(pages: NavPage[]): NavPage[] {
+  return pages
+    .filter((p) => p.isMainMenu)
+    .sort((a, b) => a.menuOrder - b.menuOrder);
+}

--- a/apps/web/src/lib/person-grid.ts
+++ b/apps/web/src/lib/person-grid.ts
@@ -1,0 +1,49 @@
+// The personGrid block's role-preserving prop (#496): `entries` is a
+// JSON-stringified array of { slug, role? }, following the contentImage
+// `picture` JSON-string-prop precedent. The legacy `slugs` CSV prop is
+// kept as a fallback the renderer still reads when entries is absent or
+// malformed. Shared between the public renderer (content-body.tsx) and
+// the editor block (content-editor.tsx) so both parse identically.
+
+export interface PersonGridEntry {
+  slug: string;
+  role?: string;
+}
+
+/**
+ * Parse a JSON-stringified personGrid entries prop. Returns null for
+ * anything that is not a wholly valid, non-empty array of
+ * { slug, role? } - the caller then falls back to the legacy slugs CSV
+ * (malformed stored content degrades, never crashes, per the renderer's
+ * conventions). Empty arrays are null so the renderer and editor agree
+ * on when the fallback applies.
+ * Slugs are trimmed; empty roles are dropped (NULL-for-unset). Roles
+ * are otherwise kept verbatim: the editor round-trips entries through
+ * this parser on every keystroke, so trimming here would eat the
+ * trailing space while someone types a multi-word role.
+ */
+export function parsePersonGridEntries(
+  raw: string | undefined,
+): PersonGridEntry[] | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+
+  const entries: PersonGridEntry[] = [];
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null) return null;
+    const { slug, role } = item as { slug?: unknown; role?: unknown };
+    if (typeof slug !== "string" || slug.trim() === "") return null;
+    if (role !== undefined && typeof role !== "string") return null;
+    entries.push({
+      slug: slug.trim(),
+      ...(role ? { role } : {}),
+    });
+  }
+  return entries.length > 0 ? entries : null;
+}

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -20,6 +20,7 @@ import { LeadsTab } from "./leads-tab";
 import { MarketingOutboxTab } from "./marketing-outbox-tab";
 import { MatchFeesTab } from "./match-fees-tab";
 import { MembersTab } from "./members-tab";
+import { PagesTab } from "./pages-tab";
 import { RecordLinkingTab } from "./record-linking-tab";
 import { SponsorshipsTab } from "./sponsorships-tab";
 import { TreasurerTab } from "./treasurer-tab";
@@ -186,6 +187,15 @@ const SECTIONS: readonly SectionDef[] = [
         label: "Events",
         visible: (role) => checkPermission(role, "content_news", "view"),
         render: () => <ContentTab kind="event" />,
+      },
+      // Appended after the existing sub-tabs so the section's default
+      // (first visible) sub-tab - what a bare ?section=content deep link
+      // opens - doesn't change underneath existing links.
+      {
+        value: "pages",
+        label: "Pages",
+        visible: (role) => checkPermission(role, "content", "view"),
+        render: () => <PagesTab />,
       },
     ],
   },

--- a/apps/web/src/pages/admin/content-editor.schema.test.ts
+++ b/apps/web/src/pages/admin/content-editor.schema.test.ts
@@ -1,0 +1,102 @@
+import { CUSTOM_BLOCK_TYPES } from "@percy-main/shared/content";
+import { describe, expect, it, vi } from "vitest";
+
+// The editor schema is constructed at module load by createReactBlockSpec
+// calls that use @blocknote/react and @blocknote/shadcn. Neither package
+// functions outside a browser/JSDOM environment, so we stub the parts
+// that touch DOM APIs.  We only need the schema's blockSpecs keys - the
+// actual block render functions are irrelevant to this assertion.
+
+vi.mock("@blocknote/react", () => ({
+  createReactBlockSpec: (config: { type: string }) => () => ({
+    config,
+    implementation: {},
+  }),
+  getDefaultReactSlashMenuItems: () => [],
+  SuggestionMenuController: () => null,
+  useCreateBlockNote: () => ({}),
+}));
+
+vi.mock("@blocknote/core", () => ({
+  BlockNoteSchema: {
+    create: (opts: { blockSpecs: Record<string, unknown> }) => ({
+      blockSpecs: opts.blockSpecs,
+      BlockNoteEditor: null,
+      PartialBlock: null,
+    }),
+  },
+  defaultBlockSpecs: {
+    paragraph: {},
+    heading: {},
+    bulletListItem: {},
+    numberedListItem: {},
+    checkListItem: {},
+    table: {},
+    codeBlock: {},
+    quote: {},
+    image: {},
+    video: {},
+    audio: {},
+    file: {},
+  },
+  filterSuggestionItems: (_items: unknown[], _query: string) => [],
+  insertOrUpdateBlockForSlashMenu: () => undefined,
+}));
+
+vi.mock("@blocknote/shadcn", () => ({
+  BlockNoteView: () => null,
+}));
+
+vi.mock("@blocknote/core/fonts/inter.css", () => ({}));
+vi.mock("@blocknote/shadcn/style.css", () => ({}));
+
+// Stub all downstream imports that touch Vite-specific transforms or DOM.
+vi.mock("@/lib/people.js", () => ({
+  getAllPeople: () => [],
+  getPersonBySlug: () => undefined,
+}));
+vi.mock("@/lib/image-map.js", () => ({
+  getImageUrl: () => undefined,
+  getPicture: () => undefined,
+}));
+vi.mock("@/components/leaderboard-content.js", () => ({
+  LeaderboardContent: () => null,
+}));
+vi.mock("@/components/records-wall.js", () => ({
+  RecordsWall: () => null,
+}));
+vi.mock("@/lib/marketing/consent.js", () => ({
+  CURRENT_CONSENT_VERSION: "v3",
+  requestConsentReopen: () => undefined,
+}));
+vi.mock("@/lib/content-images.js", () => ({
+  uploadContentImage: () => Promise.resolve({}),
+}));
+vi.mock("@/lib/api-client.js", () => ({
+  api: {},
+  callApi: () => Promise.resolve({}),
+}));
+vi.mock("@/hooks/use-has-permission.js", () => ({
+  useHasPermission: () => ({ allowed: false }),
+}));
+vi.mock("./content-kind-labels.js", () => ({
+  CONTENT_KIND_NOUNS: {},
+}));
+vi.mock("./pages-tab.lib.js", () => ({
+  buildPageTree: () => [],
+  visibleNodes: () => [],
+}));
+
+// Dynamic import so vi.mock calls above are hoisted before module execution.
+const { schema } = await import("./content-editor.js");
+
+describe("content-editor schema", () => {
+  it("registers a blockSpec for every CUSTOM_BLOCK_TYPES value", () => {
+    const registeredKeys = new Set(Object.keys(schema.blockSpecs));
+    for (const blockType of Object.values(CUSTOM_BLOCK_TYPES)) {
+      expect(registeredKeys, `missing blockSpec for "${blockType}"`).toContain(
+        blockType,
+      );
+    }
+  });
+});

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -60,6 +60,10 @@ import type { paths } from "@/lib/api.gen.js";
 import { uploadContentImage } from "@/lib/content-images.js";
 import { getAllPeople } from "@/lib/people.js";
 import {
+  parsePersonGridEntries,
+  type PersonGridEntry,
+} from "@/lib/person-grid.js";
+import {
   CONTENT_KIND_RESOURCES,
   contentBodySchema,
   CUSTOM_BLOCK_TYPES,
@@ -330,25 +334,52 @@ const personGridBlock = createReactBlockSpec(
   {
     type: CUSTOM_BLOCK_TYPES.personGrid,
     propSchema: {
-      // Comma-separated person slugs - same storage format as content-body
+      // Legacy fallback the public renderer still reads when entries is
+      // absent - kept in sync as the CSV of the selected slugs.
       slugs: { default: "" },
+      // Canonical role-preserving prop: JSON-stringified [{slug, role?}]
+      // (same precedent as contentImage's picture prop).
+      entries: { default: "" },
     },
     content: "none",
   },
   {
     render: ({ block, editor }) => {
-      // Same CSV normalisation as the public renderer: trim each
-      // segment, drop empties - "alice, bob" works either side.
-      const selected = block.props.slugs.split(",").flatMap((s) => {
-        const trimmed = s.trim();
-        return trimmed ? [trimmed] : [];
-      });
+      // entries is canonical; a block predating it (or with malformed
+      // JSON) degrades to the slugs CSV, role-less - exactly like the
+      // public renderer.
+      const entries: PersonGridEntry[] =
+        parsePersonGridEntries(block.props.entries) ??
+        block.props.slugs.split(",").flatMap((s) => {
+          const trimmed = s.trim();
+          return trimmed ? [{ slug: trimmed }] : [];
+        });
       const allPeople = getAllPeople();
+      const nameOf = (slug: string) =>
+        allPeople.find((p) => p.slug === slug)?.name ?? slug;
+      const write = (next: PersonGridEntry[]) => {
+        editor.updateBlock(block, {
+          props: {
+            ...block.props,
+            entries: JSON.stringify(next),
+            slugs: next.map((e) => e.slug).join(","),
+          },
+        });
+      };
       return (
         <div className="my-2 flex w-full flex-col gap-2">
-          {selected.length > 0 ? (
+          {entries.length > 0 ? (
             <EditorBlockPreview>
-              <mdxComponents.PersonGrid slugs={selected} />
+              {/* Same children composition as the public renderer. */}
+              <mdxComponents.PersonGrid>
+                {entries.map((entry, i) => (
+                  <mdxComponents.Person
+                    key={`${entry.slug}-${String(i)}`}
+                    slug={entry.slug}
+                    role={entry.role}
+                  />
+                ))}
+              </mdxComponents.PersonGrid>
             </EditorBlockPreview>
           ) : (
             <p className="text-sm text-stone-500">Choose people to display…</p>
@@ -361,14 +392,19 @@ const personGridBlock = createReactBlockSpec(
               aria-label="People"
               multiple
               size={Math.min(allPeople.length, 6)}
-              value={selected}
+              value={entries.map((e) => e.slug)}
               onChange={(e) => {
                 const chosen = Array.from(e.target.selectedOptions).map(
                   (o) => o.value,
                 );
-                editor.updateBlock(block, {
-                  props: { ...block.props, slugs: chosen.join(",") },
-                });
+                // People who stay selected keep their role; newly
+                // selected people start role-less.
+                write(
+                  chosen.map(
+                    (slug) =>
+                      entries.find((entry) => entry.slug === slug) ?? { slug },
+                  ),
+                );
               }}
               className="rounded border border-stone-300 bg-white p-1 text-sm"
             >
@@ -379,6 +415,25 @@ const personGridBlock = createReactBlockSpec(
               ))}
             </select>
           </div>
+          {entries.map((entry, i) => (
+            <input
+              key={`${entry.slug}-${String(i)}`}
+              aria-label={`Role shown for ${nameOf(entry.slug)}`}
+              placeholder={`Role for ${nameOf(entry.slug)} (optional)`}
+              value={entry.role ?? ""}
+              onChange={(e) => {
+                const role = e.target.value;
+                write(
+                  entries.map((current, j) =>
+                    j === i
+                      ? { slug: current.slug, ...(role !== "" && { role }) }
+                      : current,
+                  ),
+                );
+              }}
+              className="rounded border border-stone-300 bg-white p-1 text-sm"
+            />
+          ))}
         </div>
       );
     },

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -74,6 +74,7 @@ import {
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CONTENT_KIND_NOUNS } from "./content-kind-labels.js";
+import { buildPageTree, visibleNodes } from "./pages-tab.lib.js";
 
 // ── Custom blocks ───────────────────────────────────────────────────────
 //
@@ -433,6 +434,8 @@ function buildSlashItems(editor: Editor, startImageUpload: () => void) {
 interface EditorProps {
   kind: ContentKind;
   contentId: string | null;
+  /** Pages only: preset parent for a new child (?parent= URL param). */
+  newParentId?: string | null;
   onClose: () => void;
   onCreated: (id: string) => void;
 }
@@ -440,6 +443,7 @@ interface EditorProps {
 export default function ContentEditor({
   kind,
   contentId,
+  newParentId = null,
   onClose,
   onCreated,
 }: EditorProps) {
@@ -480,6 +484,7 @@ export default function ContentEditor({
       key={contentId ?? "new"}
       kind={kind}
       item={item ?? null}
+      newParentId={newParentId}
       onClose={onClose}
       onCreated={onCreated}
     />
@@ -497,6 +502,13 @@ interface FormState {
   description: string;
   // game_report
   playCricketId: string;
+  // page - menuOrder stays a string while typing; ldjson is the raw
+  // textarea value (validated/parsed only when building the payload)
+  menuOrder: string;
+  isMainMenu: boolean;
+  hideTitle: boolean;
+  ldjson: string;
+  parentId: string | null;
   // news
   tags: string[];
   authorSlug: string;
@@ -554,7 +566,10 @@ function formatUkTime(iso: string): string {
  * stored JSON may predate the current schema, so anything malformed
  * degrades to the field default rather than crashing the editor.
  */
-function initialForm(item: ContentItemDetail | null): FormState {
+function initialForm(
+  item: ContentItemDetail | null,
+  newParentId: string | null,
+): FormState {
   const metadata = item?.metadata ?? {};
   const location =
     typeof metadata.location === "object" && metadata.location !== null
@@ -565,6 +580,14 @@ function initialForm(item: ContentItemDetail | null): FormState {
     slug: item?.slug ?? "",
     description: item?.description ?? "",
     playCricketId: asString(metadata.playCricketId),
+    menuOrder: asNumberString(metadata.menuOrder) || "99",
+    isMainMenu: metadata.isMainMenu === true,
+    hideTitle: metadata.hideTitle === true,
+    ldjson:
+      typeof metadata.ldjson === "object" && metadata.ldjson !== null
+        ? JSON.stringify(metadata.ldjson, null, 2)
+        : "",
+    parentId: item !== null ? item.parentId : newParentId,
     tags: Array.isArray(metadata.tags)
       ? metadata.tags.filter(
           (tag): tag is string => typeof tag === "string" && tag !== "",
@@ -586,6 +609,19 @@ function initialForm(item: ContentItemDetail | null): FormState {
 const isBlankOrNumeric = (value: string) =>
   value.trim() === "" || !Number.isNaN(Number(value.trim()));
 
+/** Parsed ldjson object, or null when the textarea isn't a JSON object. */
+function parseLdjson(raw: string): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null;
+}
+
 /**
  * Client-side floor for per-kind metadata the API would 400 without
  * (the server revalidates everything). Returns the message shown on the
@@ -594,6 +630,20 @@ const isBlankOrNumeric = (value: string) =>
 function metadataProblem(kind: ContentKind, form: FormState): string | null {
   if (kind === "game_report" && !form.playCricketId) {
     return "Choose a Play-Cricket game first";
+  }
+  if (kind === "page") {
+    const menuOrder = Number(form.menuOrder.trim());
+    if (
+      form.menuOrder.trim() === "" ||
+      !Number.isInteger(menuOrder) ||
+      menuOrder < 0 ||
+      menuOrder > 999
+    ) {
+      return "Menu order must be a whole number from 0 to 999";
+    }
+    if (form.ldjson.trim() !== "" && parseLdjson(form.ldjson.trim()) === null) {
+      return "Structured data must be a valid JSON object (or left empty)";
+    }
   }
   if (kind === "event") {
     if (!form.when) return "Set the event start time first";
@@ -625,6 +675,16 @@ function buildMetadata(
   kind: ContentKind,
   form: FormState,
 ): Record<string, unknown> {
+  if (kind === "page") {
+    const ldjson = form.ldjson.trim();
+    return {
+      menuOrder: Number(form.menuOrder.trim()),
+      isMainMenu: form.isMainMenu,
+      hideTitle: form.hideTitle,
+      // Omitted entirely when empty - never an empty string for "no value".
+      ...(ldjson !== "" ? { ldjson: parseLdjson(ldjson) } : {}),
+    };
+  }
   if (kind === "news") {
     return {
       tags: form.tags,
@@ -803,15 +863,150 @@ function AuthorSelect({
   );
 }
 
+// Radix Select items can't have an empty value, so "top level" rides on
+// a sentinel the slug grammar can never produce (no leading hyphens).
+const ROOT_PARENT = "--root--";
+
+// menuOrder is deliberately NOT covered by this lock: it is presentation
+// only, so ordering stays editable after publish.
+const PATH_LOCKED_HINT = "Locked after publish - the page's address is fixed";
+
+function PageMetadataFields({
+  form,
+  itemId,
+  slugLocked,
+  onChange,
+}: {
+  form: FormState;
+  /** Editing target, or null when creating - excluded from the picker. */
+  itemId: string | null;
+  slugLocked: boolean;
+  onChange: (updates: Partial<FormState>) => void;
+}) {
+  // Same key as the Pages tab's tree query, so opening the editor from
+  // the tree hits the cache and the picker renders instantly.
+  const { data } = useQuery({
+    queryKey: ["admin", "content", "page-tree"],
+    queryFn: () => callApi(api.GET("/api/admin/content/page-tree")),
+  });
+  const items = useMemo(() => data?.items ?? [], [data]);
+
+  // Parent options: every page except this one and its descendants
+  // (descendants are exactly the rows whose path extends this page's -
+  // the same canonical-prefix rule the backend's cycle check uses).
+  const options = useMemo(() => {
+    const self = items.find((item) => item.id === itemId);
+    const eligible = items.filter(
+      (item) =>
+        item.id !== itemId &&
+        (self === undefined || !item.path.startsWith(`${self.path}/`)),
+    );
+    const allExpanded = new Set(eligible.map((item) => item.id));
+    return visibleNodes(buildPageTree(eligible), allExpanded);
+  }, [items, itemId]);
+
+  // While the tree query is still loading, the parent's path is unknown -
+  // show an ellipsis rather than implying the page sits at the root.
+  const parentPath =
+    form.parentId !== null
+      ? (items.find((item) => item.id === form.parentId)?.path ?? "/…")
+      : "";
+  const pathPreview = `${parentPath}/${form.slug || "…"}`;
+
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <Label>Parent page{slugLocked ? " (locked after publish)" : ""}</Label>
+        <Select
+          value={form.parentId ?? ROOT_PARENT}
+          disabled={slugLocked}
+          onValueChange={(next) => {
+            onChange({ parentId: next === ROOT_PARENT ? null : next });
+          }}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Top level" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ROOT_PARENT}>Top level (no parent)</SelectItem>
+            {options.map((node) => (
+              <SelectItem key={node.item.id} value={node.item.id}>
+                {"\u00A0".repeat(node.depth * 3)}
+                {node.item.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {slugLocked ? (
+          <span className="text-xs text-stone-500">{PATH_LOCKED_HINT}</span>
+        ) : (
+          <span className="text-xs text-stone-500">
+            Page address: <span className="font-mono">{pathPreview}</span>
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="page-menu-order">Menu order (0-999)</Label>
+        <Input
+          id="page-menu-order"
+          inputMode="numeric"
+          value={form.menuOrder}
+          onChange={(e) => {
+            onChange({ menuOrder: e.target.value });
+          }}
+        />
+        <span className="text-xs text-stone-500">
+          Lower numbers appear first among sibling pages.
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="page-is-main-menu"
+          checked={form.isMainMenu}
+          onCheckedChange={(value) => {
+            onChange({ isMainMenu: value === true });
+          }}
+        />
+        <Label htmlFor="page-is-main-menu">Show in the main menu</Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="page-hide-title"
+          checked={form.hideTitle}
+          onCheckedChange={(value) => {
+            onChange({ hideTitle: value === true });
+          }}
+        />
+        <Label htmlFor="page-hide-title">Hide the title heading</Label>
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="page-ldjson">Structured data (JSON-LD, optional)</Label>
+        <Textarea
+          id="page-ldjson"
+          rows={4}
+          className="font-mono text-xs"
+          placeholder='{"@context": "https://schema.org", …}'
+          value={form.ldjson}
+          onChange={(e) => {
+            onChange({ ldjson: e.target.value });
+          }}
+        />
+      </div>
+    </>
+  );
+}
+
 function MetadataFields({
   kind,
   form,
+  itemId,
   slugLocked,
   tagSuggestions,
   onChange,
 }: {
   kind: ContentKind;
   form: FormState;
+  itemId: string | null;
   slugLocked: boolean;
   tagSuggestions: string[];
   onChange: (updates: Partial<FormState>) => void;
@@ -852,6 +1047,14 @@ function MetadataFields({
           }}
         />
       </div>
+      {kind === "page" && (
+        <PageMetadataFields
+          form={form}
+          itemId={itemId}
+          slugLocked={slugLocked}
+          onChange={onChange}
+        />
+      )}
       {kind === "game_report" && (
         <div className="flex flex-col gap-1">
           <Label>Play-Cricket game</Label>
@@ -1417,11 +1620,13 @@ function EditorPane({
 function LoadedEditor({
   kind,
   item,
+  newParentId,
   onClose,
   onCreated,
 }: {
   kind: ContentKind;
   item: ContentItemDetail | null;
+  newParentId: string | null;
   onClose: () => void;
   onCreated: (id: string) => void;
 }) {
@@ -1435,7 +1640,9 @@ function LoadedEditor({
     "publish",
   );
 
-  const [form, setForm] = useState<FormState>(() => initialForm(item));
+  const [form, setForm] = useState<FormState>(() =>
+    initialForm(item, newParentId),
+  );
   const [consentConfirmed, setConsentConfirmed] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [lastSavedAt, setLastSavedAt] = useState<string | null>(
@@ -1488,6 +1695,9 @@ function LoadedEditor({
               description: form.description || null,
               body,
               metadata,
+              // Pages nest; every other kind is flat (the API rejects a
+              // parent on non-page kinds).
+              ...(kind === "page" ? { parentId: form.parentId } : {}),
             },
           }),
         );
@@ -1496,7 +1706,14 @@ function LoadedEditor({
         api.PUT("/api/admin/content/{contentId}", {
           params: { path: { contentId: item.id } },
           body: {
-            ...(slugLocked ? {} : { slug: form.slug }),
+            // Slug and (for pages) parent share the ever-published lock:
+            // path = parent path + slug, so neither is sent once locked.
+            ...(slugLocked
+              ? {}
+              : {
+                  slug: form.slug,
+                  ...(kind === "page" ? { parentId: form.parentId } : {}),
+                }),
             title: form.title,
             description: form.description || null,
             body,
@@ -1643,6 +1860,7 @@ function LoadedEditor({
           <MetadataFields
             kind={kind}
             form={form}
+            itemId={item?.id ?? null}
             slugLocked={slugLocked}
             tagSuggestions={tagSuggestions}
             onChange={onFormChange}

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -79,7 +79,11 @@ import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CONTENT_KIND_NOUNS } from "./content-kind-labels.js";
 import { EditorBlockPreview } from "./editor-block-preview.js";
-import { buildPageTree, visibleNodes } from "./pages-tab.lib.js";
+import {
+  buildPageTree,
+  eligibleParents,
+  visibleNodes,
+} from "./pages-tab.lib.js";
 
 // ── Custom blocks ───────────────────────────────────────────────────────
 //
@@ -1282,19 +1286,14 @@ function PageMetadataFields({
   });
   const items = useMemo(() => data?.items ?? [], [data]);
 
-  // Parent options: every page except this one and its descendants
-  // (descendants are exactly the rows whose path extends this page's -
-  // the same canonical-prefix rule the backend's cycle check uses).
+  // Parent options: see eligibleParents (excludes self, descendants and
+  // archived pages, keeping the currently-selected parent even when
+  // archived so the Select isn't blank).
   const options = useMemo(() => {
-    const self = items.find((item) => item.id === itemId);
-    const eligible = items.filter(
-      (item) =>
-        item.id !== itemId &&
-        (self === undefined || !item.path.startsWith(`${self.path}/`)),
-    );
+    const eligible = eligibleParents(items, itemId, form.parentId);
     const allExpanded = new Set(eligible.map((item) => item.id));
     return visibleNodes(buildPageTree(eligible), allExpanded);
-  }, [items, itemId]);
+  }, [items, itemId, form.parentId]);
 
   // While the tree query is still loading, the parent's path is unknown -
   // show an ellipsis rather than implying the page sits at the root.
@@ -1324,6 +1323,7 @@ function PageMetadataFields({
               <SelectItem key={node.item.id} value={node.item.id}>
                 {"\u00A0".repeat(node.depth * 3)}
                 {node.item.title}
+                {node.item.status === "archived" ? " (archived)" : ""}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -74,6 +74,7 @@ import {
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CONTENT_KIND_NOUNS } from "./content-kind-labels.js";
+import { EditorBlockPreview } from "./editor-block-preview.js";
 import { buildPageTree, visibleNodes } from "./pages-tab.lib.js";
 
 // ── Custom blocks ───────────────────────────────────────────────────────
@@ -95,10 +96,12 @@ const personBlock = createReactBlockSpec(
     render: ({ block, editor }) => (
       <div className="my-2 flex w-full max-w-xs flex-col gap-2">
         {block.props.slug ? (
-          <mdxComponents.Person
-            slug={block.props.slug}
-            role={block.props.role || undefined}
-          />
+          <EditorBlockPreview>
+            <mdxComponents.Person
+              slug={block.props.slug}
+              role={block.props.role || undefined}
+            />
+          </EditorBlockPreview>
         ) : (
           <p className="text-sm text-stone-500">Choose a person…</p>
         )}
@@ -147,9 +150,11 @@ const gamePreviewBlock = createReactBlockSpec(
     render: ({ block, editor }) => (
       <div className="my-2 w-full">
         {block.props.playCricketId ? (
-          <mdxComponents.GamePreview
-            playCricketId={block.props.playCricketId}
-          />
+          <EditorBlockPreview>
+            <mdxComponents.GamePreview
+              playCricketId={block.props.playCricketId}
+            />
+          </EditorBlockPreview>
         ) : (
           <p className="text-sm text-stone-500">Choose a game…</p>
         )}
@@ -188,11 +193,13 @@ const eventPreviewBlock = createReactBlockSpec(
       return (
         <div className="my-2 flex w-full max-w-sm flex-col gap-2">
           {complete ? (
-            <mdxComponents.EventPreview
-              id={block.props.eventId}
-              name={block.props.name}
-              when={block.props.when}
-            />
+            <EditorBlockPreview>
+              <mdxComponents.EventPreview
+                id={block.props.eventId}
+                name={block.props.name}
+                when={block.props.when}
+              />
+            </EditorBlockPreview>
           ) : (
             <p className="text-sm text-stone-500">Fill in the event details…</p>
           )}
@@ -273,22 +280,24 @@ const contentImageBlock = createReactBlockSpec(
       const picture = parsePictureProp(block.props.picture);
       return (
         <figure className="my-2 flex w-full max-w-lg flex-col gap-2">
-          {picture ? (
-            <OptimisedImage
-              picture={picture}
-              alt={block.props.alt}
-              className="h-auto max-w-full rounded-lg"
-              sizes="(max-width: 512px) 100vw, 512px"
-            />
-          ) : block.props.src ? (
-            <img
-              src={block.props.src}
-              alt={block.props.alt}
-              className="h-auto max-w-full rounded-lg"
-            />
-          ) : (
-            <p className="text-sm text-stone-500">Image uploading…</p>
-          )}
+          <EditorBlockPreview>
+            {picture ? (
+              <OptimisedImage
+                picture={picture}
+                alt={block.props.alt}
+                className="h-auto max-w-full rounded-lg"
+                sizes="(max-width: 512px) 100vw, 512px"
+              />
+            ) : block.props.src ? (
+              <img
+                src={block.props.src}
+                alt={block.props.alt}
+                className="h-auto max-w-full rounded-lg"
+              />
+            ) : (
+              <p className="text-sm text-stone-500">Image uploading…</p>
+            )}
+          </EditorBlockPreview>
           <input
             aria-label="Caption"
             placeholder="Caption (optional)"
@@ -317,6 +326,242 @@ const contentImageBlock = createReactBlockSpec(
   },
 );
 
+const personGridBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.personGrid,
+    propSchema: {
+      // Comma-separated person slugs - same storage format as content-body
+      slugs: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      // Same CSV normalisation as the public renderer: trim each
+      // segment, drop empties - "alice, bob" works either side.
+      const selected = block.props.slugs.split(",").flatMap((s) => {
+        const trimmed = s.trim();
+        return trimmed ? [trimmed] : [];
+      });
+      const allPeople = getAllPeople();
+      return (
+        <div className="my-2 flex w-full flex-col gap-2">
+          {selected.length > 0 ? (
+            <EditorBlockPreview>
+              <mdxComponents.PersonGrid slugs={selected} />
+            </EditorBlockPreview>
+          ) : (
+            <p className="text-sm text-stone-500">Choose people to display…</p>
+          )}
+          <div className="flex flex-col gap-1">
+            <p className="text-xs text-stone-500">
+              Select people (hold Ctrl/Cmd to pick multiple):
+            </p>
+            <select
+              aria-label="People"
+              multiple
+              size={Math.min(allPeople.length, 6)}
+              value={selected}
+              onChange={(e) => {
+                const chosen = Array.from(e.target.selectedOptions).map(
+                  (o) => o.value,
+                );
+                editor.updateBlock(block, {
+                  props: { ...block.props, slugs: chosen.join(",") },
+                });
+              }}
+              className="rounded border border-stone-300 bg-white p-1 text-sm"
+            >
+              {allPeople.map((p) => (
+                <option key={p.slug} value={p.slug}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      );
+    },
+  },
+);
+
+const leagueTableBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.leagueTable,
+    propSchema: {
+      divisionId: { default: "" },
+      name: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const set = (key: "divisionId" | "name", value: string) => {
+        editor.updateBlock(block, { props: { ...block.props, [key]: value } });
+      };
+      return (
+        <div className="my-2 flex w-full flex-col gap-2">
+          {block.props.divisionId ? (
+            <EditorBlockPreview>
+              <mdxComponents.LeagueTable
+                divisionId={block.props.divisionId}
+                name={block.props.name || undefined}
+              />
+            </EditorBlockPreview>
+          ) : (
+            <p className="text-sm text-stone-500">
+              Enter a division ID to preview…
+            </p>
+          )}
+          <input
+            aria-label="Division ID"
+            placeholder="Division ID (required)"
+            value={block.props.divisionId}
+            onChange={(e) => {
+              set("divisionId", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Table heading"
+            placeholder="Table heading (optional)"
+            value={block.props.name}
+            onChange={(e) => {
+              set("name", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+        </div>
+      );
+    },
+  },
+);
+
+const leaderboardBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.leaderboard,
+    propSchema: {},
+    content: "none",
+  },
+  {
+    render: () => (
+      <EditorBlockPreview className="my-2 w-full">
+        <mdxComponents.Leaderboard />
+      </EditorBlockPreview>
+    ),
+  },
+);
+
+const recordsWallBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.recordsWall,
+    propSchema: {},
+    content: "none",
+  },
+  {
+    render: () => (
+      <EditorBlockPreview className="my-2 w-full">
+        <mdxComponents.RecordsWall />
+      </EditorBlockPreview>
+    ),
+  },
+);
+
+const contactFormBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.contactForm,
+    propSchema: {
+      title: { default: "" },
+      description: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const set = (key: "title" | "description", value: string) => {
+        editor.updateBlock(block, { props: { ...block.props, [key]: value } });
+      };
+      return (
+        <div className="my-2 flex w-full flex-col gap-2">
+          {/* Inert preview: the form must not be focusable or submittable
+              (mouse OR keyboard) inside the editor canvas */}
+          <EditorBlockPreview>
+            <mdxComponents.ContactForm
+              title={block.props.title || undefined}
+              description={block.props.description || undefined}
+            />
+          </EditorBlockPreview>
+          <input
+            aria-label="Form title"
+            placeholder="Form title (optional)"
+            value={block.props.title}
+            onChange={(e) => {
+              set("title", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+          <input
+            aria-label="Form description"
+            placeholder="Description shown above the fields (optional)"
+            value={block.props.description}
+            onChange={(e) => {
+              set("description", e.target.value);
+            }}
+            className="rounded border border-stone-300 bg-white p-1 text-sm"
+          />
+        </div>
+      );
+    },
+  },
+);
+
+const cookieSettingsLinkBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.cookieSettingsLink,
+    propSchema: {
+      text: { default: "Cookie settings" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => (
+      <div className="my-2 flex w-full flex-col gap-2">
+        <EditorBlockPreview>
+          <mdxComponents.CookieSettingsLink>
+            {block.props.text || "Cookie settings"}
+          </mdxComponents.CookieSettingsLink>
+        </EditorBlockPreview>
+        <input
+          aria-label="Link text"
+          placeholder="Link text"
+          value={block.props.text}
+          onChange={(e) => {
+            editor.updateBlock(block, {
+              props: { ...block.props, text: e.target.value },
+            });
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        />
+      </div>
+    ),
+  },
+);
+
+const consentVersionBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.consentVersion,
+    propSchema: {},
+    content: "none",
+  },
+  {
+    render: () => (
+      <EditorBlockPreview className="my-2">
+        <mdxComponents.ConsentVersion />
+      </EditorBlockPreview>
+    ),
+  },
+);
+
 // BlockNote's built-in media blocks are removed: their URL-embed tab
 // would bypass the consent + EXIF-strip + responsive pipeline that the
 // contentImage block (slash menu "Upload photo") goes through.
@@ -328,13 +573,20 @@ const {
   ...allowedDefaultBlocks
 } = defaultBlockSpecs;
 
-const schema = BlockNoteSchema.create({
+export const schema = BlockNoteSchema.create({
   blockSpecs: {
     ...allowedDefaultBlocks,
     [CUSTOM_BLOCK_TYPES.person]: personBlock(),
+    [CUSTOM_BLOCK_TYPES.personGrid]: personGridBlock(),
     [CUSTOM_BLOCK_TYPES.gamePreview]: gamePreviewBlock(),
     [CUSTOM_BLOCK_TYPES.eventPreview]: eventPreviewBlock(),
     [CUSTOM_BLOCK_TYPES.contentImage]: contentImageBlock(),
+    [CUSTOM_BLOCK_TYPES.leagueTable]: leagueTableBlock(),
+    [CUSTOM_BLOCK_TYPES.leaderboard]: leaderboardBlock(),
+    [CUSTOM_BLOCK_TYPES.recordsWall]: recordsWallBlock(),
+    [CUSTOM_BLOCK_TYPES.contactForm]: contactFormBlock(),
+    [CUSTOM_BLOCK_TYPES.cookieSettingsLink]: cookieSettingsLinkBlock(),
+    [CUSTOM_BLOCK_TYPES.consentVersion]: consentVersionBlock(),
   },
 });
 
@@ -397,6 +649,18 @@ function buildSlashItems(editor: Editor, startImageUpload: () => void) {
       },
     },
     {
+      title: "Person grid",
+      subtext: "Show a grid of club member cards",
+      group: "Club content",
+      aliases: ["people", "grid", "team"],
+      icon: <span aria-hidden>👥</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.personGrid,
+        });
+      },
+    },
+    {
       title: "Game preview",
       subtext: "Link a Play-Cricket fixture or result",
       group: "Club content",
@@ -427,6 +691,78 @@ function buildSlashItems(editor: Editor, startImageUpload: () => void) {
       aliases: ["image", "photo", "picture"],
       icon: <span aria-hidden>📷</span>,
       onItemClick: startImageUpload,
+    },
+    {
+      title: "League table",
+      subtext: "Show a live Play-Cricket league standings table",
+      group: "Page widgets",
+      aliases: ["league", "table", "standings", "division"],
+      icon: <span aria-hidden>📊</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.leagueTable,
+        });
+      },
+    },
+    {
+      title: "Leaderboard",
+      subtext: "Show the club batting and bowling leaderboard",
+      group: "Page widgets",
+      aliases: ["leaderboard", "stats", "averages"],
+      icon: <span aria-hidden>🏆</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.leaderboard,
+        });
+      },
+    },
+    {
+      title: "Records wall",
+      subtext: "Show the club batting and bowling records",
+      group: "Page widgets",
+      aliases: ["records", "records wall"],
+      icon: <span aria-hidden>🎖️</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.recordsWall,
+        });
+      },
+    },
+    {
+      title: "Contact form",
+      subtext: "Embed a contact message form",
+      group: "Page widgets",
+      aliases: ["contact", "form", "message"],
+      icon: <span aria-hidden>✉️</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.contactForm,
+        });
+      },
+    },
+    {
+      title: "Cookie settings link",
+      subtext: "Inline link that reopens the cookie consent banner",
+      group: "Page widgets",
+      aliases: ["cookie", "consent", "gdpr", "privacy"],
+      icon: <span aria-hidden>🍪</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.cookieSettingsLink,
+        });
+      },
+    },
+    {
+      title: "Consent version",
+      subtext: "Display the current cookie consent policy version string",
+      group: "Page widgets",
+      aliases: ["consent version", "policy version"],
+      icon: <span aria-hidden>📋</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.consentVersion,
+        });
+      },
     },
   ];
 }

--- a/apps/web/src/pages/admin/content-state.ts
+++ b/apps/web/src/pages/admin/content-state.ts
@@ -1,0 +1,39 @@
+// Shared admin-content display helpers, used by the flat content list
+// (content-tab) and the page tree (pages-tab) so both render the same
+// badge treatment.
+
+/**
+ * What the row means editorially, not the raw status: a published item
+ * with a future published_at is Scheduled, not Live. The Live/Scheduled
+ * split is a client-side now() comparison - fine for the admin list; the
+ * public visibility decision stays server-side (publishedOnly()).
+ */
+export type DisplayState = "draft" | "scheduled" | "live" | "archived";
+
+export function displayState(item: {
+  status: string;
+  publishedAt: string | null;
+}): DisplayState {
+  if (item.status === "archived") return "archived";
+  if (item.status !== "published") return "draft";
+  return item.publishedAt !== null && Date.parse(item.publishedAt) > Date.now()
+    ? "scheduled"
+    : "live";
+}
+
+export const STATE_BADGES: Record<
+  DisplayState,
+  { label: string; variant: "default" | "secondary" | "outline" | "info" }
+> = {
+  live: { label: "Live", variant: "default" },
+  scheduled: { label: "Scheduled", variant: "info" },
+  draft: { label: "Draft", variant: "secondary" },
+  archived: { label: "Archived", variant: "outline" },
+};
+
+/**
+ * URL params are user input: anything that isn't a UUID degrades to the
+ * default rather than reaching the typed API call.
+ */
+export const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -30,44 +30,13 @@ import { lazy, Suspense } from "react";
 import { IoOpenOutline } from "react-icons/io5";
 import { useSearchParams } from "react-router";
 import { CONTENT_KIND_NOUNS } from "./content-kind-labels.js";
+import { displayState, STATE_BADGES, UUID_RE } from "./content-state.js";
 
 // The editor pulls in BlockNote (the single heaviest dependency in the
 // admin panel), so it loads as its own chunk only when an item is open.
 const ContentEditor = lazy(() => import("./content-editor.js"));
 
-/**
- * What the row means editorially, not the raw status: a published item
- * with a future published_at is Scheduled, not Live. The Live/Scheduled
- * split is a client-side now() comparison - fine for the admin list; the
- * public visibility decision stays server-side (publishedOnly()).
- */
-type DisplayState = "draft" | "scheduled" | "live" | "archived";
-
-function displayState(item: {
-  status: string;
-  publishedAt: string | null;
-}): DisplayState {
-  if (item.status === "archived") return "archived";
-  if (item.status !== "published") return "draft";
-  return item.publishedAt !== null && Date.parse(item.publishedAt) > Date.now()
-    ? "scheduled"
-    : "live";
-}
-
-const STATE_BADGES: Record<
-  DisplayState,
-  { label: string; variant: "default" | "secondary" | "outline" | "info" }
-> = {
-  live: { label: "Live", variant: "default" },
-  scheduled: { label: "Scheduled", variant: "info" },
-  draft: { label: "Draft", variant: "secondary" },
-  archived: { label: "Archived", variant: "outline" },
-};
-
 const PAGE_SIZE = 20;
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Public URL a published item is live at. Per-kind: game reports render

--- a/apps/web/src/pages/admin/editor-block-preview.test.tsx
+++ b/apps/web/src/pages/admin/editor-block-preview.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { EditorBlockPreview } from "./editor-block-preview.js";
+
+describe("EditorBlockPreview", () => {
+  it("marks the wrapper inert so nested controls are not focusable or activatable", () => {
+    const html = renderToStaticMarkup(
+      <EditorBlockPreview>
+        <button type="button">should be unreachable</button>
+      </EditorBlockPreview>,
+    );
+    // React 19 renders the boolean inert prop as a bare attribute. inert
+    // blocks focus, keyboard activation and pointer events, and carries
+    // aria-hidden semantics - the keyboard half of read-only previews.
+    expect(html).toMatch(/<div[^>]*\binert\b/);
+    // pointer-events-none stays as a fallback for partial inert support.
+    expect(html).toContain("pointer-events-none");
+    expect(html).toContain("should be unreachable");
+  });
+
+  it("merges extra classes onto the wrapper", () => {
+    const html = renderToStaticMarkup(
+      <EditorBlockPreview className="my-2 w-full">
+        <span>preview</span>
+      </EditorBlockPreview>,
+    );
+    expect(html).toContain("my-2");
+    expect(html).toContain("w-full");
+    expect(html).toContain("pointer-events-none");
+  });
+});

--- a/apps/web/src/pages/admin/editor-block-preview.tsx
+++ b/apps/web/src/pages/admin/editor-block-preview.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils.js";
+import type { ReactNode } from "react";
+
+/**
+ * Shared non-interactive wrapper for in-editor previews of custom
+ * blocks. The `inert` attribute (a React 19 boolean prop) blocks focus
+ * and keyboard activation as well as pointer interaction, and carries
+ * aria-hidden semantics - so nested forms, buttons and links (contact
+ * form submit, cookie-consent reopen, leaderboard URL state, profile
+ * links) can't be activated from inside the editor canvas.
+ * pointer-events-none stays as a belt-and-braces fallback for browsers
+ * with partial inert support.
+ */
+export function EditorBlockPreview({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div inert className={cn("pointer-events-none select-none", className)}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin/pages-tab.lib.test.ts
+++ b/apps/web/src/pages/admin/pages-tab.lib.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPageTree,
+  reorderUpdates,
+  visibleNodes,
+  type PageTreeItem,
+} from "./pages-tab.lib.js";
+
+function item(
+  id: string,
+  path: string,
+  overrides: Partial<PageTreeItem> = {},
+): PageTreeItem {
+  return {
+    id,
+    title: id,
+    slug: path.split("/").filter(Boolean).pop() ?? id,
+    path,
+    parentId: null,
+    menuOrder: 99,
+    isMainMenu: false,
+    status: "draft",
+    publishedAt: null,
+    updatedAt: "2026-06-01T10:00:00.000Z",
+    pathLocked: false,
+    ...overrides,
+  };
+}
+
+describe("buildPageTree", () => {
+  it("nests children under parents with depths", () => {
+    const tree = buildPageTree([
+      item("club", "/club"),
+      item("history", "/club/history", { parentId: "club" }),
+      item("honours", "/club/history/honours", { parentId: "history" }),
+      item("cricket", "/cricket"),
+    ]);
+    expect(tree.map((n) => n.item.id)).toEqual(["club", "cricket"]);
+    expect(tree[0].depth).toBe(0);
+    expect(tree[0].children.map((n) => n.item.id)).toEqual(["history"]);
+    expect(tree[0].children[0].depth).toBe(1);
+    expect(tree[0].children[0].children.map((n) => n.item.id)).toEqual([
+      "honours",
+    ]);
+    expect(tree[0].children[0].children[0].depth).toBe(2);
+  });
+
+  it("promotes orphans (parent missing from the list) to root level", () => {
+    const tree = buildPageTree([
+      item("club", "/club"),
+      // Parent archived/missing - must not disappear from the admin view
+      item("lost", "/gone/lost", { parentId: "gone" }),
+    ]);
+    expect(tree.map((n) => n.item.id).toSorted()).toEqual(["club", "lost"]);
+    expect(tree.every((n) => n.depth === 0)).toBe(true);
+  });
+
+  it("sorts siblings by menuOrder, then title, then path", () => {
+    const tree = buildPageTree([
+      item("zeta", "/zeta", { menuOrder: 1, title: "Zeta" }),
+      item("beta", "/beta", { menuOrder: 5, title: "Same" }),
+      item("alpha", "/alpha", { menuOrder: 5, title: "Same" }),
+      item("mid", "/mid", { menuOrder: 2, title: "Mid" }),
+    ]);
+    // menuOrder wins; the equal-99 default pair falls to title (equal
+    // here) and then path
+    expect(tree.map((n) => n.item.id)).toEqual([
+      "zeta",
+      "mid",
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("returns an empty forest for no pages", () => {
+    expect(buildPageTree([])).toEqual([]);
+  });
+});
+
+describe("visibleNodes", () => {
+  const tree = buildPageTree([
+    item("club", "/club"),
+    item("history", "/club/history", { parentId: "club" }),
+    item("honours", "/club/history/honours", { parentId: "history" }),
+    item("cricket", "/cricket"),
+  ]);
+
+  it("shows only roots when nothing is expanded", () => {
+    expect(visibleNodes(tree, new Set()).map((n) => n.item.id)).toEqual([
+      "club",
+      "cricket",
+    ]);
+  });
+
+  it("reveals children of expanded nodes only, depth-first", () => {
+    expect(visibleNodes(tree, new Set(["club"])).map((n) => n.item.id)).toEqual(
+      ["club", "history", "cricket"],
+    );
+    expect(
+      visibleNodes(tree, new Set(["club", "history"])).map((n) => n.item.id),
+    ).toEqual(["club", "history", "honours", "cricket"]);
+  });
+
+  it("ignores expansion of a collapsed ancestor's descendants", () => {
+    // history is expanded but club is not - honours stays hidden
+    expect(
+      visibleNodes(tree, new Set(["history"])).map((n) => n.item.id),
+    ).toEqual(["club", "cricket"]);
+  });
+});
+
+describe("reorderUpdates", () => {
+  it("swaps the two adjacent pages when every menuOrder is distinct", () => {
+    const siblings = [
+      item("a", "/a", { menuOrder: 1 }),
+      item("b", "/b", { menuOrder: 5 }),
+      item("c", "/c", { menuOrder: 9 }),
+    ];
+    expect(reorderUpdates(siblings, "b", "up")).toEqual([
+      { id: "b", menuOrder: 1 },
+      { id: "a", menuOrder: 5 },
+    ]);
+    expect(reorderUpdates(siblings, "b", "down")).toEqual([
+      { id: "b", menuOrder: 9 },
+      { id: "c", menuOrder: 5 },
+    ]);
+  });
+
+  it("renumbers the whole group to spaced values when defaults collide", () => {
+    const siblings = [
+      item("a", "/a", { menuOrder: 99 }),
+      item("b", "/b", { menuOrder: 99 }),
+      item("c", "/c", { menuOrder: 99 }),
+    ];
+    // b moves up: new order is b, a, c at 10/20/30
+    expect(reorderUpdates(siblings, "b", "up")).toEqual([
+      { id: "b", menuOrder: 10 },
+      { id: "a", menuOrder: 20 },
+      { id: "c", menuOrder: 30 },
+    ]);
+  });
+
+  it("only emits updates for pages whose menuOrder actually changes", () => {
+    const siblings = [
+      item("a", "/a", { menuOrder: 10 }),
+      item("b", "/b", { menuOrder: 99 }),
+      item("c", "/c", { menuOrder: 99 }),
+    ];
+    // c moves up: renumber path (duplicates exist); a already sits at 10
+    expect(reorderUpdates(siblings, "c", "up")).toEqual([
+      { id: "c", menuOrder: 20 },
+      { id: "b", menuOrder: 30 },
+    ]);
+  });
+
+  it("is a no-op at the edges and for unknown ids", () => {
+    const siblings = [
+      item("a", "/a", { menuOrder: 1 }),
+      item("b", "/b", { menuOrder: 2 }),
+    ];
+    expect(reorderUpdates(siblings, "a", "up")).toEqual([]);
+    expect(reorderUpdates(siblings, "b", "down")).toEqual([]);
+    expect(reorderUpdates(siblings, "missing", "up")).toEqual([]);
+    expect(reorderUpdates([], "a", "up")).toEqual([]);
+  });
+
+  it("keeps renumbered values inside the schema cap for huge groups", () => {
+    const siblings = Array.from({ length: 120 }, (_, i) =>
+      item(`p${String(i)}`, `/p${String(i)}`, { menuOrder: 99 }),
+    );
+    const updates = reorderUpdates(siblings, "p1", "up");
+    expect(updates.length).toBeGreaterThan(0);
+    expect(Math.max(...updates.map((u) => u.menuOrder))).toBeLessThanOrEqual(
+      999,
+    );
+  });
+});

--- a/apps/web/src/pages/admin/pages-tab.lib.test.ts
+++ b/apps/web/src/pages/admin/pages-tab.lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPageTree,
+  eligibleParents,
   reorderUpdates,
   visibleNodes,
   type PageTreeItem,
@@ -74,6 +75,65 @@ describe("buildPageTree", () => {
 
   it("returns an empty forest for no pages", () => {
     expect(buildPageTree([])).toEqual([]);
+  });
+});
+
+describe("eligibleParents", () => {
+  const items = [
+    item("club", "/club", { status: "published" }),
+    item("history", "/club/history", {
+      parentId: "club",
+      status: "published",
+    }),
+    item("honours", "/club/history/honours", {
+      parentId: "history",
+      status: "published",
+    }),
+    item("old", "/old", { status: "archived" }),
+    item("scratch", "/scratch", { status: "draft" }),
+  ];
+
+  it("excludes the page itself and its descendants", () => {
+    expect(eligibleParents(items, "history", null).map((i) => i.id)).toEqual([
+      "club",
+      "scratch",
+    ]);
+  });
+
+  it("excludes archived pages (the backend rejects them as parents)", () => {
+    expect(eligibleParents(items, null, null).map((i) => i.id)).toEqual([
+      "club",
+      "history",
+      "honours",
+      "scratch",
+    ]);
+  });
+
+  it("keeps the currently-selected parent even when archived", () => {
+    // An existing child of a since-archived parent: the Select must not
+    // go blank, so the archived parent stays (annotated in the picker).
+    expect(eligibleParents(items, "scratch", "old").map((i) => i.id)).toEqual([
+      "club",
+      "history",
+      "honours",
+      "old",
+    ]);
+  });
+
+  it("does not resurrect other archived pages for a selected parent", () => {
+    const withSecondArchived = [
+      ...items,
+      item("older", "/older", { status: "archived" }),
+    ];
+    const ids = eligibleParents(withSecondArchived, "scratch", "old").map(
+      (i) => i.id,
+    );
+    expect(ids).toContain("old");
+    expect(ids).not.toContain("older");
+  });
+
+  it("offers everything but archived when creating (itemId null)", () => {
+    expect(eligibleParents(items, null, null)).toHaveLength(4);
   });
 });
 

--- a/apps/web/src/pages/admin/pages-tab.lib.ts
+++ b/apps/web/src/pages/admin/pages-tab.lib.ts
@@ -1,0 +1,123 @@
+import type { paths } from "@/lib/api.gen.js";
+
+// Pure tree/reorder logic for the admin Pages tab, kept DOM-free so it is
+// unit-testable in plain vitest (same convention as the *-tab.reducer.ts
+// and *-tab.lib.ts siblings).
+
+/** One flat item from GET /api/admin/content/page-tree (OpenAPI-derived). */
+export type PageTreeItem =
+  paths["/api/admin/content/page-tree"]["get"]["responses"][200]["content"]["application/json"]["items"][number];
+
+export interface PageTreeNode {
+  item: PageTreeItem;
+  depth: number;
+  children: PageTreeNode[];
+}
+
+/**
+ * Sibling display order: menuOrder, then title, then path. The title
+ * tie-break keeps groups of default-99 pages alphabetical instead of
+ * insertion-ordered; path is the final total-order guarantee (titles can
+ * collide, sibling paths cannot).
+ */
+function compareSiblings(a: PageTreeItem, b: PageTreeItem): number {
+  if (a.menuOrder !== b.menuOrder) return a.menuOrder - b.menuOrder;
+  const byTitle = a.title.localeCompare(b.title);
+  if (byTitle !== 0) return byTitle;
+  return a.path.localeCompare(b.path);
+}
+
+/**
+ * Assemble the flat page list into a forest. Orphans - items whose
+ * parentId points at a page missing from the list (archived parent
+ * filtered out upstream, or genuinely gone) - are promoted to root level
+ * rather than silently disappearing from the admin view.
+ */
+export function buildPageTree(items: PageTreeItem[]): PageTreeNode[] {
+  const known = new Set(items.map((item) => item.id));
+  const childrenOf = new Map<string | null, PageTreeItem[]>();
+  for (const item of items) {
+    const key =
+      item.parentId !== null && known.has(item.parentId) ? item.parentId : null;
+    const bucket = childrenOf.get(key);
+    if (bucket) bucket.push(item);
+    else childrenOf.set(key, [item]);
+  }
+
+  const build = (item: PageTreeItem, depth: number): PageTreeNode => ({
+    item,
+    depth,
+    children: (childrenOf.get(item.id) ?? [])
+      .toSorted(compareSiblings)
+      .map((child) => build(child, depth + 1)),
+  });
+
+  return (childrenOf.get(null) ?? [])
+    .toSorted(compareSiblings)
+    .map((item) => build(item, 0));
+}
+
+/** Depth-first flatten of the subtrees whose parents are expanded. */
+export function visibleNodes(
+  nodes: PageTreeNode[],
+  expanded: ReadonlySet<string>,
+): PageTreeNode[] {
+  const out: PageTreeNode[] = [];
+  const walk = (node: PageTreeNode) => {
+    out.push(node);
+    if (expanded.has(node.item.id)) node.children.forEach(walk);
+  };
+  nodes.forEach(walk);
+  return out;
+}
+
+export interface MenuOrderUpdate {
+  id: string;
+  menuOrder: number;
+}
+
+/**
+ * The metadata updates needed to move `id` one position up or down among
+ * `siblings` (its display-ordered sibling group, the same order
+ * buildPageTree produced). Returns [] when the move is impossible
+ * (already at the edge, or not a sibling).
+ *
+ * When every sibling already has a distinct menuOrder, the two adjacent
+ * pages simply swap values. Any duplicate (typically several pages
+ * sharing the schema default 99) makes positions ambiguous, so the whole
+ * sibling group is renumbered to spaced values (10, 20, 30...) in the
+ * new order - one batch, deterministic ordering afterwards.
+ */
+export function reorderUpdates(
+  siblings: PageTreeItem[],
+  id: string,
+  direction: "up" | "down",
+): MenuOrderUpdate[] {
+  const from = siblings.findIndex((item) => item.id === id);
+  if (from === -1) return [];
+  const to = direction === "up" ? from - 1 : from + 1;
+  if (to < 0 || to >= siblings.length) return [];
+
+  const orders = siblings.map((item) => item.menuOrder);
+  const allDistinct = new Set(orders).size === orders.length;
+  if (allDistinct) {
+    return [
+      { id: siblings[from].id, menuOrder: siblings[to].menuOrder },
+      { id: siblings[to].id, menuOrder: siblings[from].menuOrder },
+    ];
+  }
+
+  const reordered = [...siblings];
+  [reordered[from], reordered[to]] = [reordered[to], reordered[from]];
+  // Spacing of 10 leaves room for manual insertion between neighbours;
+  // fall back to 1 if a group is ever so large that 10s would breach the
+  // schema's 999 cap.
+  const spacing = reordered.length * 10 > 999 ? 1 : 10;
+  const updates: MenuOrderUpdate[] = [];
+  reordered.forEach((item, index) => {
+    const menuOrder = (index + 1) * spacing;
+    // Pages already sitting on their spaced value need no write.
+    if (menuOrder !== item.menuOrder) updates.push({ id: item.id, menuOrder });
+  });
+  return updates;
+}

--- a/apps/web/src/pages/admin/pages-tab.lib.ts
+++ b/apps/web/src/pages/admin/pages-tab.lib.ts
@@ -57,6 +57,29 @@ export function buildPageTree(items: PageTreeItem[]): PageTreeNode[] {
     .map((item) => build(item, 0));
 }
 
+/**
+ * Pages eligible as a parent in the editor's parent picker: every page
+ * except the page itself, its descendants (rows whose path extends this
+ * page's - the same canonical-prefix rule the backend's cycle check
+ * uses), and archived pages (the backend 400s an archived parentId).
+ * Exception: the currently-selected parent stays in the list even when
+ * archived, so an existing child's Select isn't blank - the picker
+ * annotates it instead.
+ */
+export function eligibleParents(
+  items: PageTreeItem[],
+  itemId: string | null,
+  currentParentId: string | null,
+): PageTreeItem[] {
+  const self = items.find((item) => item.id === itemId);
+  return items.filter(
+    (item) =>
+      item.id !== itemId &&
+      (self === undefined || !item.path.startsWith(`${self.path}/`)) &&
+      (item.status !== "archived" || item.id === currentParentId),
+  );
+}
+
 /** Depth-first flatten of the subtrees whose parents are expanded. */
 export function visibleNodes(
   nodes: PageTreeNode[],

--- a/apps/web/src/pages/admin/pages-tab.tsx
+++ b/apps/web/src/pages/admin/pages-tab.tsx
@@ -1,0 +1,392 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useHasPermission } from "@/hooks/use-has-permission";
+import { api, callApi } from "@/lib/api-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { formatInTimeZone } from "date-fns-tz";
+import { lazy, Suspense } from "react";
+import {
+  IoAddOutline,
+  IoArrowDownOutline,
+  IoArrowUpOutline,
+  IoChevronDownOutline,
+  IoChevronForwardOutline,
+  IoEllipsisVertical,
+  IoOpenOutline,
+} from "react-icons/io5";
+import { useSearchParams } from "react-router";
+import { displayState, STATE_BADGES, UUID_RE } from "./content-state.js";
+import {
+  buildPageTree,
+  reorderUpdates,
+  visibleNodes,
+  type MenuOrderUpdate,
+  type PageTreeItem,
+  type PageTreeNode,
+} from "./pages-tab.lib.js";
+
+// Same lazy split as content-tab: BlockNote only loads when an item opens.
+const ContentEditor = lazy(() => import("./content-editor.js"));
+
+/** Sibling groups in display order, keyed by member id, for reordering. */
+function siblingGroups(roots: PageTreeNode[]): Map<string, PageTreeItem[]> {
+  const groups = new Map<string, PageTreeItem[]>();
+  const record = (nodes: PageTreeNode[]) => {
+    const items = nodes.map((n) => n.item);
+    for (const node of nodes) {
+      groups.set(node.item.id, items);
+      record(node.children);
+    }
+  };
+  record(roots);
+  return groups;
+}
+
+/**
+ * Page tree for the admin Content section. All UI state (open item,
+ * preset parent for a new child, expanded nodes) lives in the URL
+ * alongside the panel's section/sub params, so deep links restore the
+ * full view.
+ */
+export function PagesTab() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
+  const { allowed: canManage } = useHasPermission("content", "manage");
+
+  const itemParam = searchParams.get("item");
+  const openItem =
+    itemParam === "new" || (itemParam !== null && UUID_RE.test(itemParam))
+      ? itemParam
+      : null;
+  const parentParam = searchParams.get("parent");
+  const newParentId =
+    parentParam !== null && UUID_RE.test(parentParam) ? parentParam : null;
+  const expanded = new Set(
+    (searchParams.get("expanded") ?? "").split(",").filter(Boolean),
+  );
+
+  /**
+   * Navigation-like changes (open item, new child) push a history entry;
+   * expand/collapse replaces - like search refinement, expanding nodes
+   * must not spam history with one entry per chevron click.
+   */
+  const setParams = (
+    updates: Record<string, string | null>,
+    options: { replace?: boolean } = {},
+  ) => {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === null || value === "") params.delete(key);
+      else params.set(key, value);
+    }
+    setSearchParams(params, { replace: options.replace ?? false });
+  };
+
+  const { data, isLoading, error } = useQuery({
+    // Rooted under ["admin", "content"] so the editor's existing save/
+    // publish invalidations cover the tree without knowing about it.
+    queryKey: ["admin", "content", "page-tree"],
+    queryFn: () => callApi(api.GET("/api/admin/content/page-tree")),
+    enabled: openItem === null,
+  });
+
+  const reorderMutation = useMutation({
+    mutationFn: async (updates: MenuOrderUpdate[]) => {
+      // menuOrder lives inside the kind metadata and updates replace the
+      // whole metadata object, so merge over each page's current detail
+      // (the tree payload deliberately omits hideTitle/ldjson). Each
+      // page's read-then-write pair touches only its own row, so the
+      // batch runs in parallel.
+      await Promise.all(
+        updates.map(async (update) => {
+          const detail = await callApi(
+            api.GET("/api/admin/content/{contentId}", {
+              params: { path: { contentId: update.id } },
+            }),
+          );
+          await callApi(
+            api.PUT("/api/admin/content/{contentId}", {
+              params: { path: { contentId: update.id } },
+              body: {
+                metadata: { ...detail.metadata, menuOrder: update.menuOrder },
+              },
+            }),
+          );
+        }),
+      );
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
+      // menuOrder drives the public nav ordering; drop ["content", ...]
+      // (which includes ["content", "nav"]) so the live menu reorders too.
+      void queryClient.invalidateQueries({ queryKey: ["content"] });
+    },
+  });
+
+  if (openItem !== null) {
+    return (
+      <Suspense
+        fallback={
+          <p className="py-8 text-sm text-stone-500">Loading editor…</p>
+        }
+      >
+        <ContentEditor
+          kind="page"
+          contentId={openItem === "new" ? null : openItem}
+          newParentId={newParentId}
+          onClose={() => {
+            setParams(
+              { item: null, parent: null },
+              { replace: openItem === "new" },
+            );
+          }}
+          onCreated={(id) => {
+            // Swap "new" for the created id (and drop the parent preset):
+            // back must not return to the create form and spawn a duplicate.
+            setParams({ item: id, parent: null }, { replace: true });
+          }}
+        />
+      </Suspense>
+    );
+  }
+
+  const roots = buildPageTree(data?.items ?? []);
+  const rows = visibleNodes(roots, expanded);
+  const groups = siblingGroups(roots);
+
+  const toggleExpanded = (id: string) => {
+    const next = new Set(expanded);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setParams(
+      { expanded: Array.from(next).join(",") || null },
+      { replace: true },
+    );
+  };
+
+  const move = (item: PageTreeItem, direction: "up" | "down") => {
+    const updates = reorderUpdates(
+      groups.get(item.id) ?? [],
+      item.id,
+      direction,
+    );
+    if (updates.length > 0) reorderMutation.mutate(updates);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="max-w-xl text-xs text-stone-500">
+          Pages nest into sections. A section's landing page is the parent
+          page's own content - edit the parent to change what visitors see at
+          its address.
+        </p>
+        {canManage && (
+          <Button
+            onClick={() => {
+              setParams({ item: "new" });
+            }}
+          >
+            New page
+          </Button>
+        )}
+      </div>
+
+      {reorderMutation.error && (
+        <p className="text-sm text-red-600">
+          Couldn't reorder - {reorderMutation.error.message}
+        </p>
+      )}
+
+      {error ? (
+        <p className="py-8 text-sm text-red-600">
+          Couldn't load pages - {error.message}
+        </p>
+      ) : isLoading ? (
+        <p className="py-8 text-sm text-stone-500">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="py-8 text-sm text-stone-500">
+          No pages yet - create the first one. Pages added as children of an
+          existing page form a section, and the parent page itself is the
+          section's landing page.
+        </p>
+      ) : (
+        <ul className="divide-y divide-stone-200 rounded-lg border border-stone-200">
+          {rows.map((node) => (
+            <PageRow
+              key={node.item.id}
+              node={node}
+              expanded={expanded.has(node.item.id)}
+              canManage={canManage}
+              reordering={reorderMutation.isPending}
+              siblings={groups.get(node.item.id) ?? []}
+              onToggle={() => {
+                toggleExpanded(node.item.id);
+              }}
+              onOpen={() => {
+                setParams({ item: node.item.id });
+              }}
+              onNewChild={() => {
+                // Expand the parent too, so the new child is visible on
+                // return to the tree.
+                const nextExpanded = new Set(expanded);
+                nextExpanded.add(node.item.id);
+                setParams({
+                  item: "new",
+                  parent: node.item.id,
+                  expanded: Array.from(nextExpanded).join(","),
+                });
+              }}
+              onMove={(direction) => {
+                move(node.item, direction);
+              }}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function PageRow({
+  node,
+  expanded,
+  canManage,
+  reordering,
+  siblings,
+  onToggle,
+  onOpen,
+  onNewChild,
+  onMove,
+}: {
+  node: PageTreeNode;
+  expanded: boolean;
+  canManage: boolean;
+  reordering: boolean;
+  siblings: PageTreeItem[];
+  onToggle: () => void;
+  onOpen: () => void;
+  onNewChild: () => void;
+  onMove: (direction: "up" | "down") => void;
+}) {
+  const { item, depth, children } = node;
+  const state = displayState(item);
+  const index = siblings.findIndex((s) => s.id === item.id);
+
+  // menuOrder is presentation-only and deliberately NOT part of the
+  // publish lock (the backend accepts it for ever-published pages too),
+  // so reordering stays enabled regardless of pathLocked - only the
+  // sibling boundaries and an in-flight batch disable the moves.
+  const canMoveUp = !reordering && index > 0;
+  const canMoveDown = !reordering && index < siblings.length - 1;
+
+  return (
+    <li
+      className="flex items-center gap-2 py-2 pr-2"
+      style={{ paddingLeft: `${String(depth * 1.25 + 0.5)}rem` }}
+    >
+      {children.length > 0 ? (
+        <button
+          type="button"
+          aria-label={`${expanded ? "Collapse" : "Expand"} ${item.title}`}
+          aria-expanded={expanded}
+          className="flex size-6 shrink-0 items-center justify-center rounded text-stone-500 hover:bg-stone-100 hover:text-stone-900"
+          onClick={onToggle}
+        >
+          {expanded ? (
+            <IoChevronDownOutline className="size-4" />
+          ) : (
+            <IoChevronForwardOutline className="size-4" />
+          )}
+        </button>
+      ) : (
+        <span aria-hidden className="size-6 shrink-0" />
+      )}
+
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left"
+        onClick={onOpen}
+      >
+        <span className="truncate font-medium">
+          {item.title}
+          {children.length > 0 && (
+            <span className="ml-1 text-xs font-normal text-stone-400">
+              ({children.length})
+            </span>
+          )}
+        </span>
+        <span className="truncate text-xs text-stone-500">{item.path}</span>
+      </button>
+
+      <div className="flex shrink-0 flex-col items-end gap-0.5">
+        <Badge variant={STATE_BADGES[state].variant}>
+          {STATE_BADGES[state].label}
+        </Badge>
+        {state === "scheduled" && item.publishedAt !== null && (
+          <span className="text-xs text-stone-500">
+            {formatInTimeZone(
+              new Date(item.publishedAt),
+              "Europe/London",
+              "d MMM yyyy, HH:mm",
+            )}{" "}
+            UK time
+          </span>
+        )}
+      </div>
+
+      {canManage && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label={`Actions for ${item.title}`}
+              className="shrink-0 px-2"
+            >
+              <IoEllipsisVertical className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={onNewChild}>
+              <IoAddOutline className="size-4" />
+              New child page
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!canMoveUp}
+              onSelect={() => {
+                onMove("up");
+              }}
+            >
+              <IoArrowUpOutline className="size-4" />
+              Move up
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!canMoveDown}
+              onSelect={() => {
+                onMove("down");
+              }}
+            >
+              <IoArrowDownOutline className="size-4" />
+              Move down
+            </DropdownMenuItem>
+            {state === "live" && (
+              <DropdownMenuItem asChild>
+                <a href={item.path} target="_blank" rel="noopener noreferrer">
+                  <IoOpenOutline className="size-4" />
+                  View live page
+                </a>
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </li>
+  );
+}

--- a/apps/web/src/pages/content-page.tsx
+++ b/apps/web/src/pages/content-page.tsx
@@ -5,6 +5,7 @@ import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { useSiteNav } from "@/hooks/use-site-nav.js";
 import type { paths } from "@/lib/api.gen.js";
 import {
+  isPageGone,
   pageByPathQueryOptions,
   parsePageMetadata,
 } from "@/lib/content-queries.js";
@@ -265,6 +266,33 @@ function StaticPageView({
   );
 }
 
+function NotFoundView() {
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1>Page Not Found</h1>
+      <p>The page you're looking for doesn't exist.</p>
+    </div>
+  );
+}
+
+/**
+ * Non-404/410 API failure with no static fallback: the page may well
+ * exist, we just couldn't fetch it - distinct copy from the 404 view so
+ * visitors (and screenshots in bug reports) don't conflate an outage
+ * with a missing page.
+ */
+function LoadErrorView() {
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1>We couldn't load this page</h1>
+      <p>
+        Something went wrong fetching this page. Please try again in a few
+        minutes.
+      </p>
+    </div>
+  );
+}
+
 export function Component() {
   const { pathname } = useLocation();
 
@@ -282,30 +310,46 @@ export function Component() {
   // long-lived: pages migrate to the DB one section at a time and some
   // (e.g. legal) stay static permanently, so unmigrated paths keep
   // rendering their bundled MDX indefinitely. The MDX renders only once
-  // the query settles (confirmed 404, or an API failure - deliberate
-  // graceful degradation) so a DB-edited page never flashes its stale
-  // MDX ancestor first.
-  const { data: apiPage, isPending } = useQuery({
+  // the query settles so a DB-edited page never flashes its stale MDX
+  // ancestor first. Three terminal query states:
+  //   null      - never published in the DB: static fallback, else 404.
+  //   PAGE_GONE - 410, deliberate takedown of an ever-live page: 404
+  //               view with NO static fallback (takedowns must stick)
+  //               and NO route_not_found report (nothing is missing).
+  //   error     - API incident: static fallback where one exists,
+  //               otherwise a "couldn't load" view - never the 404 copy,
+  //               never a route_not_found report (an outage must not
+  //               spike the not-found metric).
+  const { data, isPending, isError } = useQuery({
     ...pageByPathQueryOptions(path),
     enabled: isContentPath,
   });
+  const gone = isPageGone(data);
+  const apiPage = data == null || isPageGone(data) ? undefined : data;
   const staticPage = contentPageMap.get(path);
+  // What the static corpus is allowed to contribute: a 410 takedown
+  // suppresses the bundled MDX twin entirely.
+  const staticFallback = gone ? undefined : staticPage;
 
   // Sidebar + breadcrumbs come from the merged nav for both static and
   // DB-backed pages.
   const navPages = useSiteNav();
 
   useDocumentMeta(
-    apiPage?.title ?? staticPage?.title,
-    apiPage ? (apiPage.description ?? undefined) : staticPage?.description,
+    apiPage?.title ?? staticFallback?.title,
+    apiPage ? (apiPage.description ?? undefined) : staticFallback?.description,
   );
 
   // 404s land here because router.tsx's catch-all `path: "*"` routes
   // unknown paths through ContentPage rather than triggering the
   // root errorElement (#182). Forward the miss to NR so the not-
-  // found rate is observable. Only after the API query settles - a page
-  // that is still loading is not a miss.
-  const notFound = !apiPage && !staticPage && (!isContentPath || !isPending);
+  // found rate is observable. Only a settled, confirmed miss counts:
+  // still-loading pages, 410 takedowns and API errors are not misses.
+  const notFound =
+    !staticPage &&
+    !gone &&
+    !isError &&
+    (!isContentPath || (!isPending && data === null));
   useEffect(() => {
     if (!notFound) return;
     if (window.newrelic) {
@@ -330,14 +374,15 @@ export function Component() {
     );
   }
 
-  if (staticPage) {
-    return <StaticPageView page={staticPage} navPages={navPages} path={path} />;
+  if (isError && !staticFallback) {
+    return <LoadErrorView />;
   }
 
-  return (
-    <div className="container mx-auto px-4 py-12">
-      <h1>Page Not Found</h1>
-      <p>The page you're looking for doesn't exist.</p>
-    </div>
-  );
+  if (staticFallback) {
+    return (
+      <StaticPageView page={staticFallback} navPages={navPages} path={path} />
+    );
+  }
+
+  return <NotFoundView />;
 }

--- a/apps/web/src/pages/content-page.tsx
+++ b/apps/web/src/pages/content-page.tsx
@@ -1,21 +1,35 @@
+import { ContentBody } from "@/components/content-body.js";
 import { mdxComponents } from "@/components/mdx-components.js";
+import { PageLoading } from "@/components/page-loading.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
+import { useSiteNav } from "@/hooks/use-site-nav.js";
+import type { paths } from "@/lib/api.gen.js";
 import {
-  contentPageMap,
+  pageByPathQueryOptions,
+  parsePageMetadata,
+} from "@/lib/content-queries.js";
+import { contentPageMap, type ContentPage } from "@/lib/content.js";
+import {
   getBreadcrumbs,
   getNavigationTree,
-  type ContentNode,
-} from "@/lib/content.js";
+  type NavNode,
+  type NavPage,
+} from "@/lib/nav.js";
 import { MDXProvider } from "@mdx-js/react";
-import { Fragment, useEffect, useState } from "react";
+import { contentPathSchema } from "@percy-main/shared/content";
+import { useQuery } from "@tanstack/react-query";
+import { Fragment, useEffect, useState, type ReactNode } from "react";
 import { IoChevronForward } from "react-icons/io5";
 import { Link, useLocation } from "react-router";
+
+type ApiPage =
+  paths["/api/content/page/by-path"]["get"]["responses"]["200"]["content"]["application/json"];
 
 function SidebarNav({
   tree,
   currentPath,
 }: {
-  tree: ContentNode;
+  tree: NavNode;
   currentPath: string;
 }) {
   return (
@@ -70,7 +84,7 @@ function MobileSidebarNav({
   currentPath,
   isOpen,
 }: {
-  tree: ContentNode;
+  tree: NavNode;
   currentPath: string;
   isOpen: boolean;
 }) {
@@ -119,47 +133,26 @@ function MobileSidebarNav({
   );
 }
 
-export function Component() {
-  const { pathname } = useLocation();
+/**
+ * Shared page chrome: breadcrumbs, mobile section nav and desktop sidebar
+ * built from the merged nav (#493) - static and DB-backed pages get
+ * identical navigation, so a section migrating to the DB never changes
+ * how its unmigrated siblings appear.
+ */
+function PageChrome({
+  navPages,
+  path,
+  children,
+}: {
+  navPages: NavPage[];
+  path: string;
+  children: ReactNode;
+}) {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
-  // Normalize: strip trailing slash
-  const path = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
-
-  const page = contentPageMap.get(path);
-
-  useDocumentMeta(page?.title, page?.description);
-
-  // 404s land here because router.tsx's catch-all `path: "*"` routes
-  // unknown paths through ContentPage rather than triggering the
-  // root errorElement (#182). Forward the miss to NR so the not-
-  // found rate is observable.
-  useEffect(() => {
-    if (!page) {
-      if (window.newrelic) {
-        window.newrelic.noticeError(new Error(`route_not_found ${path}`), {
-          kind: "route_not_found",
-          route: path,
-        });
-      } else {
-        console.warn("route_not_found (NR not loaded):", path);
-      }
-    }
-  }, [page, path]);
-
-  if (!page) {
-    return (
-      <div className="container mx-auto px-4 py-12">
-        <h1>Page Not Found</h1>
-        <p>The page you're looking for doesn't exist.</p>
-      </div>
-    );
-  }
-
-  const navTree = getNavigationTree(path);
-  const breadcrumbs = getBreadcrumbs(path);
+  const navTree = getNavigationTree(navPages, path);
+  const breadcrumbs = getBreadcrumbs(navPages, path);
   const hasSidebar = navTree && navTree.children.length > 0;
-  const PageContent = page.Component;
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -218,15 +211,133 @@ export function Component() {
         )}
 
         {/* Content */}
-        <div className="flex min-w-0 grow flex-col">
-          <MDXProvider components={mdxComponents}>
-            <div className="mdx-content flex flex-col *:mb-4">
-              {!page.hideTitle && <h2>{page.title}</h2>}
-              <PageContent />
-            </div>
-          </MDXProvider>
-        </div>
+        <div className="flex min-w-0 grow flex-col">{children}</div>
       </div>
+    </div>
+  );
+}
+
+/** DB-backed page (page hierarchy, #493). */
+function ApiPageView({
+  page,
+  navPages,
+  path,
+}: {
+  page: ApiPage;
+  navPages: NavPage[];
+  path: string;
+}) {
+  const meta = parsePageMetadata(page.metadata);
+
+  // metadata.ldjson is deliberately not rendered: the static pipeline
+  // parses ldjson from frontmatter but nothing injects it into the
+  // document (no page sets it today), so parity means carrying the field
+  // without inventing a <script type="application/ld+json"> here.
+  return (
+    <PageChrome navPages={navPages} path={path}>
+      {!meta?.hideTitle && <h2 className="mb-4">{page.title}</h2>}
+      <ContentBody body={page.body} />
+    </PageChrome>
+  );
+}
+
+/** Bundled MDX page - the static pipeline rendering. */
+function StaticPageView({
+  page,
+  navPages,
+  path,
+}: {
+  page: ContentPage;
+  navPages: NavPage[];
+  path: string;
+}) {
+  const PageContent = page.Component;
+
+  return (
+    <PageChrome navPages={navPages} path={path}>
+      <MDXProvider components={mdxComponents}>
+        <div className="mdx-content flex flex-col *:mb-4">
+          {!page.hideTitle && <h2>{page.title}</h2>}
+          <PageContent />
+        </div>
+      </MDXProvider>
+    </PageChrome>
+  );
+}
+
+export function Component() {
+  const { pathname } = useLocation();
+
+  // Normalize: strip trailing slash
+  const path = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
+
+  // Only paths the backend could ever serve (lowercase /slug segments -
+  // the shared contentPathSchema is the source of truth) hit the API;
+  // anything else skips the query and behaves exactly as the static
+  // pipeline always has.
+  const isContentPath = contentPathSchema.safeParse(path).success;
+
+  // DB-backed page first (page hierarchy, #493). Unlike the news/events
+  // TRANSITION FALLBACK (#489), the static MDX fallback here is
+  // long-lived: pages migrate to the DB one section at a time and some
+  // (e.g. legal) stay static permanently, so unmigrated paths keep
+  // rendering their bundled MDX indefinitely. The MDX renders only once
+  // the query settles (confirmed 404, or an API failure - deliberate
+  // graceful degradation) so a DB-edited page never flashes its stale
+  // MDX ancestor first.
+  const { data: apiPage, isPending } = useQuery({
+    ...pageByPathQueryOptions(path),
+    enabled: isContentPath,
+  });
+  const staticPage = contentPageMap.get(path);
+
+  // Sidebar + breadcrumbs come from the merged nav for both static and
+  // DB-backed pages.
+  const navPages = useSiteNav();
+
+  useDocumentMeta(
+    apiPage?.title ?? staticPage?.title,
+    apiPage ? (apiPage.description ?? undefined) : staticPage?.description,
+  );
+
+  // 404s land here because router.tsx's catch-all `path: "*"` routes
+  // unknown paths through ContentPage rather than triggering the
+  // root errorElement (#182). Forward the miss to NR so the not-
+  // found rate is observable. Only after the API query settles - a page
+  // that is still loading is not a miss.
+  const notFound = !apiPage && !staticPage && (!isContentPath || !isPending);
+  useEffect(() => {
+    if (!notFound) return;
+    if (window.newrelic) {
+      window.newrelic.noticeError(new Error(`route_not_found ${path}`), {
+        kind: "route_not_found",
+        route: path,
+      });
+    } else {
+      console.warn("route_not_found (NR not loaded):", path);
+    }
+  }, [notFound, path]);
+
+  if (apiPage) {
+    return <ApiPageView page={apiPage} navPages={navPages} path={path} />;
+  }
+
+  if (isContentPath && isPending) {
+    return (
+      <div className="container mx-auto px-4 py-6">
+        <PageLoading />
+      </div>
+    );
+  }
+
+  if (staticPage) {
+    return <StaticPageView page={staticPage} navPages={navPages} path={path} />;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1>Page Not Found</h1>
+      <p>The page you're looking for doesn't exist.</p>
     </div>
   );
 }

--- a/docs/content-blocks.md
+++ b/docs/content-blocks.md
@@ -1,0 +1,169 @@
+# Content blocks reference
+
+Every custom block available in the content editor. Use the `/` slash menu while editing to insert them.
+
+Blocks are stored as part of the page body and render identically whether the page was authored with the editor or migrated from an older MDX file.
+
+---
+
+## Person card
+
+**Slash menu:** Club content > Person card
+
+Displays a profile card for a single club member, including their photo, name, and a link to their full profile page.
+
+| Prop | Type   | Required | Default | Notes                                                     |
+| ---- | ------ | -------- | ------- | --------------------------------------------------------- |
+| slug | string | Yes      |         | The person's URL slug (e.g. `alex-slaven`)                |
+| role | string | No       |         | Optional label shown beneath the name (e.g. "Head Coach") |
+
+**Typical usage:** Introduce a committee member or coach on a team page.
+
+---
+
+## Person grid
+
+**Slash menu:** Club content > Person grid
+
+Displays a responsive grid of person cards. Choose one or more people using the multi-select control inside the editor (hold Ctrl or Cmd to pick more than one).
+
+| Prop  | Type   | Required | Default | Notes                                                                                         |
+| ----- | ------ | -------- | ------- | --------------------------------------------------------------------------------------------- |
+| slugs | string | Yes      |         | Comma-separated list of person slugs (stored and managed automatically by the editor control) |
+
+**Typical usage:** Show the full committee, a coaching team, or the playing squad on an "About" page.
+
+---
+
+## Game preview
+
+**Slash menu:** Club content > Game preview
+
+Shows a live fixture or result card, pulling data from Play-Cricket. Displays the teams, date, competition, home/away indicator, and the final score where available.
+
+| Prop          | Type   | Required | Default | Notes                                                                      |
+| ------------- | ------ | -------- | ------- | -------------------------------------------------------------------------- |
+| playCricketId | string | Yes      |         | The Play-Cricket match identifier (choose from the dropdown in the editor) |
+
+**Typical usage:** Highlight a recent result or upcoming fixture inside a news article or report.
+
+---
+
+## Event preview
+
+**Slash menu:** Club content > Event preview
+
+Shows a compact event card with the date, name, and a link to the full calendar entry.
+
+| Prop    | Type   | Required | Default | Notes                                 |
+| ------- | ------ | -------- | ------- | ------------------------------------- |
+| eventId | string | Yes      |         | The internal event identifier         |
+| name    | string | Yes      |         | The event display name                |
+| when    | string | Yes      |         | The event date (ISO date or datetime) |
+
+**Typical usage:** Promote an upcoming club event from within a page or news post.
+
+---
+
+## Upload photo
+
+**Slash menu:** Club content > Upload photo
+
+Uploads an image through the consent and processing pipeline and inserts a responsive photo block. You must tick the photo consent box in the left panel before uploading.
+
+| Prop    | Type   | Required | Default | Notes                                                             |
+| ------- | ------ | -------- | ------- | ----------------------------------------------------------------- |
+| src     | string | Yes      |         | Set automatically after upload                                    |
+| alt     | string | No       |         | Describe the photo for screen readers                             |
+| caption | string | No       |         | Short caption shown beneath the image                             |
+| picture | string | No       |         | JSON descriptor used for responsive rendering (set automatically) |
+
+**Typical usage:** Add match photos, venue images, or team photos to a page or article.
+
+---
+
+## League table
+
+**Slash menu:** Page widgets > League table
+
+Fetches and displays a live standings table from Play-Cricket for a given division.
+
+If `divisionId` is not set the block renders nothing (degrades silently). No division listing is currently available through the API, so you need to look up the division ID from Play-Cricket directly.
+
+| Prop       | Type   | Required | Default | Notes                                |
+| ---------- | ------ | -------- | ------- | ------------------------------------ |
+| divisionId | string | Yes      |         | The Play-Cricket division identifier |
+| name       | string | No       |         | Heading shown above the table        |
+
+**Typical usage:** Embed the current season standings on a teams or results page.
+
+---
+
+## Leaderboard
+
+**Slash menu:** Page widgets > Leaderboard
+
+Displays the club's batting and bowling leaderboard for the current season. No configuration required.
+
+| Prop   | Type | Required | Default | Notes |
+| ------ | ---- | -------- | ------- | ----- |
+| (none) |      |          |         |       |
+
+**Typical usage:** Add to a stats or season summary page.
+
+---
+
+## Records wall
+
+**Slash menu:** Page widgets > Records wall
+
+Displays the club's all-time batting and bowling records. No configuration required.
+
+| Prop   | Type | Required | Default | Notes |
+| ------ | ---- | -------- | ------- | ----- |
+| (none) |      |          |         |       |
+
+**Typical usage:** Add to a history or honours page.
+
+---
+
+## Contact form
+
+**Slash menu:** Page widgets > Contact form
+
+Embeds a contact message form. Submissions are sent by email to the club. The form cannot be submitted from inside the editor canvas (it is read-only there).
+
+| Prop        | Type   | Required | Default | Notes                                 |
+| ----------- | ------ | -------- | ------- | ------------------------------------- |
+| title       | string | No       |         | Heading shown above the form fields   |
+| description | string | No       |         | Short paragraph shown below the title |
+
+**Typical usage:** Add to a "Contact us" page or any page where you want people to be able to send the club a message.
+
+---
+
+## Cookie settings link
+
+**Slash menu:** Page widgets > Cookie settings link
+
+Renders an inline link that, when clicked, reopens the cookie consent banner so the visitor can change their preferences.
+
+| Prop | Type   | Required | Default         | Notes                 |
+| ---- | ------ | -------- | --------------- | --------------------- |
+| text | string | No       | Cookie settings | The visible link text |
+
+**Typical usage:** Add to a Privacy Policy or Cookie Policy page so readers can update their preferences without hunting for a button.
+
+---
+
+## Consent version
+
+**Slash menu:** Page widgets > Consent version
+
+Displays the current cookie consent policy version string inline in the text. Useful on policy pages where you want to reference which version of the policy is currently active.
+
+| Prop   | Type | Required | Default | Notes |
+| ------ | ---- | -------- | ------- | ----- |
+| (none) |      |          |         |       |
+
+**Typical usage:** Include in the cookie or privacy policy page body so the version number stays accurate without manual editing.

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -90,6 +90,21 @@ export const contentSlugSchema = z
     "Slug must be lowercase letters, numbers and hyphens",
   );
 
+// ── Paths (pages only) ──────────────────────────────────────────────────
+//
+// A page's materialised URL path: one or more "/" + slug segments, each
+// segment shaped exactly like contentSlugSchema. Locked (with the slug
+// and parent) once the page has ever been published.
+
+export const contentPathSchema = z
+  .string()
+  .min(2)
+  .max(1000)
+  .regex(
+    /^(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)+$/,
+    "Path must be one or more /slug segments (lowercase letters, numbers and hyphens)",
+  );
+
 // ── Kind-specific metadata (replaces MDX frontmatter) ───────────────────
 //
 // Validated on every write by the content API. Only kinds with a schema
@@ -99,6 +114,21 @@ export const gameReportMetadataSchema = z.object({
   playCricketId: z.string().min(1),
 });
 export type GameReportMetadata = z.infer<typeof gameReportMetadataSchema>;
+
+/**
+ * Page metadata mirrors the static MDX frontmatter (apps/web
+ * lib/content.ts) so a DB-backed page renders indistinguishably from its
+ * static version: menuOrder/isMainMenu drive nav placement, hideTitle
+ * suppresses the H1, ldjson is pasted structured data (omitted when
+ * unset - never an empty string).
+ */
+export const pageMetadataSchema = z.object({
+  menuOrder: z.number().int().min(0).max(999).default(99),
+  isMainMenu: z.boolean().default(false),
+  hideTitle: z.boolean().default(false),
+  ldjson: z.record(z.string(), z.unknown()).optional(),
+});
+export type PageMetadata = z.infer<typeof pageMetadataSchema>;
 
 /**
  * One news tag. Shared between stored metadata (newsMetadataSchema) and
@@ -137,6 +167,7 @@ export type EventMetadata = z.infer<typeof eventMetadataSchema>;
 export const CONTENT_METADATA_SCHEMAS: Partial<
   Record<ContentKind, z.ZodType<Record<string, unknown>>>
 > = {
+  page: pageMetadataSchema,
   news: newsMetadataSchema,
   event: eventMetadataSchema,
   game_report: gameReportMetadataSchema,

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -105,6 +105,46 @@ export const contentPathSchema = z
     "Path must be one or more /slug segments (lowercase letters, numbers and hyphens)",
   );
 
+/**
+ * Top-level URL space a ROOT page may not occupy. Only the first path
+ * segment routes, so child pages are unaffected.
+ *
+ * Two sources:
+ *  - the SPA router's top-level literals (apps/web/src/router.tsx) -
+ *    they are matched ahead of the content catch-all, so a root page at
+ *    one of these could never be reached;
+ *  - infra prefixes (API mount, upload/asset serving, the content API
+ *    itself).
+ *
+ * Keep in lockstep with router.tsx when adding top-level routes.
+ */
+export const RESERVED_ROOT_SLUGS: ReadonlySet<string> = new Set([
+  // SPA router top-level literals
+  "news",
+  "calendar",
+  "person",
+  "fantasy",
+  "leaderboard",
+  "game",
+  "report-incident",
+  "purchase",
+  "payment",
+  "nets",
+  "availability",
+  "tell-me-about",
+  "auth",
+  "members",
+  "membership",
+  "scout",
+  "admin",
+  "junior-manager",
+  // Infra prefixes
+  "api",
+  "uploads",
+  "assets",
+  "content",
+]);
+
 // ── Kind-specific metadata (replaces MDX frontmatter) ───────────────────
 //
 // Validated on every write by the content API. Only kinds with a schema

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -191,4 +191,10 @@ export const CUSTOM_BLOCK_TYPES = {
   // PictureSource descriptor from the upload API so public pages render
   // the responsive ladder without any lookup.
   contentImage: "contentImage",
+  leagueTable: "leagueTable",
+  leaderboard: "leaderboard",
+  recordsWall: "recordsWall",
+  contactForm: "contactForm",
+  cookieSettingsLink: "cookieSettingsLink",
+  consentVersion: "consentVersion",
 } as const;


### PR DESCRIPTION
Closes #492. Four sub-issue PRs squashed onto this branch, each codex-reviewed before merge: #518 (#493 hierarchy + nav API), #519 (#494 admin tree), #520 (#495 component coverage), #521 (#496 pages migration).

## What this delivers
- **Page hierarchy in the DB**: `page` kind is now editable; parentId + materialised path (computed from slug + parent while unpublished, locked once ever-published; published descendants pin ancestor slugs). Cycle prevention, sibling-slug 409s, descendant path cascade on rename. Publish gates: parent must be published and a child's go-live can't precede its parent's; unpublish/archive reject with published children. All transitions transactional with FOR UPDATE locks.
- **Public nav + page APIs**: `GET /content/nav` (published pages: path/title/menuOrder/isMainMenu) and `GET /content/page/by-path` (canonical page lookup).
- **Merged nav model (incremental migration)**: the SPA merges API nav items with the bundled static page list (API wins per path); tree/breadcrumb/menu logic now pure + unit-tested. The catch-all page route is DB-first with the bundled MDX as fallback - same pattern as news (#489), but long-lived since legal stays static permanently. Main menu reads the merged nav.
- **Admin Pages tree**: hierarchy view with status badges, URL-persisted expansion/selection, create-child, parent picker with live path preview, sibling reorder via menuOrder, phone-friendly kebab actions.
- **Full component coverage (pre-release gate)**: every mdx-components.tsx component is insertable from the editor and rendered by ContentBody: person, personGrid (now role-preserving), gamePreview, eventPreview, contentImage, leagueTable, leaderboard, recordsWall, contactForm, cookieSettingsLink, consentVersion. In-editor previews are live, read-only, and inert (not keyboard-reachable). Editor docs at docs/content-blocks.md.
- **Pages migration script**: `migrate-pages.ts` converts content/pages/** (directory layout -> hierarchy, `_index.mdx` = parent item, deterministic image ids, idempotent path-keyed upsert, revision snapshots) and prints the nav-payload snapshot. Dry run on the real corpus: **29 migrate / 2 stay static with logged reasons / 1 excluded (legal)**.

## Decisions made during the epic (please veto if wrong)
1. **menuOrder is presentation-only and NOT publish-locked** - issue #494's wording was self-contradictory ("reorder only while unpublished" vs "published pages can still edit metadata that does not affect path"). Locking it would leave live sections permanently un-sortable when new pages join them. Move (parent/path) IS locked.
2. **Child go-live >= parent's published_at** (codex finding): preserves top-down section scheduling while preventing a live child under a not-yet-visible parent.
3. **personGrid grew an `entries` JSON prop** ([{slug, role?}]) after migration revealed the slugs-CSV design dropped 60+ role labels on committee/captain/coach grids.
4. ~~Two pages stay static~~ **Resolved**: Alex hand-edited `cricket/kit-shop` and `cricket/safeguarding` to convertible forms (9e2e018); the dry run now converts the full corpus: 31 migrate / 0 failed / 1 excluded (legal).
5. **ldjson is stored but not rendered** - parity with the static pipeline, which also never rendered it.
6. Trade-off inherited from the issue spec: unmigrated static pages show a brief loading state until the by-path query settles per stale window.

## Post-merge sequence (not in this PR)
1. Run `migrate-pages.ts` against prod (after the news/events migration per #516's sequence), verify nav payload + spot-check pages.
2. Cleanup PR: prune migrated MDX, reduce lib/content.ts to the legal/static remnant, remove the #489 news fallback.

## Verification on this branch
api 653 unit + 466 integration (testcontainers), web 540 unit, typecheck/lint zero warnings, web build clean. Each sub-PR additionally codex-reviewed with all findings fixed (gate races, keyboard-reachable previews, fallback mismatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes (post-review commit c54916d)
Full-diff review by codex + three independent reviewers (backend integrity, frontend/UX, adversarial). All confirmed findings fixed:
1. **Publish re-schedule stranding** (high): re-publishing a parent with a later go-live now 400s if any published child precedes it.
2. **Write-skew on tree mutations** (medium, 2 reviewers): all page-tree mutations take `pg_advisory_xact_lock(hashtext('content-page-tree'))` - closes concurrent-move cycles, stale cascade paths on create-vs-rename, and rename-vs-publish lock bypass. Bonus: title-only saves no longer write stale parent_id/path back.
3. **Reserved root slugs** (medium): root pages can no longer claim `/admin`, `/news`, `/uploads`, etc. (RESERVED_ROOT_SLUGS in shared, 400 on create/rename/move-to-root).
4. **Computed-path validation** (low, 2 reviewers): create/update/cascade paths must satisfy `contentPathSchema`, matching the migration script and the SPA's query gate.
5. **Archived parents** (low, 2 reviewers): rejected server-side, excluded from the picker (current selection kept, annotated).
6. **Takedown tombstones** (codex): unpublishing/archiving an ever-live page no longer resurrects its bundled MDX twin - by-path returns 410, nav carries `removed[]`, the SPA suppresses the static fallback and nav entry for tombstoned paths. API errors on DB-only pages now render a distinct load-failure state and no longer fire the NR `route_not_found` metric.

Post-fix verification: api 672 unit + 470 integration, web 555 unit, typecheck/lint zero warnings, build clean.

