### PR TITLE
Person content kind: metadata schema, API, people_editor gating (#498)

### DIFF
--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -5,6 +5,7 @@ import {
 } from "fastify-type-provider-zod";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { errorHandler } from "../../lib/error-handler.ts";
+import { buildTestApp } from "../../test/app.ts";
 import {
   seedTestUser,
   startTestContainer,
@@ -680,6 +681,280 @@ describe("content service (integration)", () => {
       } finally {
         await app.close();
       }
+    });
+  });
+
+  describe("person kind: lifecycle + safeguarding boundary (HTTP)", () => {
+    // Person profiles carry safeguarding-adjacent flags, so they are
+    // gated by content_people (people_editor / content_admin) instead of
+    // the shared content roles (#498). The boundary is an acceptance
+    // criterion in its own right, so this suite runs the REAL stack -
+    // better-auth sessions, requireAuth, assertContentPermission - not
+    // service calls.
+    let app: Awaited<ReturnType<typeof buildTestApp>>;
+    let peopleEditor: string;
+    let newsEditor: string;
+    let reportsEditor: string;
+    let contentAdmin: string;
+    /** Draft person owned by the service user - the read/write target. */
+    let fixtureId: string;
+
+    const PASSWORD = "Sup3rSecure!password";
+
+    /** Sign up + verify + sign in; returns the session cookie header. */
+    async function sessionFor(role: string): Promise<string> {
+      const email = `${crypto.randomUUID()}@example.com`;
+      const signUp = await app.inject({
+        method: "POST",
+        url: "/api/auth/sign-up/email",
+        payload: { email, password: PASSWORD, name: `Test ${role}` },
+      });
+      expect(signUp.statusCode).toBe(200);
+      // Verified email + role set directly: this suite tests the content
+      // permission boundary, not the verification email flow.
+      await ctx.db
+        .updateTable("user")
+        .set({ role, emailVerified: true })
+        .where("email", "=", email)
+        .execute();
+      const signIn = await app.inject({
+        method: "POST",
+        url: "/api/auth/sign-in/email",
+        payload: { email, password: PASSWORD },
+      });
+      expect(signIn.statusCode).toBe(200);
+      const setCookie = signIn.headers["set-cookie"];
+      const raw = Array.isArray(setCookie)
+        ? setCookie
+        : typeof setCookie === "string"
+          ? [setCookie]
+          : [];
+      const cookie = raw
+        .map((entry) => entry.split(";")[0])
+        .filter(Boolean)
+        .join("; ");
+      expect(cookie).not.toBe("");
+      return cookie;
+    }
+
+    const personPayload = (slug: string) => ({
+      kind: "person",
+      slug,
+      title: "Edith Example",
+      description: null,
+      body: body("A short bio."),
+      metadata: { isDBSChecked: false, hasLeftClub: false },
+    });
+
+    beforeAll(async () => {
+      app = await buildTestApp(ctx.db, ctx.dialect);
+      [peopleEditor, newsEditor, reportsEditor, contentAdmin] =
+        await Promise.all([
+          sessionFor("people_editor"),
+          sessionFor("news_editor"),
+          sessionFor("reports_editor"),
+          sessionFor("content_admin"),
+        ]);
+      ({ id: fixtureId } = await createContent(ctx.db)({
+        kind: "person",
+        slug: "boundary-fixture",
+        title: "Boundary Fixture",
+        description: null,
+        body: body("Fixture bio."),
+        metadata: {},
+        userId,
+      }));
+    }, 120_000);
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it("people_editor: create, edit the DBS flag, publish, public serve, revisions", async () => {
+      const create = await app.inject({
+        method: "POST",
+        url: "/api/admin/content",
+        headers: { cookie: peopleEditor },
+        payload: personPayload("edith-example"),
+      });
+      expect(create.statusCode).toBe(200);
+      const { id } = create.json<{ id: string }>();
+
+      const list = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=person",
+        headers: { cookie: peopleEditor },
+      });
+      expect(list.statusCode).toBe(200);
+      expect(
+        list.json<{ items: Array<{ id: string }> }>().items.map((i) => i.id),
+      ).toContain(id);
+
+      // Draft profiles leak nothing publicly
+      const draftPublic = await app.inject({
+        method: "GET",
+        url: "/api/content/person/edith-example",
+      });
+      expect(draftPublic.statusCode).toBe(404);
+
+      // The safeguarding edit itself: toggle the DBS flag
+      const update = await app.inject({
+        method: "PUT",
+        url: `/api/admin/content/${id}`,
+        headers: { cookie: peopleEditor },
+        payload: { metadata: { isDBSChecked: true, hasLeftClub: false } },
+      });
+      expect(update.statusCode).toBe(200);
+
+      const publish = await app.inject({
+        method: "POST",
+        url: `/api/admin/content/${id}/publish`,
+        headers: { cookie: peopleEditor },
+        payload: {},
+      });
+      expect(publish.statusCode).toBe(200);
+
+      // Public route serves the published profile (no auth) with the
+      // projected metadata
+      const pub = await app.inject({
+        method: "GET",
+        url: "/api/content/person/edith-example",
+      });
+      expect(pub.statusCode).toBe(200);
+      const served = pub.json<{
+        title: string;
+        metadata: Record<string, unknown>;
+      }>();
+      expect(served.title).toBe("Edith Example");
+      expect(served.metadata).toEqual({
+        isDBSChecked: true,
+        hasLeftClub: false,
+      });
+
+      // Both saves are in the revision history
+      const revs = await app.inject({
+        method: "GET",
+        url: `/api/admin/content/${id}/revisions`,
+        headers: { cookie: peopleEditor },
+      });
+      expect(revs.statusCode).toBe(200);
+      expect(revs.json<{ revisions: unknown[] }>().revisions).toHaveLength(2);
+    });
+
+    it.each([
+      ["news_editor", () => newsEditor],
+      ["reports_editor", () => reportsEditor],
+    ])(
+      "%s can neither read nor write person content",
+      async (_role, cookieOf) => {
+        const cookie = cookieOf();
+        const attempts = [
+          app.inject({
+            method: "GET",
+            url: "/api/admin/content?kind=person",
+            headers: { cookie },
+          }),
+          app.inject({
+            method: "GET",
+            url: `/api/admin/content/${fixtureId}`,
+            headers: { cookie },
+          }),
+          app.inject({
+            method: "POST",
+            url: "/api/admin/content",
+            headers: { cookie },
+            payload: personPayload("smuggled-profile"),
+          }),
+          app.inject({
+            method: "PUT",
+            url: `/api/admin/content/${fixtureId}`,
+            headers: { cookie },
+            payload: { metadata: { isDBSChecked: true, hasLeftClub: false } },
+          }),
+          app.inject({
+            method: "POST",
+            url: `/api/admin/content/${fixtureId}/publish`,
+            headers: { cookie },
+            payload: {},
+          }),
+          app.inject({
+            method: "POST",
+            url: `/api/admin/content/${fixtureId}/archive`,
+            headers: { cookie },
+          }),
+          app.inject({
+            method: "GET",
+            url: `/api/admin/content/${fixtureId}/revisions`,
+            headers: { cookie },
+          }),
+        ];
+        for (const attempt of await Promise.all(attempts)) {
+          expect(attempt.statusCode).toBe(403);
+        }
+        // And nothing was written or leaked
+        const fixture = await getContent(ctx.db)(fixtureId);
+        expect(fixture.metadata).toEqual({
+          isDBSChecked: false,
+          hasLeftClub: false,
+        });
+        expect(fixture.status).toBe("draft");
+      },
+    );
+
+    it("the boundary cuts both ways: people_editor has no reach into other kinds", async () => {
+      const newsList = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=news",
+        headers: { cookie: peopleEditor },
+      });
+      expect(newsList.statusCode).toBe(403);
+
+      const newsCreate = await app.inject({
+        method: "POST",
+        url: "/api/admin/content",
+        headers: { cookie: peopleEditor },
+        payload: {
+          kind: "news",
+          slug: "people-editor-news",
+          title: "Not allowed",
+          description: null,
+          body: body("Nope."),
+          metadata: { tags: [] },
+        },
+      });
+      expect(newsCreate.statusCode).toBe(403);
+
+      const reportsList = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=game_report",
+        headers: { cookie: peopleEditor },
+      });
+      expect(reportsList.statusCode).toBe(403);
+    });
+
+    it("content_admin manages person content like any other kind", async () => {
+      const list = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=person",
+        headers: { cookie: contentAdmin },
+      });
+      expect(list.statusCode).toBe(200);
+
+      const update = await app.inject({
+        method: "PUT",
+        url: `/api/admin/content/${fixtureId}`,
+        headers: { cookie: contentAdmin },
+        payload: { description: "Updated by the content admin" },
+      });
+      expect(update.statusCode).toBe(200);
+    });
+
+    it("anonymous admin requests are 401, not 403", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=person",
+      });
+      expect(res.statusCode).toBe(401);
     });
   });
 

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -179,12 +179,6 @@ beforeEach(() => {
 });
 
 describe("createContent", () => {
-  it("rejects kinds that are not editable yet", async () => {
-    await expect(
-      createContent(db)(validCreate({ kind: "person", metadata: {} })),
-    ).rejects.toMatchObject({ statusCode: 400 });
-  });
-
   it("rejects metadata that fails the kind schema", async () => {
     await expect(
       createContent(db)(validCreate({ metadata: {} })),
@@ -310,6 +304,97 @@ describe("news and event metadata", () => {
         userId: "user-1",
         metadata: { tags: "seniors" },
       }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});
+
+describe("person metadata", () => {
+  const personCreate = (metadata: Record<string, unknown>) =>
+    validCreate({
+      kind: "person" as const,
+      slug: "alice-smith",
+      title: "Alice Smith",
+      metadata,
+    });
+  const validPhoto = {
+    sources: {
+      webp: "/uploads/content/abc/img-320.webp 320w, /uploads/content/abc/img-640.webp 640w",
+    },
+    img: { src: "/uploads/content/abc/img-1920.jpeg", w: 1920, h: 1080 },
+  };
+
+  it("applies the flag defaults when metadata is empty", async () => {
+    await createContent(db)(personCreate({}));
+    const inserted = valuesArgFor() as { metadata: string };
+    expect(JSON.parse(inserted.metadata)).toEqual({
+      isDBSChecked: false,
+      hasLeftClub: false,
+    });
+  });
+
+  it("creates a person with flags and a photo descriptor", async () => {
+    await createContent(db)(
+      personCreate({
+        isDBSChecked: true,
+        hasLeftClub: false,
+        photo: validPhoto,
+      }),
+    );
+    const inserted = valuesArgFor() as { metadata: string };
+    expect(JSON.parse(inserted.metadata)).toEqual({
+      isDBSChecked: true,
+      hasLeftClub: false,
+      photo: validPhoto,
+    });
+  });
+
+  it("strips a name key - title is the single source of the display name", async () => {
+    await createContent(db)(personCreate({ name: "Someone Else" }));
+    const inserted = valuesArgFor() as { metadata: string };
+    expect(JSON.parse(inserted.metadata)).not.toHaveProperty("name");
+  });
+
+  it("rejects a photo src that is not https or site-relative", async () => {
+    await expect(
+      createContent(db)(
+        personCreate({
+          photo: {
+            ...validPhoto,
+            img: { src: "javascript:alert(1)", w: 1, h: 1 },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    await expect(
+      createContent(db)(
+        personCreate({
+          photo: {
+            ...validPhoto,
+            img: { src: "http://evil.example/x.jpg", w: 1, h: 1 },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects a srcset smuggling an unsafe URL among safe ones", async () => {
+    await expect(
+      createContent(db)(
+        personCreate({
+          photo: {
+            ...validPhoto,
+            sources: {
+              webp: "/uploads/content/abc/img-320.webp 320w, http://evil.example/x.webp 640w",
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects non-boolean flags rather than coercing", async () => {
+    await expect(
+      createContent(db)(personCreate({ isDBSChecked: "yes" })),
     ).rejects.toMatchObject({ statusCode: 400 });
   });
 });

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -24,9 +24,10 @@ function throwHttpError(statusCode: number, message: string): never {
 }
 
 /**
- * Validate kind-specific metadata against the shared schema map. Kinds
- * without a schema are not editable through the API yet (later phases
- * add theirs).
+ * Validate kind-specific metadata against the shared schema map. Every
+ * kind has a schema as of Phase 4; the missing-schema guard stays as a
+ * backstop so a future kind added to CONTENT_KINDS without one fails
+ * closed instead of accepting arbitrary metadata.
  */
 function parseMetadata(kind: ContentKind, metadata: Record<string, unknown>) {
   const schema = CONTENT_METADATA_SCHEMAS[kind];
@@ -1143,10 +1144,12 @@ function toPublic(row: {
   const kind = row.kind as ContentKind;
   // The metadata schema map doubles as the allowlist of kinds the public
   // API serves at all, and projecting through it strips undeclared keys.
-  // NOTE for later phases: a kind whose declared metadata is itself not
-  // fully public (person carries safeguarding-adjacent flags) must add a
-  // dedicated public projection schema here rather than reusing its write
-  // schema.
+  // Person reuses its write schema deliberately (#498): isDBSChecked and
+  // hasLeftClub are safeguarding-ADJACENT but public by design - the
+  // static site has always rendered the DBS badge and filtered rosters on
+  // hasLeftClub, and the content_people gate protects who can WRITE the
+  // flags, not who can see them. A future kind whose declared metadata is
+  // not fully public must add a dedicated projection schema here.
   const schema = CONTENT_METADATA_SCHEMAS[kind];
   if (!schema) throwHttpError(404, "Content not found");
   const metadata = schema.safeParse(row.metadata);

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -197,6 +197,16 @@ const SECTIONS: readonly SectionDef[] = [
         visible: (role) => checkPermission(role, "content", "view"),
         render: () => <PagesTab />,
       },
+      // "Profiles", not "People": the admin panel's default section is
+      // already called People (members/groups/juniors), and these are
+      // the public profile pages. Gated separately (content_people) -
+      // profiles carry safeguarding-adjacent flags.
+      {
+        value: "profiles",
+        label: "Profiles",
+        visible: (role) => checkPermission(role, "content_people", "view"),
+        render: () => <ContentTab kind="person" />,
+      },
     ],
   },
   {

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -252,6 +252,12 @@ function parsePictureProp(raw: string): PictureSource | null {
   } catch {
     return null;
   }
+  return parsePictureValue(parsed);
+}
+
+/** Same structural floor over an already-parsed value (person metadata
+ * stores the descriptor as an object, not a JSON string). */
+function parsePictureValue(parsed: unknown): PictureSource | null {
   // Same structural floor as the public renderer: enough shape that
   // OptimisedImage cannot crash on a malformed stored descriptor.
   const candidate = parsed as {
@@ -917,6 +923,11 @@ interface FormState {
   locationPostcode: string;
   locationLat: string;
   locationLon: string;
+  // person - title doubles as the person's name; photo holds the upload
+  // API's PictureSource descriptor (null until a photo is uploaded)
+  isDBSChecked: boolean;
+  hasLeftClub: boolean;
+  photo: PictureSource | null;
 }
 
 // ── Per-kind metadata: hydrate / validate / build ───────────────────────
@@ -998,6 +1009,9 @@ function initialForm(
     locationPostcode: asString(location?.postcode),
     locationLat: asNumberString(location?.lat),
     locationLon: asNumberString(location?.lon),
+    isDBSChecked: metadata.isDBSChecked === true,
+    hasLeftClub: metadata.hasLeftClub === true,
+    photo: parsePictureValue(metadata.photo),
   };
 }
 
@@ -1106,6 +1120,14 @@ function buildMetadata(
             },
           }
         : {}),
+    };
+  }
+  if (kind === "person") {
+    return {
+      isDBSChecked: form.isDBSChecked,
+      hasLeftClub: form.hasLeftClub,
+      // Omitted entirely when there is no photo - never null/"".
+      ...(form.photo !== null ? { photo: form.photo } : {}),
     };
   }
   return { playCricketId: form.playCricketId };
@@ -1387,12 +1409,166 @@ function PageMetadataFields({
   );
 }
 
+function PersonPhotoField({
+  photo,
+  personName,
+  consentConfirmed,
+  onChange,
+}: {
+  photo: PictureSource | null;
+  personName: string;
+  consentConfirmed: boolean;
+  onChange: (photo: PictureSource | null) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onFileChosen = async (file: File) => {
+    setUploading(true);
+    setError(null);
+    try {
+      // Same pipeline as editor images: presign -> S3 PUT -> confirm
+      // (EXIF strip + responsive ladder). The descriptor lands in
+      // metadata.photo instead of a contentImage block.
+      const uploaded = await uploadContentImage(file, {});
+      onChange(uploaded.picture);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Upload failed - try again",
+      );
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label>Profile photo (optional)</Label>
+      {photo !== null ? (
+        <OptimisedImage
+          picture={photo}
+          alt={personName || "Profile photo"}
+          className="size-32 rounded-full object-cover"
+          sizes="128px"
+          width={128}
+          height={128}
+        />
+      ) : (
+        <p className="text-xs text-stone-500">
+          No photo yet - the public profile shows a placeholder.
+        </p>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = "";
+          if (file) void onFileChosen(file);
+        }}
+      />
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={uploading}
+          onClick={() => {
+            setError(null);
+            if (!consentConfirmed) {
+              setError("Tick the photo consent box below before uploading.");
+              return;
+            }
+            fileInputRef.current?.click();
+          }}
+        >
+          {uploading
+            ? "Uploading…"
+            : photo !== null
+              ? "Replace photo"
+              : "Upload photo"}
+        </Button>
+        {photo !== null && (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={uploading}
+            onClick={() => {
+              onChange(null);
+            }}
+          >
+            Remove photo
+          </Button>
+        )}
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}
+
+function PersonMetadataFields({
+  form,
+  consentConfirmed,
+  onChange,
+}: {
+  form: FormState;
+  consentConfirmed: boolean;
+  onChange: (updates: Partial<FormState>) => void;
+}) {
+  return (
+    <>
+      <PersonPhotoField
+        photo={form.photo}
+        personName={form.title}
+        consentConfirmed={consentConfirmed}
+        onChange={(photo) => {
+          onChange({ photo });
+        }}
+      />
+      <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-stone-50 p-3">
+        <p className="text-xs leading-snug text-stone-700">
+          Safeguarding: both flags below appear on the public website, so keep
+          them accurate. Only tick DBS checked once the club has verified a
+          current certificate, and untick it if the check lapses.
+        </p>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="person-dbs-checked"
+            checked={form.isDBSChecked}
+            onCheckedChange={(value) => {
+              onChange({ isDBSChecked: value === true });
+            }}
+          />
+          <Label htmlFor="person-dbs-checked">
+            DBS checked (shows the DBS badge on the profile)
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="person-has-left-club"
+            checked={form.hasLeftClub}
+            onCheckedChange={(value) => {
+              onChange({ hasLeftClub: value === true });
+            }}
+          />
+          <Label htmlFor="person-has-left-club">
+            Has left the club (kept out of player and sponsorship pickers)
+          </Label>
+        </div>
+      </div>
+    </>
+  );
+}
+
 function MetadataFields({
   kind,
   form,
   itemId,
   slugLocked,
   tagSuggestions,
+  consentConfirmed,
   onChange,
 }: {
   kind: ContentKind;
@@ -1400,12 +1576,15 @@ function MetadataFields({
   itemId: string | null;
   slugLocked: boolean;
   tagSuggestions: string[];
+  consentConfirmed: boolean;
   onChange: (updates: Partial<FormState>) => void;
 }) {
   return (
     <>
       <div className="flex flex-col gap-1">
-        <Label htmlFor="content-title">Title</Label>
+        <Label htmlFor="content-title">
+          {kind === "person" ? "Name" : "Title"}
+        </Label>
         <Input
           id="content-title"
           value={form.title}
@@ -1601,6 +1780,13 @@ function MetadataFields({
             </div>
           )}
         </>
+      )}
+      {kind === "person" && (
+        <PersonMetadataFields
+          form={form}
+          consentConfirmed={consentConfirmed}
+          onChange={onChange}
+        />
       )}
     </>
   );
@@ -2254,6 +2440,7 @@ function LoadedEditor({
             itemId={item?.id ?? null}
             slugLocked={slugLocked}
             tagSuggestions={tagSuggestions}
+            consentConfirmed={consentConfirmed}
             onChange={onFormChange}
           />
           {item !== null && (

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -55,6 +55,7 @@ function liveUrl(
   }
   if (kind === "news") return `/news/article/${item.slug}`;
   if (kind === "event") return `/calendar/event/${item.slug}`;
+  if (kind === "person") return `/person/${item.slug}`;
   return null;
 }
 

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -204,6 +204,62 @@ export const eventMetadataSchema = z.object({
 });
 export type EventMetadata = z.infer<typeof eventMetadataSchema>;
 
+/**
+ * Image sources the public site will render: https or site-relative
+ * (uploads live under /uploads/*). Mirrors the public renderer's
+ * isSafeImageSrc so a stored descriptor can never smuggle a protocol the
+ * renderer would have to reject.
+ */
+const SAFE_IMAGE_SRC = /^(?:https:|\/(?!\/))/i;
+
+const safeSrcset = z
+  .string()
+  .min(1)
+  .refine(
+    (srcset) =>
+      srcset
+        .split(",")
+        .map((part) => part.trim().split(/\s+/)[0])
+        .every((url) => url !== undefined && SAFE_IMAGE_SRC.test(url)),
+    "Every srcset URL must be https or site-relative",
+  );
+
+/**
+ * A person's profile photo: the PictureSource descriptor returned by the
+ * content-images upload API (responsive srcsets per format + the largest
+ * fallback image), stored inline so the public profile renders without
+ * any lookup - the same precedent as the contentImage block's picture
+ * prop. Alt text is not stored: the photo is always rendered with the
+ * person's name as its alt.
+ */
+export const personPhotoSchema = z.object({
+  sources: z.record(z.string(), safeSrcset),
+  img: z.object({
+    src: z.string().regex(SAFE_IMAGE_SRC, "Must be https or site-relative"),
+    w: z.number().int().positive(),
+    h: z.number().int().positive(),
+  }),
+});
+export type PersonPhoto = z.infer<typeof personPhotoSchema>;
+
+/**
+ * Person metadata (Phase 4, #498). The person's name lives in the item's
+ * `title` column like every other kind's display name - duplicating it
+ * here would create two sources of truth. The flags are
+ * safeguarding-adjacent, which is why the person kind is gated by
+ * content_people (people_editor / content_admin) rather than the general
+ * content roles. Both flags are deliberately public: the static site has
+ * always rendered the DBS badge on profiles and filtered rosters on
+ * hasLeftClub, and parents being able to see who is DBS checked is the
+ * point of the badge. The gate protects who can WRITE them.
+ */
+export const personMetadataSchema = z.object({
+  isDBSChecked: z.boolean().default(false),
+  hasLeftClub: z.boolean().default(false),
+  photo: personPhotoSchema.optional(),
+});
+export type PersonMetadata = z.infer<typeof personMetadataSchema>;
+
 export const CONTENT_METADATA_SCHEMAS: Partial<
   Record<ContentKind, z.ZodType<Record<string, unknown>>>
 > = {
@@ -211,6 +267,7 @@ export const CONTENT_METADATA_SCHEMAS: Partial<
   news: newsMetadataSchema,
   event: eventMetadataSchema,
   game_report: gameReportMetadataSchema,
+  person: personMetadataSchema,
 };
 
 // ── Custom block types ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #498. Part of epic #497 (targets the epic branch).

## What

Enables the `person` content kind that has existed as a placeholder since Phase 1:

- **Shared schema**: `personMetadataSchema` = `{ isDBSChecked, hasLeftClub, photo? }` with both flags defaulting to false. `photo` is the PictureSource descriptor returned by the Phase 1 image upload pipeline, stored inline (same precedent as the contentImage block); every src/srcset URL is constrained to https or site-relative so a stored descriptor can never smuggle a protocol the renderer rejects.
- **API**: registering the schema in `CONTENT_METADATA_SCHEMAS` lights up the existing kind-agnostic admin routes (gated by `content_people` via `CONTENT_KIND_RESOURCES`) and the public `GET /content/person/:slug` route. No route or transport schema changes; the OpenAPI spec is unchanged.
- **Public projection decision**: person reuses its write schema as the public projection, deliberately. Both flags have always been public on the static site (the DBS badge renders on profiles; rosters filter on hasLeftClub) - `content_people` protects who can *write* them. The service NOTE is updated to record this.
- **Admin UI**: "Profiles" sub-tab under Content (named to avoid clashing with the existing People section), visible only with `content_people` view. Person editor: Title field relabelled Name, profile photo upload/replace/remove through the consent + EXIF-strip + responsive pipeline, and the two safeguarding flags as explicit toggles with a short in-UI safeguarding note.

## Deviation from the issue text

The issue sketched metadata as `{ name, ... }`. The person's name lives in the item's `title` column instead (like every other kind's display name) - duplicating it in metadata would create two sources of truth and the admin editor would need to hide or sync the title field. A unit test pins the decision (a `name` metadata key is stripped).

Also removed the "rejects kinds that are not editable yet" unit test: person was its example kind and every kind now has a schema. The missing-schema guard in `parseMetadata` stays as a fail-closed backstop.

## Acceptance criteria

- [x] news_editor / reports_editor cannot read or write person content - integration suite runs the real HTTP stack (better-auth sessions, requireAuth, assertContentPermission) and asserts 403 on list/get/create/update/publish/archive/revisions, plus no writes landed
- [x] people_editor can edit a bio, toggle the DBS flag, and replace a photo end to end (create -> edit flag -> publish -> public serve -> revisions over HTTP; photo replacement is the same upload pipeline exercised by the existing content-images tests)
- [x] Integration tests cover the permission boundary explicitly, both directions (people_editor gets 403 on news/game_report)

## Tests

- `apps/api` unit: 677 passed (new person metadata describe: defaults, photo descriptor, unsafe-src rejection incl. srcset smuggling, name stripping, non-boolean flag rejection)
- `apps/api` content integration (testcontainers): 36 passed (new HTTP boundary suite with four real role sessions)
- lint, typecheck, prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)