### PR TITLE
feat(content-editor): WYSIWYG person grid editing

### DIFF
--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -1,5 +1,8 @@
 import { LeaderboardContent } from "@/components/leaderboard-content.js";
-import { OptimisedImage } from "@/components/optimised-image.js";
+import {
+  OptimisedImage,
+  type PictureSource,
+} from "@/components/optimised-image.js";
 import { OutcomeBadge } from "@/components/outcome-badge.js";
 import { RecordsWall as RecordsWallComponent } from "@/components/records-wall.js";
 import { Button } from "@/components/ui/button.js";
@@ -31,21 +34,31 @@ function RecordsWall() {
   return <RecordsWallComponent />;
 }
 
-function Person({ slug, role }: { slug: string; role?: string }) {
-  // Merged roster: DB-backed people first, bundled MDX corpus as the
-  // per-slug fallback during the migration transition (#499). One cached
-  // list query serves every card on the page.
-  const person = usePeople().get(slug);
-  const name = person?.name ?? slug;
-  const picture = person?.picture ?? ANON_PICTURE;
-
+/**
+ * Presentational person card, shared with the personGrid editor block so
+ * the in-editor cards stay pixel-identical to the public ones (#527).
+ * `children` fills the slot under the name (public: role text + profile
+ * link; editor: an inline role input).
+ */
+export function PersonCardShell({
+  name,
+  picture,
+  photoUrl,
+  children,
+}: {
+  name: string;
+  picture?: PictureSource;
+  photoUrl?: string;
+  children?: ReactNode;
+}) {
+  const resolvedPicture = picture ?? ANON_PICTURE;
   return (
     <div className="person h-full rounded-lg bg-white pb-4 text-stone-900 shadow-md">
       <div className="from-cta h-2 rounded-t-lg bg-gradient-to-r to-orange-400" />
       <div className="mx-auto mt-4 size-24 overflow-hidden rounded-full border-4 border-stone-100">
-        {picture ? (
+        {resolvedPicture ? (
           <OptimisedImage
-            picture={picture}
+            picture={resolvedPicture}
             alt={name}
             className="size-24 object-cover object-center"
             sizes="96px"
@@ -53,22 +66,44 @@ function Person({ slug, role }: { slug: string; role?: string }) {
         ) : (
           <img
             className="size-24 object-cover object-center"
-            src={person?.photoUrl ?? ANON_IMAGE}
+            src={photoUrl ?? ANON_IMAGE}
             alt={name}
           />
         )}
       </div>
       <div className="mt-3 text-center">
         <h5 className="pb-1 font-semibold">{name}</h5>
-        {role && <p className="text-sm text-stone-600">{role}</p>}
-        <Link
-          to={`/person/${slug}`}
-          className="text-primary mt-2 inline-block px-2 text-sm font-medium hover:underline"
-        >
-          Profile
-        </Link>
+        {children}
       </div>
     </div>
+  );
+}
+
+/** Grid layout shared with the personGrid editor block (#527). */
+export const PERSON_GRID_CLASSES =
+  "grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4";
+
+function Person({ slug, role }: { slug: string; role?: string }) {
+  // Merged roster: DB-backed people first, bundled MDX corpus as the
+  // per-slug fallback during the migration transition (#499). One cached
+  // list query serves every card on the page.
+  const person = usePeople().get(slug);
+  const name = person?.name ?? slug;
+
+  return (
+    <PersonCardShell
+      name={name}
+      picture={person?.picture}
+      photoUrl={person?.photoUrl}
+    >
+      {role && <p className="text-sm text-stone-600">{role}</p>}
+      <Link
+        to={`/person/${slug}`}
+        className="text-primary mt-2 inline-block px-2 text-sm font-medium hover:underline"
+      >
+        Profile
+      </Link>
+    </PersonCardShell>
   );
 }
 
@@ -80,14 +115,10 @@ function PersonGrid({
   children?: ReactNode;
 }) {
   if (children) {
-    return (
-      <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {children}
-      </div>
-    );
+    return <div className={PERSON_GRID_CLASSES}>{children}</div>;
   }
   return (
-    <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div className={PERSON_GRID_CLASSES}>
       {slugs?.map((slug) => (
         <Person key={slug} slug={slug} />
       ))}

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -84,6 +84,7 @@ import {
   eligibleParents,
   visibleNodes,
 } from "./pages-tab.lib.js";
+import { PersonGridEditor } from "./person-grid-editor.js";
 import {
   blocksToLines,
   detailLines,
@@ -404,99 +405,13 @@ const personGridBlock = createReactBlockSpec(
         });
       };
       return (
-        <div className="my-2 flex w-full flex-col gap-2">
-          {entries.length > 0 ? (
-            <EditorBlockPreview>
-              {/* Same children composition as the public renderer. */}
-              <mdxComponents.PersonGrid>
-                {entries.map((entry, i) => (
-                  <mdxComponents.Person
-                    key={`${entry.slug}-${String(i)}`}
-                    slug={entry.slug}
-                    role={entry.role}
-                  />
-                ))}
-              </mdxComponents.PersonGrid>
-            </EditorBlockPreview>
-          ) : (
-            <p className="text-sm text-stone-500">Choose people to display…</p>
-          )}
-          <PersonGridControls entries={entries} onWrite={write} />
+        <div className="my-2 w-full">
+          <PersonGridEditor entries={entries} onWrite={write} />
         </div>
       );
     },
   },
 );
-
-/**
- * The grid block's people controls, a component of its own so the merged
- * roster hook lives outside the block-spec render function.
- */
-function PersonGridControls({
-  entries,
-  onWrite,
-}: {
-  entries: PersonGridEntry[];
-  onWrite: (next: PersonGridEntry[]) => void;
-}) {
-  const allPeople = usePeopleList();
-  const nameOf = (slug: string) =>
-    allPeople.find((p) => p.slug === slug)?.name ?? slug;
-  return (
-    <>
-      <div className="flex flex-col gap-1">
-        <p className="text-xs text-stone-500">
-          Select people (hold Ctrl/Cmd to pick multiple):
-        </p>
-        <select
-          aria-label="People"
-          multiple
-          size={Math.min(allPeople.length, 6)}
-          value={entries.map((e) => e.slug)}
-          onChange={(e) => {
-            const chosen = Array.from(e.target.selectedOptions).map(
-              (o) => o.value,
-            );
-            // People who stay selected keep their role; newly
-            // selected people start role-less.
-            onWrite(
-              chosen.map(
-                (slug) =>
-                  entries.find((entry) => entry.slug === slug) ?? { slug },
-              ),
-            );
-          }}
-          className="rounded border border-stone-300 bg-white p-1 text-sm"
-        >
-          {allPeople.map((p) => (
-            <option key={p.slug} value={p.slug}>
-              {p.name}
-            </option>
-          ))}
-        </select>
-      </div>
-      {entries.map((entry, i) => (
-        <input
-          key={`${entry.slug}-${String(i)}`}
-          aria-label={`Role shown for ${nameOf(entry.slug)}`}
-          placeholder={`Role for ${nameOf(entry.slug)} (optional)`}
-          value={entry.role ?? ""}
-          onChange={(e) => {
-            const role = e.target.value;
-            onWrite(
-              entries.map((current, j) =>
-                j === i
-                  ? { slug: current.slug, ...(role !== "" && { role }) }
-                  : current,
-              ),
-            );
-          }}
-          className="rounded border border-stone-300 bg-white p-1 text-sm"
-        />
-      ))}
-    </>
-  );
-}
 
 const leagueTableBlock = createReactBlockSpec(
   {

--- a/apps/web/src/pages/admin/person-grid-editor.test.tsx
+++ b/apps/web/src/pages/admin/person-grid-editor.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+// The shared card shell lives in mdx-components, which transitively
+// imports the people corpus (.mdx files) and the vite-imagetools image
+// map, neither of which exists outside a Vite build - stub the lookups,
+// the editor only needs their shapes.
+vi.mock("@/lib/people.js", () => ({
+  getPersonBySlug: () => undefined,
+  getAllPeople: () => [
+    {
+      slug: "alex-slaven",
+      name: "Alex Slaven",
+      photo: undefined,
+      photoPicture: undefined,
+    },
+    {
+      slug: "bob-jones",
+      name: "Bob Jones",
+      photo: undefined,
+      photoPicture: undefined,
+    },
+  ],
+}));
+vi.mock("@/lib/image-map.js", () => ({
+  getImageUrl: () => undefined,
+  getPicture: () => undefined,
+}));
+vi.mock("@/lib/marketing/consent.js", () => ({
+  CURRENT_CONSENT_VERSION: "v3",
+  requestConsentReopen: () => undefined,
+}));
+
+import type { PersonGridEntry } from "@/lib/person-grid.js";
+import { PersonGridEditor } from "./person-grid-editor.js";
+
+// usePeople rides a react-query list query (disabled here, so the
+// merged roster is just the static corpus stub above).
+function renderGrid(entries: PersonGridEntry[]): string {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, enabled: false } },
+  });
+  return renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <PersonGridEditor
+        entries={entries}
+        onWrite={() => {
+          /* static render - never fired */
+        }}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("PersonGridEditor", () => {
+  it("renders a card per entry with an inline role input", () => {
+    const html = renderGrid([
+      { slug: "alex-slaven", role: "Captain" },
+      { slug: "bob-jones" },
+    ]);
+    expect(html).toContain("Alex Slaven");
+    expect(html).toContain("Bob Jones");
+    expect(html).toContain('aria-label="Role shown for Alex Slaven"');
+    expect(html).toContain('value="Captain"');
+    // Role-less entries get an empty input, not "undefined".
+    expect(html).toContain('aria-label="Role shown for Bob Jones"');
+    expect(html).not.toContain("undefined");
+  });
+
+  it("falls back to the slug as the name for unknown people", () => {
+    const html = renderGrid([{ slug: "mystery-person" }]);
+    expect(html).toContain("mystery-person");
+    expect(html).toContain('aria-label="Role shown for mystery-person"');
+  });
+
+  it("renders a remove button on every card", () => {
+    const html = renderGrid([
+      { slug: "alex-slaven" },
+      { slug: "mystery-person" },
+    ]);
+    expect(html).toContain('aria-label="Remove Alex Slaven from the grid"');
+    expect(html).toContain('aria-label="Remove mystery-person from the grid"');
+  });
+
+  it("shows the add card while people remain to be added", () => {
+    const html = renderGrid([{ slug: "alex-slaven" }]);
+    expect(html).toContain('aria-label="Add a person to the grid"');
+    expect(html).toContain("Add person");
+  });
+
+  it("shows only the add card for an empty grid", () => {
+    const html = renderGrid([]);
+    expect(html).toContain('aria-label="Add a person to the grid"');
+    expect(html).not.toContain("Role shown for");
+  });
+
+  it("hides the add card once everyone is in the grid", () => {
+    const html = renderGrid([{ slug: "alex-slaven" }, { slug: "bob-jones" }]);
+    expect(html).not.toContain("Add a person to the grid");
+  });
+});

--- a/apps/web/src/pages/admin/person-grid-editor.tsx
+++ b/apps/web/src/pages/admin/person-grid-editor.tsx
@@ -1,0 +1,126 @@
+import {
+  PERSON_GRID_CLASSES,
+  PersonCardShell,
+} from "@/components/mdx-components.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select.js";
+import type { PersonGridEntry } from "@/lib/person-grid.js";
+import {
+  usePeople,
+  usePeopleList,
+  type PersonSummary,
+} from "@/lib/use-people.js";
+
+/**
+ * WYSIWYG controls for the personGrid block (#527): the grid itself is
+ * the editor. Each card renders the shared public card shell with an
+ * inline role input and a top-right remove button, and the trailing
+ * dashed "+" card appends a person - so what authors see is what the
+ * published page shows.
+ */
+export function PersonGridEditor({
+  entries,
+  onWrite,
+}: {
+  entries: PersonGridEntry[];
+  onWrite: (next: PersonGridEntry[]) => void;
+}) {
+  const people = usePeople();
+  const allPeople = usePeopleList();
+  const inGrid = new Set(entries.map((entry) => entry.slug));
+
+  const setRole = (index: number, role: string) => {
+    onWrite(
+      entries.map((entry, i) =>
+        i === index
+          ? // Empty role is omitted, never stored as "" (NULL-for-unset).
+            { slug: entry.slug, ...(role !== "" && { role }) }
+          : entry,
+      ),
+    );
+  };
+
+  return (
+    <div className={PERSON_GRID_CLASSES}>
+      {entries.map((entry, i) => {
+        const person = people.get(entry.slug);
+        const name = person?.name ?? entry.slug;
+        return (
+          <div key={`${entry.slug}-${String(i)}`} className="relative">
+            <PersonCardShell
+              name={name}
+              picture={person?.picture}
+              photoUrl={person?.photoUrl}
+            >
+              <input
+                aria-label={`Role shown for ${name}`}
+                placeholder="Role (optional)"
+                value={entry.role ?? ""}
+                onChange={(e) => {
+                  setRole(i, e.target.value);
+                }}
+                className="mx-auto block w-5/6 rounded border border-stone-200 bg-white px-1 py-0.5 text-center text-sm text-stone-600 placeholder:text-stone-400"
+              />
+            </PersonCardShell>
+            <button
+              type="button"
+              aria-label={`Remove ${name} from the grid`}
+              onClick={() => {
+                onWrite(entries.filter((_, j) => j !== i));
+              }}
+              className="absolute top-1 right-1 flex size-6 items-center justify-center rounded-full bg-white text-stone-500 shadow hover:bg-stone-100 hover:text-stone-900"
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+      <AddPersonCard
+        people={allPeople.filter((p) => !inGrid.has(p.slug))}
+        onAdd={(slug) => {
+          onWrite([...entries, { slug }]);
+        }}
+      />
+    </div>
+  );
+}
+
+/**
+ * The empty "+" card: the whole card is a Select trigger, so one click
+ * opens the person picker. Kept always-empty (value="") so each pick
+ * appends and the card resets. Hidden once everyone is already in the
+ * grid - there is nobody left to add.
+ */
+function AddPersonCard({
+  people,
+  onAdd,
+}: {
+  people: PersonSummary[];
+  onAdd: (slug: string) => void;
+}) {
+  if (people.length === 0) return null;
+  return (
+    <Select value="" onValueChange={onAdd}>
+      <SelectTrigger
+        aria-label="Add a person to the grid"
+        className="h-full min-h-48 w-full flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed border-stone-300 bg-transparent whitespace-normal shadow-none hover:border-stone-400 hover:bg-stone-50"
+      >
+        <span aria-hidden className="text-4xl leading-none text-stone-400">
+          +
+        </span>
+        <span className="text-sm text-stone-500">Add person</span>
+      </SelectTrigger>
+      <SelectContent>
+        {people.map((p) => (
+          <SelectItem key={p.slug} value={p.slug}>
+            {p.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}


### PR DESCRIPTION
Closes #527

## What changed

The personGrid block in the content editor previously rendered an inert preview with a Ctrl/Cmd multiselect and a detached stack of role inputs underneath. That UI is gone. The grid itself is now the editor:

- **Role typed directly on the card** - each card carries an inline role input where the public card shows the role text.
- **"x" at the top right of each card** removes that person from the grid.
- **A dashed "+" card** at the end of the grid opens a person picker (one click) and appends the chosen person; people already in the grid are excluded from the picker, and the card hides once everyone is added.

To keep the editor truly WYSIWYG, the public card markup is extracted into a shared `PersonCardShell` (and the grid layout into `PERSON_GRID_CLASSES`) in `mdx-components.tsx`, used by both the public renderer and the new `PersonGridEditor`. The public `Person`/`PersonGrid` output is byte-identical to before.

Block props are unchanged (`entries` JSON canonical, legacy `slugs` CSV kept in sync), so the public renderer, revision diffing, and stored content are unaffected.

## Verification

- Static-render tests for `PersonGridEditor` (cards + role inputs, remove buttons, add-card visibility, slug fallback for unknown people).
- Verified end to end in the local app: inserted a grid via the slash menu on a draft page, added two people via the "+" card (picker correctly excluded the already-added person), typed "Club Captain" directly on a card, removed a card (remaining card kept its role), saved, and confirmed the stored block props and the Preview tab's public render. Test draft cleaned up afterwards.
- `pnpm test` (web, 577 passed), `pnpm typecheck`, `pnpm lint`, `pnpm format` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)