### PR TITLE
Revision history UI: view, diff, restore (#500)

### DIFF
--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -20,6 +20,7 @@ import {
   getContent,
   getPublishedContent,
   getPublishedGameReport,
+  getRevision,
   listContent,
   listPageTree,
   listPublishedEvents,
@@ -162,6 +163,60 @@ describe("content service (integration)", () => {
     // Publishing again without a date keeps the original live-from time
     const again = await publishContent(ctx.db)({ contentId: id, userId });
     expect(again.publishedAt).toBe(past);
+  });
+
+  it("serves a single revision in full for diff/restore (#500)", async () => {
+    const { id } = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "rev-detail",
+      title: "Rev detail",
+      description: null,
+      body: body("Original paragraph."),
+      metadata: { playCricketId: "999111" },
+      userId,
+    });
+    await updateContent(ctx.db)({
+      contentId: id,
+      title: "Rev detail v2",
+      body: body("Edited paragraph."),
+      userId,
+    });
+
+    const { revisions } = await listRevisions(ctx.db)(id);
+    expect(revisions).toHaveLength(2);
+    const creation = revisions[1];
+    if (!creation) throw new Error("expected the creation revision");
+
+    // The creation revision carries the full pre-edit state - exactly
+    // what restore copies back into the editor.
+    const detail = await getRevision(ctx.db)({
+      contentId: id,
+      revisionId: creation.id,
+    });
+    expect(detail.title).toBe("Rev detail");
+    expect(detail.metadata).toEqual({ playCricketId: "999111" });
+    expect(detail.body).toMatchObject([
+      { content: [{ text: "Original paragraph." }] },
+    ]);
+
+    // A revision is only reachable under its own item's id - the route
+    // gates permissions on the item's kind, so cross-item reads would
+    // bypass the per-kind model.
+    const other = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "rev-detail-other",
+      title: "Other",
+      description: null,
+      body: body("Other."),
+      metadata: { playCricketId: "999112" },
+      userId,
+    });
+    await expect(
+      getRevision(ctx.db)({ contentId: other.id, revisionId: creation.id }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    await expect(
+      getRevision(ctx.db)({ contentId: id, revisionId: crypto.randomUUID() }),
+    ).rejects.toMatchObject({ statusCode: 404 });
   });
 
   it("enforces per-kind slug uniqueness on create", async () => {
@@ -838,7 +893,25 @@ describe("content service (integration)", () => {
         headers: { cookie: peopleEditor },
       });
       expect(revs.statusCode).toBe(200);
-      expect(revs.json<{ revisions: unknown[] }>().revisions).toHaveLength(2);
+      const { revisions } = revs.json<{
+        revisions: Array<{ id: string }>;
+      }>();
+      expect(revisions).toHaveLength(2);
+
+      // The single-revision endpoint (#500) returns the full pre-edit
+      // state for diff/restore - the creation revision still has the
+      // DBS flag unticked.
+      const creation = revisions[1];
+      if (!creation) throw new Error("expected the creation revision");
+      const detail = await app.inject({
+        method: "GET",
+        url: `/api/admin/content/${id}/revisions/${creation.id}`,
+        headers: { cookie: peopleEditor },
+      });
+      expect(detail.statusCode).toBe(200);
+      expect(
+        detail.json<{ metadata: Record<string, unknown> }>().metadata,
+      ).toEqual({ isDBSChecked: false, hasLeftClub: false });
     });
 
     it.each([
@@ -885,6 +958,13 @@ describe("content service (integration)", () => {
           app.inject({
             method: "GET",
             url: `/api/admin/content/${fixtureId}/revisions`,
+            headers: { cookie },
+          }),
+          // Permission check precedes the revision lookup, so a random
+          // revision id still proves the 403 boundary.
+          app.inject({
+            method: "GET",
+            url: `/api/admin/content/${fixtureId}/revisions/${crypto.randomUUID()}`,
             headers: { cookie },
           }),
         ];

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -29,6 +29,8 @@ import {
   publicContentParamsSchema,
   publicContentResponseSchema,
   publishContentSchema,
+  revisionDetailResponseSchema,
+  revisionIdParamSchema,
   updateContentSchema,
 } from "./schemas.ts";
 import {
@@ -40,6 +42,7 @@ import {
   getPublishedGameReport,
   getPublishedNav,
   getPublishedPageByPath,
+  getRevision,
   listContent,
   listPageTree,
   listPublishedEvents,
@@ -87,6 +90,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const unpublish = unpublishContent(app.db);
   const archive = archiveContent(app.db);
   const revisions = listRevisions(app.db);
+  const revision = getRevision(app.db);
   const publicGet = getPublishedContent(app.db);
   const publicGameReport = getPublishedGameReport(app.db);
   const publicNews = listPublishedNews(app.db);
@@ -265,6 +269,25 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       const { kind } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "view");
       return await revisions(request.params.contentId);
+    },
+  );
+
+  app.get(
+    "/admin/content/:contentId/revisions/:revisionId",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: revisionIdParamSchema,
+        response: { 200: revisionDetailResponseSchema },
+      },
+    },
+    async (request) => {
+      // Same gate as the list: the revision's own permission model is
+      // the item's kind (the service scopes the lookup to contentId, so
+      // a revision is never reachable under a different item's id).
+      const { kind } = await metaOf(request.params.contentId);
+      assertContentPermission(request, kind, "view");
+      return await revision(request.params);
     },
   );
 

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -157,6 +157,28 @@ export const listRevisionsResponseSchema = z.object({
   ),
 });
 
