### PR TITLE
Migrate people profiles + render from the API (#499)

### DIFF
--- a/apps/api/scripts/image-pipeline.ts
+++ b/apps/api/scripts/image-pipeline.ts
@@ -45,11 +45,55 @@ export interface Converted {
 }
 
 /**
- * Convert one MDX body, resolving each <Image> through the editor-upload
- * processing pipeline (locally - nothing is written here, so --dry-run
- * conversion is complete and writes can be deferred until after the
- * skip/insert decision). The processed-image cache spans articles so a
- * re-used asset is only decoded once.
+ * Run one "/images/..." asset through the editor-upload processing
+ * pipeline (locally - nothing is written here, so --dry-run conversion
+ * is complete and writes can be deferred until after the skip/insert
+ * decision). The cache spans items so a re-used asset is only decoded
+ * once. Used for body <Image> tags and for frontmatter photos (people
+ * profiles, #498) alike.
+ */
+export async function prepareAsset(
+  src: string,
+  alt: string | null,
+  cache: Map<string, PendingImage>,
+): Promise<PendingImage> {
+  const imageId = imageIdForAsset(src);
+  const cached = cache.get(imageId);
+  if (cached) return cached;
+
+  if (!src.startsWith("/images/")) {
+    throw new Error(`unexpected image src '${src}'`);
+  }
+  const assetPath = path.resolve(ASSETS_DIR, src.slice("/images/".length));
+  // A '..' segment in the src could otherwise resolve outside the
+  // bundled assets tree and upload an arbitrary readable file.
+  if (!assetPath.startsWith(ASSETS_DIR + path.sep)) {
+    throw new Error(`image src '${src}' escapes the assets directory`);
+  }
+  let original: Buffer;
+  try {
+    original = await fs.readFile(assetPath);
+  } catch {
+    throw new MissingImageError(src);
+  }
+  const processed = await processImage(
+    original,
+    imageId,
+    CONTENT_IMAGES_PREFIX,
+  );
+  const pending: PendingImage = {
+    imageId,
+    publicPath: src,
+    alt,
+    processed,
+    bytes: original.byteLength,
+  };
+  cache.set(imageId, pending);
+  return pending;
+}
+
+/**
+ * Convert one MDX body, resolving each <Image> through prepareAsset.
  */
 export async function convertBody(
   body: string,
@@ -57,38 +101,7 @@ export async function convertBody(
 ): Promise<Converted> {
   const images: PendingImage[] = [];
   const blocks = await mdxToBlocks(body, async ({ src, alt, caption }) => {
-    const imageId = imageIdForAsset(src);
-    let pending = cache.get(imageId);
-    if (!pending) {
-      if (!src.startsWith("/images/")) {
-        throw new Error(`unexpected image src '${src}'`);
-      }
-      const assetPath = path.resolve(ASSETS_DIR, src.slice("/images/".length));
-      // A '..' segment in the src could otherwise resolve outside the
-      // bundled assets tree and upload an arbitrary readable file.
-      if (!assetPath.startsWith(ASSETS_DIR + path.sep)) {
-        throw new Error(`image src '${src}' escapes the assets directory`);
-      }
-      let original: Buffer;
-      try {
-        original = await fs.readFile(assetPath);
-      } catch {
-        throw new MissingImageError(src);
-      }
-      const processed = await processImage(
-        original,
-        imageId,
-        CONTENT_IMAGES_PREFIX,
-      );
-      pending = {
-        imageId,
-        publicPath: src,
-        alt: alt ?? null,
-        processed,
-        bytes: original.byteLength,
-      };
-      cache.set(imageId, pending);
-    }
+    const pending = await prepareAsset(src, alt ?? null, cache);
     images.push(pending);
     // Exactly the prop set the editor inserts (content-editor.tsx): the
     // plain src falls back to the ladder's largest original-format

--- a/apps/api/scripts/mdx-to-blocks.test.ts
+++ b/apps/api/scripts/mdx-to-blocks.test.ts
@@ -14,6 +14,7 @@ import {
   parseEventSource,
   parseNewsSource,
   parsePageSource,
+  parsePersonSource,
   resolveLocation,
   segmentMdx,
   type ResolveContentImage,
@@ -740,6 +741,64 @@ describe("parseEventSource", () => {
     );
     expect(parsed.finish).toBeUndefined();
     expect(parsed.location).toBeUndefined();
+  });
+});
+
+describe("parsePersonSource", () => {
+  it("parses full frontmatter", () => {
+    const parsed = parsePersonSource(
+      [
+        "---",
+        "name: Alex Young",
+        "slug: alex-young",
+        "photo: /images/contentful/abc/photo.jpeg",
+        "isDBSChecked: true",
+        "hasLeftClub: false",
+        "---",
+        "",
+        "Bio text.",
+      ].join("\n"),
+    );
+    expect(parsed).toEqual({
+      name: "Alex Young",
+      slug: "alex-young",
+      photo: "/images/contentful/abc/photo.jpeg",
+      isDBSChecked: true,
+      hasLeftClub: false,
+      body: "Bio text.",
+    });
+  });
+
+  it("defaults the flags and treats the photo as optional, like the static loader", () => {
+    const parsed = parsePersonSource(
+      ["---", "name: Aaditya Kapil", "slug: aaditya-kapil", "---"].join("\n"),
+    );
+    expect(parsed).toEqual({
+      name: "Aaditya Kapil",
+      slug: "aaditya-kapil",
+      isDBSChecked: false,
+      hasLeftClub: false,
+      body: "",
+    });
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() =>
+      parsePersonSource(["---", "slug: x", "---", "Bio."].join("\n")),
+    ).toThrow();
+    expect(() =>
+      parsePersonSource(["---", "name: X", "---", "Bio."].join("\n")),
+    ).toThrow();
+  });
+
+  it("rejects non-boolean flags rather than coercing", () => {
+    expect(() =>
+      parsePersonSource(
+        ["---", "name: X", "slug: x", "isDBSChecked: yes please", "---"].join(
+          "\n",
+        ),
+      ),
+    ).toThrow();
   });
 });
 

--- a/apps/api/scripts/mdx-to-blocks.ts
+++ b/apps/api/scripts/mdx-to-blocks.ts
@@ -574,6 +574,39 @@ export function parsePageSource(source: string): PageSource {
   };
 }
 
+// Mirrors the static people loader's frontmatter handling (apps/web
+// lib/people.ts): name/slug always present, photo is a public
+// "/images/..." path, the safeguarding flags default to false.
+const personFrontmatterSchema = z.object({
+  name: z.string().min(1),
+  slug: z.string().min(1),
+  photo: z.string().min(1).optional(),
+  isDBSChecked: z.boolean().default(false),
+  hasLeftClub: z.boolean().default(false),
+});
+
+export interface PersonSource {
+  name: string;
+  slug: string;
+  photo?: string;
+  isDBSChecked: boolean;
+  hasLeftClub: boolean;
+  body: string;
+}
+
+export function parsePersonSource(source: string): PersonSource {
+  const { raw, body } = splitFrontmatter(source);
+  const fm = personFrontmatterSchema.parse(raw);
+  return {
+    name: fm.name,
+    slug: fm.slug,
+    ...(fm.photo !== undefined && { photo: fm.photo }),
+    isDBSChecked: fm.isDBSChecked,
+    hasLeftClub: fm.hasLeftClub,
+    body,
+  };
+}
+
 // ── Event locations ─────────────────────────────────────────────────────
 
 export interface RawLocation {

--- a/apps/api/scripts/migrate-people.ts
+++ b/apps/api/scripts/migrate-people.ts
@@ -1,0 +1,400 @@
+/**
+ * One-off migration (#499): import the legacy MDX people profiles into
+ * the content API's tables as published person items. The frontmatter
+ * maps onto title (name) + person metadata (isDBSChecked / hasLeftClub /
+ * photo); the bio body converts to blocks; the profile photo goes
+ * through the same processing pipeline as editor uploads, with consent
+ * recorded as confirmed (pre-existing content - the consent workflow
+ * applies to new editor uploads).
+ *
+ * Idempotent: upserts by (kind=person, slug). Unchanged items are
+ * skipped; image ids are UUIDv5-derived from the source asset path, so
+ * re-runs reuse the same S3 keys and content_image rows. Items that
+ * differ from the DB are skipped with a warning unless --force (the DB
+ * is canonical after cutover).
+ *
+ * Usage (local):
+ *   DATABASE_URL=postgres://percy:percy@localhost:5433/percy_main \
+ *     S3_BUCKET=percy-main-receipts-local \
+ *     S3_ENDPOINT=http://localhost:4566 \
+ *     AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+ *     pnpm exec tsx scripts/migrate-people.ts --user <user-id> [--dry-run] [--force]
+ *
+ * Environment:
+ *   DATABASE_URL  required always (dry runs read existing rows).
+ *   S3_BUCKET     required unless --dry-run; the CloudFront uploads
+ *                 bucket (prod: see infra outputs; local: the
+ *                 percy-main-receipts-local LocalStack bucket).
+ *   S3_REGION     optional, defaults to eu-west-2.
+ *   S3_ENDPOINT   optional; set to http://localhost:4566 for LocalStack.
+ *   AWS credentials come from the SDK default chain - for a real prod
+ *   run set AWS_PROFILE=percy-main (matching the CLI profile rule).
+ *
+ * Against prod, run with the standard prod access pattern and the
+ * admin_rw URL - coordinate first; never point this at prod casually.
+ */
+import { createClient } from "@percy-main/db";
+import {
+  contentBodySchema,
+  contentSlugSchema,
+  personMetadataSchema,
+} from "@percy-main/shared/content";
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  createContentImageStore,
+  type ContentImageStore,
+} from "../src/lib/s3-content-images.ts";
+import {
+  convertBody,
+  ensureImages,
+  planImageUploads,
+  prepareAsset,
+  type PendingImage,
+} from "./image-pipeline.ts";
+import { blocksEqualIgnoringIds } from "./markdown-to-blocks.ts";
+import { jsonEqual, parsePersonSource } from "./mdx-to-blocks.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PEOPLE_DIR = path.resolve(__dirname, "../../web/content/people");
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const userFlag = args.indexOf("--user");
+  const userId = userFlag >= 0 ? args[userFlag + 1] : undefined;
+  const dryRun = args.includes("--dry-run");
+  const force = args.includes("--force");
+  if (!userId) {
+    console.error(
+      "Usage: tsx scripts/migrate-people.ts --user <user-id> [--dry-run] [--force]",
+    );
+    process.exit(1);
+  }
+  return { userId, dryRun, force };
+}
+
+async function main() {
+  const { userId, dryRun, force } = parseArgs();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+
+  // The store is only needed for real runs - a dry run must not touch S3.
+  let store: ContentImageStore | null = null;
+  if (!dryRun) {
+    const bucket = process.env.S3_BUCKET;
+    if (!bucket) {
+      console.error("S3_BUCKET is required (omit only with --dry-run)");
+      process.exit(1);
+    }
+    store = createContentImageStore({
+      S3_BUCKET: bucket,
+      S3_REGION: process.env.S3_REGION ?? "eu-west-2",
+      S3_ENDPOINT: process.env.S3_ENDPOINT,
+      // Unused here (no presigned uploads) but part of the store config.
+      CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
+    });
+  }
+
+  const { client: db } = createClient(databaseUrl);
+
+  const attributedTo = await db
+    .selectFrom("user")
+    .select(["name", "email"])
+    .where("id", "=", userId)
+    .executeTakeFirst();
+  if (!attributedTo) {
+    console.error(`No user with id '${userId}'`);
+    await db.destroy();
+    process.exit(1);
+  }
+  console.log(
+    `Attributing imports to: ${attributedTo.name} <${attributedTo.email}>`,
+  );
+
+  const files = (await fs.readdir(PEOPLE_DIR))
+    .filter((f) => f.endsWith(".mdx"))
+    .sort();
+  console.log(`Found ${String(files.length)} people in ${PEOPLE_DIR}`);
+
+  const counts = {
+    inserted: 0,
+    updated: 0,
+    unchanged: 0,
+    skipped: 0,
+    failed: 0,
+  };
+  let imagesUploaded = 0;
+  let imagesReused = 0;
+  const imageCache = new Map<string, PendingImage>();
+  // Dry-run only: ids already reported as "would upload", so an asset
+  // shared by two profiles is not double-counted.
+  const plannedUploads = new Set<string>();
+
+  // ONE shared go-live instant for everything inserted this run - people
+  // profiles have no meaningful per-item publication date.
+  const publishedAt = new Date();
+
+  const failures: { file: string; reason: string }[] = [];
+  const skipped: { file: string; reason: string }[] = [];
+  const migrated: { slug: string; action: string }[] = [];
+  // Frontmatter slugs seen this run: the DB's (kind, slug) unique index
+  // would catch a duplicate anyway, but a friendly per-file failure beats
+  // a raw constraint violation mid-run.
+  const seenSlugs = new Set<string>();
+
+  const fail = (file: string, reason: string) => {
+    counts.failed += 1;
+    failures.push({ file, reason });
+    console.warn(`  ! ${file}: ${reason}`);
+  };
+
+  for (const file of files) {
+    // ── Parse + convert ───────────────────────────────────────────────
+    interface Prepared {
+      slug: string;
+      title: string;
+      metadata: Record<string, unknown>;
+      blocks: ReturnType<typeof contentBodySchema.parse>;
+      images: PendingImage[];
+    }
+    const prepared: Prepared | null = await (async () => {
+      try {
+        const source = await fs.readFile(path.join(PEOPLE_DIR, file), "utf8");
+        const parsed = parsePersonSource(source);
+        const slug = contentSlugSchema.parse(parsed.slug);
+        if (seenSlugs.has(slug)) {
+          throw new Error(`duplicate slug '${slug}' in the people corpus`);
+        }
+        seenSlugs.add(slug);
+        const converted = await convertBody(parsed.body, imageCache);
+        const images = [...converted.images];
+        let photo: PendingImage | undefined;
+        if (parsed.photo !== undefined) {
+          // The photo's alt is always the person's name at render time,
+          // so none is stored on the image row.
+          photo = await prepareAsset(parsed.photo, null, imageCache);
+          images.push(photo);
+        }
+        // The service validates metadata + body on every write; the
+        // script writes directly, so it runs the same gates.
+        const metadata = personMetadataSchema.parse({
+          isDBSChecked: parsed.isDBSChecked,
+          hasLeftClub: parsed.hasLeftClub,
+          ...(photo !== undefined && { photo: photo.processed.picture }),
+        });
+        const blocks = contentBodySchema.parse(converted.blocks);
+        return { slug, title: parsed.name, metadata, blocks, images };
+      } catch (err) {
+        fail(file, err instanceof Error ? err.message : String(err));
+        return null;
+      }
+    })();
+    if (prepared === null) continue;
+    const { slug, title, metadata, blocks, images } = prepared;
+
+    // ── Upsert ────────────────────────────────────────────────────────
+    const existing = await db
+      .selectFrom("content_item")
+      .select(["id", "body", "title", "description", "metadata", "status"])
+      .where("kind", "=", "person")
+      .where("slug", "=", slug)
+      .executeTakeFirst();
+
+    if (existing) {
+      // Same stance as the earlier migrations: a non-published row would
+      // still 404 publicly, and a published row an editor may have
+      // touched is only overwritten under --force (post-cutover the DB
+      // is canonical and the MDX is the stale ancestor).
+      if (existing.status !== "published") {
+        counts.skipped += 1;
+        const reason = `a ${existing.status} person already exists at '${slug}' - the public endpoint will 404. Publish or remove it, then re-run.`;
+        skipped.push({ file, reason });
+        console.warn(`  ! ${file}: ${reason}`);
+        continue;
+      }
+
+      const unchanged =
+        blocksEqualIgnoringIds(existing.body, blocks) &&
+        existing.title === title &&
+        existing.description === null &&
+        jsonEqual(existing.metadata, metadata);
+      if (unchanged) {
+        counts.unchanged += 1;
+        migrated.push({ slug, action: "unchanged" });
+        console.log(`  = ${file} unchanged (${existing.title})`);
+        continue;
+      }
+      if (!force) {
+        counts.skipped += 1;
+        const reason = `published profile '${existing.title}' differs from the MDX conversion (likely edited in the DB). Skipping - re-run with --force to overwrite.`;
+        skipped.push({ file, reason });
+        console.warn(`  ! ${file}: ${reason}`);
+        continue;
+      }
+
+      if (dryRun) {
+        const { newImages, reused } = await planImageUploads(
+          db,
+          images,
+          plannedUploads,
+        );
+        imagesReused += reused;
+        imagesUploaded += newImages.length;
+        console.log(
+          `  ~ ${file} would update '${title}' (${String(blocks.length)} blocks, ${String(images.length)} images)`,
+        );
+        for (const image of newImages) {
+          console.log(`    ~ would upload ${image.publicPath}`);
+        }
+        counts.updated += 1;
+        migrated.push({ slug, action: "updated" });
+        continue;
+      }
+
+      if (!store) throw new Error("store unavailable outside a real run");
+      const ensured = await ensureImages(db, store, userId, images);
+      imagesUploaded += ensured.uploaded;
+      imagesReused += ensured.reused;
+
+      // slug/status/published_at untouched: rewriting published_at would
+      // rewrite the profile's go-live history.
+      await db.transaction().execute(async (tx) => {
+        await tx
+          .updateTable("content_item")
+          .set({
+            title,
+            description: null,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(metadata),
+            updated_by: userId,
+            updated_at: new Date(),
+          })
+          .where("id", "=", existing.id)
+          .execute();
+        await tx
+          .insertInto("content_revision")
+          .values({
+            content_id: existing.id,
+            title,
+            description: null,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(metadata),
+            saved_by: userId,
+          })
+          .execute();
+      });
+      counts.updated += 1;
+      migrated.push({ slug, action: "updated" });
+      console.log(`  ^ ${file} updated (${title})`);
+      continue;
+    }
+
+    // ── Insert ────────────────────────────────────────────────────────
+    if (dryRun) {
+      const { newImages, reused } = await planImageUploads(
+        db,
+        images,
+        plannedUploads,
+      );
+      imagesReused += reused;
+      imagesUploaded += newImages.length;
+      console.log(
+        `  ~ ${file} would insert '${title}' (${String(blocks.length)} blocks, ${String(images.length)} images, published_at ${publishedAt.toISOString()})`,
+      );
+      for (const image of newImages) {
+        console.log(`    ~ would upload ${image.publicPath}`);
+      }
+      counts.inserted += 1;
+      migrated.push({ slug, action: "inserted" });
+      continue;
+    }
+
+    if (!store) throw new Error("store unavailable outside a real run");
+    // Images first: like the editor flow, content_image rows + variants
+    // exist before any item referencing them is saved.
+    const ensured = await ensureImages(db, store, userId, images);
+    imagesUploaded += ensured.uploaded;
+    imagesReused += ensured.reused;
+
+    await db.transaction().execute(async (tx) => {
+      const inserted = await tx
+        .insertInto("content_item")
+        .values({
+          kind: "person",
+          slug,
+          title,
+          description: null,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          status: "published",
+          published_at: publishedAt,
+          created_by: userId,
+          updated_by: userId,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      await tx
+        .insertInto("content_revision")
+        .values({
+          content_id: inserted.id,
+          title,
+          description: null,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          saved_by: userId,
+        })
+        .execute();
+    });
+    counts.inserted += 1;
+    migrated.push({ slug, action: "inserted" });
+    console.log(`  + ${file} inserted as '${title}'`);
+  }
+
+  // ── Report ────────────────────────────────────────────────────────────
+
+  console.log("");
+  console.log("=== Migration report ===");
+  console.log(
+    `People: ${String(counts.inserted)} inserted, ${String(counts.updated)} updated, ${String(counts.unchanged)} unchanged, ${String(counts.skipped)} skipped, ${String(counts.failed)} failed`,
+  );
+  console.log(
+    `Images: ${String(imagesUploaded)} ${dryRun ? "would be uploaded" : "uploaded"}, ${String(imagesReused)} reused`,
+  );
+
+  console.log(`Migrated (${String(migrated.length)}):`);
+  for (const item of migrated) {
+    console.log(`  ${item.slug} (${item.action})`);
+  }
+  console.log(`Failed (${String(failures.length)}):`);
+  for (const failure of failures) {
+    console.log(`  ${failure.file}: ${failure.reason}`);
+  }
+  console.log(`Skipped (${String(skipped.length)}):`);
+  for (const item of skipped) {
+    console.log(`  ${item.file}: ${item.reason}`);
+  }
+
+  console.log(
+    `Done with ${String(failures.length + skipped.length)} warnings${dryRun ? " (dry run)" : ""}`,
+  );
+  if (failures.length + skipped.length > 0) {
+    // People have a per-slug fallback: a profile with no published DB row
+    // keeps rendering from the static bundle (TRANSITION FALLBACK #489),
+    // so a partial migration is safe - but the static MDX cleanup must
+    // not remove files listed above.
+    console.warn(
+      "NOTE: failed/skipped profiles keep rendering from the static bundle " +
+        "via the per-slug fallback. Do NOT delete their MDX in the " +
+        "cleanup PR until they are resolved and re-run.",
+    );
+    process.exitCode = 2;
+  }
+  await db.destroy();
+}
+
+await main();

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -999,6 +999,52 @@ describe("content service (integration)", () => {
         hasLeftClub: true,
       });
     });
