### PR TITLE
Epic: Live content editing - Phase 4: People profiles + polish (#497)

### DIFF
--- a/apps/api/scripts/image-pipeline.ts
+++ b/apps/api/scripts/image-pipeline.ts
@@ -45,11 +45,55 @@ export interface Converted {
 }
 
 /**
- * Convert one MDX body, resolving each <Image> through the editor-upload
- * processing pipeline (locally - nothing is written here, so --dry-run
- * conversion is complete and writes can be deferred until after the
- * skip/insert decision). The processed-image cache spans articles so a
- * re-used asset is only decoded once.
+ * Run one "/images/..." asset through the editor-upload processing
+ * pipeline (locally - nothing is written here, so --dry-run conversion
+ * is complete and writes can be deferred until after the skip/insert
+ * decision). The cache spans items so a re-used asset is only decoded
+ * once. Used for body <Image> tags and for frontmatter photos (people
+ * profiles, #498) alike.
+ */
+export async function prepareAsset(
+  src: string,
+  alt: string | null,
+  cache: Map<string, PendingImage>,
+): Promise<PendingImage> {
+  const imageId = imageIdForAsset(src);
+  const cached = cache.get(imageId);
+  if (cached) return cached;
+
+  if (!src.startsWith("/images/")) {
+    throw new Error(`unexpected image src '${src}'`);
+  }
+  const assetPath = path.resolve(ASSETS_DIR, src.slice("/images/".length));
+  // A '..' segment in the src could otherwise resolve outside the
+  // bundled assets tree and upload an arbitrary readable file.
+  if (!assetPath.startsWith(ASSETS_DIR + path.sep)) {
+    throw new Error(`image src '${src}' escapes the assets directory`);
+  }
+  let original: Buffer;
+  try {
+    original = await fs.readFile(assetPath);
+  } catch {
+    throw new MissingImageError(src);
+  }
+  const processed = await processImage(
+    original,
+    imageId,
+    CONTENT_IMAGES_PREFIX,
+  );
+  const pending: PendingImage = {
+    imageId,
+    publicPath: src,
+    alt,
+    processed,
+    bytes: original.byteLength,
+  };
+  cache.set(imageId, pending);
+  return pending;
+}
+
+/**
+ * Convert one MDX body, resolving each <Image> through prepareAsset.
  */
 export async function convertBody(
   body: string,
@@ -57,38 +101,7 @@ export async function convertBody(
 ): Promise<Converted> {
   const images: PendingImage[] = [];
   const blocks = await mdxToBlocks(body, async ({ src, alt, caption }) => {
-    const imageId = imageIdForAsset(src);
-    let pending = cache.get(imageId);
-    if (!pending) {
-      if (!src.startsWith("/images/")) {
-        throw new Error(`unexpected image src '${src}'`);
-      }
-      const assetPath = path.resolve(ASSETS_DIR, src.slice("/images/".length));
-      // A '..' segment in the src could otherwise resolve outside the
-      // bundled assets tree and upload an arbitrary readable file.
-      if (!assetPath.startsWith(ASSETS_DIR + path.sep)) {
-        throw new Error(`image src '${src}' escapes the assets directory`);
-      }
-      let original: Buffer;
-      try {
-        original = await fs.readFile(assetPath);
-      } catch {
-        throw new MissingImageError(src);
-      }
-      const processed = await processImage(
-        original,
-        imageId,
-        CONTENT_IMAGES_PREFIX,
-      );
-      pending = {
-        imageId,
-        publicPath: src,
-        alt: alt ?? null,
-        processed,
-        bytes: original.byteLength,
-      };
-      cache.set(imageId, pending);
-    }
+    const pending = await prepareAsset(src, alt ?? null, cache);
     images.push(pending);
     // Exactly the prop set the editor inserts (content-editor.tsx): the
     // plain src falls back to the ladder's largest original-format

--- a/apps/api/scripts/mdx-to-blocks.test.ts
+++ b/apps/api/scripts/mdx-to-blocks.test.ts
@@ -14,6 +14,7 @@ import {
   parseEventSource,
   parseNewsSource,
   parsePageSource,
+  parsePersonSource,
   resolveLocation,
   segmentMdx,
   type ResolveContentImage,
@@ -740,6 +741,64 @@ describe("parseEventSource", () => {
     );
     expect(parsed.finish).toBeUndefined();
     expect(parsed.location).toBeUndefined();
+  });
+});
+
+describe("parsePersonSource", () => {
+  it("parses full frontmatter", () => {
+    const parsed = parsePersonSource(
+      [
+        "---",
+        "name: Alex Young",
+        "slug: alex-young",
+        "photo: /images/contentful/abc/photo.jpeg",
+        "isDBSChecked: true",
+        "hasLeftClub: false",
+        "---",
+        "",
+        "Bio text.",
+      ].join("\n"),
+    );
+    expect(parsed).toEqual({
+      name: "Alex Young",
+      slug: "alex-young",
+      photo: "/images/contentful/abc/photo.jpeg",
+      isDBSChecked: true,
+      hasLeftClub: false,
+      body: "Bio text.",
+    });
+  });
+
+  it("defaults the flags and treats the photo as optional, like the static loader", () => {
+    const parsed = parsePersonSource(
+      ["---", "name: Aaditya Kapil", "slug: aaditya-kapil", "---"].join("\n"),
+    );
+    expect(parsed).toEqual({
+      name: "Aaditya Kapil",
+      slug: "aaditya-kapil",
+      isDBSChecked: false,
+      hasLeftClub: false,
+      body: "",
+    });
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() =>
+      parsePersonSource(["---", "slug: x", "---", "Bio."].join("\n")),
+    ).toThrow();
+    expect(() =>
+      parsePersonSource(["---", "name: X", "---", "Bio."].join("\n")),
+    ).toThrow();
+  });
+
+  it("rejects non-boolean flags rather than coercing", () => {
+    expect(() =>
+      parsePersonSource(
+        ["---", "name: X", "slug: x", "isDBSChecked: yes please", "---"].join(
+          "\n",
+        ),
+      ),
+    ).toThrow();
   });
 });
 

--- a/apps/api/scripts/mdx-to-blocks.ts
+++ b/apps/api/scripts/mdx-to-blocks.ts
@@ -574,6 +574,39 @@ export function parsePageSource(source: string): PageSource {
   };
 }
 
+// Mirrors the static people loader's frontmatter handling (apps/web
+// lib/people.ts): name/slug always present, photo is a public
+// "/images/..." path, the safeguarding flags default to false.
+const personFrontmatterSchema = z.object({
+  name: z.string().min(1),
+  slug: z.string().min(1),
+  photo: z.string().min(1).optional(),
+  isDBSChecked: z.boolean().default(false),
+  hasLeftClub: z.boolean().default(false),
+});
+
+export interface PersonSource {
+  name: string;
+  slug: string;
+  photo?: string;
+  isDBSChecked: boolean;
+  hasLeftClub: boolean;
+  body: string;
+}
+
+export function parsePersonSource(source: string): PersonSource {
+  const { raw, body } = splitFrontmatter(source);
+  const fm = personFrontmatterSchema.parse(raw);
+  return {
+    name: fm.name,
+    slug: fm.slug,
+    ...(fm.photo !== undefined && { photo: fm.photo }),
+    isDBSChecked: fm.isDBSChecked,
+    hasLeftClub: fm.hasLeftClub,
+    body,
+  };
+}
+
 // ── Event locations ─────────────────────────────────────────────────────
 
 export interface RawLocation {

--- a/apps/api/scripts/migrate-people.ts
+++ b/apps/api/scripts/migrate-people.ts
@@ -1,0 +1,400 @@
+/**
+ * One-off migration (#499): import the legacy MDX people profiles into
+ * the content API's tables as published person items. The frontmatter
+ * maps onto title (name) + person metadata (isDBSChecked / hasLeftClub /
+ * photo); the bio body converts to blocks; the profile photo goes
+ * through the same processing pipeline as editor uploads, with consent
+ * recorded as confirmed (pre-existing content - the consent workflow
+ * applies to new editor uploads).
+ *
+ * Idempotent: upserts by (kind=person, slug). Unchanged items are
+ * skipped; image ids are UUIDv5-derived from the source asset path, so
+ * re-runs reuse the same S3 keys and content_image rows. Items that
+ * differ from the DB are skipped with a warning unless --force (the DB
+ * is canonical after cutover).
+ *
+ * Usage (local):
+ *   DATABASE_URL=postgres://percy:percy@localhost:5433/percy_main \
+ *     S3_BUCKET=percy-main-receipts-local \
+ *     S3_ENDPOINT=http://localhost:4566 \
+ *     AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+ *     pnpm exec tsx scripts/migrate-people.ts --user <user-id> [--dry-run] [--force]
+ *
+ * Environment:
+ *   DATABASE_URL  required always (dry runs read existing rows).
+ *   S3_BUCKET     required unless --dry-run; the CloudFront uploads
+ *                 bucket (prod: see infra outputs; local: the
+ *                 percy-main-receipts-local LocalStack bucket).
+ *   S3_REGION     optional, defaults to eu-west-2.
+ *   S3_ENDPOINT   optional; set to http://localhost:4566 for LocalStack.
+ *   AWS credentials come from the SDK default chain - for a real prod
+ *   run set AWS_PROFILE=percy-main (matching the CLI profile rule).
+ *
+ * Against prod, run with the standard prod access pattern and the
+ * admin_rw URL - coordinate first; never point this at prod casually.
+ */
+import { createClient } from "@percy-main/db";
+import {
+  contentBodySchema,
+  contentSlugSchema,
+  personMetadataSchema,
+} from "@percy-main/shared/content";
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  createContentImageStore,
+  type ContentImageStore,
+} from "../src/lib/s3-content-images.ts";
+import {
+  convertBody,
+  ensureImages,
+  planImageUploads,
+  prepareAsset,
+  type PendingImage,
+} from "./image-pipeline.ts";
+import { blocksEqualIgnoringIds } from "./markdown-to-blocks.ts";
+import { jsonEqual, parsePersonSource } from "./mdx-to-blocks.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PEOPLE_DIR = path.resolve(__dirname, "../../web/content/people");
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const userFlag = args.indexOf("--user");
+  const userId = userFlag >= 0 ? args[userFlag + 1] : undefined;
+  const dryRun = args.includes("--dry-run");
+  const force = args.includes("--force");
+  if (!userId) {
+    console.error(
+      "Usage: tsx scripts/migrate-people.ts --user <user-id> [--dry-run] [--force]",
+    );
+    process.exit(1);
+  }
+  return { userId, dryRun, force };
+}
+
+async function main() {
+  const { userId, dryRun, force } = parseArgs();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is required");
+    process.exit(1);
+  }
+
+  // The store is only needed for real runs - a dry run must not touch S3.
+  let store: ContentImageStore | null = null;
+  if (!dryRun) {
+    const bucket = process.env.S3_BUCKET;
+    if (!bucket) {
+      console.error("S3_BUCKET is required (omit only with --dry-run)");
+      process.exit(1);
+    }
+    store = createContentImageStore({
+      S3_BUCKET: bucket,
+      S3_REGION: process.env.S3_REGION ?? "eu-west-2",
+      S3_ENDPOINT: process.env.S3_ENDPOINT,
+      // Unused here (no presigned uploads) but part of the store config.
+      CONTENT_IMAGE_UPLOAD_URL_EXPIRY_SECONDS: 900,
+    });
+  }
+
+  const { client: db } = createClient(databaseUrl);
+
+  const attributedTo = await db
+    .selectFrom("user")
+    .select(["name", "email"])
+    .where("id", "=", userId)
+    .executeTakeFirst();
+  if (!attributedTo) {
+    console.error(`No user with id '${userId}'`);
+    await db.destroy();
+    process.exit(1);
+  }
+  console.log(
+    `Attributing imports to: ${attributedTo.name} <${attributedTo.email}>`,
+  );
+
+  const files = (await fs.readdir(PEOPLE_DIR))
+    .filter((f) => f.endsWith(".mdx"))
+    .sort();
+  console.log(`Found ${String(files.length)} people in ${PEOPLE_DIR}`);
+
+  const counts = {
+    inserted: 0,
+    updated: 0,
+    unchanged: 0,
+    skipped: 0,
+    failed: 0,
+  };
+  let imagesUploaded = 0;
+  let imagesReused = 0;
+  const imageCache = new Map<string, PendingImage>();
+  // Dry-run only: ids already reported as "would upload", so an asset
+  // shared by two profiles is not double-counted.
+  const plannedUploads = new Set<string>();
+
+  // ONE shared go-live instant for everything inserted this run - people
+  // profiles have no meaningful per-item publication date.
+  const publishedAt = new Date();
+
+  const failures: { file: string; reason: string }[] = [];
+  const skipped: { file: string; reason: string }[] = [];
+  const migrated: { slug: string; action: string }[] = [];
+  // Frontmatter slugs seen this run: the DB's (kind, slug) unique index
+  // would catch a duplicate anyway, but a friendly per-file failure beats
+  // a raw constraint violation mid-run.
+  const seenSlugs = new Set<string>();
+
+  const fail = (file: string, reason: string) => {
+    counts.failed += 1;
+    failures.push({ file, reason });
+    console.warn(`  ! ${file}: ${reason}`);
+  };
+
+  for (const file of files) {
+    // ── Parse + convert ───────────────────────────────────────────────
+    interface Prepared {
+      slug: string;
+      title: string;
+      metadata: Record<string, unknown>;
+      blocks: ReturnType<typeof contentBodySchema.parse>;
+      images: PendingImage[];
+    }
+    const prepared: Prepared | null = await (async () => {
+      try {
+        const source = await fs.readFile(path.join(PEOPLE_DIR, file), "utf8");
+        const parsed = parsePersonSource(source);
+        const slug = contentSlugSchema.parse(parsed.slug);
+        if (seenSlugs.has(slug)) {
+          throw new Error(`duplicate slug '${slug}' in the people corpus`);
+        }
+        seenSlugs.add(slug);
+        const converted = await convertBody(parsed.body, imageCache);
+        const images = [...converted.images];
+        let photo: PendingImage | undefined;
+        if (parsed.photo !== undefined) {
+          // The photo's alt is always the person's name at render time,
+          // so none is stored on the image row.
+          photo = await prepareAsset(parsed.photo, null, imageCache);
+          images.push(photo);
+        }
+        // The service validates metadata + body on every write; the
+        // script writes directly, so it runs the same gates.
+        const metadata = personMetadataSchema.parse({
+          isDBSChecked: parsed.isDBSChecked,
+          hasLeftClub: parsed.hasLeftClub,
+          ...(photo !== undefined && { photo: photo.processed.picture }),
+        });
+        const blocks = contentBodySchema.parse(converted.blocks);
+        return { slug, title: parsed.name, metadata, blocks, images };
+      } catch (err) {
+        fail(file, err instanceof Error ? err.message : String(err));
+        return null;
+      }
+    })();
+    if (prepared === null) continue;
+    const { slug, title, metadata, blocks, images } = prepared;
+
+    // ── Upsert ────────────────────────────────────────────────────────
+    const existing = await db
+      .selectFrom("content_item")
+      .select(["id", "body", "title", "description", "metadata", "status"])
+      .where("kind", "=", "person")
+      .where("slug", "=", slug)
+      .executeTakeFirst();
+
+    if (existing) {
+      // Same stance as the earlier migrations: a non-published row would
+      // still 404 publicly, and a published row an editor may have
+      // touched is only overwritten under --force (post-cutover the DB
+      // is canonical and the MDX is the stale ancestor).
+      if (existing.status !== "published") {
+        counts.skipped += 1;
+        const reason = `a ${existing.status} person already exists at '${slug}' - the public endpoint will 404. Publish or remove it, then re-run.`;
+        skipped.push({ file, reason });
+        console.warn(`  ! ${file}: ${reason}`);
+        continue;
+      }
+
+      const unchanged =
+        blocksEqualIgnoringIds(existing.body, blocks) &&
+        existing.title === title &&
+        existing.description === null &&
+        jsonEqual(existing.metadata, metadata);
+      if (unchanged) {
+        counts.unchanged += 1;
+        migrated.push({ slug, action: "unchanged" });
+        console.log(`  = ${file} unchanged (${existing.title})`);
+        continue;
+      }
+      if (!force) {
+        counts.skipped += 1;
+        const reason = `published profile '${existing.title}' differs from the MDX conversion (likely edited in the DB). Skipping - re-run with --force to overwrite.`;
+        skipped.push({ file, reason });
+        console.warn(`  ! ${file}: ${reason}`);
+        continue;
+      }
+
+      if (dryRun) {
+        const { newImages, reused } = await planImageUploads(
+          db,
+          images,
+          plannedUploads,
+        );
+        imagesReused += reused;
+        imagesUploaded += newImages.length;
+        console.log(
+          `  ~ ${file} would update '${title}' (${String(blocks.length)} blocks, ${String(images.length)} images)`,
+        );
+        for (const image of newImages) {
+          console.log(`    ~ would upload ${image.publicPath}`);
+        }
+        counts.updated += 1;
+        migrated.push({ slug, action: "updated" });
+        continue;
+      }
+
+      if (!store) throw new Error("store unavailable outside a real run");
+      const ensured = await ensureImages(db, store, userId, images);
+      imagesUploaded += ensured.uploaded;
+      imagesReused += ensured.reused;
+
+      // slug/status/published_at untouched: rewriting published_at would
+      // rewrite the profile's go-live history.
+      await db.transaction().execute(async (tx) => {
+        await tx
+          .updateTable("content_item")
+          .set({
+            title,
+            description: null,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(metadata),
+            updated_by: userId,
+            updated_at: new Date(),
+          })
+          .where("id", "=", existing.id)
+          .execute();
+        await tx
+          .insertInto("content_revision")
+          .values({
+            content_id: existing.id,
+            title,
+            description: null,
+            body: JSON.stringify(blocks),
+            metadata: JSON.stringify(metadata),
+            saved_by: userId,
+          })
+          .execute();
+      });
+      counts.updated += 1;
+      migrated.push({ slug, action: "updated" });
+      console.log(`  ^ ${file} updated (${title})`);
+      continue;
+    }
+
+    // ── Insert ────────────────────────────────────────────────────────
+    if (dryRun) {
+      const { newImages, reused } = await planImageUploads(
+        db,
+        images,
+        plannedUploads,
+      );
+      imagesReused += reused;
+      imagesUploaded += newImages.length;
+      console.log(
+        `  ~ ${file} would insert '${title}' (${String(blocks.length)} blocks, ${String(images.length)} images, published_at ${publishedAt.toISOString()})`,
+      );
+      for (const image of newImages) {
+        console.log(`    ~ would upload ${image.publicPath}`);
+      }
+      counts.inserted += 1;
+      migrated.push({ slug, action: "inserted" });
+      continue;
+    }
+
+    if (!store) throw new Error("store unavailable outside a real run");
+    // Images first: like the editor flow, content_image rows + variants
+    // exist before any item referencing them is saved.
+    const ensured = await ensureImages(db, store, userId, images);
+    imagesUploaded += ensured.uploaded;
+    imagesReused += ensured.reused;
+
+    await db.transaction().execute(async (tx) => {
+      const inserted = await tx
+        .insertInto("content_item")
+        .values({
+          kind: "person",
+          slug,
+          title,
+          description: null,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          status: "published",
+          published_at: publishedAt,
+          created_by: userId,
+          updated_by: userId,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      await tx
+        .insertInto("content_revision")
+        .values({
+          content_id: inserted.id,
+          title,
+          description: null,
+          body: JSON.stringify(blocks),
+          metadata: JSON.stringify(metadata),
+          saved_by: userId,
+        })
+        .execute();
+    });
+    counts.inserted += 1;
+    migrated.push({ slug, action: "inserted" });
+    console.log(`  + ${file} inserted as '${title}'`);
+  }
+
+  // ── Report ────────────────────────────────────────────────────────────
+
+  console.log("");
+  console.log("=== Migration report ===");
+  console.log(
+    `People: ${String(counts.inserted)} inserted, ${String(counts.updated)} updated, ${String(counts.unchanged)} unchanged, ${String(counts.skipped)} skipped, ${String(counts.failed)} failed`,
+  );
+  console.log(
+    `Images: ${String(imagesUploaded)} ${dryRun ? "would be uploaded" : "uploaded"}, ${String(imagesReused)} reused`,
+  );
+
+  console.log(`Migrated (${String(migrated.length)}):`);
+  for (const item of migrated) {
+    console.log(`  ${item.slug} (${item.action})`);
+  }
+  console.log(`Failed (${String(failures.length)}):`);
+  for (const failure of failures) {
+    console.log(`  ${failure.file}: ${failure.reason}`);
+  }
+  console.log(`Skipped (${String(skipped.length)}):`);
+  for (const item of skipped) {
+    console.log(`  ${item.file}: ${item.reason}`);
+  }
+
+  console.log(
+    `Done with ${String(failures.length + skipped.length)} warnings${dryRun ? " (dry run)" : ""}`,
+  );
+  if (failures.length + skipped.length > 0) {
+    // People have a per-slug fallback: a profile with no published DB row
+    // keeps rendering from the static bundle (TRANSITION FALLBACK #489),
+    // so a partial migration is safe - but the static MDX cleanup must
+    // not remove files listed above.
+    console.warn(
+      "NOTE: failed/skipped profiles keep rendering from the static bundle " +
+        "via the per-slug fallback. Do NOT delete their MDX in the " +
+        "cleanup PR until they are resolved and re-run.",
+    );
+    process.exitCode = 2;
+  }
+  await db.destroy();
+}
+
+await main();

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -20,6 +20,7 @@ import {
   getContent,
   getPublishedContent,
   getPublishedGameReport,
+  getRevision,
   listContent,
   listPageTree,
   listPublishedEvents,
@@ -162,6 +163,60 @@ describe("content service (integration)", () => {
     // Publishing again without a date keeps the original live-from time
     const again = await publishContent(ctx.db)({ contentId: id, userId });
     expect(again.publishedAt).toBe(past);
+  });
+
+  it("serves a single revision in full for diff/restore (#500)", async () => {
+    const { id } = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "rev-detail",
+      title: "Rev detail",
+      description: null,
+      body: body("Original paragraph."),
+      metadata: { playCricketId: "999111" },
+      userId,
+    });
+    await updateContent(ctx.db)({
+      contentId: id,
+      title: "Rev detail v2",
+      body: body("Edited paragraph."),
+      userId,
+    });
+
+    const { revisions } = await listRevisions(ctx.db)(id);
+    expect(revisions).toHaveLength(2);
+    const creation = revisions[1];
+    if (!creation) throw new Error("expected the creation revision");
+
+    // The creation revision carries the full pre-edit state - exactly
+    // what restore copies back into the editor.
+    const detail = await getRevision(ctx.db)({
+      contentId: id,
+      revisionId: creation.id,
+    });
+    expect(detail.title).toBe("Rev detail");
+    expect(detail.metadata).toEqual({ playCricketId: "999111" });
+    expect(detail.body).toMatchObject([
+      { content: [{ text: "Original paragraph." }] },
+    ]);
+
+    // A revision is only reachable under its own item's id - the route
+    // gates permissions on the item's kind, so cross-item reads would
+    // bypass the per-kind model.
+    const other = await createContent(ctx.db)({
+      kind: "game_report",
+      slug: "rev-detail-other",
+      title: "Other",
+      description: null,
+      body: body("Other."),
+      metadata: { playCricketId: "999112" },
+      userId,
+    });
+    await expect(
+      getRevision(ctx.db)({ contentId: other.id, revisionId: creation.id }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    await expect(
+      getRevision(ctx.db)({ contentId: id, revisionId: crypto.randomUUID() }),
+    ).rejects.toMatchObject({ statusCode: 404 });
   });
 
   it("enforces per-kind slug uniqueness on create", async () => {
@@ -838,7 +893,25 @@ describe("content service (integration)", () => {
         headers: { cookie: peopleEditor },
       });
       expect(revs.statusCode).toBe(200);
-      expect(revs.json<{ revisions: unknown[] }>().revisions).toHaveLength(2);
+      const { revisions } = revs.json<{
+        revisions: Array<{ id: string }>;
+      }>();
+      expect(revisions).toHaveLength(2);
+
+      // The single-revision endpoint (#500) returns the full pre-edit
+      // state for diff/restore - the creation revision still has the
+      // DBS flag unticked.
+      const creation = revisions[1];
+      if (!creation) throw new Error("expected the creation revision");
+      const detail = await app.inject({
+        method: "GET",
+        url: `/api/admin/content/${id}/revisions/${creation.id}`,
+        headers: { cookie: peopleEditor },
+      });
+      expect(detail.statusCode).toBe(200);
+      expect(
+        detail.json<{ metadata: Record<string, unknown> }>().metadata,
+      ).toEqual({ isDBSChecked: false, hasLeftClub: false });
     });
 
     it.each([
@@ -885,6 +958,13 @@ describe("content service (integration)", () => {
           app.inject({
             method: "GET",
             url: `/api/admin/content/${fixtureId}/revisions`,
+            headers: { cookie },
+          }),
+          // Permission check precedes the revision lookup, so a random
+          // revision id still proves the 403 boundary.
+          app.inject({
+            method: "GET",
+            url: `/api/admin/content/${fixtureId}/revisions/${crypto.randomUUID()}`,
             headers: { cookie },
           }),
         ];

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -956,6 +956,95 @@ describe("content service (integration)", () => {
       });
       expect(res.statusCode).toBe(401);
     });
+
+    it("the public roster lists published people only, title-ordered", async () => {
+      // One published (from the lifecycle test) + the draft fixture. Add
+      // a second published person to assert ordering.
+      const { id } = await createContent(ctx.db)({
+        kind: "person",
+        slug: "aaron-aardvark",
+        title: "Aaron Aardvark",
+        description: null,
+        body: body("First alphabetically."),
+        metadata: { isDBSChecked: false, hasLeftClub: true },
+        userId,
+      });
+      await publishContent(ctx.db)({ contentId: id, userId });
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/content/people",
+      });
+      expect(res.statusCode).toBe(200);
+      const { items } = res.json<{
+        items: Array<{
+          slug: string;
+          title: string;
+          metadata: Record<string, unknown>;
+        }>;
+      }>();
+      const slugs = items.map((i) => i.slug);
+      expect(slugs).toContain("aaron-aardvark");
+      expect(slugs).toContain("edith-example");
+      // The draft fixture stays out of the public roster
+      expect(slugs).not.toContain("boundary-fixture");
+      // Title-ordered
+      expect(slugs.indexOf("aaron-aardvark")).toBeLessThan(
+        slugs.indexOf("edith-example"),
+      );
+      // Metadata is projected through the person schema
+      const aaron = items.find((i) => i.slug === "aaron-aardvark");
+      expect(aaron?.metadata).toEqual({
+        isDBSChecked: false,
+        hasLeftClub: true,
+      });
+    });
+
+    it("tombstones a taken-down profile: 410 by slug, listed in removed", async () => {
+      // The SPA falls back to its bundled static profile on 404, so a
+      // takedown (safeguarding-relevant for people) must not read as
+      // "missing" - same rule as the page by-path tombstone.
+      const { id } = await createContent(ctx.db)({
+        kind: "person",
+        slug: "tomb-person",
+        title: "Tomb Person",
+        description: null,
+        body: body("Was live."),
+        metadata: {},
+        userId,
+      });
+      await publishContent(ctx.db)({ contentId: id, userId });
+      await unpublishContent(ctx.db)({ contentId: id, userId });
+
+      const bySlug = await app.inject({
+        method: "GET",
+        url: "/api/content/person/tomb-person",
+      });
+      expect(bySlug.statusCode).toBe(410);
+      expect(bySlug.json()).toEqual({
+        error: "This profile has been removed",
+      });
+      expect(bySlug.headers.etag).toBeUndefined();
+
+      const roster = await app.inject({
+        method: "GET",
+        url: "/api/content/people",
+      });
+      const { items, removed } = roster.json<{
+        items: Array<{ slug: string }>;
+        removed: string[];
+      }>();
+      expect(removed).toContain("tomb-person");
+      expect(items.map((i) => i.slug)).not.toContain("tomb-person");
+
+      // Never-live drafts stay 404 and out of removed - they leak nothing
+      const draft = await app.inject({
+        method: "GET",
+        url: "/api/content/person/boundary-fixture",
+      });
+      expect(draft.statusCode).toBe(404);
+      expect(removed).not.toContain("boundary-fixture");
+    });
   });
 
   describe("page hierarchy", () => {

--- a/apps/api/src/features/content/integration.test.ts
+++ b/apps/api/src/features/content/integration.test.ts
@@ -5,6 +5,7 @@ import {
 } from "fastify-type-provider-zod";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { errorHandler } from "../../lib/error-handler.ts";
+import { buildTestApp } from "../../test/app.ts";
 import {
   seedTestUser,
   startTestContainer,
@@ -680,6 +681,280 @@ describe("content service (integration)", () => {
       } finally {
         await app.close();
       }
+    });
+  });
+
+  describe("person kind: lifecycle + safeguarding boundary (HTTP)", () => {
+    // Person profiles carry safeguarding-adjacent flags, so they are
+    // gated by content_people (people_editor / content_admin) instead of
+    // the shared content roles (#498). The boundary is an acceptance
+    // criterion in its own right, so this suite runs the REAL stack -
+    // better-auth sessions, requireAuth, assertContentPermission - not
+    // service calls.
+    let app: Awaited<ReturnType<typeof buildTestApp>>;
+    let peopleEditor: string;
+    let newsEditor: string;
+    let reportsEditor: string;
+    let contentAdmin: string;
+    /** Draft person owned by the service user - the read/write target. */
+    let fixtureId: string;
+
+    const PASSWORD = "Sup3rSecure!password";
+
+    /** Sign up + verify + sign in; returns the session cookie header. */
+    async function sessionFor(role: string): Promise<string> {
+      const email = `${crypto.randomUUID()}@example.com`;
+      const signUp = await app.inject({
+        method: "POST",
+        url: "/api/auth/sign-up/email",
+        payload: { email, password: PASSWORD, name: `Test ${role}` },
+      });
+      expect(signUp.statusCode).toBe(200);
+      // Verified email + role set directly: this suite tests the content
+      // permission boundary, not the verification email flow.
+      await ctx.db
+        .updateTable("user")
+        .set({ role, emailVerified: true })
+        .where("email", "=", email)
+        .execute();
+      const signIn = await app.inject({
+        method: "POST",
+        url: "/api/auth/sign-in/email",
+        payload: { email, password: PASSWORD },
+      });
+      expect(signIn.statusCode).toBe(200);
+      const setCookie = signIn.headers["set-cookie"];
+      const raw = Array.isArray(setCookie)
+        ? setCookie
+        : typeof setCookie === "string"
+          ? [setCookie]
+          : [];
+      const cookie = raw
+        .map((entry) => entry.split(";")[0])
+        .filter(Boolean)
+        .join("; ");
+      expect(cookie).not.toBe("");
+      return cookie;
+    }
+
+    const personPayload = (slug: string) => ({
+      kind: "person",
+      slug,
+      title: "Edith Example",
+      description: null,
+      body: body("A short bio."),
+      metadata: { isDBSChecked: false, hasLeftClub: false },
+    });
+
+    beforeAll(async () => {
+      app = await buildTestApp(ctx.db, ctx.dialect);
+      [peopleEditor, newsEditor, reportsEditor, contentAdmin] =
+        await Promise.all([
+          sessionFor("people_editor"),
+          sessionFor("news_editor"),
+          sessionFor("reports_editor"),
+          sessionFor("content_admin"),
+        ]);
+      ({ id: fixtureId } = await createContent(ctx.db)({
+        kind: "person",
+        slug: "boundary-fixture",
+        title: "Boundary Fixture",
+        description: null,
+        body: body("Fixture bio."),
+        metadata: {},
+        userId,
+      }));
+    }, 120_000);
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it("people_editor: create, edit the DBS flag, publish, public serve, revisions", async () => {
+      const create = await app.inject({
+        method: "POST",
+        url: "/api/admin/content",
+        headers: { cookie: peopleEditor },
+        payload: personPayload("edith-example"),
+      });
+      expect(create.statusCode).toBe(200);
+      const { id } = create.json<{ id: string }>();
+
+      const list = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=person",
+        headers: { cookie: peopleEditor },
+      });
+      expect(list.statusCode).toBe(200);
+      expect(
+        list.json<{ items: Array<{ id: string }> }>().items.map((i) => i.id),
+      ).toContain(id);
+
+      // Draft profiles leak nothing publicly
+      const draftPublic = await app.inject({
+        method: "GET",
+        url: "/api/content/person/edith-example",
+      });
+      expect(draftPublic.statusCode).toBe(404);
+
+      // The safeguarding edit itself: toggle the DBS flag
+      const update = await app.inject({
+        method: "PUT",
+        url: `/api/admin/content/${id}`,
+        headers: { cookie: peopleEditor },
+        payload: { metadata: { isDBSChecked: true, hasLeftClub: false } },
+      });
+      expect(update.statusCode).toBe(200);
+
+      const publish = await app.inject({
+        method: "POST",
+        url: `/api/admin/content/${id}/publish`,
+        headers: { cookie: peopleEditor },
+        payload: {},
+      });
+      expect(publish.statusCode).toBe(200);
+
+      // Public route serves the published profile (no auth) with the
+      // projected metadata
+      const pub = await app.inject({
+        method: "GET",
+        url: "/api/content/person/edith-example",
+      });
+      expect(pub.statusCode).toBe(200);
+      const served = pub.json<{
+        title: string;
+        metadata: Record<string, unknown>;
+      }>();
+      expect(served.title).toBe("Edith Example");
+      expect(served.metadata).toEqual({
+        isDBSChecked: true,
+        hasLeftClub: false,
+      });
+
+      // Both saves are in the revision history
+      const revs = await app.inject({
+        method: "GET",
+        url: `/api/admin/content/${id}/revisions`,
+        headers: { cookie: peopleEditor },
+      });
+      expect(revs.statusCode).toBe(200);
+      expect(revs.json<{ revisions: unknown[] }>().revisions).toHaveLength(2);
+    });
+
+    it.each([
+      ["news_editor", () => newsEditor],
+      ["reports_editor", () => reportsEditor],
+    ])(
+      "%s can neither read nor write person content",
+      async (_role, cookieOf) => {
+        const cookie = cookieOf();
+        const attempts = [
+          app.inject({
+            method: "GET",
+            url: "/api/admin/content?kind=person",
+            headers: { cookie },
+          }),
+          app.inject({
+            method: "GET",
+            url: `/api/admin/content/${fixtureId}`,
+            headers: { cookie },
+          }),
+          app.inject({
+            method: "POST",
+            url: "/api/admin/content",
+            headers: { cookie },
+            payload: personPayload("smuggled-profile"),
+          }),
+          app.inject({
+            method: "PUT",
+            url: `/api/admin/content/${fixtureId}`,
+            headers: { cookie },
+            payload: { metadata: { isDBSChecked: true, hasLeftClub: false } },
+          }),
+          app.inject({
+            method: "POST",
+            url: `/api/admin/content/${fixtureId}/publish`,
+            headers: { cookie },
+            payload: {},
+          }),
+          app.inject({
+            method: "POST",
+            url: `/api/admin/content/${fixtureId}/archive`,
+            headers: { cookie },
+          }),
+          app.inject({
+            method: "GET",
+            url: `/api/admin/content/${fixtureId}/revisions`,
+            headers: { cookie },
+          }),
+        ];
+        for (const attempt of await Promise.all(attempts)) {
+          expect(attempt.statusCode).toBe(403);
+        }
+        // And nothing was written or leaked
+        const fixture = await getContent(ctx.db)(fixtureId);
+        expect(fixture.metadata).toEqual({
+          isDBSChecked: false,
+          hasLeftClub: false,
+        });
+        expect(fixture.status).toBe("draft");
+      },
+    );
+
+    it("the boundary cuts both ways: people_editor has no reach into other kinds", async () => {
+      const newsList = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=news",
+        headers: { cookie: peopleEditor },
+      });
+      expect(newsList.statusCode).toBe(403);
+
+      const newsCreate = await app.inject({
+        method: "POST",
+        url: "/api/admin/content",
+        headers: { cookie: peopleEditor },
+        payload: {
+          kind: "news",
+          slug: "people-editor-news",
+          title: "Not allowed",
+          description: null,
+          body: body("Nope."),
+          metadata: { tags: [] },
+        },
+      });
+      expect(newsCreate.statusCode).toBe(403);
+
+      const reportsList = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=game_report",
+        headers: { cookie: peopleEditor },
+      });
+      expect(reportsList.statusCode).toBe(403);
+    });
+
+    it("content_admin manages person content like any other kind", async () => {
+      const list = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=person",
+        headers: { cookie: contentAdmin },
+      });
+      expect(list.statusCode).toBe(200);
+
+      const update = await app.inject({
+        method: "PUT",
+        url: `/api/admin/content/${fixtureId}`,
+        headers: { cookie: contentAdmin },
+        payload: { description: "Updated by the content admin" },
+      });
+      expect(update.statusCode).toBe(200);
+    });
+
+    it("anonymous admin requests are 401, not 403", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/admin/content?kind=person",
+      });
+      expect(res.statusCode).toBe(401);
     });
   });
 

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -29,6 +29,8 @@ import {
   publicContentParamsSchema,
   publicContentResponseSchema,
   publishContentSchema,
+  revisionDetailResponseSchema,
+  revisionIdParamSchema,
   updateContentSchema,
 } from "./schemas.ts";
 import {
@@ -40,6 +42,7 @@ import {
   getPublishedGameReport,
   getPublishedNav,
   getPublishedPageByPath,
+  getRevision,
   listContent,
   listPageTree,
   listPublishedEvents,
@@ -87,6 +90,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const unpublish = unpublishContent(app.db);
   const archive = archiveContent(app.db);
   const revisions = listRevisions(app.db);
+  const revision = getRevision(app.db);
   const publicGet = getPublishedContent(app.db);
   const publicGameReport = getPublishedGameReport(app.db);
   const publicNews = listPublishedNews(app.db);
@@ -265,6 +269,25 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       const { kind } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "view");
       return await revisions(request.params.contentId);
+    },
+  );
+
+  app.get(
+    "/admin/content/:contentId/revisions/:revisionId",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        params: revisionIdParamSchema,
+        response: { 200: revisionDetailResponseSchema },
+      },
+    },
+    async (request) => {
+      // Same gate as the list: the revision's own permission model is
+      // the item's kind (the service scopes the lookup to contentId, so
+      // a revision is never reachable under a different item's id).
+      const { kind } = await metaOf(request.params.contentId);
+      assertContentPermission(request, kind, "view");
+      return await revision(request.params);
     },
   );
 

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -20,6 +20,7 @@ import {
   listEventsResponseSchema,
   listNewsQuerySchema,
   listNewsResponseSchema,
+  listPeopleResponseSchema,
   listRevisionsResponseSchema,
   navResponseSchema,
   pageByPathQuerySchema,
@@ -43,6 +44,7 @@ import {
   listPageTree,
   listPublishedEvents,
   listPublishedNews,
+  listPublishedPeople,
   listRevisions,
   publishContent,
   unpublishContent,
@@ -89,6 +91,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const publicGameReport = getPublishedGameReport(app.db);
   const publicNews = listPublishedNews(app.db);
   const publicEvents = listPublishedEvents(app.db);
+  const publicPeople = listPublishedPeople(app.db);
   const publicNav = getPublishedNav(app.db);
   const publicPageByPath = getPublishedPageByPath(app.db);
 
@@ -295,12 +298,20 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     },
   );
 