+export const revisionIdParamSchema = z.object({
+  contentId: z.uuid(),
+  revisionId: z.uuid(),
+});
+
+/**
+ * One revision in full - body and metadata included - for the history
+ * UI's diff and restore (#500). Slug/parent are not part of a revision:
+ * they identify the item rather than its content, and restoring must
+ * never bypass the slug/path locks.
+ */
+export const revisionDetailResponseSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  body: contentBodyTransportSchema,
+  metadata: contentMetadataSchema,
+  savedAt: z.string(),
+  savedBy: z.string(),
+  savedByName: z.string().nullable(),
+});
+
 // ── Public ──────────────────────────────────────────────────────────────
 
 export const publicContentParamsSchema = z.object({

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -1124,6 +1124,50 @@ export function listRevisions(db: Kysely<DB>) {
   };
 }
 
+export function getRevision(db: Kysely<DB>) {
+  return async (params: { contentId: string; revisionId: string }) => {
+    // The content_id filter makes the lookup tenant-safe within the
+    // route's permission model: the route gates on the CONTENT item's
+    // kind, so a revision must never be reachable under a different
+    // (more permissive) item's id.
+    const row = await db
+      .selectFrom("content_revision")
+      .leftJoin("user as saver", "saver.id", "content_revision.saved_by")
+      .select([
+        "content_revision.id",
+        "content_revision.title",
+        "content_revision.description",
+        "content_revision.body",
+        "content_revision.metadata",
+        "content_revision.saved_at",
+        "content_revision.saved_by",
+        "saver.name as saved_by_name",
+      ])
+      .where("content_revision.id", "=", params.revisionId)
+      .where("content_revision.content_id", "=", params.contentId)
+      .executeTakeFirst();
+    if (!row) throwHttpError(404, "Revision not found");
+
+    // A stored body failing the schema is a server-side data problem,
+    // not a bad request - same stance as getContent.
+    const parsedBody = contentBodySchema.safeParse(row.body);
+    if (!parsedBody.success) {
+      throwHttpError(500, "Stored body does not match the block schema");
+    }
+
+    return {
+      id: row.id,
+      title: row.title,
+      description: row.description,
+      body: parsedBody.data,
+      metadata: row.metadata as Record<string, unknown>,
+      savedAt: row.saved_at.toISOString(),
+      savedBy: row.saved_by,
+      savedByName: row.saved_by_name,
+    };
+  };
+}
+
 // ── Public reads ────────────────────────────────────────────────────────
 
 function toPublic(row: {

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13716,6 +13716,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content/{contentId}/revisions/{revisionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                    revisionId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            savedAt: string;
+                            savedBy: string;
+                            savedByName: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -24693,6 +24693,125 @@
         }
       }
     },
+    "/api/admin/content/{contentId}/revisions/{revisionId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "revisionId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "savedAt": {
+                      "type": "string"
+                    },
+                    "savedBy": {
+                      "type": "string"
+                    },
+                    "savedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "savedAt",
+                    "savedBy",
+                    "savedByName"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
       "get": {
         "parameters": [

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13716,6 +13716,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content/{contentId}/revisions/{revisionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                    revisionId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            savedAt: string;
+                            savedBy: string;
+                            savedByName: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -24693,6 +24693,125 @@
         }
       }
     },
+    "/api/admin/content/{contentId}/revisions/{revisionId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "revisionId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "savedAt": {
+                      "type": "string"
+                    },
+                    "savedBy": {
+                      "type": "string"
+                    },
+                    "savedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "savedAt",
+                    "savedBy",
+                    "savedByName"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
       "get": {
         "parameters": [

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -2235,7 +2235,7 @@ function RevisionDialog({
   item: ContentItemDetail;
   revisionId: string;
   canRestore: boolean;
-  onRestore: (revision: RevisionDetail) => void;
+  onRestore: (revision: RevisionDetail) => boolean;
   onClose: () => void;
 }) {
   const {
@@ -2329,8 +2329,9 @@ function RevisionDialog({
           {canRestore && revision && (
             <Button
               onClick={() => {
-                onRestore(revision);
-                onClose();
+                // Stays open when the author backs out of overwriting
+                // unsaved work.
+                if (onRestore(revision)) onClose();
               }}
             >
               Restore this version
@@ -2349,7 +2350,7 @@ function HistoryCard({
 }: {
   item: ContentItemDetail;
   canRestore: boolean;
-  onRestore: (revision: RevisionDetail) => void;
+  onRestore: (revision: RevisionDetail) => boolean;
 }) {
   const { data, isLoading, error } = useQuery({
     queryKey: ["admin", "content", "revisions", item.id],
@@ -2437,7 +2438,19 @@ function useRevisionRestore({
 }) {
   const [restoreNotice, setRestoreNotice] = useState<string | null>(null);
 
-  const restoreRevision = (revision: RevisionDetail) => {
+  /**
+   * Returns false when the author backs out of overwriting unsaved
+   * work - the dialog stays open so nothing is lost either way.
+   */
+  const restoreRevision = (revision: RevisionDetail): boolean => {
+    if (
+      dirtyRef.current &&
+      !window.confirm(
+        "Restoring will replace your unsaved changes with this version. Continue?",
+      )
+    ) {
+      return false;
+    }
     editor.replaceBlocks(
       editor.document,
       revision.body.length > 0
@@ -2454,6 +2467,7 @@ function useRevisionRestore({
     setRestoreNotice(
       `Restored the version from ${formatUkTime(revision.savedAt)} - review it, then save to keep it.`,
     );
+    return true;
   };
 
   return {

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -84,6 +84,12 @@ import {
   eligibleParents,
   visibleNodes,
 } from "./pages-tab.lib.js";
+import {
+  blocksToLines,
+  detailLines,
+  diffLines,
+  type DiffLine,
+} from "./revision-diff.js";
 
 // ── Custom blocks ───────────────────────────────────────────────────────
 //
@@ -1010,23 +1016,19 @@ function formatUkTime(iso: string): string {
 }
 
 /**
- * Hydrate per-kind fields from stored metadata. Defensive on purpose:
- * stored JSON may predate the current schema, so anything malformed
- * degrades to the field default rather than crashing the editor.
+ * Hydrate per-kind form fields from stored metadata. Defensive on
+ * purpose: stored JSON may predate the current schema, so anything
+ * malformed degrades to the field default rather than crashing the
+ * editor. Shared by the initial load and revision restore (#500).
  */
-function initialForm(
-  item: ContentItemDetail | null,
-  newParentId: string | null,
-): FormState {
-  const metadata = item?.metadata ?? {};
+function metadataFormFields(
+  metadata: Record<string, unknown>,
+): Omit<FormState, "title" | "slug" | "description" | "parentId"> {
   const location =
     typeof metadata.location === "object" && metadata.location !== null
       ? (metadata.location as Record<string, unknown>)
       : null;
   return {
-    title: item?.title ?? "",
-    slug: item?.slug ?? "",
-    description: item?.description ?? "",
     playCricketId: asString(metadata.playCricketId),
     menuOrder: asNumberString(metadata.menuOrder) || "99",
     isMainMenu: metadata.isMainMenu === true,
@@ -1035,7 +1037,6 @@ function initialForm(
       typeof metadata.ldjson === "object" && metadata.ldjson !== null
         ? JSON.stringify(metadata.ldjson, null, 2)
         : "",
-    parentId: item !== null ? item.parentId : newParentId,
     tags: Array.isArray(metadata.tags)
       ? metadata.tags.filter(
           (tag): tag is string => typeof tag === "string" && tag !== "",
@@ -1054,6 +1055,19 @@ function initialForm(
     isDBSChecked: metadata.isDBSChecked === true,
     hasLeftClub: metadata.hasLeftClub === true,
     photo: parsePictureValue(metadata.photo),
+  };
+}
+
+function initialForm(
+  item: ContentItemDetail | null,
+  newParentId: string | null,
+): FormState {
+  return {
+    title: item?.title ?? "",
+    slug: item?.slug ?? "",
+    description: item?.description ?? "",
+    parentId: item !== null ? item.parentId : newParentId,
+    ...metadataFormFields(item?.metadata ?? {}),
   };
 }
 
@@ -2179,6 +2193,278 @@ function ConsentBox({
   );
 }
 
+// ── Revision history (#500) ─────────────────────────────────────────────
+
+type RevisionDetail =
+  paths["/api/admin/content/{contentId}/revisions/{revisionId}"]["get"]["responses"][200]["content"]["application/json"];
+
+function DiffView({ lines }: { lines: DiffLine[] }) {
+  if (lines.length === 0 || lines.every((line) => line.type === "same")) {
+    return <p className="text-sm text-stone-500">No differences.</p>;
+  }
+  return (
+    <div className="max-h-72 overflow-auto rounded border border-stone-200 bg-white p-2 font-mono text-xs whitespace-pre-wrap">
+      {/* Index keys are safe here: the diff is a pure projection of
+          immutable data, rebuilt whole whenever either side changes. */}
+      {lines.map((line, i) => (
+        <div
+          key={`diff-${String(i)}`}
+          className={
+            line.type === "removed"
+              ? "bg-red-50 text-red-700"
+              : line.type === "added"
+                ? "bg-green-50 text-green-700"
+                : "text-stone-600"
+          }
+        >
+          {line.type === "removed" ? "- " : line.type === "added" ? "+ " : "  "}
+          {line.text || " "}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RevisionDialog({
+  item,
+  revisionId,
+  canRestore,
+  onRestore,
+  onClose,
+}: {
+  item: ContentItemDetail;
+  revisionId: string;
+  canRestore: boolean;
+  onRestore: (revision: RevisionDetail) => void;
+  onClose: () => void;
+}) {
+  const {
+    data: revision,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["admin", "content", "revision", item.id, revisionId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/content/{contentId}/revisions/{revisionId}", {
+          params: { path: { contentId: item.id, revisionId } },
+        }),
+      ),
+  });
+
+  // Both diffs read "this version -> latest saved version": red lines
+  // exist only in this version (restore brings them back), green lines
+  // were added since. Unsaved editor changes are not part of either side.
+  const bodyDiff = useMemo(
+    () =>
+      revision
+        ? diffLines(blocksToLines(revision.body), blocksToLines(item.body))
+        : [],
+    [revision, item.body],
+  );
+  const detailsDiff = useMemo(
+    () =>
+      revision
+        ? diffLines(
+            detailLines(revision),
+            detailLines({
+              title: item.title,
+              description: item.description,
+              metadata: item.metadata,
+            }),
+          )
+        : [],
+    [revision, item],
+  );
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>
+            {revision
+              ? `Version from ${formatUkTime(revision.savedAt)}`
+              : "Version"}
+          </DialogTitle>
+          <DialogDescription>
+            Compared with the latest saved version:{" "}
+            <span className="text-red-700">- only in this version</span>,{" "}
+            <span className="text-green-700">+ added since</span>. Restoring
+            copies this version into the editor - nothing changes until you
+            save.
+          </DialogDescription>
+        </DialogHeader>
+        {error ? (
+          <p className="text-sm text-red-600">
+            Couldn&apos;t load this version - {error.message}
+          </p>
+        ) : isLoading || !revision ? (
+          <p className="text-sm text-stone-500">Loading…</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {revision.savedByName && (
+              <p className="text-sm text-stone-600">
+                Saved by {revision.savedByName}
+              </p>
+            )}
+            <div>
+              <h4 className="mb-1 text-sm font-medium">Content</h4>
+              <DiffView lines={bodyDiff} />
+            </div>
+            <div>
+              <h4 className="mb-1 text-sm font-medium">Details</h4>
+              <DiffView lines={detailsDiff} />
+            </div>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+          {canRestore && revision && (
+            <Button
+              onClick={() => {
+                onRestore(revision);
+                onClose();
+              }}
+            >
+              Restore this version
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function HistoryCard({
+  item,
+  canRestore,
+  onRestore,
+}: {
+  item: ContentItemDetail;
+  canRestore: boolean;
+  onRestore: (revision: RevisionDetail) => void;
+}) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["admin", "content", "revisions", item.id],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/content/{contentId}/revisions", {
+          params: { path: { contentId: item.id } },
+        }),
+      ),
+  });
+  const [openRevisionId, setOpenRevisionId] = useState<string | null>(null);
+  const revisions = data?.revisions ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">History</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        {error ? (
+          <p className="text-sm text-red-600">
+            Couldn&apos;t load history - {error.message}
+          </p>
+        ) : isLoading ? (
+          <p className="text-sm text-stone-500">Loading…</p>
+        ) : (
+          <ul className="flex max-h-64 flex-col gap-1 overflow-y-auto">
+            {revisions.map((rev, i) => (
+              <li key={rev.id}>
+                <button
+                  type="button"
+                  className="w-full rounded px-1 py-1 text-left hover:bg-stone-100"
+                  onClick={() => {
+                    setOpenRevisionId(rev.id);
+                  }}
+                >
+                  <span className="block text-sm">
+                    {formatUkTime(rev.savedAt)}
+                    {i === 0 ? " (latest)" : ""}
+                  </span>
+                  <span className="block text-xs text-stone-500">
+                    {rev.savedByName ?? "Unknown"}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <p className="text-xs text-stone-500">
+          Every save keeps the previous version here, so nothing is ever lost.
+          Open one to compare or restore it.
+        </p>
+      </CardContent>
+      {openRevisionId !== null && (
+        <RevisionDialog
+          item={item}
+          revisionId={openRevisionId}
+          canRestore={canRestore}
+          onRestore={onRestore}
+          onClose={() => {
+            setOpenRevisionId(null);
+          }}
+        />
+      )}
+    </Card>
+  );
+}
+
+/**
+ * Copy a revision into the working draft (#500): the editor and form
+ * take the revision's body/metadata, and nothing persists until the
+ * author saves - which writes a NEW revision, so the timeline stays
+ * append-only and history is never rewritten. Slug and (for pages)
+ * parent are not part of a revision and stay as they are. Restoring
+ * never changes publish status.
+ */
+function useRevisionRestore({
+  editor,
+  setForm,
+  dirtyRef,
+}: {
+  editor: Editor;
+  setForm: React.Dispatch<React.SetStateAction<FormState>>;
+  dirtyRef: React.RefObject<boolean>;
+}) {
+  const [restoreNotice, setRestoreNotice] = useState<string | null>(null);
+
+  const restoreRevision = (revision: RevisionDetail) => {
+    editor.replaceBlocks(
+      editor.document,
+      revision.body.length > 0
+        ? (revision.body as PartialBlock[])
+        : [{ type: "paragraph" }],
+    );
+    setForm((prev) => ({
+      ...prev,
+      title: revision.title,
+      description: revision.description ?? "",
+      ...metadataFormFields(revision.metadata),
+    }));
+    dirtyRef.current = true;
+    setRestoreNotice(
+      `Restored the version from ${formatUkTime(revision.savedAt)} - review it, then save to keep it.`,
+    );
+  };
+
+  return {
+    restoreNotice,
+    clearRestoreNotice: () => {
+      setRestoreNotice(null);
+    },
+    restoreRevision,
+  };
+}
+
 function EditorPane({
   editor,
   slashItems,
@@ -2300,6 +2586,9 @@ function LoadedEditor({
   const editorBody = () =>
     contentBodySchema.parse(JSON.parse(JSON.stringify(editor.document)));
 
+  const { restoreNotice, clearRestoreNotice, restoreRevision } =
+    useRevisionRestore({ editor, setForm, dirtyRef });
+
   const saveMutation = useMutation({
     mutationFn: async () => {
       const body = editorBody();
@@ -2343,6 +2632,7 @@ function LoadedEditor({
     },
     onSuccess: (result) => {
       dirtyRef.current = false;
+      clearRestoreNotice();
       setLastSavedAt(new Date().toISOString());
       void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
       // Saving a published item changes the live page immediately; drop
@@ -2474,6 +2764,10 @@ function LoadedEditor({
         </p>
       )}
 
+      {restoreNotice && (
+        <p className="text-sm text-amber-700">{restoreNotice}</p>
+      )}
+
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <div className="flex flex-col gap-3 lg:col-span-1">
           <MetadataFields
@@ -2491,6 +2785,13 @@ function LoadedEditor({
               canPublish={canPublish}
               canManage={canManage}
               beforePublish={() => saveMutation.mutateAsync()}
+            />
+          )}
+          {item !== null && (
+            <HistoryCard
+              item={item}
+              canRestore={canSave}
+              onRestore={restoreRevision}
             />
           )}
           <ConsentBox

--- a/apps/web/src/pages/admin/revision-diff.test.ts
+++ b/apps/web/src/pages/admin/revision-diff.test.ts
@@ -96,6 +96,56 @@ describe("blocksToLines", () => {
     ]);
   });
 
+  it("covers every render-relevant custom-block prop, so a prop-only change always diffs", () => {
+    const block = (type: string, props: Record<string, unknown>) => [
+      { id: "1", type, props, children: [] },
+    ];
+    // A role change inside a person grid (entries is canonical)
+    expect(
+      blocksToLines(
+        block("personGrid", {
+          slugs: "a,b",
+          entries: '[{"slug":"a","role":"Captain"},{"slug":"b"}]',
+        }),
+      ),
+    ).not.toEqual(
+      blocksToLines(
+        block("personGrid", {
+          slugs: "a,b",
+          entries: '[{"slug":"a"},{"slug":"b"}]',
+        }),
+      ),
+    );
+    // A replaced photo with identical alt/caption
+    expect(
+      blocksToLines(
+        block("contentImage", { alt: "x", caption: "", src: "/uploads/a.jpg" }),
+      ),
+    ).not.toEqual(
+      blocksToLines(
+        block("contentImage", { alt: "x", caption: "", src: "/uploads/b.jpg" }),
+      ),
+    );
+    // An event preview repointed at a different event, same display name
+    expect(
+      blocksToLines(
+        block("eventPreview", {
+          eventId: "e1",
+          name: "AGM",
+          when: "2026-01-01",
+        }),
+      ),
+    ).not.toEqual(
+      blocksToLines(
+        block("eventPreview", {
+          eventId: "e2",
+          name: "AGM",
+          when: "2026-01-01",
+        }),
+      ),
+    );
+  });
+
   it("degrades malformed input to empty output rather than throwing", () => {
     expect(blocksToLines(null)).toEqual([]);
     expect(blocksToLines("not blocks")).toEqual([]);

--- a/apps/web/src/pages/admin/revision-diff.test.ts
+++ b/apps/web/src/pages/admin/revision-diff.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { blocksToLines, detailLines, diffLines } from "./revision-diff.js";
+
+const text = (t: string) => [{ type: "text", text: t, styles: {} }];
+
+describe("blocksToLines", () => {
+  it("projects common block types to readable lines", () => {
+    const body = [
+      {
+        id: "1",
+        type: "heading",
+        props: { level: 2 },
+        content: text("Ground rules"),
+        children: [],
+      },
+      {
+        id: "2",
+        type: "paragraph",
+        props: {},
+        content: text("Be kind."),
+        children: [],
+      },
+      {
+        id: "3",
+        type: "bulletListItem",
+        props: {},
+        content: text("No spikes indoors"),
+        children: [
+          {
+            id: "3a",
+            type: "bulletListItem",
+            props: {},
+            content: text("Even on Sundays"),
+            children: [],
+          },
+        ],
+      },
+      {
+        id: "4",
+        type: "contentImage",
+        props: { alt: "The pavilion", caption: "Summer 2025" },
+        children: [],
+      },
+      {
+        id: "5",
+        type: "person",
+        props: { slug: "alex-young", role: "Captain" },
+        children: [],
+      },
+    ];
+    expect(blocksToLines(body)).toEqual([
+      "## Ground rules",
+      "Be kind.",
+      "- No spikes indoors",
+      "  - Even on Sundays",
+      "[Photo: The pavilion - Summer 2025]",
+      "[Person card: alex-young (Captain)]",
+    ]);
+  });
+
+  it("flattens link text into the line", () => {
+    const body = [
+      {
+        id: "1",
+        type: "paragraph",
+        props: {},
+        content: [
+          { type: "text", text: "See the ", styles: {} },
+          { type: "link", href: "/fixtures", content: text("fixtures") },
+        ],
+        children: [],
+      },
+    ];
+    expect(blocksToLines(body)).toEqual(["See the fixtures"]);
+  });
+
+  it("projects tables row by row", () => {
+    const body = [
+      {
+        id: "1",
+        type: "table",
+        props: {},
+        content: {
+          type: "tableContent",
+          rows: [
+            { cells: [text("Team"), text("Points")] },
+            { cells: [{ content: text("Firsts") }, { content: text("42") }] },
+          ],
+        },
+        children: [],
+      },
+    ];
+    expect(blocksToLines(body)).toEqual([
+      "| Team | Points |",
+      "| Firsts | 42 |",
+    ]);
+  });
+
+  it("degrades malformed input to empty output rather than throwing", () => {
+    expect(blocksToLines(null)).toEqual([]);
+    expect(blocksToLines("not blocks")).toEqual([]);
+    // Non-object entries vanish; an object with a junk type degrades to
+    // a blank text line.
+    expect(blocksToLines([null, 7, { type: 9 }])).toEqual([""]);
+  });
+});
+
+describe("detailLines", () => {
+  it("sorts metadata keys so JSONB key-order churn never reads as a change", () => {
+    const a = detailLines({
+      title: "T",
+      description: null,
+      metadata: { tags: ["x"], authorSlug: "a" },
+    });
+    const b = detailLines({
+      title: "T",
+      description: null,
+      metadata: { authorSlug: "a", tags: ["x"] },
+    });
+    expect(a).toEqual(b);
+    expect(a[0]).toBe("Title: T");
+    expect(a[1]).toBe("Description: ");
+  });
+});
+
+describe("diffLines", () => {
+  it("marks the deleted paragraph - the recovery scenario", () => {
+    const revision = ["Intro", "The lost paragraph.", "Outro"];
+    const current = ["Intro", "Outro"];
+    expect(diffLines(revision, current)).toEqual([
+      { type: "same", text: "Intro" },
+      { type: "removed", text: "The lost paragraph." },
+      { type: "same", text: "Outro" },
+    ]);
+  });
+
+  it("marks additions since the revision", () => {
+    expect(diffLines(["a"], ["a", "b"])).toEqual([
+      { type: "same", text: "a" },
+      { type: "added", text: "b" },
+    ]);
+  });
+
+  it("handles a full replacement", () => {
+    expect(diffLines(["old"], ["new"])).toEqual([
+      { type: "removed", text: "old" },
+      { type: "added", text: "new" },
+    ]);
+  });
+
+  it("handles empty sides", () => {
+    expect(diffLines([], ["a"])).toEqual([{ type: "added", text: "a" }]);
+    expect(diffLines(["a"], [])).toEqual([{ type: "removed", text: "a" }]);
+    expect(diffLines([], [])).toEqual([]);
+  });
+});

--- a/apps/web/src/pages/admin/revision-diff.ts
+++ b/apps/web/src/pages/admin/revision-diff.ts
@@ -1,0 +1,244 @@
+import { CUSTOM_BLOCK_TYPES } from "@percy-main/shared/content";
+
+// Plain-text projection + line diff for the revision history UI (#500).
+// Per the issue, a text diff of body + metadata is sufficient - no
+// rendered visual diff - so blocks project to one line each (type-aware
+// prefix + inline text) and the diff is a classic line LCS. Everything
+// here is pure so it unit-tests without a DOM.
+
+export interface DiffLine {
+  type: "same" | "added" | "removed";
+  text: string;
+}
+
+function inlineText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((node: unknown) => {
+      if (typeof node !== "object" || node === null) return "";
+      const candidate = node as {
+        type?: unknown;
+        text?: unknown;
+        content?: unknown;
+      };
+      if (typeof candidate.text === "string") return candidate.text;
+      if (candidate.type === "link") return inlineText(candidate.content);
+      return "";
+    })
+    .join("");
+}
+
+/** Table content is structured (rows of cells), not an inline array. */
+function tableText(content: unknown): string[] {
+  const rows = (content as { rows?: unknown } | null)?.rows;
+  if (!Array.isArray(rows)) return ["[Table]"];
+  return rows.map((row: unknown) => {
+    const cells = (row as { cells?: unknown } | null)?.cells;
+    if (!Array.isArray(cells)) return "|";
+    const texts = cells.map((cell: unknown) => {
+      // Cells are inline arrays in older documents, or objects with a
+      // content array in newer ones.
+      if (Array.isArray(cell)) return inlineText(cell);
+      return inlineText((cell as { content?: unknown } | null)?.content);
+    });
+    return `| ${texts.join(" | ")} |`;
+  });
+}
+
+function stringProp(props: Record<string, unknown>, name: string): string {
+  const value = props[name];
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * One human-readable line (or a few, for tables) per block. Custom
+ * blocks render as bracketed labels - enough for an editor to see that
+ * "the photo moved" without a visual diff.
+ */
+function blockLines(block: unknown, depth: number): string[] {
+  if (typeof block !== "object" || block === null) return [];
+  const candidate = block as {
+    type?: unknown;
+    props?: unknown;
+    content?: unknown;
+    children?: unknown;
+  };
+  const type = typeof candidate.type === "string" ? candidate.type : "";
+  const props =
+    typeof candidate.props === "object" && candidate.props !== null
+      ? (candidate.props as Record<string, unknown>)
+      : {};
+  const indent = "  ".repeat(depth);
+  const text = inlineText(candidate.content);
+
+  const lines: string[] = [];
+  switch (type) {
+    case "heading": {
+      const level = typeof props.level === "number" ? props.level : 1;
+      lines.push(`${indent}${"#".repeat(level)} ${text}`);
+      break;
+    }
+    case "bulletListItem":
+      lines.push(`${indent}- ${text}`);
+      break;
+    case "numberedListItem":
+      lines.push(`${indent}1. ${text}`);
+      break;
+    case "checkListItem":
+      lines.push(`${indent}[${props.checked === true ? "x" : " "}] ${text}`);
+      break;
+    case "quote":
+      lines.push(`${indent}> ${text}`);
+      break;
+    case "codeBlock":
+      for (const codeLine of text.split("\n")) {
+        lines.push(`${indent}    ${codeLine}`);
+      }
+      break;
+    case "table":
+      for (const rowLine of tableText(candidate.content)) {
+        lines.push(`${indent}${rowLine}`);
+      }
+      break;
+    case CUSTOM_BLOCK_TYPES.person: {
+      const role = stringProp(props, "role");
+      lines.push(
+        `${indent}[Person card: ${stringProp(props, "slug")}${role ? ` (${role})` : ""}]`,
+      );
+      break;
+    }
+    case CUSTOM_BLOCK_TYPES.personGrid:
+      lines.push(`${indent}[Person grid: ${stringProp(props, "slugs")}]`);
+      break;
+    case CUSTOM_BLOCK_TYPES.contentImage: {
+      const alt = stringProp(props, "alt");
+      const caption = stringProp(props, "caption");
+      lines.push(
+        `${indent}[Photo${alt ? `: ${alt}` : ""}${caption ? ` - ${caption}` : ""}]`,
+      );
+      break;
+    }
+    case CUSTOM_BLOCK_TYPES.gamePreview:
+      lines.push(
+        `${indent}[Game preview: ${stringProp(props, "playCricketId")}]`,
+      );
+      break;
+    case CUSTOM_BLOCK_TYPES.eventPreview:
+      lines.push(`${indent}[Event preview: ${stringProp(props, "name")}]`);
+      break;
+    case CUSTOM_BLOCK_TYPES.leagueTable:
+      lines.push(`${indent}[League table: ${stringProp(props, "divisionId")}]`);
+      break;
+    case CUSTOM_BLOCK_TYPES.leaderboard:
+      lines.push(`${indent}[Leaderboard]`);
+      break;
+    case CUSTOM_BLOCK_TYPES.recordsWall:
+      lines.push(`${indent}[Records wall]`);
+      break;
+    case CUSTOM_BLOCK_TYPES.contactForm:
+      lines.push(`${indent}[Contact form]`);
+      break;
+    case CUSTOM_BLOCK_TYPES.cookieSettingsLink:
+      lines.push(`${indent}[Cookie settings link]`);
+      break;
+    case CUSTOM_BLOCK_TYPES.consentVersion:
+      lines.push(`${indent}[Consent version]`);
+      break;
+    default:
+      // Paragraphs and anything unrecognised: plain text. Blank
+      // paragraphs are kept so spacing changes still show.
+      lines.push(`${indent}${text}`);
+      break;
+  }
+  if (Array.isArray(candidate.children)) {
+    for (const child of candidate.children) {
+      lines.push(...blockLines(child, depth + 1));
+    }
+  }
+  return lines;
+}
+
+/** Project a stored body (block array) onto comparable text lines. */
+export function blocksToLines(body: unknown): string[] {
+  if (!Array.isArray(body)) return [];
+  return body.flatMap((block: unknown) => blockLines(block, 0));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (typeof value === "object" && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Item details (title/description/metadata) as comparable lines. Keys
+ * are sorted so JSONB key-order churn never reads as a change.
+ */
+export function detailLines(item: {
+  title: string;
+  description: string | null;
+  metadata: Record<string, unknown>;
+}): string[] {
+  return [
+    `Title: ${item.title}`,
+    `Description: ${item.description ?? ""}`,
+    ...JSON.stringify(sortKeysDeep(item.metadata), null, 2).split("\n"),
+  ];
+}
+
+/**
+ * Line diff via longest common subsequence - the bodies are club pages,
+ * tens of lines, so the quadratic table is fine.
+ */
+export function diffLines(before: string[], after: string[]): DiffLine[] {
+  const n = before.length;
+  const m = after.length;
+  // lcs(i, j) = LCS length of before.slice(i) vs after.slice(j), stored
+  // flat to keep index access checked-friendly.
+  const width = m + 1;
+  const table = new Array<number>((n + 1) * width).fill(0);
+  const lcs = (i: number, j: number) => table[i * width + j] ?? 0;
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      table[i * width + j] =
+        before[i] === after[j]
+          ? lcs(i + 1, j + 1) + 1
+          : Math.max(lcs(i + 1, j), lcs(i, j + 1));
+    }
+  }
+
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    const a = before[i];
+    const b = after[j];
+    if (a === undefined || b === undefined) break;
+    if (a === b) {
+      out.push({ type: "same", text: a });
+      i += 1;
+      j += 1;
+    } else if (lcs(i + 1, j) >= lcs(i, j + 1)) {
+      out.push({ type: "removed", text: a });
+      i += 1;
+    } else {
+      out.push({ type: "added", text: b });
+      j += 1;
+    }
+  }
+  for (; i < n; i++) {
+    const a = before[i];
+    if (a !== undefined) out.push({ type: "removed", text: a });
+  }
+  for (; j < m; j++) {
+    const b = after[j];
+    if (b !== undefined) out.push({ type: "added", text: b });
+  }
+  return out;
+}

--- a/apps/web/src/pages/admin/revision-diff.ts
+++ b/apps/web/src/pages/admin/revision-diff.ts
@@ -100,6 +100,9 @@ function blockLines(block: unknown, depth: number): string[] {
         lines.push(`${indent}${rowLine}`);
       }
       break;
+    // Custom block labels must cover EVERY render-relevant prop: a prop
+    // change the projection drops would diff as "No differences" while
+    // restore still changes the live page.
     case CUSTOM_BLOCK_TYPES.person: {
       const role = stringProp(props, "role");
       lines.push(
@@ -107,14 +110,23 @@ function blockLines(block: unknown, depth: number): string[] {
       );
       break;
     }
-    case CUSTOM_BLOCK_TYPES.personGrid:
-      lines.push(`${indent}[Person grid: ${stringProp(props, "slugs")}]`);
+    case CUSTOM_BLOCK_TYPES.personGrid: {
+      // entries is the canonical role-preserving prop (compact JSON);
+      // legacy blocks only have the slugs CSV.
+      const entries = stringProp(props, "entries");
+      lines.push(
+        `${indent}[Person grid: ${entries || stringProp(props, "slugs")}]`,
+      );
       break;
+    }
     case CUSTOM_BLOCK_TYPES.contentImage: {
       const alt = stringProp(props, "alt");
       const caption = stringProp(props, "caption");
+      // src identifies the uploaded image (it is the descriptor's
+      // fallback URL), so a replaced photo always shows in the diff.
+      const src = stringProp(props, "src");
       lines.push(
-        `${indent}[Photo${alt ? `: ${alt}` : ""}${caption ? ` - ${caption}` : ""}]`,
+        `${indent}[Photo${alt ? `: ${alt}` : ""}${caption ? ` - ${caption}` : ""}${src ? ` (${src})` : ""}]`,
       );
       break;
     }
@@ -124,23 +136,38 @@ function blockLines(block: unknown, depth: number): string[] {
       );
       break;
     case CUSTOM_BLOCK_TYPES.eventPreview:
-      lines.push(`${indent}[Event preview: ${stringProp(props, "name")}]`);
+      lines.push(
+        `${indent}[Event preview: ${stringProp(props, "name")} (${stringProp(props, "eventId")}, ${stringProp(props, "when")})]`,
+      );
       break;
-    case CUSTOM_BLOCK_TYPES.leagueTable:
-      lines.push(`${indent}[League table: ${stringProp(props, "divisionId")}]`);
+    case CUSTOM_BLOCK_TYPES.leagueTable: {
+      const name = stringProp(props, "name");
+      lines.push(
+        `${indent}[League table: ${stringProp(props, "divisionId")}${name ? ` - ${name}` : ""}]`,
+      );
       break;
+    }
     case CUSTOM_BLOCK_TYPES.leaderboard:
       lines.push(`${indent}[Leaderboard]`);
       break;
     case CUSTOM_BLOCK_TYPES.recordsWall:
       lines.push(`${indent}[Records wall]`);
       break;
-    case CUSTOM_BLOCK_TYPES.contactForm:
-      lines.push(`${indent}[Contact form]`);
+    case CUSTOM_BLOCK_TYPES.contactForm: {
+      const title = stringProp(props, "title");
+      const description = stringProp(props, "description");
+      lines.push(
+        `${indent}[Contact form${title ? `: ${title}` : ""}${description ? ` - ${description}` : ""}]`,
+      );
       break;
-    case CUSTOM_BLOCK_TYPES.cookieSettingsLink:
-      lines.push(`${indent}[Cookie settings link]`);
+    }
+    case CUSTOM_BLOCK_TYPES.cookieSettingsLink: {
+      const linkText = stringProp(props, "text");
+      lines.push(
+        `${indent}[Cookie settings link${linkText ? `: ${linkText}` : ""}]`,
+      );
       break;
+    }
     case CUSTOM_BLOCK_TYPES.consentVersion:
       lines.push(`${indent}[Consent version]`);
       break;


### PR DESCRIPTION
Closes #500. Part of epic #497 (targets the epic branch, follows #498/#499).

## What

Revisions have been captured on every save since Phase 1; this adds the UI plus the one missing endpoint.

- **API**: `GET /admin/content/:contentId/revisions/:revisionId` returns one revision in full (title, description, body, metadata, who, when). The lookup is scoped to the content id so a revision is never reachable under a different - possibly more permissive - item's id, and the route gates on the item's kind with the same per-kind view permission as the revision list. Slug/parent are not part of a revision (they identify the item and stay behind their publish locks).
- **History card** in the editor sidebar: every save listed with author and UK-time timestamp. Opening one shows a plain-text diff against the latest saved version, split into Content (body) and Details (title/description/metadata).
- **Diff** (`revision-diff.ts`, pure + unit-tested, no new dependency): blocks project to one readable line each - headings as `## …`, list items with nesting, tables row by row, custom blocks as bracketed labels (`[Photo: …]`, `[Person card: …]`) - then a line LCS marks what's only in the revision (red) vs added since (green). Metadata keys are sorted before comparison so JSONB key-order churn never reads as a change.
- **Restore** copies the revision's body and metadata into the BlockNote editor and form as the working draft, with an amber notice ("review it, then save to keep it"). Nothing persists until the author saves - which writes a NEW revision through the existing update path, so the timeline is append-only and history is never rewritten. Publish status never changes; on a published item the existing save button still reads "Save & update live page", so going live remains the author's explicit action.

## Acceptance criteria

- [x] Accidental paragraph deletion recoverable by a non-techy editor in under a minute: open the item -> History card -> click the version before the mistake -> the deleted paragraph shows as a red line -> "Restore this version" -> Save. The diff unit test pins exactly this scenario.
- [x] Restore creates a new revision; timeline append-only - restore only stages the working draft; persistence goes through the normal PUT, which writes a revision like any other save (existing behaviour, covered by integration tests).
- [x] Gated by the same per-kind permissions as editing: the new endpoint reuses the per-kind view gate (403s added to the safeguarding boundary suite); the Restore button only renders when the user can actually save (manage + publish-if-published).

## Tests

- `revision-diff.test.ts`: block projection (headings/lists/tables/links/custom blocks/malformed input), sorted-key detail lines, and diffs including the deleted-paragraph recovery case.
- Integration: full revision detail round-trip (pre-edit state served), cross-item revision 404s, random-id 404, and 403s for news_editor/reports_editor on the new endpoint (39 content integration tests green).
- Monorepo lint (incl. react-doctor), typecheck, unit tests green (api 681, web 564).

🤖 Generated with [Claude Code](https://claude.com/claude-code)