+
+    it("tombstones a taken-down profile: 410 by slug, listed in removed", async () => {
+      // The SPA falls back to its bundled static profile on 404, so a
+      // takedown (safeguarding-relevant for people) must not read as
+      // "missing" - same rule as the page by-path tombstone.
+      const { id } = await createContent(ctx.db)({
+        kind: "person",
+        slug: "tomb-person",
+        title: "Tomb Person",
+        description: null,
+        body: body("Was live."),
+        metadata: {},
+        userId,
+      });
+      await publishContent(ctx.db)({ contentId: id, userId });
+      await unpublishContent(ctx.db)({ contentId: id, userId });
+
+      const bySlug = await app.inject({
+        method: "GET",
+        url: "/api/content/person/tomb-person",
+      });
+      expect(bySlug.statusCode).toBe(410);
+      expect(bySlug.json()).toEqual({
+        error: "This profile has been removed",
+      });
+      expect(bySlug.headers.etag).toBeUndefined();
+
+      const roster = await app.inject({
+        method: "GET",
+        url: "/api/content/people",
+      });
+      const { items, removed } = roster.json<{
+        items: Array<{ slug: string }>;
+        removed: string[];
+      }>();
+      expect(removed).toContain("tomb-person");
+      expect(items.map((i) => i.slug)).not.toContain("tomb-person");
+
+      // Never-live drafts stay 404 and out of removed - they leak nothing
+      const draft = await app.inject({
+        method: "GET",
+        url: "/api/content/person/boundary-fixture",
+      });
+      expect(draft.statusCode).toBe(404);
+      expect(removed).not.toContain("boundary-fixture");
+    });
   });
 
   describe("page hierarchy", () => {

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -956,6 +956,49 @@ describe("content service (integration)", () => {
       });
       expect(res.statusCode).toBe(401);
     });