+  // 410 = person tombstone: the profile WAS live at this slug but has
+  // been taken down; the SPA must not fall back to its bundled static
+  // version (404 keeps that fallback for never-live slugs). Other kinds
+  // never produce a 410 here.
   app.get(
     "/content/:kind/:slug",
     {
       schema: {
         params: publicContentParamsSchema,
-        response: { 200: publicContentResponseSchema, 304: z.null() },
+        response: {
+          200: publicContentResponseSchema,
+          304: z.null(),
+          410: goneResponseSchema,
+        },
       },
     },
     async (request, reply) => {
@@ -369,6 +380,18 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async () => {
       return await publicEvents();
+    },
+  );
+
+  app.get(
+    "/content/people",
+    {
+      schema: {
+        response: { 200: listPeopleResponseSchema },
+      },
+    },
+    async () => {
+      return await publicPeople();
     },
   );
 

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -225,6 +225,22 @@ export const listEventsResponseSchema = z.object({
   items: z.array(publicListItemSchema),
 });
 
+/**
+ * All published people, title-ordered. Backs person cards/grids, the
+ * public profile index and the editor's people pickers from a single
+ * cached request (~55 rows sitewide, so no pagination).
+ */
+export const listPeopleResponseSchema = z.object({
+  items: z.array(publicListItemSchema),
+  /**
+   * Tombstoned slugs: people who were publicly live but are no longer
+   * visible (unpublished/archived after going live). The SPA drops
+   * matching entries from its bundled static corpus so a takedown does
+   * not resurrect the stale static profile (same pattern as nav.removed).
+   */
+  removed: z.array(z.string()),
+});
+
 // ── Public: pages (nav + by-path) ───────────────────────────────────────
 
 /**

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -157,6 +157,28 @@ export const listRevisionsResponseSchema = z.object({
   ),
 });
 
+export const revisionIdParamSchema = z.object({
+  contentId: z.uuid(),
+  revisionId: z.uuid(),
+});
+
+/**
+ * One revision in full - body and metadata included - for the history
+ * UI's diff and restore (#500). Slug/parent are not part of a revision:
+ * they identify the item rather than its content, and restoring must
+ * never bypass the slug/path locks.
+ */
+export const revisionDetailResponseSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  body: contentBodyTransportSchema,
+  metadata: contentMetadataSchema,
+  savedAt: z.string(),
+  savedBy: z.string(),
+  savedByName: z.string().nullable(),
+});
+
 // ── Public ──────────────────────────────────────────────────────────────
 
 export const publicContentParamsSchema = z.object({

--- a/apps/api/src/features/content/service.test.ts
+++ b/apps/api/src/features/content/service.test.ts
@@ -179,12 +179,6 @@ beforeEach(() => {
 });
 
 describe("createContent", () => {
-  it("rejects kinds that are not editable yet", async () => {
-    await expect(
-      createContent(db)(validCreate({ kind: "person", metadata: {} })),
-    ).rejects.toMatchObject({ statusCode: 400 });
-  });
-
   it("rejects metadata that fails the kind schema", async () => {
     await expect(
       createContent(db)(validCreate({ metadata: {} })),
@@ -310,6 +304,97 @@ describe("news and event metadata", () => {
         userId: "user-1",
         metadata: { tags: "seniors" },
       }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});
+
+describe("person metadata", () => {
+  const personCreate = (metadata: Record<string, unknown>) =>
+    validCreate({
+      kind: "person" as const,
+      slug: "alice-smith",
+      title: "Alice Smith",
+      metadata,
+    });
+  const validPhoto = {
+    sources: {
+      webp: "/uploads/content/abc/img-320.webp 320w, /uploads/content/abc/img-640.webp 640w",
+    },
+    img: { src: "/uploads/content/abc/img-1920.jpeg", w: 1920, h: 1080 },
+  };
+
+  it("applies the flag defaults when metadata is empty", async () => {
+    await createContent(db)(personCreate({}));
+    const inserted = valuesArgFor() as { metadata: string };
+    expect(JSON.parse(inserted.metadata)).toEqual({
+      isDBSChecked: false,
+      hasLeftClub: false,
+    });
+  });
+
+  it("creates a person with flags and a photo descriptor", async () => {
+    await createContent(db)(
+      personCreate({
+        isDBSChecked: true,
+        hasLeftClub: false,
+        photo: validPhoto,
+      }),
+    );
+    const inserted = valuesArgFor() as { metadata: string };
+    expect(JSON.parse(inserted.metadata)).toEqual({
+      isDBSChecked: true,
+      hasLeftClub: false,
+      photo: validPhoto,
+    });
+  });
+
+  it("strips a name key - title is the single source of the display name", async () => {
+    await createContent(db)(personCreate({ name: "Someone Else" }));
+    const inserted = valuesArgFor() as { metadata: string };
+    expect(JSON.parse(inserted.metadata)).not.toHaveProperty("name");
+  });
+
+  it("rejects a photo src that is not https or site-relative", async () => {
+    await expect(
+      createContent(db)(
+        personCreate({
+          photo: {
+            ...validPhoto,
+            img: { src: "javascript:alert(1)", w: 1, h: 1 },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    await expect(
+      createContent(db)(
+        personCreate({
+          photo: {
+            ...validPhoto,
+            img: { src: "http://evil.example/x.jpg", w: 1, h: 1 },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects a srcset smuggling an unsafe URL among safe ones", async () => {
+    await expect(
+      createContent(db)(
+        personCreate({
+          photo: {
+            ...validPhoto,
+            sources: {
+              webp: "/uploads/content/abc/img-320.webp 320w, http://evil.example/x.webp 640w",
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects non-boolean flags rather than coercing", async () => {
+    await expect(
+      createContent(db)(personCreate({ isDBSChecked: "yes" })),
     ).rejects.toMatchObject({ statusCode: 400 });
   });
 });

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -1124,6 +1124,50 @@ export function listRevisions(db: Kysely<DB>) {
   };
 }
 
+export function getRevision(db: Kysely<DB>) {
+  return async (params: { contentId: string; revisionId: string }) => {
+    // The content_id filter makes the lookup tenant-safe within the
+    // route's permission model: the route gates on the CONTENT item's
+    // kind, so a revision must never be reachable under a different
+    // (more permissive) item's id.
+    const row = await db
+      .selectFrom("content_revision")
+      .leftJoin("user as saver", "saver.id", "content_revision.saved_by")
+      .select([
+        "content_revision.id",
+        "content_revision.title",
+        "content_revision.description",
+        "content_revision.body",
+        "content_revision.metadata",
+        "content_revision.saved_at",
+        "content_revision.saved_by",
+        "saver.name as saved_by_name",
+      ])
+      .where("content_revision.id", "=", params.revisionId)
+      .where("content_revision.content_id", "=", params.contentId)
+      .executeTakeFirst();
+    if (!row) throwHttpError(404, "Revision not found");
+
+    // A stored body failing the schema is a server-side data problem,
+    // not a bad request - same stance as getContent.
+    const parsedBody = contentBodySchema.safeParse(row.body);
+    if (!parsedBody.success) {
+      throwHttpError(500, "Stored body does not match the block schema");
+    }
+
+    return {
+      id: row.id,
+      title: row.title,
+      description: row.description,
+      body: parsedBody.data,
+      metadata: row.metadata as Record<string, unknown>,
+      savedAt: row.saved_at.toISOString(),
+      savedBy: row.saved_by,
+      savedByName: row.saved_by_name,
+    };
+  };
+}
+
 // ── Public reads ────────────────────────────────────────────────────────
 
 function toPublic(row: {

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -6,6 +6,7 @@ import {
   eventMetadataSchema,
   newsMetadataSchema,
   pageMetadataSchema,
+  personMetadataSchema,
   RESERVED_ROOT_SLUGS,
   type ContentKind,
   type ContentStatus,
@@ -1205,7 +1206,26 @@ export function getPublishedContent(db: Kysely<DB>) {
 
     const row = await query.executeTakeFirst();
 
-    if (!row) throwHttpError(404, "Content not found");
+    if (!row) {
+      // Person tombstone, mirroring the by-path page rule: the SPA falls
+      // back to its bundled static profile on 404, so taking down a
+      // migrated profile (unpublish/archive - safeguarding-relevant for
+      // people) must not read as "missing" and resurrect the stale
+      // static version. Ever-live (past published_at) but not visible
+      // now is 410 Gone; never-live rows stay 404 and leak nothing.
+      if (params.kind === "person") {
+        const tombstone = await db
+          .selectFrom("content_item")
+          .select("id")
+          .where("kind", "=", "person")
+          .where("slug", "=", params.slug)
+          .where("published_at", "is not", null)
+          .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`)
+          .executeTakeFirst();
+        if (tombstone) throwHttpError(410, "This profile has been removed");
+      }
+      throwHttpError(404, "Content not found");
+    }
     return toPublic(row);
   };
 }
@@ -1451,6 +1471,42 @@ export function listPublishedEvents(db: Kysely<DB>) {
 
     return {
       items: rows.map((row) => toPublicListItem(eventMetadataSchema, row)),
+    };
+  };
+}
+
+export function listPublishedPeople(db: Kysely<DB>) {
+  return async () => {
+    // No pagination: ~55 profiles sitewide, and every consumer (person
+    // cards, grids, the profile pickers in the editor) wants the whole
+    // roster in one cached request - resolving cards per-slug would be
+    // an N+1 every time a page renders a person grid.
+    const rows = await publishedOnly(db)
+      .select(publicListColumns)
+      .where("kind", "=", "person")
+      .orderBy("title", "asc")
+      .execute();
+
+    // Tombstoned slugs (same ever-live test as the by-slug 410): people
+    // who WERE publicly live but are not visible now. The SPA drops
+    // matching entries from its bundled static corpus so a takedown does
+    // not resurrect the stale static profile in cards and pickers. The
+    // status partition makes the two queries consistent without a
+    // transaction: a row is either published (items candidate) or not
+    // (removed candidate), never both.
+    const removedRows = await db
+      .selectFrom("content_item")
+      .select("slug")
+      .where("kind", "=", "person")
+      .where("status", "!=", "published")
+      .where("published_at", "is not", null)
+      .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`)
+      .orderBy("slug", "asc")
+      .execute();
+
+    return {
+      items: rows.map((row) => toPublicListItem(personMetadataSchema, row)),
+      removed: removedRows.map((row) => row.slug),
     };
   };
 }

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -24,9 +24,10 @@ function throwHttpError(statusCode: number, message: string): never {
 }
 
 /**
- * Validate kind-specific metadata against the shared schema map. Kinds
- * without a schema are not editable through the API yet (later phases
- * add theirs).
+ * Validate kind-specific metadata against the shared schema map. Every
+ * kind has a schema as of Phase 4; the missing-schema guard stays as a
+ * backstop so a future kind added to CONTENT_KINDS without one fails
+ * closed instead of accepting arbitrary metadata.
  */
 function parseMetadata(kind: ContentKind, metadata: Record<string, unknown>) {
   const schema = CONTENT_METADATA_SCHEMAS[kind];
@@ -1143,10 +1144,12 @@ function toPublic(row: {
   const kind = row.kind as ContentKind;
   // The metadata schema map doubles as the allowlist of kinds the public
   // API serves at all, and projecting through it strips undeclared keys.
-  // NOTE for later phases: a kind whose declared metadata is itself not
-  // fully public (person carries safeguarding-adjacent flags) must add a
-  // dedicated public projection schema here rather than reusing its write
-  // schema.
+  // Person reuses its write schema deliberately (#498): isDBSChecked and
+  // hasLeftClub are safeguarding-ADJACENT but public by design - the
+  // static site has always rendered the DBS badge and filtered rosters on
+  // hasLeftClub, and the content_people gate protects who can WRITE the
+  // flags, not who can see them. A future kind whose declared metadata is
+  // not fully public must add a dedicated projection schema here.
   const schema = CONTENT_METADATA_SCHEMAS[kind];
   if (!schema) throwHttpError(404, "Content not found");
   const metadata = schema.safeParse(row.metadata);

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13716,6 +13716,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content/{contentId}/revisions/{revisionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                    revisionId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            savedAt: string;
+                            savedBy: string;
+                            savedByName: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13841,6 +13841,17 @@ export interface paths {
                         "application/json": null;
                     };
                 };
+                /** @description Default Response */
+                410: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         put?: never;
@@ -14024,6 +14035,54 @@ export interface paths {
                                 publishedAt: string;
                                 updatedAt: string;
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/people": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                slug: string;
+                                title: string;
+                                description: string | null;
+                                metadata: {
+                                    [key: string]: unknown;
+                                };
+                                publishedAt: string;
+                                updatedAt: string;
+                            }[];
+                            removed: string[];
                         };
                     };
                 };

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -24971,6 +24971,25 @@
                 }
               }
             }
+          },
+          "410": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }
@@ -25337,6 +25356,76 @@
                   },
                   "required": [
                     "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/people": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "slug",
+                          "title",
+                          "description",
+                          "metadata",
+                          "publishedAt",
+                          "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "removed": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "removed"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -24693,6 +24693,125 @@
         }
       }
     },
+    "/api/admin/content/{contentId}/revisions/{revisionId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "revisionId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "savedAt": {
+                      "type": "string"
+                    },
+                    "savedBy": {
+                      "type": "string"
+                    },
+                    "savedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "savedAt",
+                    "savedBy",
+                    "savedByName"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
       "get": {
         "parameters": [

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -12,7 +12,7 @@ import {
   CURRENT_CONSENT_VERSION,
   requestConsentReopen,
 } from "@/lib/marketing/consent.js";
-import { getPersonBySlug } from "@/lib/people.js";
+import { usePeople } from "@/lib/use-people.js";
 import { cn } from "@/lib/utils.js";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { formatInTimeZone } from "date-fns-tz";
@@ -32,9 +32,12 @@ function RecordsWall() {
 }
 
 function Person({ slug, role }: { slug: string; role?: string }) {
-  const person = getPersonBySlug(slug);
+  // Merged roster: DB-backed people first, bundled MDX corpus as the
+  // per-slug fallback during the migration transition (#499). One cached
+  // list query serves every card on the page.
+  const person = usePeople().get(slug);
   const name = person?.name ?? slug;
-  const picture = person?.photoPicture ?? ANON_PICTURE;
+  const picture = person?.picture ?? ANON_PICTURE;
 
   return (
     <div className="person h-full rounded-lg bg-white pb-4 text-stone-900 shadow-md">
@@ -50,7 +53,7 @@ function Person({ slug, role }: { slug: string; role?: string }) {
         ) : (
           <img
             className="size-24 object-cover object-center"
-            src={person?.photo ?? ANON_IMAGE}
+            src={person?.photoUrl ?? ANON_IMAGE}
             alt={name}
           />
         )}

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13716,6 +13716,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/content/{contentId}/revisions/{revisionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    contentId: string;
+                    revisionId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            title: string;
+                            description: string | null;
+                            body: {
+                                id: string;
+                                type: string;
+                                props: {
+                                    [key: string]: string | number | boolean;
+                                };
+                                content?: unknown;
+                                children: unknown[];
+                            }[];
+                            metadata: {
+                                [key: string]: unknown;
+                            };
+                            savedAt: string;
+                            savedBy: string;
+                            savedByName: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13841,6 +13841,17 @@ export interface paths {
                         "application/json": null;
                     };
                 };
+                /** @description Default Response */
+                410: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
             };
         };
         put?: never;
@@ -14024,6 +14035,54 @@ export interface paths {
                                 publishedAt: string;
                                 updatedAt: string;
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/content/people": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                slug: string;
+                                title: string;
+                                description: string | null;
+                                metadata: {
+                                    [key: string]: unknown;
+                                };
+                                publishedAt: string;
+                                updatedAt: string;
+                            }[];
+                            removed: string[];
                         };
                     };
                 };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -24971,6 +24971,25 @@
                 }
               }
             }
+          },
+          "410": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }
@@ -25337,6 +25356,76 @@
                   },
                   "required": [
                     "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/people": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "slug",
+                          "title",
+                          "description",
+                          "metadata",
+                          "publishedAt",
+                          "updatedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "removed": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "removed"
                   ],
                   "additionalProperties": false
                 }

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -24693,6 +24693,125 @@
         }
       }
     },
+    "/api/admin/content/{contentId}/revisions/{revisionId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "contentId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "revisionId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "props": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ]
+                            }
+                          },
+                          "content": {},
+                          "children": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "props",
+                          "children"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "savedAt": {
+                      "type": "string"
+                    },
+                    "savedBy": {
+                      "type": "string"
+                    },
+                    "savedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "description",
+                    "body",
+                    "metadata",
+                    "savedAt",
+                    "savedBy",
+                    "savedByName"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/content/game-report/by-play-cricket-id/{playCricketId}": {
       "get": {
         "parameters": [

--- a/apps/web/src/lib/content-queries.ts
+++ b/apps/web/src/lib/content-queries.ts
@@ -2,9 +2,11 @@ import {
   eventMetadataSchema,
   newsMetadataSchema,
   pageMetadataSchema,
+  personMetadataSchema,
   type EventMetadata,
   type NewsMetadata,
   type PageMetadata,
+  type PersonMetadata,
 } from "@percy-main/shared/content";
 import { queryOptions } from "@tanstack/react-query";
 import { api, callApi } from "./api-client.js";
@@ -90,6 +92,34 @@ export function eventQueryOptions(slug: string) {
   });
 }
 
+export function personQueryOptions(slug: string) {
+  return queryOptions({
+    queryKey: ["content", "person", slug],
+    queryFn: async () => {
+      try {
+        return await callApi(
+          api.GET("/api/content/{kind}/{slug}", {
+            params: { path: { kind: "person", slug } },
+          }),
+        );
+      } catch (err) {
+        const status = (err as { status?: number }).status;
+        // Never published in the DB - callers fall back to the bundled
+        // MDX.
+        if (status === 404) return null;
+        // Ever-live profile taken down (unpublished/archived). A
+        // terminal data state, not an error: callers render "not found"
+        // without the static fallback - a takedown must not resurrect
+        // the bundled MDX profile (same sentinel as pages).
+        if (status === 410) return PAGE_GONE;
+        throw err;
+      }
+    },
+    staleTime: detailStaleTime,
+    retry: false,
+  });
+}
+
 export function pageByPathQueryOptions(path: string) {
   return queryOptions({
     queryKey: ["content", "page", path],
@@ -164,6 +194,16 @@ export function eventsListQueryOptions() {
   });
 }
 
+// One cached roster backs every person card, grid and picker - resolving
+// cards per-slug would be an N+1 each time a page renders a person grid.
+export function peopleListQueryOptions() {
+  return queryOptions({
+    queryKey: ["content", "people-list"],
+    queryFn: () => callApi(api.GET("/api/content/people")),
+    staleTime: STALE_TIME,
+  });
+}
+
 // The generated OpenAPI types carry metadata as a loose record; the shared
 // Zod schemas are the source of truth for each kind's shape, so narrow
 // through them rather than asserting.
@@ -182,5 +222,12 @@ export function parseEventMetadata(
 
 export function parsePageMetadata(metadata: unknown): PageMetadata | undefined {
   const parsed = pageMetadataSchema.safeParse(metadata);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function parsePersonMetadata(
+  metadata: unknown,
+): PersonMetadata | undefined {
+  const parsed = personMetadataSchema.safeParse(metadata);
   return parsed.success ? parsed.data : undefined;
 }

--- a/apps/web/src/lib/content-queries.ts
+++ b/apps/web/src/lib/content-queries.ts
@@ -196,6 +196,11 @@ export function eventsListQueryOptions() {
 
 // One cached roster backs every person card, grid and picker - resolving
 // cards per-slug would be an N+1 each time a page renders a person grid.
+// The flat 5-minute staleTime bounds how long a takedown can keep a
+// person's CARD visible (the full profile page converges within
+// NOT_FOUND_STALE_TIME via its own 410-aware query, and publish/save
+// invalidate ["content"] outright) - the same bounded-staleness stance
+// the other lists take.
 export function peopleListQueryOptions() {
   return queryOptions({
     queryKey: ["content", "people-list"],

--- a/apps/web/src/lib/use-people.test.ts
+++ b/apps/web/src/lib/use-people.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+// use-people transitively imports the people corpus (.mdx files), which
+// only exists inside a Vite build - stub the loader; mergePeople takes
+// the static list as a parameter so the stub never matters here.
+vi.mock("@/lib/people.js", () => ({
+  getAllPeople: () => [],
+  getPersonBySlug: () => undefined,
+}));
+
+import { mergePeople } from "./use-people.js";
+
+// mergePeople is pure - the hook only feeds it getAllPeople() + the live
+// query data - so the transition-fallback semantics test directly.
+
+const staticAlex = {
+  slug: "alex-young",
+  name: "Alex Young (static)",
+  photo: "/images/contentful/abc/photo.jpeg",
+  isDBSChecked: true,
+  hasLeftClub: false,
+};
+const staticBryan = {
+  slug: "bryan-cowey",
+  name: "Bryan Cowey",
+  isDBSChecked: false,
+  hasLeftClub: true,
+};
+
+const apiAlex = {
+  slug: "alex-young",
+  title: "Alex Young",
+  metadata: { isDBSChecked: true, hasLeftClub: false },
+};
+
+describe("mergePeople", () => {
+  it("renders the static corpus while the query has no data", () => {
+    const map = mergePeople([staticAlex, staticBryan], undefined);
+    expect(map.size).toBe(2);
+    expect(map.get("alex-young")?.name).toBe("Alex Young (static)");
+    expect(map.get("bryan-cowey")?.hasLeftClub).toBe(true);
+  });
+
+  it("the API wins per slug; unmigrated static people fill the gaps", () => {
+    const map = mergePeople([staticAlex, staticBryan], {
+      items: [apiAlex],
+      removed: [],
+    });
+    expect(map.get("alex-young")?.name).toBe("Alex Young");
+    expect(map.get("bryan-cowey")?.name).toBe("Bryan Cowey");
+  });
+
+  it("a tombstoned slug is dropped from the static corpus", () => {
+    const map = mergePeople([staticAlex, staticBryan], {
+      items: [],
+      removed: ["alex-young"],
+    });
+    expect(map.has("alex-young")).toBe(false);
+    expect(map.has("bryan-cowey")).toBe(true);
+  });
+
+  it("never resurrects a tombstone, even if the server sent the slug in items too", () => {
+    const map = mergePeople([staticAlex], {
+      items: [apiAlex],
+      removed: ["alex-young"],
+    });
+    expect(map.has("alex-young")).toBe(false);
+  });
+
+  it("keeps the static entry when an API row's metadata fails its schema", () => {
+    const map = mergePeople([staticAlex], {
+      items: [
+        {
+          slug: "alex-young",
+          title: "Broken",
+          metadata: { isDBSChecked: "yes" },
+        },
+      ],
+      removed: [],
+    });
+    expect(map.get("alex-young")?.name).toBe("Alex Young (static)");
+  });
+
+  it("carries the API photo descriptor through as the picture", () => {
+    const photo = {
+      sources: { webp: "/uploads/content/x/320.webp 320w" },
+      img: { src: "/uploads/content/x/640.jpg", w: 640, h: 480 },
+    };
+    const map = mergePeople([], {
+      items: [
+        {
+          slug: "new-signing",
+          title: "New Signing",
+          metadata: { isDBSChecked: false, hasLeftClub: false, photo },
+        },
+      ],
+      removed: [],
+    });
+    expect(map.get("new-signing")?.picture).toEqual(photo);
+  });
+});

--- a/apps/web/src/lib/use-people.ts
+++ b/apps/web/src/lib/use-people.ts
@@ -1,0 +1,81 @@
+import type { PictureSource } from "@/components/optimised-image.js";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import {
+  parsePersonMetadata,
+  peopleListQueryOptions,
+} from "./content-queries.js";
+import { getAllPeople } from "./people.js";
+
+// DB-backed people resolution (#499) with the bundled MDX corpus as a
+// per-slug fallback until the migration is verified in prod (TRANSITION
+// FALLBACK #489 - the cleanup PR removes people.ts and the fallback
+// together). The whole roster rides one cached list query, so a page
+// full of person cards costs one request, not one per card.
+
+/** Person fields shared by API-backed and static-bundled profiles. */
+export interface PersonSummary {
+  slug: string;
+  name: string;
+  /** Responsive picture (API photo descriptor or static optimised import). */
+  picture?: PictureSource;
+  /** Static corpus only: plain <img> URL when no picture exists. */
+  photoUrl?: string;
+  isDBSChecked: boolean;
+  hasLeftClub: boolean;
+}
+
+/**
+ * Every known person, keyed by slug. The API roster wins per slug; static
+ * people missing from it (not migrated yet, or the query is still
+ * pending/failed) fill the gaps, so cards render instantly from the
+ * bundle and never break on API trouble.
+ */
+export function usePeople(): Map<string, PersonSummary> {
+  const { data } = useQuery(peopleListQueryOptions());
+
+  return useMemo(() => {
+    const map = new Map<string, PersonSummary>();
+    for (const person of getAllPeople()) {
+      map.set(person.slug, {
+        slug: person.slug,
+        name: person.name,
+        ...(person.photoPicture !== undefined && {
+          picture: person.photoPicture,
+        }),
+        ...(person.photo !== undefined && { photoUrl: person.photo }),
+        isDBSChecked: person.isDBSChecked,
+        hasLeftClub: person.hasLeftClub,
+      });
+    }
+    // Tombstones: profiles that WERE live but have been taken down must
+    // not resurrect from the static bundle (same rule as nav.removed).
+    for (const slug of data?.removed ?? []) {
+      map.delete(slug);
+    }
+    for (const item of data?.items ?? []) {
+      const meta = parsePersonMetadata(item.metadata);
+      // A roster row whose metadata fails its schema is unrenderable -
+      // keep the static entry (if any) rather than a half-built one.
+      if (!meta) continue;
+      map.set(item.slug, {
+        slug: item.slug,
+        name: item.title,
+        ...(meta.photo !== undefined && { picture: meta.photo }),
+        isDBSChecked: meta.isDBSChecked,
+        hasLeftClub: meta.hasLeftClub,
+      });
+    }
+    return map;
+  }, [data]);
+}
+
+/** The merged roster as a name-sorted list (pickers, grids). */
+export function usePeopleList(): PersonSummary[] {
+  const people = usePeople();
+  return useMemo(
+    () =>
+      Array.from(people.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    [people],
+  );
+}

--- a/apps/web/src/lib/use-people.ts
+++ b/apps/web/src/lib/use-people.ts
@@ -25,49 +25,83 @@ export interface PersonSummary {
   hasLeftClub: boolean;
 }
 
+/** The static loader's fields the merge reads (people.ts PersonData). */
+interface StaticPerson {
+  slug: string;
+  name: string;
+  photo?: string;
+  photoPicture?: PictureSource;
+  isDBSChecked: boolean;
+  hasLeftClub: boolean;
+}
+
+interface PeopleListData {
+  items: Array<{ slug: string; title: string; metadata: unknown }>;
+  removed: string[];
+}
+
 /**
- * Every known person, keyed by slug. The API roster wins per slug; static
- * people missing from it (not migrated yet, or the query is still
- * pending/failed) fill the gaps, so cards render instantly from the
- * bundle and never break on API trouble.
+ * Merge the API roster over the static corpus, by slug. Pure and
+ * exported for tests; usePeople feeds it the live query data.
+ *
+ * The API wins per slug; static people missing from it (not migrated
+ * yet, or the query has no data) fill the gaps, so cards render
+ * instantly from the bundle and never break on API trouble. Tombstoned
+ * slugs (data.removed) are dropped AND guarded against in the items
+ * pass, so a taken-down profile cannot resurrect from the static bundle
+ * even if the server's items/removed partition were ever violated.
+ *
+ * Known fail-open window, accepted deliberately: while the query is
+ * pending or has never succeeded, the static corpus renders unfiltered,
+ * so a tombstoned person's CARD (name + photo only - cards carry no DBS
+ * badge or flags) can appear until the roster lands; a background
+ * refetch failure keeps the last successful response, tombstones
+ * included. The full profile page fails CLOSED on API errors instead
+ * (person-profile.tsx) - that is the page with the safeguarding
+ * surface. The window disappears with the static corpus in the cleanup
+ * PR.
  */
+export function mergePeople(
+  staticPeople: readonly StaticPerson[],
+  data: PeopleListData | undefined,
+): Map<string, PersonSummary> {
+  const removed = new Set(data?.removed ?? []);
+  const map = new Map<string, PersonSummary>();
+  for (const person of staticPeople) {
+    if (removed.has(person.slug)) continue;
+    map.set(person.slug, {
+      slug: person.slug,
+      name: person.name,
+      ...(person.photoPicture !== undefined && {
+        picture: person.photoPicture,
+      }),
+      ...(person.photo !== undefined && { photoUrl: person.photo }),
+      isDBSChecked: person.isDBSChecked,
+      hasLeftClub: person.hasLeftClub,
+    });
+  }
+  for (const item of data?.items ?? []) {
+    // Never resurrect a tombstone, whatever the server sent.
+    if (removed.has(item.slug)) continue;
+    const meta = parsePersonMetadata(item.metadata);
+    // A roster row whose metadata fails its schema is unrenderable -
+    // keep the static entry (if any) rather than a half-built one.
+    if (!meta) continue;
+    map.set(item.slug, {
+      slug: item.slug,
+      name: item.title,
+      ...(meta.photo !== undefined && { picture: meta.photo }),
+      isDBSChecked: meta.isDBSChecked,
+      hasLeftClub: meta.hasLeftClub,
+    });
+  }
+  return map;
+}
+
+/** Every known person, keyed by slug - see mergePeople for semantics. */
 export function usePeople(): Map<string, PersonSummary> {
   const { data } = useQuery(peopleListQueryOptions());
-
-  return useMemo(() => {
-    const map = new Map<string, PersonSummary>();
-    for (const person of getAllPeople()) {
-      map.set(person.slug, {
-        slug: person.slug,
-        name: person.name,
-        ...(person.photoPicture !== undefined && {
-          picture: person.photoPicture,
-        }),
-        ...(person.photo !== undefined && { photoUrl: person.photo }),
-        isDBSChecked: person.isDBSChecked,
-        hasLeftClub: person.hasLeftClub,
-      });
-    }
-    // Tombstones: profiles that WERE live but have been taken down must
-    // not resurrect from the static bundle (same rule as nav.removed).
-    for (const slug of data?.removed ?? []) {
-      map.delete(slug);
-    }
-    for (const item of data?.items ?? []) {
-      const meta = parsePersonMetadata(item.metadata);
-      // A roster row whose metadata fails its schema is unrenderable -
-      // keep the static entry (if any) rather than a half-built one.
-      if (!meta) continue;
-      map.set(item.slug, {
-        slug: item.slug,
-        name: item.title,
-        ...(meta.photo !== undefined && { picture: meta.photo }),
-        isDBSChecked: meta.isDBSChecked,
-        hasLeftClub: meta.hasLeftClub,
-      });
-    }
-    return map;
-  }, [data]);
+  return useMemo(() => mergePeople(getAllPeople(), data), [data]);
 }
 
 /** The merged roster as a name-sorted list (pickers, grids). */

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -197,6 +197,16 @@ const SECTIONS: readonly SectionDef[] = [
         visible: (role) => checkPermission(role, "content", "view"),
         render: () => <PagesTab />,
       },
+      // "Profiles", not "People": the admin panel's default section is
+      // already called People (members/groups/juniors), and these are
+      // the public profile pages. Gated separately (content_people) -
+      // profiles carry safeguarding-adjacent flags.
+      {
+        value: "profiles",
+        label: "Profiles",
+        visible: (role) => checkPermission(role, "content_people", "view"),
+        render: () => <ContentTab kind="person" />,
+      },
     ],
   },
   {

--- a/apps/web/src/pages/admin/content-editor.schema.test.ts
+++ b/apps/web/src/pages/admin/content-editor.schema.test.ts
@@ -55,6 +55,10 @@ vi.mock("@/lib/people.js", () => ({
   getAllPeople: () => [],
   getPersonBySlug: () => undefined,
 }));
+vi.mock("@/lib/use-people.js", () => ({
+  usePeople: () => new Map<string, never>(),
+  usePeopleList: () => [],
+}));
 vi.mock("@/lib/image-map.js", () => ({
   getImageUrl: () => undefined,
   getPicture: () => undefined,

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -252,6 +252,12 @@ function parsePictureProp(raw: string): PictureSource | null {
   } catch {
     return null;
   }
+  return parsePictureValue(parsed);
+}
+
+/** Same structural floor over an already-parsed value (person metadata
+ * stores the descriptor as an object, not a JSON string). */
+function parsePictureValue(parsed: unknown): PictureSource | null {
   // Same structural floor as the public renderer: enough shape that
   // OptimisedImage cannot crash on a malformed stored descriptor.
   const candidate = parsed as {
@@ -917,6 +923,11 @@ interface FormState {
   locationPostcode: string;
   locationLat: string;
   locationLon: string;
+  // person - title doubles as the person's name; photo holds the upload
+  // API's PictureSource descriptor (null until a photo is uploaded)
+  isDBSChecked: boolean;
+  hasLeftClub: boolean;
+  photo: PictureSource | null;
 }
 
 // ── Per-kind metadata: hydrate / validate / build ───────────────────────
@@ -998,6 +1009,9 @@ function initialForm(
     locationPostcode: asString(location?.postcode),
     locationLat: asNumberString(location?.lat),
     locationLon: asNumberString(location?.lon),
+    isDBSChecked: metadata.isDBSChecked === true,
+    hasLeftClub: metadata.hasLeftClub === true,
+    photo: parsePictureValue(metadata.photo),
   };
 }
 
@@ -1106,6 +1120,14 @@ function buildMetadata(
             },
           }
         : {}),
+    };
+  }
+  if (kind === "person") {
+    return {
+      isDBSChecked: form.isDBSChecked,
+      hasLeftClub: form.hasLeftClub,
+      // Omitted entirely when there is no photo - never null/"".
+      ...(form.photo !== null ? { photo: form.photo } : {}),
     };
   }
   return { playCricketId: form.playCricketId };
@@ -1387,12 +1409,166 @@ function PageMetadataFields({
   );
 }
 
+function PersonPhotoField({
+  photo,
+  personName,
+  consentConfirmed,
+  onChange,
+}: {
+  photo: PictureSource | null;
+  personName: string;
+  consentConfirmed: boolean;
+  onChange: (photo: PictureSource | null) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onFileChosen = async (file: File) => {
+    setUploading(true);
+    setError(null);
+    try {
+      // Same pipeline as editor images: presign -> S3 PUT -> confirm
+      // (EXIF strip + responsive ladder). The descriptor lands in
+      // metadata.photo instead of a contentImage block.
+      const uploaded = await uploadContentImage(file, {});
+      onChange(uploaded.picture);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Upload failed - try again",
+      );
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label>Profile photo (optional)</Label>
+      {photo !== null ? (
+        <OptimisedImage
+          picture={photo}
+          alt={personName || "Profile photo"}
+          className="size-32 rounded-full object-cover"
+          sizes="128px"
+          width={128}
+          height={128}
+        />
+      ) : (
+        <p className="text-xs text-stone-500">
+          No photo yet - the public profile shows a placeholder.
+        </p>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = "";
+          if (file) void onFileChosen(file);
+        }}
+      />
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={uploading}
+          onClick={() => {
+            setError(null);
+            if (!consentConfirmed) {
+              setError("Tick the photo consent box below before uploading.");
+              return;
+            }
+            fileInputRef.current?.click();
+          }}
+        >
+          {uploading
+            ? "Uploading…"
+            : photo !== null
+              ? "Replace photo"
+              : "Upload photo"}
+        </Button>
+        {photo !== null && (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={uploading}
+            onClick={() => {
+              onChange(null);
+            }}
+          >
+            Remove photo
+          </Button>
+        )}
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}
+
+function PersonMetadataFields({
+  form,
+  consentConfirmed,
+  onChange,
+}: {
+  form: FormState;
+  consentConfirmed: boolean;
+  onChange: (updates: Partial<FormState>) => void;
+}) {
+  return (
+    <>
+      <PersonPhotoField
+        photo={form.photo}
+        personName={form.title}
+        consentConfirmed={consentConfirmed}
+        onChange={(photo) => {
+          onChange({ photo });
+        }}
+      />
+      <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-stone-50 p-3">
+        <p className="text-xs leading-snug text-stone-700">
+          Safeguarding: both flags below appear on the public website, so keep
+          them accurate. Only tick DBS checked once the club has verified a
+          current certificate, and untick it if the check lapses.
+        </p>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="person-dbs-checked"
+            checked={form.isDBSChecked}
+            onCheckedChange={(value) => {
+              onChange({ isDBSChecked: value === true });
+            }}
+          />
+          <Label htmlFor="person-dbs-checked">
+            DBS checked (shows the DBS badge on the profile)
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="person-has-left-club"
+            checked={form.hasLeftClub}
+            onCheckedChange={(value) => {
+              onChange({ hasLeftClub: value === true });
+            }}
+          />
+          <Label htmlFor="person-has-left-club">
+            Has left the club (kept out of player and sponsorship pickers)
+          </Label>
+        </div>
+      </div>
+    </>
+  );
+}
+
 function MetadataFields({
   kind,
   form,
   itemId,
   slugLocked,
   tagSuggestions,
+  consentConfirmed,
   onChange,
 }: {
   kind: ContentKind;
@@ -1400,12 +1576,15 @@ function MetadataFields({
   itemId: string | null;
   slugLocked: boolean;
   tagSuggestions: string[];
+  consentConfirmed: boolean;
   onChange: (updates: Partial<FormState>) => void;
 }) {
   return (
     <>
       <div className="flex flex-col gap-1">
-        <Label htmlFor="content-title">Title</Label>
+        <Label htmlFor="content-title">
+          {kind === "person" ? "Name" : "Title"}
+        </Label>
         <Input
           id="content-title"
           value={form.title}
@@ -1601,6 +1780,13 @@ function MetadataFields({
             </div>
           )}
         </>
+      )}
+      {kind === "person" && (
+        <PersonMetadataFields
+          form={form}
+          consentConfirmed={consentConfirmed}
+          onChange={onChange}
+        />
       )}
     </>
   );
@@ -2254,6 +2440,7 @@ function LoadedEditor({
             itemId={item?.id ?? null}
             slugLocked={slugLocked}
             tagSuggestions={tagSuggestions}
+            consentConfirmed={consentConfirmed}
             onChange={onFormChange}
           />
           {item !== null && (

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -84,6 +84,12 @@ import {
   eligibleParents,
   visibleNodes,
 } from "./pages-tab.lib.js";
+import {
+  blocksToLines,
+  detailLines,
+  diffLines,
+  type DiffLine,
+} from "./revision-diff.js";
 
 // ── Custom blocks ───────────────────────────────────────────────────────
 //
@@ -1010,23 +1016,19 @@ function formatUkTime(iso: string): string {
 }
 
 /**
- * Hydrate per-kind fields from stored metadata. Defensive on purpose:
- * stored JSON may predate the current schema, so anything malformed
- * degrades to the field default rather than crashing the editor.
+ * Hydrate per-kind form fields from stored metadata. Defensive on
+ * purpose: stored JSON may predate the current schema, so anything
+ * malformed degrades to the field default rather than crashing the
+ * editor. Shared by the initial load and revision restore (#500).
  */
-function initialForm(
-  item: ContentItemDetail | null,
-  newParentId: string | null,
-): FormState {
-  const metadata = item?.metadata ?? {};
+function metadataFormFields(
+  metadata: Record<string, unknown>,
+): Omit<FormState, "title" | "slug" | "description" | "parentId"> {
   const location =
     typeof metadata.location === "object" && metadata.location !== null
       ? (metadata.location as Record<string, unknown>)
       : null;
   return {
-    title: item?.title ?? "",
-    slug: item?.slug ?? "",
-    description: item?.description ?? "",
     playCricketId: asString(metadata.playCricketId),
     menuOrder: asNumberString(metadata.menuOrder) || "99",
     isMainMenu: metadata.isMainMenu === true,
@@ -1035,7 +1037,6 @@ function initialForm(
       typeof metadata.ldjson === "object" && metadata.ldjson !== null
         ? JSON.stringify(metadata.ldjson, null, 2)
         : "",
-    parentId: item !== null ? item.parentId : newParentId,
     tags: Array.isArray(metadata.tags)
       ? metadata.tags.filter(
           (tag): tag is string => typeof tag === "string" && tag !== "",
@@ -1054,6 +1055,19 @@ function initialForm(
     isDBSChecked: metadata.isDBSChecked === true,
     hasLeftClub: metadata.hasLeftClub === true,
     photo: parsePictureValue(metadata.photo),
+  };
+}
+
+function initialForm(
+  item: ContentItemDetail | null,
+  newParentId: string | null,
+): FormState {
+  return {
+    title: item?.title ?? "",
+    slug: item?.slug ?? "",
+    description: item?.description ?? "",
+    parentId: item !== null ? item.parentId : newParentId,
+    ...metadataFormFields(item?.metadata ?? {}),
   };
 }
 
@@ -2179,6 +2193,292 @@ function ConsentBox({
   );
 }
 
+// ── Revision history (#500) ─────────────────────────────────────────────
+
+type RevisionDetail =
+  paths["/api/admin/content/{contentId}/revisions/{revisionId}"]["get"]["responses"][200]["content"]["application/json"];
+
+function DiffView({ lines }: { lines: DiffLine[] }) {
+  if (lines.length === 0 || lines.every((line) => line.type === "same")) {
+    return <p className="text-sm text-stone-500">No differences.</p>;
+  }
+  return (
+    <div className="max-h-72 overflow-auto rounded border border-stone-200 bg-white p-2 font-mono text-xs whitespace-pre-wrap">
+      {/* Index keys are safe here: the diff is a pure projection of
+          immutable data, rebuilt whole whenever either side changes. */}
+      {lines.map((line, i) => (
+        <div
+          key={`diff-${String(i)}`}
+          className={
+            line.type === "removed"
+              ? "bg-red-50 text-red-700"
+              : line.type === "added"
+                ? "bg-green-50 text-green-700"
+                : "text-stone-600"
+          }
+        >
+          {line.type === "removed" ? "- " : line.type === "added" ? "+ " : "  "}
+          {line.text || " "}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RevisionDialog({
+  item,
+  revisionId,
+  canRestore,
+  onRestore,
+  onClose,
+}: {
+  item: ContentItemDetail;
+  revisionId: string;
+  canRestore: boolean;
+  onRestore: (revision: RevisionDetail) => boolean;
+  onClose: () => void;
+}) {
+  const {
+    data: revision,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["admin", "content", "revision", item.id, revisionId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/content/{contentId}/revisions/{revisionId}", {
+          params: { path: { contentId: item.id, revisionId } },
+        }),
+      ),
+  });
+
+  // Both diffs read "this version -> latest saved version": red lines
+  // exist only in this version (restore brings them back), green lines
+  // were added since. Unsaved editor changes are not part of either side.
+  const bodyDiff = useMemo(
+    () =>
+      revision
+        ? diffLines(blocksToLines(revision.body), blocksToLines(item.body))
+        : [],
+    [revision, item.body],
+  );
+  const detailsDiff = useMemo(
+    () =>
+      revision
+        ? diffLines(
+            detailLines(revision),
+            detailLines({
+              title: item.title,
+              description: item.description,
+              metadata: item.metadata,
+            }),
+          )
+        : [],
+    [revision, item],
+  );
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>
+            {revision
+              ? `Version from ${formatUkTime(revision.savedAt)}`
+              : "Version"}
+          </DialogTitle>
+          <DialogDescription>
+            Compared with the latest saved version:{" "}
+            <span className="text-red-700">- only in this version</span>,{" "}
+            <span className="text-green-700">+ added since</span>. Restoring
+            copies this version into the editor - nothing changes until you
+            save.
+          </DialogDescription>
+        </DialogHeader>
+        {error ? (
+          <p className="text-sm text-red-600">
+            Couldn&apos;t load this version - {error.message}
+          </p>
+        ) : isLoading || !revision ? (
+          <p className="text-sm text-stone-500">Loading…</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {revision.savedByName && (
+              <p className="text-sm text-stone-600">
+                Saved by {revision.savedByName}
+              </p>
+            )}
+            <div>
+              <h4 className="mb-1 text-sm font-medium">Content</h4>
+              <DiffView lines={bodyDiff} />
+            </div>
+            <div>
+              <h4 className="mb-1 text-sm font-medium">Details</h4>
+              <DiffView lines={detailsDiff} />
+            </div>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+          {canRestore && revision && (
+            <Button
+              onClick={() => {
+                // Stays open when the author backs out of overwriting
+                // unsaved work.
+                if (onRestore(revision)) onClose();
+              }}
+            >
+              Restore this version
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function HistoryCard({
+  item,
+  canRestore,
+  onRestore,
+}: {
+  item: ContentItemDetail;
+  canRestore: boolean;
+  onRestore: (revision: RevisionDetail) => boolean;
+}) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["admin", "content", "revisions", item.id],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/content/{contentId}/revisions", {
+          params: { path: { contentId: item.id } },
+        }),
+      ),
+  });
+  const [openRevisionId, setOpenRevisionId] = useState<string | null>(null);
+  const revisions = data?.revisions ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">History</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        {error ? (
+          <p className="text-sm text-red-600">
+            Couldn&apos;t load history - {error.message}
+          </p>
+        ) : isLoading ? (
+          <p className="text-sm text-stone-500">Loading…</p>
+        ) : (
+          <ul className="flex max-h-64 flex-col gap-1 overflow-y-auto">
+            {revisions.map((rev, i) => (
+              <li key={rev.id}>
+                <button
+                  type="button"
+                  className="w-full rounded px-1 py-1 text-left hover:bg-stone-100"
+                  onClick={() => {
+                    setOpenRevisionId(rev.id);
+                  }}
+                >
+                  <span className="block text-sm">
+                    {formatUkTime(rev.savedAt)}
+                    {i === 0 ? " (latest)" : ""}
+                  </span>
+                  <span className="block text-xs text-stone-500">
+                    {rev.savedByName ?? "Unknown"}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <p className="text-xs text-stone-500">
+          Every save keeps the previous version here, so nothing is ever lost.
+          Open one to compare or restore it.
+        </p>
+      </CardContent>
+      {openRevisionId !== null && (
+        <RevisionDialog
+          item={item}
+          revisionId={openRevisionId}
+          canRestore={canRestore}
+          onRestore={onRestore}
+          onClose={() => {
+            setOpenRevisionId(null);
+          }}
+        />
+      )}
+    </Card>
+  );
+}
+
+/**
+ * Copy a revision into the working draft (#500): the editor and form
+ * take the revision's body/metadata, and nothing persists until the
+ * author saves - which writes a NEW revision, so the timeline stays
+ * append-only and history is never rewritten. Slug and (for pages)
+ * parent are not part of a revision and stay as they are. Restoring
+ * never changes publish status.
+ */
+function useRevisionRestore({
+  editor,
+  setForm,
+  dirtyRef,
+}: {
+  editor: Editor;
+  setForm: React.Dispatch<React.SetStateAction<FormState>>;
+  dirtyRef: React.RefObject<boolean>;
+}) {
+  const [restoreNotice, setRestoreNotice] = useState<string | null>(null);
+
+  /**
+   * Returns false when the author backs out of overwriting unsaved
+   * work - the dialog stays open so nothing is lost either way.
+   */
+  const restoreRevision = (revision: RevisionDetail): boolean => {
+    if (
+      dirtyRef.current &&
+      !window.confirm(
+        "Restoring will replace your unsaved changes with this version. Continue?",
+      )
+    ) {
+      return false;
+    }
+    editor.replaceBlocks(
+      editor.document,
+      revision.body.length > 0
+        ? (revision.body as PartialBlock[])
+        : [{ type: "paragraph" }],
+    );
+    setForm((prev) => ({
+      ...prev,
+      title: revision.title,
+      description: revision.description ?? "",
+      ...metadataFormFields(revision.metadata),
+    }));
+    dirtyRef.current = true;
+    setRestoreNotice(
+      `Restored the version from ${formatUkTime(revision.savedAt)} - review it, then save to keep it.`,
+    );
+    return true;
+  };
+
+  return {
+    restoreNotice,
+    clearRestoreNotice: () => {
+      setRestoreNotice(null);
+    },
+    restoreRevision,
+  };
+}
+
 function EditorPane({
   editor,
   slashItems,
@@ -2300,6 +2600,9 @@ function LoadedEditor({
   const editorBody = () =>
     contentBodySchema.parse(JSON.parse(JSON.stringify(editor.document)));
 
+  const { restoreNotice, clearRestoreNotice, restoreRevision } =
+    useRevisionRestore({ editor, setForm, dirtyRef });
+
   const saveMutation = useMutation({
     mutationFn: async () => {
       const body = editorBody();
@@ -2343,6 +2646,7 @@ function LoadedEditor({
     },
     onSuccess: (result) => {
       dirtyRef.current = false;
+      clearRestoreNotice();
       setLastSavedAt(new Date().toISOString());
       void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
       // Saving a published item changes the live page immediately; drop
@@ -2474,6 +2778,10 @@ function LoadedEditor({
         </p>
       )}
 
+      {restoreNotice && (
+        <p className="text-sm text-amber-700">{restoreNotice}</p>
+      )}
+
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <div className="flex flex-col gap-3 lg:col-span-1">
           <MetadataFields
@@ -2491,6 +2799,13 @@ function LoadedEditor({
               canPublish={canPublish}
               canManage={canManage}
               beforePublish={() => saveMutation.mutateAsync()}
+            />
+          )}
+          {item !== null && (
+            <HistoryCard
+              item={item}
+              canRestore={canSave}
+              onRestore={restoreRevision}
             />
           )}
           <ConsentBox

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -58,11 +58,11 @@ import { useHasPermission } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client.js";
 import type { paths } from "@/lib/api.gen.js";
 import { uploadContentImage } from "@/lib/content-images.js";
-import { getAllPeople } from "@/lib/people.js";
 import {
   parsePersonGridEntries,
   type PersonGridEntry,
 } from "@/lib/person-grid.js";
+import { usePeopleList } from "@/lib/use-people.js";
 import {
   CONTENT_KIND_RESOURCES,
   contentBodySchema,
@@ -91,6 +91,39 @@ import {
 // maps them 1:1. Each block renders the real public component read-only
 // in-editor, with minimal prop controls underneath.
 
+/**
+ * Single-person picker over the merged roster (DB-backed people first,
+ * static corpus filling the gaps during the migration transition). A
+ * component of its own so the roster hook lives outside the block-spec
+ * render functions.
+ */
+function PersonSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (slug: string) => void;
+}) {
+  const people = usePeopleList();
+  return (
+    <select
+      aria-label="Person"
+      value={value}
+      onChange={(e) => {
+        onChange(e.target.value);
+      }}
+      className="rounded border border-stone-300 bg-white p-1 text-sm"
+    >
+      <option value="">Choose a person…</option>
+      {people.map((p) => (
+        <option key={p.slug} value={p.slug}>
+          {p.name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
 const personBlock = createReactBlockSpec(
   {
     type: CUSTOM_BLOCK_TYPES.person,
@@ -113,23 +146,14 @@ const personBlock = createReactBlockSpec(
         ) : (
           <p className="text-sm text-stone-500">Choose a person…</p>
         )}
-        <select
-          aria-label="Person"
+        <PersonSelect
           value={block.props.slug}
-          onChange={(e) => {
+          onChange={(slug) => {
             editor.updateBlock(block, {
-              props: { ...block.props, slug: e.target.value },
+              props: { ...block.props, slug },
             });
           }}
-          className="rounded border border-stone-300 bg-white p-1 text-sm"
-        >
-          <option value="">Choose a person…</option>
-          {getAllPeople().map((p) => (
-            <option key={p.slug} value={p.slug}>
-              {p.name}
-            </option>
-          ))}
-        </select>
+        />
         <input
           aria-label="Role shown on the card"
           placeholder="Role (optional)"
@@ -364,9 +388,6 @@ const personGridBlock = createReactBlockSpec(
           const trimmed = s.trim();
           return trimmed ? [{ slug: trimmed }] : [];
         });
-      const allPeople = getAllPeople();
-      const nameOf = (slug: string) =>
-        allPeople.find((p) => p.slug === slug)?.name ?? slug;
       const write = (next: PersonGridEntry[]) => {
         editor.updateBlock(block, {
           props: {
@@ -394,61 +415,82 @@ const personGridBlock = createReactBlockSpec(
           ) : (
             <p className="text-sm text-stone-500">Choose people to display…</p>
           )}
-          <div className="flex flex-col gap-1">
-            <p className="text-xs text-stone-500">
-              Select people (hold Ctrl/Cmd to pick multiple):
-            </p>
-            <select
-              aria-label="People"
-              multiple
-              size={Math.min(allPeople.length, 6)}
-              value={entries.map((e) => e.slug)}
-              onChange={(e) => {
-                const chosen = Array.from(e.target.selectedOptions).map(
-                  (o) => o.value,
-                );
-                // People who stay selected keep their role; newly
-                // selected people start role-less.
-                write(
-                  chosen.map(
-                    (slug) =>
-                      entries.find((entry) => entry.slug === slug) ?? { slug },
-                  ),
-                );
-              }}
-              className="rounded border border-stone-300 bg-white p-1 text-sm"
-            >
-              {allPeople.map((p) => (
-                <option key={p.slug} value={p.slug}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          {entries.map((entry, i) => (
-            <input
-              key={`${entry.slug}-${String(i)}`}
-              aria-label={`Role shown for ${nameOf(entry.slug)}`}
-              placeholder={`Role for ${nameOf(entry.slug)} (optional)`}
-              value={entry.role ?? ""}
-              onChange={(e) => {
-                const role = e.target.value;
-                write(
-                  entries.map((current, j) =>
-                    j === i
-                      ? { slug: current.slug, ...(role !== "" && { role }) }
-                      : current,
-                  ),
-                );
-              }}
-              className="rounded border border-stone-300 bg-white p-1 text-sm"
-            />
-          ))}
+          <PersonGridControls entries={entries} onWrite={write} />
         </div>
       );
     },
   },
 );
+
+/**
+ * The grid block's people controls, a component of its own so the merged
+ * roster hook lives outside the block-spec render function.
+ */
+function PersonGridControls({
+  entries,
+  onWrite,
+}: {
+  entries: PersonGridEntry[];
+  onWrite: (next: PersonGridEntry[]) => void;
+}) {
+  const allPeople = usePeopleList();
+  const nameOf = (slug: string) =>
+    allPeople.find((p) => p.slug === slug)?.name ?? slug;
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <p className="text-xs text-stone-500">
+          Select people (hold Ctrl/Cmd to pick multiple):
+        </p>
+        <select
+          aria-label="People"
+          multiple
+          size={Math.min(allPeople.length, 6)}
+          value={entries.map((e) => e.slug)}
+          onChange={(e) => {
+            const chosen = Array.from(e.target.selectedOptions).map(
+              (o) => o.value,
+            );
+            // People who stay selected keep their role; newly
+            // selected people start role-less.
+            onWrite(
+              chosen.map(
+                (slug) =>
+                  entries.find((entry) => entry.slug === slug) ?? { slug },
+              ),
+            );
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        >
+          {allPeople.map((p) => (
+            <option key={p.slug} value={p.slug}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      {entries.map((entry, i) => (
+        <input
+          key={`${entry.slug}-${String(i)}`}
+          aria-label={`Role shown for ${nameOf(entry.slug)}`}
+          placeholder={`Role for ${nameOf(entry.slug)} (optional)`}
+          value={entry.role ?? ""}
+          onChange={(e) => {
+            const role = e.target.value;
+            onWrite(
+              entries.map((current, j) =>
+                j === i
+                  ? { slug: current.slug, ...(role !== "" && { role }) }
+                  : current,
+              ),
+            );
+          }}
+          className="rounded border border-stone-300 bg-white p-1 text-sm"
+        />
+      ))}
+    </>
+  );
+}
 
 const leagueTableBlock = createReactBlockSpec(
   {
@@ -1257,7 +1299,7 @@ function AuthorSelect({
   value: string;
   onChange: (slug: string) => void;
 }) {
-  const people = getAllPeople().sort((a, b) => a.name.localeCompare(b.name));
+  const people = usePeopleList();
   return (
     <Select
       value={value === "" ? NO_AUTHOR : value}

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -55,6 +55,7 @@ function liveUrl(
   }
   if (kind === "news") return `/news/article/${item.slug}`;
   if (kind === "event") return `/calendar/event/${item.slug}`;
+  if (kind === "person") return `/person/${item.slug}`;
   return null;
 }
 

--- a/apps/web/src/pages/admin/revision-diff.test.ts
+++ b/apps/web/src/pages/admin/revision-diff.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import { blocksToLines, detailLines, diffLines } from "./revision-diff.js";
+
+const text = (t: string) => [{ type: "text", text: t, styles: {} }];
+
+describe("blocksToLines", () => {
+  it("projects common block types to readable lines", () => {
+    const body = [
+      {
+        id: "1",
+        type: "heading",
+        props: { level: 2 },
+        content: text("Ground rules"),
+        children: [],
+      },
+      {
+        id: "2",
+        type: "paragraph",
+        props: {},
+        content: text("Be kind."),
+        children: [],
+      },
+      {
+        id: "3",
+        type: "bulletListItem",
+        props: {},
+        content: text("No spikes indoors"),
+        children: [
+          {
+            id: "3a",
+            type: "bulletListItem",
+            props: {},
+            content: text("Even on Sundays"),
+            children: [],
+          },
+        ],
+      },
+      {
+        id: "4",
+        type: "contentImage",
+        props: { alt: "The pavilion", caption: "Summer 2025" },
+        children: [],
+      },
+      {
+        id: "5",
+        type: "person",
+        props: { slug: "alex-young", role: "Captain" },
+        children: [],
+      },
+    ];
+    expect(blocksToLines(body)).toEqual([
+      "## Ground rules",
+      "Be kind.",
+      "- No spikes indoors",
+      "  - Even on Sundays",
+      "[Photo: The pavilion - Summer 2025]",
+      "[Person card: alex-young (Captain)]",
+    ]);
+  });
+
+  it("flattens link text into the line", () => {
+    const body = [
+      {
+        id: "1",
+        type: "paragraph",
+        props: {},
+        content: [
+          { type: "text", text: "See the ", styles: {} },
+          { type: "link", href: "/fixtures", content: text("fixtures") },
+        ],
+        children: [],
+      },
+    ];
+    expect(blocksToLines(body)).toEqual(["See the fixtures"]);
+  });
+
+  it("projects tables row by row", () => {
+    const body = [
+      {
+        id: "1",
+        type: "table",
+        props: {},
+        content: {
+          type: "tableContent",
+          rows: [
+            { cells: [text("Team"), text("Points")] },
+            { cells: [{ content: text("Firsts") }, { content: text("42") }] },
+          ],
+        },
+        children: [],
+      },
+    ];
+    expect(blocksToLines(body)).toEqual([
+      "| Team | Points |",
+      "| Firsts | 42 |",
+    ]);
+  });
+
+  it("covers every render-relevant custom-block prop, so a prop-only change always diffs", () => {
+    const block = (type: string, props: Record<string, unknown>) => [
+      { id: "1", type, props, children: [] },
+    ];
+    // A role change inside a person grid (entries is canonical)
+    expect(
+      blocksToLines(
+        block("personGrid", {
+          slugs: "a,b",
+          entries: '[{"slug":"a","role":"Captain"},{"slug":"b"}]',
+        }),
+      ),
+    ).not.toEqual(
+      blocksToLines(
+        block("personGrid", {
+          slugs: "a,b",
+          entries: '[{"slug":"a"},{"slug":"b"}]',
+        }),
+      ),
+    );
+    // A replaced photo with identical alt/caption
+    expect(
+      blocksToLines(
+        block("contentImage", { alt: "x", caption: "", src: "/uploads/a.jpg" }),
+      ),
+    ).not.toEqual(
+      blocksToLines(
+        block("contentImage", { alt: "x", caption: "", src: "/uploads/b.jpg" }),
+      ),
+    );
+    // An event preview repointed at a different event, same display name
+    expect(
+      blocksToLines(
+        block("eventPreview", {
+          eventId: "e1",
+          name: "AGM",
+          when: "2026-01-01",
+        }),
+      ),
+    ).not.toEqual(
+      blocksToLines(
+        block("eventPreview", {
+          eventId: "e2",
+          name: "AGM",
+          when: "2026-01-01",
+        }),
+      ),
+    );
+  });
+
+  it("degrades malformed input to empty output rather than throwing", () => {
+    expect(blocksToLines(null)).toEqual([]);
+    expect(blocksToLines("not blocks")).toEqual([]);
+    // Non-object entries vanish; an object with a junk type degrades to
+    // a blank text line.
+    expect(blocksToLines([null, 7, { type: 9 }])).toEqual([""]);
+  });
+});
+
+describe("detailLines", () => {
+  it("sorts metadata keys so JSONB key-order churn never reads as a change", () => {
+    const a = detailLines({
+      title: "T",
+      description: null,
+      metadata: { tags: ["x"], authorSlug: "a" },
+    });
+    const b = detailLines({
+      title: "T",
+      description: null,
+      metadata: { authorSlug: "a", tags: ["x"] },
+    });
+    expect(a).toEqual(b);
+    expect(a[0]).toBe("Title: T");
+    expect(a[1]).toBe("Description: ");
+  });
+});
+
+describe("diffLines", () => {
+  it("marks the deleted paragraph - the recovery scenario", () => {
+    const revision = ["Intro", "The lost paragraph.", "Outro"];
+    const current = ["Intro", "Outro"];
+    expect(diffLines(revision, current)).toEqual([
+      { type: "same", text: "Intro" },
+      { type: "removed", text: "The lost paragraph." },
+      { type: "same", text: "Outro" },
+    ]);
+  });
+
+  it("marks additions since the revision", () => {
+    expect(diffLines(["a"], ["a", "b"])).toEqual([
+      { type: "same", text: "a" },
+      { type: "added", text: "b" },
+    ]);
+  });
+
+  it("handles a full replacement", () => {
+    expect(diffLines(["old"], ["new"])).toEqual([
+      { type: "removed", text: "old" },
+      { type: "added", text: "new" },
+    ]);
+  });
+
+  it("handles empty sides", () => {
+    expect(diffLines([], ["a"])).toEqual([{ type: "added", text: "a" }]);
+    expect(diffLines(["a"], [])).toEqual([{ type: "removed", text: "a" }]);
+    expect(diffLines([], [])).toEqual([]);
+  });
+});

--- a/apps/web/src/pages/admin/revision-diff.ts
+++ b/apps/web/src/pages/admin/revision-diff.ts
@@ -1,0 +1,271 @@
+import { CUSTOM_BLOCK_TYPES } from "@percy-main/shared/content";
+
+// Plain-text projection + line diff for the revision history UI (#500).
+// Per the issue, a text diff of body + metadata is sufficient - no
+// rendered visual diff - so blocks project to one line each (type-aware
+// prefix + inline text) and the diff is a classic line LCS. Everything
+// here is pure so it unit-tests without a DOM.
+
+export interface DiffLine {
+  type: "same" | "added" | "removed";
+  text: string;
+}
+
+function inlineText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((node: unknown) => {
+      if (typeof node !== "object" || node === null) return "";
+      const candidate = node as {
+        type?: unknown;
+        text?: unknown;
+        content?: unknown;
+      };
+      if (typeof candidate.text === "string") return candidate.text;
+      if (candidate.type === "link") return inlineText(candidate.content);
+      return "";
+    })
+    .join("");
+}
+
+/** Table content is structured (rows of cells), not an inline array. */
+function tableText(content: unknown): string[] {
+  const rows = (content as { rows?: unknown } | null)?.rows;
+  if (!Array.isArray(rows)) return ["[Table]"];
+  return rows.map((row: unknown) => {
+    const cells = (row as { cells?: unknown } | null)?.cells;
+    if (!Array.isArray(cells)) return "|";
+    const texts = cells.map((cell: unknown) => {
+      // Cells are inline arrays in older documents, or objects with a
+      // content array in newer ones.
+      if (Array.isArray(cell)) return inlineText(cell);
+      return inlineText((cell as { content?: unknown } | null)?.content);
+    });
+    return `| ${texts.join(" | ")} |`;
+  });
+}
+
+function stringProp(props: Record<string, unknown>, name: string): string {
+  const value = props[name];
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * One human-readable line (or a few, for tables) per block. Custom
+ * blocks render as bracketed labels - enough for an editor to see that
+ * "the photo moved" without a visual diff.
+ */
+function blockLines(block: unknown, depth: number): string[] {
+  if (typeof block !== "object" || block === null) return [];
+  const candidate = block as {
+    type?: unknown;
+    props?: unknown;
+    content?: unknown;
+    children?: unknown;
+  };
+  const type = typeof candidate.type === "string" ? candidate.type : "";
+  const props =
+    typeof candidate.props === "object" && candidate.props !== null
+      ? (candidate.props as Record<string, unknown>)
+      : {};
+  const indent = "  ".repeat(depth);
+  const text = inlineText(candidate.content);
+
+  const lines: string[] = [];
+  switch (type) {
+    case "heading": {
+      const level = typeof props.level === "number" ? props.level : 1;
+      lines.push(`${indent}${"#".repeat(level)} ${text}`);
+      break;
+    }
+    case "bulletListItem":
+      lines.push(`${indent}- ${text}`);
+      break;
+    case "numberedListItem":
+      lines.push(`${indent}1. ${text}`);
+      break;
+    case "checkListItem":
+      lines.push(`${indent}[${props.checked === true ? "x" : " "}] ${text}`);
+      break;
+    case "quote":
+      lines.push(`${indent}> ${text}`);
+      break;
+    case "codeBlock":
+      for (const codeLine of text.split("\n")) {
+        lines.push(`${indent}    ${codeLine}`);
+      }
+      break;
+    case "table":
+      for (const rowLine of tableText(candidate.content)) {
+        lines.push(`${indent}${rowLine}`);
+      }
+      break;
+    // Custom block labels must cover EVERY render-relevant prop: a prop
+    // change the projection drops would diff as "No differences" while
+    // restore still changes the live page.
+    case CUSTOM_BLOCK_TYPES.person: {
+      const role = stringProp(props, "role");
+      lines.push(
+        `${indent}[Person card: ${stringProp(props, "slug")}${role ? ` (${role})` : ""}]`,
+      );
+      break;
+    }
+    case CUSTOM_BLOCK_TYPES.personGrid: {
+      // entries is the canonical role-preserving prop (compact JSON);
+      // legacy blocks only have the slugs CSV.
+      const entries = stringProp(props, "entries");
+      lines.push(
+        `${indent}[Person grid: ${entries || stringProp(props, "slugs")}]`,
+      );
+      break;
+    }
+    case CUSTOM_BLOCK_TYPES.contentImage: {
+      const alt = stringProp(props, "alt");
+      const caption = stringProp(props, "caption");
+      // src identifies the uploaded image (it is the descriptor's
+      // fallback URL), so a replaced photo always shows in the diff.
+      const src = stringProp(props, "src");
+      lines.push(
+        `${indent}[Photo${alt ? `: ${alt}` : ""}${caption ? ` - ${caption}` : ""}${src ? ` (${src})` : ""}]`,
+      );
+      break;
+    }
+    case CUSTOM_BLOCK_TYPES.gamePreview:
+      lines.push(
+        `${indent}[Game preview: ${stringProp(props, "playCricketId")}]`,
+      );
+      break;
+    case CUSTOM_BLOCK_TYPES.eventPreview:
+      lines.push(
+        `${indent}[Event preview: ${stringProp(props, "name")} (${stringProp(props, "eventId")}, ${stringProp(props, "when")})]`,
+      );
+      break;
+    case CUSTOM_BLOCK_TYPES.leagueTable: {
+      const name = stringProp(props, "name");
+      lines.push(
+        `${indent}[League table: ${stringProp(props, "divisionId")}${name ? ` - ${name}` : ""}]`,
+      );
+      break;
+    }
+    case CUSTOM_BLOCK_TYPES.leaderboard:
+      lines.push(`${indent}[Leaderboard]`);
+      break;
+    case CUSTOM_BLOCK_TYPES.recordsWall:
+      lines.push(`${indent}[Records wall]`);
+      break;
+    case CUSTOM_BLOCK_TYPES.contactForm: {
+      const title = stringProp(props, "title");
+      const description = stringProp(props, "description");
+      lines.push(
+        `${indent}[Contact form${title ? `: ${title}` : ""}${description ? ` - ${description}` : ""}]`,
+      );
+      break;
+    }
+    case CUSTOM_BLOCK_TYPES.cookieSettingsLink: {
+      const linkText = stringProp(props, "text");
+      lines.push(
+        `${indent}[Cookie settings link${linkText ? `: ${linkText}` : ""}]`,
+      );
+      break;
+    }
+    case CUSTOM_BLOCK_TYPES.consentVersion:
+      lines.push(`${indent}[Consent version]`);
+      break;
+    default:
+      // Paragraphs and anything unrecognised: plain text. Blank
+      // paragraphs are kept so spacing changes still show.
+      lines.push(`${indent}${text}`);
+      break;
+  }
+  if (Array.isArray(candidate.children)) {
+    for (const child of candidate.children) {
+      lines.push(...blockLines(child, depth + 1));
+    }
+  }
+  return lines;
+}
+
+/** Project a stored body (block array) onto comparable text lines. */
+export function blocksToLines(body: unknown): string[] {
+  if (!Array.isArray(body)) return [];
+  return body.flatMap((block: unknown) => blockLines(block, 0));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (typeof value === "object" && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Item details (title/description/metadata) as comparable lines. Keys
+ * are sorted so JSONB key-order churn never reads as a change.
+ */
+export function detailLines(item: {
+  title: string;
+  description: string | null;
+  metadata: Record<string, unknown>;
+}): string[] {
+  return [
+    `Title: ${item.title}`,
+    `Description: ${item.description ?? ""}`,
+    ...JSON.stringify(sortKeysDeep(item.metadata), null, 2).split("\n"),
+  ];
+}
+
+/**
+ * Line diff via longest common subsequence - the bodies are club pages,
+ * tens of lines, so the quadratic table is fine.
+ */
+export function diffLines(before: string[], after: string[]): DiffLine[] {
+  const n = before.length;
+  const m = after.length;
+  // lcs(i, j) = LCS length of before.slice(i) vs after.slice(j), stored
+  // flat to keep index access checked-friendly.
+  const width = m + 1;
+  const table = new Array<number>((n + 1) * width).fill(0);
+  const lcs = (i: number, j: number) => table[i * width + j] ?? 0;
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      table[i * width + j] =
+        before[i] === after[j]
+          ? lcs(i + 1, j + 1) + 1
+          : Math.max(lcs(i + 1, j), lcs(i, j + 1));
+    }
+  }
+
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    const a = before[i];
+    const b = after[j];
+    if (a === undefined || b === undefined) break;
+    if (a === b) {
+      out.push({ type: "same", text: a });
+      i += 1;
+      j += 1;
+    } else if (lcs(i + 1, j) >= lcs(i, j + 1)) {
+      out.push({ type: "removed", text: a });
+      i += 1;
+    } else {
+      out.push({ type: "added", text: b });
+      j += 1;
+    }
+  }
+  for (; i < n; i++) {
+    const a = before[i];
+    if (a !== undefined) out.push({ type: "removed", text: a });
+  }
+  for (; j < m; j++) {
+    const b = after[j];
+    if (b !== undefined) out.push({ type: "added", text: b });
+  }
+  return out;
+}

--- a/apps/web/src/pages/admin/sponsorships-tab.tsx
+++ b/apps/web/src/pages/admin/sponsorships-tab.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import { resizeLogo } from "@/lib/logo-resize";
-import { getAllPeople } from "@/lib/people";
+import { usePeopleList } from "@/lib/use-people";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useReducer, useRef, useState } from "react";
 import {
@@ -62,9 +62,11 @@ function PlayerSelect({
   const [query, setQuery] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
-  const available = getAllPeople()
-    .filter((p) => !p.hasLeftClub && !takenSlugs.has(p.slug))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  // Merged roster (DB-backed first, static fallback). Same semantics as
+  // the static loader: people who have left the club are not sponsorable.
+  const available = usePeopleList().filter(
+    (p) => !p.hasLeftClub && !takenSlugs.has(p.slug),
+  );
 
   const filtered = query.trim()
     ? available.filter((p) =>

--- a/apps/web/src/pages/person/person-profile.tsx
+++ b/apps/web/src/pages/person/person-profile.tsx
@@ -1,9 +1,21 @@
+import { ContentBody } from "@/components/content-body.js";
 import { mdxComponents } from "@/components/mdx-components.js";
-import { OptimisedImage } from "@/components/optimised-image.js";
+import {
+  OptimisedImage,
+  type PictureSource,
+} from "@/components/optimised-image.js";
+import { PageLoading } from "@/components/page-loading.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
+import {
+  isPageGone,
+  parsePersonMetadata,
+  personQueryOptions,
+} from "@/lib/content-queries.js";
 import { getImageUrl, getPicture } from "@/lib/image-map.js";
 import { getPersonBySlug } from "@/lib/people.js";
 import { MDXProvider } from "@mdx-js/react";
+import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { IoChevronForward } from "react-icons/io5";
 import { Link, useParams } from "react-router";
 import { PlayerSponsor } from "./player-sponsor.js";
@@ -12,25 +24,27 @@ import { PlayerStats } from "./player-stats.js";
 const ANON_IMAGE = getImageUrl("/images/anon.jpg");
 const ANON_PICTURE = getPicture("/images/anon.jpg");
 
-export function Component() {
-  const params = useParams();
-  const person = getPersonBySlug(params.slug ?? "");
-
-  useDocumentMeta(person?.name ?? "Player Profile");
-
-  if (!person) {
-    return (
-      <div className="container mx-auto px-4 py-12">
-        <h1>Person Not Found</h1>
-        <p>The person you&apos;re looking for doesn&apos;t exist.</p>
-        <Link to="/people" className="text-primary hover:underline">
-          Back to People
-        </Link>
-      </div>
-    );
-  }
-
-  const Bio = person.Component;
+/**
+ * Shared profile chrome for both sources: breadcrumbs, photo, bio, the
+ * stats sidebar and sponsorship CTA (deliberately untouched by #499 -
+ * both key off the slug alone).
+ */
+function ProfileView({
+  slug,
+  name,
+  picture,
+  photoUrl,
+  isDBSChecked,
+  bio,
+}: {
+  slug: string;
+  name: string;
+  picture?: PictureSource;
+  photoUrl?: string;
+  isDBSChecked: boolean;
+  bio: ReactNode;
+}) {
+  const effectivePicture = picture ?? ANON_PICTURE;
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -40,48 +54,41 @@ export function Component() {
           People
         </Link>
         <IoChevronForward className="text-stone-400" size={14} />
-        <span className="text-dark font-medium">{person.name}</span>
+        <span className="text-dark font-medium">{name}</span>
       </div>
 
       <div className="flex flex-col gap-6 md:flex-row">
         <div className="flex-1">
           <div className="mb-4 flex flex-col items-center justify-between gap-4 md:flex-row">
             <div className="flex flex-col items-center justify-start gap-4 md:flex-row">
-              {(() => {
-                const picture = person.photoPicture ?? ANON_PICTURE;
-                return picture ? (
-                  <OptimisedImage
-                    picture={picture}
-                    alt={person.name}
-                    className="mb-0 max-h-48 rounded-full"
-                    sizes="132px"
-                    width={132}
-                    height={132}
-                  />
-                ) : (
-                  <img
-                    className="mb-0 max-h-48 rounded-full"
-                    src={person.photo ?? ANON_IMAGE}
-                    alt={person.name}
-                    width={132}
-                    height={132}
-                  />
-                );
-              })()}
+              {effectivePicture ? (
+                <OptimisedImage
+                  picture={effectivePicture}
+                  alt={name}
+                  className="mb-0 max-h-48 rounded-full"
+                  sizes="132px"
+                  width={132}
+                  height={132}
+                />
+              ) : (
+                <img
+                  className="mb-0 max-h-48 rounded-full"
+                  src={photoUrl ?? ANON_IMAGE}
+                  alt={name}
+                  width={132}
+                  height={132}
+                />
+              )}
             </div>
           </div>
 
-          <MDXProvider components={mdxComponents}>
-            <div className="mdx-content flex flex-col *:mb-4">
-              <Bio />
-            </div>
-          </MDXProvider>
+          {bio}
 
-          <PlayerStats slug={person.slug} />
+          <PlayerStats slug={slug} />
         </div>
 
         <aside className="w-full shrink-0 md:w-64">
-          {person.isDBSChecked && (
+          {isDBSChecked && (
             <div className="mb-4 flex justify-center">
               <img
                 src="/images/dbs-checked.png"
@@ -91,9 +98,79 @@ export function Component() {
               />
             </div>
           )}
-          <PlayerSponsor slug={person.slug} />
+          <PlayerSponsor slug={slug} />
         </aside>
       </div>
+    </div>
+  );
+}
+
+export function Component() {
+  const params = useParams();
+  const slug = params.slug ?? "";
+
+  // DB-backed profile first (#499); the bundled MDX corpus stays as
+  // fallback until the people migration is verified in prod, then gets
+  // deleted in a follow-up. The MDX renders only once the query settles
+  // (confirmed 404, or an API failure - deliberate graceful degradation)
+  // so an edited DB profile never flashes its stale MDX ancestor first.
+  // A 410 tombstone (ever-live profile taken down) suppresses the static
+  // fallback entirely: a takedown must not resurrect the bundled MDX.
+  const { data, isPending } = useQuery(personQueryOptions(slug));
+  const gone = isPageGone(data);
+  const apiPerson = data == null || isPageGone(data) ? undefined : data;
+  const staticPerson = gone ? undefined : getPersonBySlug(slug);
+
+  useDocumentMeta(apiPerson?.title ?? staticPerson?.name ?? "Player Profile");
+
+  if (apiPerson) {
+    const meta = parsePersonMetadata(apiPerson.metadata);
+    return (
+      <ProfileView
+        slug={apiPerson.slug}
+        name={apiPerson.title}
+        picture={meta?.photo}
+        isDBSChecked={meta?.isDBSChecked === true}
+        bio={<ContentBody body={apiPerson.body} />}
+      />
+    );
+  }
+
+  if (isPending) {
+    return (
+      <div className="container mx-auto px-4 py-6">
+        <PageLoading />
+      </div>
+    );
+  }
+
+  if (staticPerson) {
+    const Bio = staticPerson.Component;
+    return (
+      <ProfileView
+        slug={staticPerson.slug}
+        name={staticPerson.name}
+        picture={staticPerson.photoPicture}
+        photoUrl={staticPerson.photo}
+        isDBSChecked={staticPerson.isDBSChecked}
+        bio={
+          <MDXProvider components={mdxComponents}>
+            <div className="mdx-content flex flex-col *:mb-4">
+              <Bio />
+            </div>
+          </MDXProvider>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <h1>Person Not Found</h1>
+      <p>The person you&apos;re looking for doesn&apos;t exist.</p>
+      <Link to="/people" className="text-primary hover:underline">
+        Back to People
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/pages/person/person-profile.tsx
+++ b/apps/web/src/pages/person/person-profile.tsx
@@ -111,15 +111,16 @@ export function Component() {
 
   // DB-backed profile first (#499); the bundled MDX corpus stays as
   // fallback until the people migration is verified in prod, then gets
-  // deleted in a follow-up. The MDX renders only once the query settles
-  // (confirmed 404, or an API failure - deliberate graceful degradation)
-  // so an edited DB profile never flashes its stale MDX ancestor first.
-  // A 410 tombstone (ever-live profile taken down) suppresses the static
-  // fallback entirely: a takedown must not resurrect the bundled MDX.
-  const { data, isPending } = useQuery(personQueryOptions(slug));
+  // deleted in a follow-up. The MDX renders only on a CONFIRMED 404 -
+  // never published in the DB - so an edited DB profile can't flash its
+  // stale MDX ancestor, and never on an API error: unlike news/pages,
+  // profiles fail CLOSED on incidents, because a 5xx must not resurrect
+  // a profile whose takedown (410 tombstone / unpublish) the API can't
+  // currently vouch for. Safeguarding beats graceful degradation here.
+  const { data, isPending, isError } = useQuery(personQueryOptions(slug));
   const gone = isPageGone(data);
   const apiPerson = data == null || isPageGone(data) ? undefined : data;
-  const staticPerson = gone ? undefined : getPersonBySlug(slug);
+  const staticPerson = gone || isError ? undefined : getPersonBySlug(slug);
 
   useDocumentMeta(apiPerson?.title ?? staticPerson?.name ?? "Player Profile");
 
@@ -140,6 +141,20 @@ export function Component() {
     return (
       <div className="container mx-auto px-4 py-6">
         <PageLoading />
+      </div>
+    );
+  }
+
+  if (isError) {
+    // Deliberately NOT the not-found copy: the profile may exist, we
+    // just can't confirm its current state.
+    return (
+      <div className="container mx-auto px-4 py-12">
+        <h1>Profile Unavailable</h1>
+        <p>We couldn&apos;t load this profile right now - try again shortly.</p>
+        <Link to="/people" className="text-primary hover:underline">
+          Back to People
+        </Link>
       </div>
     );
   }

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -204,6 +204,62 @@ export const eventMetadataSchema = z.object({
 });
 export type EventMetadata = z.infer<typeof eventMetadataSchema>;
 
+/**
+ * Image sources the public site will render: https or site-relative
+ * (uploads live under /uploads/*). Mirrors the public renderer's
+ * isSafeImageSrc so a stored descriptor can never smuggle a protocol the
+ * renderer would have to reject.
+ */
+const SAFE_IMAGE_SRC = /^(?:https:|\/(?!\/))/i;
+
+const safeSrcset = z
+  .string()
+  .min(1)
+  .refine(
+    (srcset) =>
+      srcset
+        .split(",")
+        .map((part) => part.trim().split(/\s+/)[0])
+        .every((url) => url !== undefined && SAFE_IMAGE_SRC.test(url)),
+    "Every srcset URL must be https or site-relative",
+  );
+
+/**
+ * A person's profile photo: the PictureSource descriptor returned by the
+ * content-images upload API (responsive srcsets per format + the largest
+ * fallback image), stored inline so the public profile renders without
+ * any lookup - the same precedent as the contentImage block's picture
+ * prop. Alt text is not stored: the photo is always rendered with the
+ * person's name as its alt.
+ */
+export const personPhotoSchema = z.object({
+  sources: z.record(z.string(), safeSrcset),
+  img: z.object({
+    src: z.string().regex(SAFE_IMAGE_SRC, "Must be https or site-relative"),
+    w: z.number().int().positive(),
+    h: z.number().int().positive(),
+  }),
+});
+export type PersonPhoto = z.infer<typeof personPhotoSchema>;
+
+/**
+ * Person metadata (Phase 4, #498). The person's name lives in the item's
+ * `title` column like every other kind's display name - duplicating it
+ * here would create two sources of truth. The flags are
+ * safeguarding-adjacent, which is why the person kind is gated by
+ * content_people (people_editor / content_admin) rather than the general
+ * content roles. Both flags are deliberately public: the static site has
+ * always rendered the DBS badge on profiles and filtered rosters on
+ * hasLeftClub, and parents being able to see who is DBS checked is the
+ * point of the badge. The gate protects who can WRITE them.
+ */
+export const personMetadataSchema = z.object({
+  isDBSChecked: z.boolean().default(false),
+  hasLeftClub: z.boolean().default(false),
+  photo: personPhotoSchema.optional(),
+});
+export type PersonMetadata = z.infer<typeof personMetadataSchema>;
+
 export const CONTENT_METADATA_SCHEMAS: Partial<
   Record<ContentKind, z.ZodType<Record<string, unknown>>>
 > = {
@@ -211,6 +267,7 @@ export const CONTENT_METADATA_SCHEMAS: Partial<
   news: newsMetadataSchema,
   event: eventMetadataSchema,
   game_report: gameReportMetadataSchema,
+  person: personMetadataSchema,
 };
 
 // ── Custom block types ──────────────────────────────────────────────────

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -180,9 +180,10 @@ export const newsTagSchema = z.string().min(1).max(100);
 
 export const newsMetadataSchema = z.object({
   tags: z.array(newsTagSchema),
-  // References the static people corpus, which stays as MDX in the web
-  // app until Phase 4 - so only the format is validated here. The admin
-  // UI's people picker is what ties the slug to a real person.
+  // References a person by slug (the DB-backed person kind as of Phase 4,
+  // with the static corpus as transition fallback) - only the format is
+  // validated here. The admin UI's people picker is what ties the slug
+  // to a real person.
   authorSlug: contentSlugSchema.optional(),
 });
 export type NewsMetadata = z.infer<typeof newsMetadataSchema>;


### PR DESCRIPTION
Closes #497 (and via the squashed sub-PRs: #498, #499, #500). The final phase of the live content editing project (#479): people profiles become DB-backed and editable behind their own safeguarding-gated role, and editors get revision history with diff and restore.

## Sub-issue PRs (squashed onto this branch, each codex-reviewed)

- **#523 / #498 - Person content kind.** `personMetadataSchema` (`isDBSChecked`/`hasLeftClub` defaulting false + optional photo descriptor with https/site-relative-only URLs); registering it enables the kind end to end through the existing kind-agnostic routes, gated by `content_people` (people_editor/content_admin only). Admin "Profiles" sub-tab with photo upload through the consent + EXIF-strip + responsive pipeline and explicit safeguarding toggles with an in-UI note. Public projection reuses the write schema deliberately - both flags have always been public on the static site; the gate protects writes. The person's name lives in `title` (not duplicated in metadata as the issue text sketched - one source of truth, pinned by a test).
- **#524 / #499 - Migration + API rendering.** `migrate-people.ts` imports the 56 MDX profiles (idempotent by (kind, slug); local run: 56 inserted + 20 photos, re-run: 56 unchanged). New public `GET /content/people` roster answers the person-grid N+1 with one cached request. `use-people.ts` merges DB people over the static corpus per slug (TRANSITION FALLBACK #489); person-profile.tsx is API-first with the same settled-query fallback as news/pages; Person cards, editor pickers and the sponsorships player picker (keeping its `!hasLeftClub` filter) all resolve from the merged roster. Codex finding fixed: takedown tombstones - an ever-live profile that is unpublished/archived returns 410 by slug and appears in the roster's `removed[]`, so it cannot resurrect from the static bundle.
- **#525 / #500 - Revision history UI.** New `GET .../revisions/:revisionId` (scoped to the item, same per-kind view gate). History card in the editor: every save with who/when; per-revision dialog shows a dependency-free text diff (blocks projected to readable lines covering every render-relevant prop; metadata with sorted keys) against the latest saved version. Restore copies the revision into the working draft - confirming first over unsaved work - and persists only via the normal save, which writes a new revision: the timeline stays append-only and publish status never changes. Codex findings fixed in place (prop coverage, unsaved-work confirm).

## Epic acceptance (from #497)

- [x] ~55 people profiles DB-backed: migration validated locally end to end (56/56, idempotent); prod run is post-merge (below)
- [x] Editable by a people_editor: full lifecycle exercised over the real HTTP stack with better-auth sessions; news_editor/reports_editor get 403 on every person operation and people_editor cannot reach other kinds
- [x] Editors can view/restore revision history on any content item, gated per kind

## Tests

- api unit 681, web unit 565 (new: person metadata schema, parsePersonSource, revision-diff), shared 9
- api integration 479, including the new safeguarding boundary suite (4 real role sessions), person tombstones, roster projection, and revision detail round-trips
- lint (zero warnings policy), typecheck, prettier all green

## Post-merge operational steps

1. Run the prod people migration (same access pattern as Phases 2/3): `migrate-people.ts --user <id> --dry-run` first, then for real with the uploads bucket.
2. Spot-check profiles (photo variants, DBS badge, bio parity), then assign `people_editor` to the relevant volunteers.
3. After verification: cleanup PR removing `content/people/`, `lib/people.ts` and the remaining static-loader consumers (news bylines, sponsor-checkout, share-my-team) - the issue's final bullet, deliberately not in this epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)