+
+    it("the public roster lists published people only, title-ordered", async () => {
+      // One published (from the lifecycle test) + the draft fixture. Add
+      // a second published person to assert ordering.
+      const { id } = await createContent(ctx.db)({
+        kind: "person",
+        slug: "aaron-aardvark",
+        title: "Aaron Aardvark",
+        description: null,
+        body: body("First alphabetically."),
+        metadata: { isDBSChecked: false, hasLeftClub: true },
+        userId,
+      });
+      await publishContent(ctx.db)({ contentId: id, userId });
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/content/people",
+      });
+      expect(res.statusCode).toBe(200);
+      const { items } = res.json<{
+        items: Array<{
+          slug: string;
+          title: string;
+          metadata: Record<string, unknown>;
+        }>;
+      }>();
+      const slugs = items.map((i) => i.slug);
+      expect(slugs).toContain("aaron-aardvark");
+      expect(slugs).toContain("edith-example");
+      // The draft fixture stays out of the public roster
+      expect(slugs).not.toContain("boundary-fixture");
+      // Title-ordered
+      expect(slugs.indexOf("aaron-aardvark")).toBeLessThan(
+        slugs.indexOf("edith-example"),
+      );
+      // Metadata is projected through the person schema
+      const aaron = items.find((i) => i.slug === "aaron-aardvark");
+      expect(aaron?.metadata).toEqual({
+        isDBSChecked: false,
+        hasLeftClub: true,
+      });
+    });
   });
 
   describe("page hierarchy", () => {

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -298,12 +298,20 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   );
 
+  // 410 = person tombstone: the profile WAS live at this slug but has
+  // been taken down; the SPA must not fall back to its bundled static
+  // version (404 keeps that fallback for never-live slugs). Other kinds
+  // never produce a 410 here.
   app.get(
     "/content/:kind/:slug",
     {
       schema: {
         params: publicContentParamsSchema,
-        response: { 200: publicContentResponseSchema, 304: z.null() },
+        response: {
+          200: publicContentResponseSchema,
+          304: z.null(),
+          410: goneResponseSchema,
+        },
       },
     },
     async (request, reply) => {

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -20,6 +20,7 @@ import {
   listEventsResponseSchema,
   listNewsQuerySchema,
   listNewsResponseSchema,
+  listPeopleResponseSchema,
   listRevisionsResponseSchema,
   navResponseSchema,
   pageByPathQuerySchema,
@@ -43,6 +44,7 @@ import {
   listPageTree,
   listPublishedEvents,
   listPublishedNews,
+  listPublishedPeople,
   listRevisions,
   publishContent,
   unpublishContent,
@@ -89,6 +91,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const publicGameReport = getPublishedGameReport(app.db);
   const publicNews = listPublishedNews(app.db);
   const publicEvents = listPublishedEvents(app.db);
+  const publicPeople = listPublishedPeople(app.db);
   const publicNav = getPublishedNav(app.db);
   const publicPageByPath = getPublishedPageByPath(app.db);
 
@@ -369,6 +372,18 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async () => {
       return await publicEvents();
+    },
+  );
+
+  app.get(
+    "/content/people",
+    {
+      schema: {
+        response: { 200: listPeopleResponseSchema },
+      },
+    },
+    async () => {
+      return await publicPeople();
     },
   );
 

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -225,6 +225,15 @@ export const listEventsResponseSchema = z.object({
   items: z.array(publicListItemSchema),
 });
 
+/**
+ * All published people, title-ordered. Backs person cards/grids, the
+ * public profile index and the editor's people pickers from a single
+ * cached request (~55 rows sitewide, so no pagination).
+ */
+export const listPeopleResponseSchema = z.object({
+  items: z.array(publicListItemSchema),
+});
+
 // ── Public: pages (nav + by-path) ───────────────────────────────────────
 
 /**

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -232,6 +232,13 @@ export const listEventsResponseSchema = z.object({
  */
 export const listPeopleResponseSchema = z.object({
   items: z.array(publicListItemSchema),
+  /**
+   * Tombstoned slugs: people who were publicly live but are no longer
+   * visible (unpublished/archived after going live). The SPA drops
+   * matching entries from its bundled static corpus so a takedown does
+   * not resurrect the stale static profile (same pattern as nav.removed).
+   */
+  removed: z.array(z.string()),
 });
 
 // ── Public: pages (nav + by-path) ───────────────────────────────────────

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -1206,7 +1206,26 @@ export function getPublishedContent(db: Kysely<DB>) {
 
     const row = await query.executeTakeFirst();
 
-    if (!row) throwHttpError(404, "Content not found");
+    if (!row) {
+      // Person tombstone, mirroring the by-path page rule: the SPA falls
+      // back to its bundled static profile on 404, so taking down a
+      // migrated profile (unpublish/archive - safeguarding-relevant for
+      // people) must not read as "missing" and resurrect the stale
+      // static version. Ever-live (past published_at) but not visible
+      // now is 410 Gone; never-live rows stay 404 and leak nothing.
+      if (params.kind === "person") {
+        const tombstone = await db
+          .selectFrom("content_item")
+          .select("id")
+          .where("kind", "=", "person")
+          .where("slug", "=", params.slug)
+          .where("published_at", "is not", null)
+          .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`)
+          .executeTakeFirst();
+        if (tombstone) throwHttpError(410, "This profile has been removed");
+      }
+      throwHttpError(404, "Content not found");
+    }
     return toPublic(row);
   };
 }
@@ -1468,8 +1487,26 @@ export function listPublishedPeople(db: Kysely<DB>) {
       .orderBy("title", "asc")
       .execute();
 
+    // Tombstoned slugs (same ever-live test as the by-slug 410): people
+    // who WERE publicly live but are not visible now. The SPA drops
+    // matching entries from its bundled static corpus so a takedown does
+    // not resurrect the stale static profile in cards and pickers. The
+    // status partition makes the two queries consistent without a
+    // transaction: a row is either published (items candidate) or not
+    // (removed candidate), never both.
+    const removedRows = await db
+      .selectFrom("content_item")
+      .select("slug")
+      .where("kind", "=", "person")
+      .where("status", "!=", "published")
+      .where("published_at", "is not", null)
+      .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`)
+      .orderBy("slug", "asc")
+      .execute();
+
     return {
       items: rows.map((row) => toPublicListItem(personMetadataSchema, row)),
+      removed: removedRows.map((row) => row.slug),
     };
   };
 }

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -6,6 +6,7 @@ import {
   eventMetadataSchema,
   newsMetadataSchema,
   pageMetadataSchema,
+  personMetadataSchema,
   RESERVED_ROOT_SLUGS,
   type ContentKind,
   type ContentStatus,
@@ -1451,6 +1452,24 @@ export function listPublishedEvents(db: Kysely<DB>) {
 
     return {
       items: rows.map((row) => toPublicListItem(eventMetadataSchema, row)),
+    };
+  };
+}
+
+export function listPublishedPeople(db: Kysely<DB>) {
+  return async () => {
+    // No pagination: ~55 profiles sitewide, and every consumer (person
+    // cards, grids, the profile pickers in the editor) wants the whole
+    // roster in one cached request - resolving cards per-slug would be
+    // an N+1 every time a page renders a person grid.
+    const rows = await publishedOnly(db)
+      .select(publicListColumns)
+      .where("kind", "=", "person")
+      .orderBy("title", "asc")
+      .execute();
+
+    return {
+      items: rows.map((row) => toPublicListItem(personMetadataSchema, row)),
     };
   };
 }

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13841,6 +13841,17 @@ export interface paths {
                         "application/json": null;
                     };
                 };
+                /** @description Default Response */
+                410: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         put?: never;
@@ -14071,6 +14082,7 @@ export interface paths {
                                 publishedAt: string;
                                 updatedAt: string;
                             }[];
+                            removed: string[];
                         };
                     };
                 };

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -14037,6 +14037,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/content/people": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                slug: string;
+                                title: string;
+                                description: string | null;
+                                metadata: {
+                                    [key: string]: unknown;
+                                };
+                                publishedAt: string;
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/nav": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -25346,6 +25346,69 @@
         }
       }
     },
+    "/api/content/people": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "slug",
+                          "title",
+                          "description",
+                          "metadata",
+                          "publishedAt",
+                          "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/nav": {
       "get": {
         "responses": {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -24971,6 +24971,25 @@
                 }
               }
             }
+          },
+          "410": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }
@@ -25396,10 +25415,17 @@
                         ],
                         "additionalProperties": false
                       }
+                    },
+                    "removed": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
-                    "items"
+                    "items",
+                    "removed"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -12,7 +12,7 @@ import {
   CURRENT_CONSENT_VERSION,
   requestConsentReopen,
 } from "@/lib/marketing/consent.js";
-import { getPersonBySlug } from "@/lib/people.js";
+import { usePeople } from "@/lib/use-people.js";
 import { cn } from "@/lib/utils.js";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { formatInTimeZone } from "date-fns-tz";
@@ -32,9 +32,12 @@ function RecordsWall() {
 }
 
 function Person({ slug, role }: { slug: string; role?: string }) {
-  const person = getPersonBySlug(slug);
+  // Merged roster: DB-backed people first, bundled MDX corpus as the
+  // per-slug fallback during the migration transition (#499). One cached
+  // list query serves every card on the page.
+  const person = usePeople().get(slug);
   const name = person?.name ?? slug;
-  const picture = person?.photoPicture ?? ANON_PICTURE;
+  const picture = person?.picture ?? ANON_PICTURE;
 
   return (
     <div className="person h-full rounded-lg bg-white pb-4 text-stone-900 shadow-md">
@@ -50,7 +53,7 @@ function Person({ slug, role }: { slug: string; role?: string }) {
         ) : (
           <img
             className="size-24 object-cover object-center"
-            src={person?.photo ?? ANON_IMAGE}
+            src={person?.photoUrl ?? ANON_IMAGE}
             alt={name}
           />
         )}

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13841,6 +13841,17 @@ export interface paths {
                         "application/json": null;
                     };
                 };
+                /** @description Default Response */
+                410: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         put?: never;
@@ -14071,6 +14082,7 @@ export interface paths {
                                 publishedAt: string;
                                 updatedAt: string;
                             }[];
+                            removed: string[];
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -14037,6 +14037,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/content/people": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                slug: string;
+                                title: string;
+                                description: string | null;
+                                metadata: {
+                                    [key: string]: unknown;
+                                };
+                                publishedAt: string;
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/nav": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -25346,6 +25346,69 @@
         }
       }
     },
+    "/api/content/people": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "slug",
+                          "title",
+                          "description",
+                          "metadata",
+                          "publishedAt",
+                          "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/nav": {
       "get": {
         "responses": {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -24971,6 +24971,25 @@
                 }
               }
             }
+          },
+          "410": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }
@@ -25396,10 +25415,17 @@
                         ],
                         "additionalProperties": false
                       }
+                    },
+                    "removed": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
-                    "items"
+                    "items",
+                    "removed"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/lib/content-queries.ts
+++ b/apps/web/src/lib/content-queries.ts
@@ -2,9 +2,11 @@ import {
   eventMetadataSchema,
   newsMetadataSchema,
   pageMetadataSchema,
+  personMetadataSchema,
   type EventMetadata,
   type NewsMetadata,
   type PageMetadata,
+  type PersonMetadata,
 } from "@percy-main/shared/content";
 import { queryOptions } from "@tanstack/react-query";
 import { api, callApi } from "./api-client.js";
@@ -77,6 +79,27 @@ export function eventQueryOptions(slug: string) {
         return await callApi(
           api.GET("/api/content/{kind}/{slug}", {
             params: { path: { kind: "event", slug } },
+          }),
+        );
+      } catch (err) {
+        // Not published in the DB - callers fall back to the bundled MDX.
+        if ((err as { status?: number }).status === 404) return null;
+        throw err;
+      }
+    },
+    staleTime: detailStaleTime,
+    retry: false,
+  });
+}
+
+export function personQueryOptions(slug: string) {
+  return queryOptions({
+    queryKey: ["content", "person", slug],
+    queryFn: async () => {
+      try {
+        return await callApi(
+          api.GET("/api/content/{kind}/{slug}", {
+            params: { path: { kind: "person", slug } },
           }),
         );
       } catch (err) {
@@ -164,6 +187,16 @@ export function eventsListQueryOptions() {
   });
 }
 
+// One cached roster backs every person card, grid and picker - resolving
+// cards per-slug would be an N+1 each time a page renders a person grid.
+export function peopleListQueryOptions() {
+  return queryOptions({
+    queryKey: ["content", "people-list"],
+    queryFn: () => callApi(api.GET("/api/content/people")),
+    staleTime: STALE_TIME,
+  });
+}
+
 // The generated OpenAPI types carry metadata as a loose record; the shared
 // Zod schemas are the source of truth for each kind's shape, so narrow
 // through them rather than asserting.
@@ -182,5 +215,12 @@ export function parseEventMetadata(
 
 export function parsePageMetadata(metadata: unknown): PageMetadata | undefined {
   const parsed = pageMetadataSchema.safeParse(metadata);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function parsePersonMetadata(
+  metadata: unknown,
+): PersonMetadata | undefined {
+  const parsed = personMetadataSchema.safeParse(metadata);
   return parsed.success ? parsed.data : undefined;
 }

--- a/apps/web/src/lib/content-queries.ts
+++ b/apps/web/src/lib/content-queries.ts
@@ -103,8 +103,15 @@ export function personQueryOptions(slug: string) {
           }),
         );
       } catch (err) {
-        // Not published in the DB - callers fall back to the bundled MDX.
-        if ((err as { status?: number }).status === 404) return null;
+        const status = (err as { status?: number }).status;
+        // Never published in the DB - callers fall back to the bundled
+        // MDX.
+        if (status === 404) return null;
+        // Ever-live profile taken down (unpublished/archived). A
+        // terminal data state, not an error: callers render "not found"
+        // without the static fallback - a takedown must not resurrect
+        // the bundled MDX profile (same sentinel as pages).
+        if (status === 410) return PAGE_GONE;
         throw err;
       }
     },

--- a/apps/web/src/lib/use-people.ts
+++ b/apps/web/src/lib/use-people.ts
@@ -1,0 +1,76 @@
+import type { PictureSource } from "@/components/optimised-image.js";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import {
+  parsePersonMetadata,
+  peopleListQueryOptions,
+} from "./content-queries.js";
+import { getAllPeople } from "./people.js";
+
+// DB-backed people resolution (#499) with the bundled MDX corpus as a
+// per-slug fallback until the migration is verified in prod (TRANSITION
+// FALLBACK #489 - the cleanup PR removes people.ts and the fallback
+// together). The whole roster rides one cached list query, so a page
+// full of person cards costs one request, not one per card.
+
+/** Person fields shared by API-backed and static-bundled profiles. */
+export interface PersonSummary {
+  slug: string;
+  name: string;
+  /** Responsive picture (API photo descriptor or static optimised import). */
+  picture?: PictureSource;
+  /** Static corpus only: plain <img> URL when no picture exists. */
+  photoUrl?: string;
+  isDBSChecked: boolean;
+  hasLeftClub: boolean;
+}
+
+/**
+ * Every known person, keyed by slug. The API roster wins per slug; static
+ * people missing from it (not migrated yet, or the query is still
+ * pending/failed) fill the gaps, so cards render instantly from the
+ * bundle and never break on API trouble.
+ */
+export function usePeople(): Map<string, PersonSummary> {
+  const { data } = useQuery(peopleListQueryOptions());
+
+  return useMemo(() => {
+    const map = new Map<string, PersonSummary>();
+    for (const person of getAllPeople()) {
+      map.set(person.slug, {
+        slug: person.slug,
+        name: person.name,
+        ...(person.photoPicture !== undefined && {
+          picture: person.photoPicture,
+        }),
+        ...(person.photo !== undefined && { photoUrl: person.photo }),
+        isDBSChecked: person.isDBSChecked,
+        hasLeftClub: person.hasLeftClub,
+      });
+    }
+    for (const item of data?.items ?? []) {
+      const meta = parsePersonMetadata(item.metadata);
+      // A roster row whose metadata fails its schema is unrenderable -
+      // keep the static entry (if any) rather than a half-built one.
+      if (!meta) continue;
+      map.set(item.slug, {
+        slug: item.slug,
+        name: item.title,
+        ...(meta.photo !== undefined && { picture: meta.photo }),
+        isDBSChecked: meta.isDBSChecked,
+        hasLeftClub: meta.hasLeftClub,
+      });
+    }
+    return map;
+  }, [data]);
+}
+
+/** The merged roster as a name-sorted list (pickers, grids). */
+export function usePeopleList(): PersonSummary[] {
+  const people = usePeople();
+  return useMemo(
+    () =>
+      Array.from(people.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    [people],
+  );
+}

--- a/apps/web/src/lib/use-people.ts
+++ b/apps/web/src/lib/use-people.ts
@@ -48,6 +48,11 @@ export function usePeople(): Map<string, PersonSummary> {
         hasLeftClub: person.hasLeftClub,
       });
     }
+    // Tombstones: profiles that WERE live but have been taken down must
+    // not resurrect from the static bundle (same rule as nav.removed).
+    for (const slug of data?.removed ?? []) {
+      map.delete(slug);
+    }
     for (const item of data?.items ?? []) {
       const meta = parsePersonMetadata(item.metadata);
       // A roster row whose metadata fails its schema is unrenderable -

--- a/apps/web/src/pages/admin/content-editor.schema.test.ts
+++ b/apps/web/src/pages/admin/content-editor.schema.test.ts
@@ -55,6 +55,10 @@ vi.mock("@/lib/people.js", () => ({
   getAllPeople: () => [],
   getPersonBySlug: () => undefined,
 }));
+vi.mock("@/lib/use-people.js", () => ({
+  usePeople: () => new Map<string, never>(),
+  usePeopleList: () => [],
+}));
 vi.mock("@/lib/image-map.js", () => ({
   getImageUrl: () => undefined,
   getPicture: () => undefined,

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -58,11 +58,11 @@ import { useHasPermission } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client.js";
 import type { paths } from "@/lib/api.gen.js";
 import { uploadContentImage } from "@/lib/content-images.js";
-import { getAllPeople } from "@/lib/people.js";
 import {
   parsePersonGridEntries,
   type PersonGridEntry,
 } from "@/lib/person-grid.js";
+import { usePeopleList } from "@/lib/use-people.js";
 import {
   CONTENT_KIND_RESOURCES,
   contentBodySchema,
@@ -91,6 +91,39 @@ import {
 // maps them 1:1. Each block renders the real public component read-only
 // in-editor, with minimal prop controls underneath.
 
+/**
+ * Single-person picker over the merged roster (DB-backed people first,
+ * static corpus filling the gaps during the migration transition). A
+ * component of its own so the roster hook lives outside the block-spec
+ * render functions.
+ */
+function PersonSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (slug: string) => void;
+}) {
+  const people = usePeopleList();
+  return (
+    <select
+      aria-label="Person"
+      value={value}
+      onChange={(e) => {
+        onChange(e.target.value);
+      }}
+      className="rounded border border-stone-300 bg-white p-1 text-sm"
+    >
+      <option value="">Choose a person…</option>
+      {people.map((p) => (
+        <option key={p.slug} value={p.slug}>
+          {p.name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
 const personBlock = createReactBlockSpec(
   {
     type: CUSTOM_BLOCK_TYPES.person,
@@ -113,23 +146,14 @@ const personBlock = createReactBlockSpec(
         ) : (
           <p className="text-sm text-stone-500">Choose a person…</p>
         )}
-        <select
-          aria-label="Person"
+        <PersonSelect
           value={block.props.slug}
-          onChange={(e) => {
+          onChange={(slug) => {
             editor.updateBlock(block, {
-              props: { ...block.props, slug: e.target.value },
+              props: { ...block.props, slug },
             });
           }}
-          className="rounded border border-stone-300 bg-white p-1 text-sm"
-        >
-          <option value="">Choose a person…</option>
-          {getAllPeople().map((p) => (
-            <option key={p.slug} value={p.slug}>
-              {p.name}
-            </option>
-          ))}
-        </select>
+        />
         <input
           aria-label="Role shown on the card"
           placeholder="Role (optional)"
@@ -364,9 +388,6 @@ const personGridBlock = createReactBlockSpec(
           const trimmed = s.trim();
           return trimmed ? [{ slug: trimmed }] : [];
         });
-      const allPeople = getAllPeople();
-      const nameOf = (slug: string) =>
-        allPeople.find((p) => p.slug === slug)?.name ?? slug;
       const write = (next: PersonGridEntry[]) => {
         editor.updateBlock(block, {
           props: {
@@ -394,61 +415,82 @@ const personGridBlock = createReactBlockSpec(
           ) : (
             <p className="text-sm text-stone-500">Choose people to display…</p>
           )}
-          <div className="flex flex-col gap-1">
-            <p className="text-xs text-stone-500">
-              Select people (hold Ctrl/Cmd to pick multiple):
-            </p>
-            <select
-              aria-label="People"
-              multiple
-              size={Math.min(allPeople.length, 6)}
-              value={entries.map((e) => e.slug)}
-              onChange={(e) => {
-                const chosen = Array.from(e.target.selectedOptions).map(
-                  (o) => o.value,
-                );
-                // People who stay selected keep their role; newly
-                // selected people start role-less.
-                write(
-                  chosen.map(
-                    (slug) =>
-                      entries.find((entry) => entry.slug === slug) ?? { slug },
-                  ),
-                );
-              }}
-              className="rounded border border-stone-300 bg-white p-1 text-sm"
-            >
-              {allPeople.map((p) => (
-                <option key={p.slug} value={p.slug}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          {entries.map((entry, i) => (
-            <input
-              key={`${entry.slug}-${String(i)}`}
-              aria-label={`Role shown for ${nameOf(entry.slug)}`}
-              placeholder={`Role for ${nameOf(entry.slug)} (optional)`}
-              value={entry.role ?? ""}
-              onChange={(e) => {
-                const role = e.target.value;
-                write(
-                  entries.map((current, j) =>
-                    j === i
-                      ? { slug: current.slug, ...(role !== "" && { role }) }
-                      : current,
-                  ),
-                );
-              }}
-              className="rounded border border-stone-300 bg-white p-1 text-sm"
-            />
-          ))}
+          <PersonGridControls entries={entries} onWrite={write} />
         </div>
       );
     },
   },
 );
+
+/**
+ * The grid block's people controls, a component of its own so the merged
+ * roster hook lives outside the block-spec render function.
+ */
+function PersonGridControls({
+  entries,
+  onWrite,
+}: {
+  entries: PersonGridEntry[];
+  onWrite: (next: PersonGridEntry[]) => void;
+}) {
+  const allPeople = usePeopleList();
+  const nameOf = (slug: string) =>
+    allPeople.find((p) => p.slug === slug)?.name ?? slug;
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <p className="text-xs text-stone-500">
+          Select people (hold Ctrl/Cmd to pick multiple):
+        </p>
+        <select
+          aria-label="People"
+          multiple
+          size={Math.min(allPeople.length, 6)}
+          value={entries.map((e) => e.slug)}
+          onChange={(e) => {
+            const chosen = Array.from(e.target.selectedOptions).map(
+              (o) => o.value,
+            );
+            // People who stay selected keep their role; newly
+            // selected people start role-less.
+            onWrite(
+              chosen.map(
+                (slug) =>
+                  entries.find((entry) => entry.slug === slug) ?? { slug },
+              ),
+            );
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        >
+          {allPeople.map((p) => (
+            <option key={p.slug} value={p.slug}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      {entries.map((entry, i) => (
+        <input
+          key={`${entry.slug}-${String(i)}`}
+          aria-label={`Role shown for ${nameOf(entry.slug)}`}
+          placeholder={`Role for ${nameOf(entry.slug)} (optional)`}
+          value={entry.role ?? ""}
+          onChange={(e) => {
+            const role = e.target.value;
+            onWrite(
+              entries.map((current, j) =>
+                j === i
+                  ? { slug: current.slug, ...(role !== "" && { role }) }
+                  : current,
+              ),
+            );
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        />
+      ))}
+    </>
+  );
+}
 
 const leagueTableBlock = createReactBlockSpec(
   {
@@ -1257,7 +1299,7 @@ function AuthorSelect({
   value: string;
   onChange: (slug: string) => void;
 }) {
-  const people = getAllPeople().sort((a, b) => a.name.localeCompare(b.name));
+  const people = usePeopleList();
   return (
     <Select
       value={value === "" ? NO_AUTHOR : value}

--- a/apps/web/src/pages/admin/sponsorships-tab.tsx
+++ b/apps/web/src/pages/admin/sponsorships-tab.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import { resizeLogo } from "@/lib/logo-resize";
-import { getAllPeople } from "@/lib/people";
+import { usePeopleList } from "@/lib/use-people";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useReducer, useRef, useState } from "react";
 import {
@@ -62,9 +62,11 @@ function PlayerSelect({
   const [query, setQuery] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
-  const available = getAllPeople()
-    .filter((p) => !p.hasLeftClub && !takenSlugs.has(p.slug))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  // Merged roster (DB-backed first, static fallback). Same semantics as
+  // the static loader: people who have left the club are not sponsorable.
+  const available = usePeopleList().filter(
+    (p) => !p.hasLeftClub && !takenSlugs.has(p.slug),
+  );
 
   const filtered = query.trim()
     ? available.filter((p) =>

--- a/apps/web/src/pages/person/person-profile.tsx
+++ b/apps/web/src/pages/person/person-profile.tsx
@@ -1,9 +1,20 @@
+import { ContentBody } from "@/components/content-body.js";
 import { mdxComponents } from "@/components/mdx-components.js";
-import { OptimisedImage } from "@/components/optimised-image.js";
+import {
+  OptimisedImage,
+  type PictureSource,
+} from "@/components/optimised-image.js";
+import { PageLoading } from "@/components/page-loading.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
+import {
+  parsePersonMetadata,
+  personQueryOptions,
+} from "@/lib/content-queries.js";
 import { getImageUrl, getPicture } from "@/lib/image-map.js";
 import { getPersonBySlug } from "@/lib/people.js";
 import { MDXProvider } from "@mdx-js/react";
+import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { IoChevronForward } from "react-icons/io5";
 import { Link, useParams } from "react-router";
 import { PlayerSponsor } from "./player-sponsor.js";
@@ -12,25 +23,27 @@ import { PlayerStats } from "./player-stats.js";
 const ANON_IMAGE = getImageUrl("/images/anon.jpg");
 const ANON_PICTURE = getPicture("/images/anon.jpg");
 
-export function Component() {
-  const params = useParams();
-  const person = getPersonBySlug(params.slug ?? "");
-
-  useDocumentMeta(person?.name ?? "Player Profile");
-
-  if (!person) {
-    return (
-      <div className="container mx-auto px-4 py-12">
-        <h1>Person Not Found</h1>
-        <p>The person you&apos;re looking for doesn&apos;t exist.</p>
-        <Link to="/people" className="text-primary hover:underline">
-          Back to People
-        </Link>
-      </div>
-    );
-  }
-
-  const Bio = person.Component;
+/**
+ * Shared profile chrome for both sources: breadcrumbs, photo, bio, the
+ * stats sidebar and sponsorship CTA (deliberately untouched by #499 -
+ * both key off the slug alone).
+ */
+function ProfileView({
+  slug,
+  name,
+  picture,
+  photoUrl,
+  isDBSChecked,
+  bio,
+}: {
+  slug: string;
+  name: string;
+  picture?: PictureSource;
+  photoUrl?: string;
+  isDBSChecked: boolean;
+  bio: ReactNode;
+}) {
+  const effectivePicture = picture ?? ANON_PICTURE;
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -40,48 +53,41 @@ export function Component() {
           People
         </Link>
         <IoChevronForward className="text-stone-400" size={14} />
-        <span className="text-dark font-medium">{person.name}</span>
+        <span className="text-dark font-medium">{name}</span>
       </div>
 
       <div className="flex flex-col gap-6 md:flex-row">
         <div className="flex-1">
           <div className="mb-4 flex flex-col items-center justify-between gap-4 md:flex-row">
             <div className="flex flex-col items-center justify-start gap-4 md:flex-row">
-              {(() => {
-                const picture = person.photoPicture ?? ANON_PICTURE;
-                return picture ? (
-                  <OptimisedImage
-                    picture={picture}
-                    alt={person.name}
-                    className="mb-0 max-h-48 rounded-full"
-                    sizes="132px"
-                    width={132}
-                    height={132}
-                  />
-                ) : (
-                  <img
-                    className="mb-0 max-h-48 rounded-full"
-                    src={person.photo ?? ANON_IMAGE}
-                    alt={person.name}
-                    width={132}
-                    height={132}
-                  />
-                );
-              })()}
+              {effectivePicture ? (
+                <OptimisedImage
+                  picture={effectivePicture}
+                  alt={name}
+                  className="mb-0 max-h-48 rounded-full"
+                  sizes="132px"
+                  width={132}
+                  height={132}
+                />
+              ) : (
+                <img
+                  className="mb-0 max-h-48 rounded-full"
+                  src={photoUrl ?? ANON_IMAGE}
+                  alt={name}
+                  width={132}
+                  height={132}
+                />
+              )}
             </div>
           </div>
 
-          <MDXProvider components={mdxComponents}>
-            <div className="mdx-content flex flex-col *:mb-4">
-              <Bio />
-            </div>
-          </MDXProvider>
+          {bio}
 
-          <PlayerStats slug={person.slug} />
+          <PlayerStats slug={slug} />
         </div>
 
         <aside className="w-full shrink-0 md:w-64">
-          {person.isDBSChecked && (
+          {isDBSChecked && (
             <div className="mb-4 flex justify-center">
               <img
                 src="/images/dbs-checked.png"
@@ -91,9 +97,75 @@ export function Component() {
               />
             </div>
           )}
-          <PlayerSponsor slug={person.slug} />
+          <PlayerSponsor slug={slug} />
         </aside>
       </div>
+    </div>
+  );
+}
+
+export function Component() {
+  const params = useParams();
+  const slug = params.slug ?? "";
+
+  // DB-backed profile first (#499); the bundled MDX corpus stays as
+  // fallback until the people migration is verified in prod, then gets
+  // deleted in a follow-up. The MDX renders only once the query settles
+  // (confirmed 404, or an API failure - deliberate graceful degradation)
+  // so an edited DB profile never flashes its stale MDX ancestor first.
+  const { data: apiPerson, isPending } = useQuery(personQueryOptions(slug));
+  const staticPerson = getPersonBySlug(slug);
+
+  useDocumentMeta(apiPerson?.title ?? staticPerson?.name ?? "Player Profile");
+
+  if (apiPerson) {
+    const meta = parsePersonMetadata(apiPerson.metadata);
+    return (
+      <ProfileView
+        slug={apiPerson.slug}
+        name={apiPerson.title}
+        picture={meta?.photo}
+        isDBSChecked={meta?.isDBSChecked === true}
+        bio={<ContentBody body={apiPerson.body} />}
+      />
+    );
+  }
+
+  if (isPending) {
+    return (
+      <div className="container mx-auto px-4 py-6">
+        <PageLoading />
+      </div>
+    );
+  }
+
+  if (staticPerson) {
+    const Bio = staticPerson.Component;
+    return (
+      <ProfileView
+        slug={staticPerson.slug}
+        name={staticPerson.name}
+        picture={staticPerson.photoPicture}
+        photoUrl={staticPerson.photo}
+        isDBSChecked={staticPerson.isDBSChecked}
+        bio={
+          <MDXProvider components={mdxComponents}>
+            <div className="mdx-content flex flex-col *:mb-4">
+              <Bio />
+            </div>
+          </MDXProvider>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1>Person Not Found</h1>
+      <p>The person you&apos;re looking for doesn&apos;t exist.</p>
+      <Link to="/people" className="text-primary hover:underline">
+        Back to People
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/pages/person/person-profile.tsx
+++ b/apps/web/src/pages/person/person-profile.tsx
@@ -7,6 +7,7 @@ import {
 import { PageLoading } from "@/components/page-loading.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import {
+  isPageGone,
   parsePersonMetadata,
   personQueryOptions,
 } from "@/lib/content-queries.js";
@@ -113,8 +114,12 @@ export function Component() {
   // deleted in a follow-up. The MDX renders only once the query settles
   // (confirmed 404, or an API failure - deliberate graceful degradation)
   // so an edited DB profile never flashes its stale MDX ancestor first.
-  const { data: apiPerson, isPending } = useQuery(personQueryOptions(slug));
-  const staticPerson = getPersonBySlug(slug);
+  // A 410 tombstone (ever-live profile taken down) suppresses the static
+  // fallback entirely: a takedown must not resurrect the bundled MDX.
+  const { data, isPending } = useQuery(personQueryOptions(slug));
+  const gone = isPageGone(data);
+  const apiPerson = data == null || isPageGone(data) ? undefined : data;
+  const staticPerson = gone ? undefined : getPersonBySlug(slug);
 
   useDocumentMeta(apiPerson?.title ?? staticPerson?.name ?? "Player Profile");
 

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -180,9 +180,10 @@ export const newsTagSchema = z.string().min(1).max(100);
 
 export const newsMetadataSchema = z.object({
   tags: z.array(newsTagSchema),
-  // References the static people corpus, which stays as MDX in the web
-  // app until Phase 4 - so only the format is validated here. The admin
-  // UI's people picker is what ties the slug to a real person.
+  // References a person by slug (the DB-backed person kind as of Phase 4,
+  // with the static corpus as transition fallback) - only the format is
+  // validated here. The admin UI's people picker is what ties the slug
+  // to a real person.
   authorSlug: contentSlugSchema.optional(),
 });
 export type NewsMetadata = z.infer<typeof newsMetadataSchema>;


### PR DESCRIPTION
Closes #499. Part of epic #497 (targets the epic branch, follows #498/PR #523).

## What

- **Migration script** (`apps/api/scripts/migrate-people.ts`): imports the 56 MDX profiles as published person items. Frontmatter maps to title (name) + person metadata; bios convert through the shared mdx-to-blocks pipeline (fails loudly on anything unconvertible); the 20 profile photos run through the same processing pipeline as editor uploads (EXIF strip, responsive WebP ladder, UUIDv5 ids derived from the source path) with `consent_confirmed: true` recorded for pre-existing content. Idempotent upsert by (kind, slug); published rows that differ are skipped unless `--force`; one shared go-live instant per run. `prepareAsset` was factored out of `convertBody` so frontmatter photos reuse the body-image machinery.
- **Public roster endpoint** `GET /content/people`: every published person, title-ordered, summary fields only. This is the N+1 answer from the issue: any number of person cards/grids on a page resolve from one cached request.
- **Merged resolution layer** (`lib/use-people.ts`): DB-backed people win per slug; the bundled MDX corpus fills the gaps while the query is pending/failed or a profile isn't migrated yet (TRANSITION FALLBACK #489). Cards render instantly from the bundle with zero flash and degrade gracefully on API trouble.
- **person-profile.tsx**: API-first with static fallback, identical settled-query pattern to news/pages (DB profile renders; pending shows loading; confirmed miss falls back to MDX; neither = not found). Stats sidebar + sponsorship CTA untouched (slug-keyed).
- **Consumers switched to the merged roster**: the public Person card (used by the person/personGrid blocks via ContentBody), the editor's person + person-grid pickers, the news author picker, and the sponsorships player picker (which keeps its `!hasLeftClub` filter - the one place the loader filters on it).

## Still on the static loader (deliberate)

News bylines (`news-article`, `news-list-view`, `home`), `sponsor-checkout`, `share-my-team-button` and `lib/news.ts` still read `lib/people.ts`. They keep working unchanged through the transition and move over in the post-verification cleanup PR that removes `content/people/` and `lib/people.ts` (the issue's final bullet, deliberately outside this epic).

## Acceptance criteria

- [x] All profiles spot-checked: local run against docker Postgres + LocalStack migrated 56/56 with 0 failures and 20 photos uploaded (5-variant ladders); re-run reports 56 unchanged (idempotent); DB row inspection confirms flags, photo descriptor (`/uploads/content/<uuid>/...`) and one revision per item. Prod spot-check happens at prod migration time, as with Phases 2/3.
- [x] Person cards across migrated pages/news still render correctly - same components, now fed by the merged roster; ContentBody tests cover the card rendering path.
- [x] hasLeftClub semantics preserved: the sponsorships picker keeps filtering `!hasLeftClub` over the merged roster; flag arrives via person metadata for DB-backed people.

## Tests

- New `parsePersonSource` unit tests (frontmatter parity with the static loader: defaults, optional photo, loud failures).
- New integration test: `/api/content/people` lists published people only, title-ordered, metadata projected through the person schema (37 content integration tests green).
- Full monorepo lint, typecheck, unit tests green (api 681, web 555).

## Post-merge operational note

After the epic merges to main, run the prod people migration (same access pattern as Phases 2/3) before people_editors start authoring, then verify before raising the cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)