### PR TITLE
feat(content-editor): make the edit canvas the preview, drop the Preview tab

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -524,56 +524,171 @@
   --color-secondary: #f5f5f4;
 }
 
-/* MDX content prose styles */
-.mdx-content a {
+/* Editor canvas WYSIWYG parity: the edit canvas IS the page preview, so
+   the canvas re-applies the public content styles that BlockNote's
+   stylesheet would otherwise override. BlockNote's CSS is unlayered and
+   loads with the editor chunk (after this file), so every rule here has
+   to win on specificity, not source order. */
+
+/* Body text: site font + text colour + leading-relaxed - BlockNote
+   ships Inter at line-height 1.5. */
+.bn-shadcn .bn-default-styles {
+  font-family: var(--font-primary);
+}
+.bn-shadcn .bn-editor {
+  color: var(--color-text);
+}
+.bn-shadcn .bn-block-outer {
+  line-height: 1.625;
+}
+
+/* Headings: BlockNote sizes these via an em --level scale (h1 = 3em);
+   re-point each level at the site heading scale, including the base
+   layer's md breakpoint bumps for h1/h3. Family, weight, colour and
+   line-height already reach the inner h1-h6 from the base layer. */
+.bn-shadcn [data-content-type="heading"] {
+  --level: var(--font-size-h1-sm);
+}
+.bn-shadcn [data-content-type="heading"][data-level="2"] {
+  --level: var(--font-size-h2-sm);
+}
+.bn-shadcn [data-content-type="heading"][data-level="3"] {
+  --level: var(--font-size-h3-sm);
+}
+.bn-shadcn [data-content-type="heading"][data-level="4"] {
+  --level: var(--font-size-h4);
+}
+.bn-shadcn [data-content-type="heading"][data-level="5"] {
+  --level: var(--font-size-h5);
+}
+.bn-shadcn [data-content-type="heading"][data-level="6"] {
+  --level: var(--font-size-h6);
+}
+@media (min-width: 768px) {
+  .bn-shadcn [data-content-type="heading"] {
+    --level: var(--font-size-h2);
+  }
+  .bn-shadcn [data-content-type="heading"][data-level="3"] {
+    --level: var(--font-size-h3);
+  }
+}
+
+/* Custom blocks render real site components, so undo the ProseMirror
+   editing-text inheritance (white-space: break-spaces + overflow-wrap:
+   break-word) that public pages never see - without this, the league
+   table compresses itself by breaking team names mid-word instead of
+   overflowing into its horizontal scroll. Scoped to our custom block
+   types: BlockNote's own editable blocks (paragraphs, its table cells)
+   need the ProseMirror wrapping behaviour. */
+.bn-shadcn
+  .bn-block-content:is(
+    [data-content-type="person"],
+    [data-content-type="personGrid"],
+    [data-content-type="gamePreview"],
+    [data-content-type="eventPreview"],
+    [data-content-type="contentImage"],
+    [data-content-type="leagueTable"],
+    [data-content-type="leaderboard"],
+    [data-content-type="recordsWall"],
+    [data-content-type="contactForm"],
+    [data-content-type="cookieSettingsLink"],
+    [data-content-type="consentVersion"]
+  ) {
+  white-space: normal;
+  overflow-wrap: normal;
+
+  /* ProseMirror forces table-layout: fixed for its editable tables;
+     data tables inside custom blocks (league table, leaderboard) size
+     their columns to content like the public page. */
+  & table {
+    table-layout: auto;
+  }
+}
+
+/* Quotes: the branded callout card, not BlockNote's plain gray bar. */
+.bn-shadcn [data-content-type="quote"] blockquote {
+  @apply border-cta bg-surface rounded-lg border-l-4 p-6 shadow-sm;
+  color: var(--color-text);
+}
+
+/* Links: blue with hover underline, as in .mdx-content (BlockNote
+   reverts anchors to the always-underlined UA default). */
+.bn-shadcn .bn-editor .bn-inline-content a {
+  @apply text-blue-600 no-underline hover:underline dark:text-blue-400;
+}
+
+/* Tables: horizontal rules only, like the published table styles
+   (BlockNote draws a full #ddd grid). Column edges still show up via
+   BlockNote's hover handles while editing. */
+.bn-shadcn .bn-editor [data-content-type="table"] table {
+  @apply text-sm;
+}
+.bn-shadcn .bn-editor [data-content-type="table"] th,
+.bn-shadcn .bn-editor [data-content-type="table"] td {
+  @apply border-0 border-b border-gray-100 px-4 py-2;
+}
+.bn-shadcn .bn-editor [data-content-type="table"] th {
+  @apply border-b-2 border-gray-200 bg-gray-50 font-semibold text-gray-700;
+}
+.bn-shadcn .bn-editor [data-content-type="table"] tr:last-child td {
+  @apply border-b-0;
+}
+
+/* MDX content prose styles. Also applied inside the editor canvas
+   (.bn-editor) so custom blocks - which render the same components as
+   the public pages - pick up the same element styles; the WYSIWYG
+   canvas is the preview. Where BlockNote's own later-loaded CSS
+   out-ranks these (its links, quotes, and editable tables), the
+   .bn-shadcn parity rules above re-assert the public look. */
+:is(.mdx-content, .bn-editor) a {
   @apply text-blue-600 hover:underline dark:text-blue-400;
 }
 
-.mdx-content ul {
+:is(.mdx-content, .bn-editor) ul {
   @apply ml-4 list-disc;
 }
 
-.mdx-content ul > li {
+:is(.mdx-content, .bn-editor) ul > li {
   @apply mb-2;
 }
 
-.mdx-content ul > li > ul {
+:is(.mdx-content, .bn-editor) ul > li > ul {
   list-style-type: circle;
 }
 
-.mdx-content ol {
+:is(.mdx-content, .bn-editor) ol {
   @apply ml-4 list-decimal;
 }
 
-.mdx-content ol > li {
+:is(.mdx-content, .bn-editor) ol > li {
   @apply mb-2;
 }
 
-.mdx-content blockquote {
+:is(.mdx-content, .bn-editor) blockquote {
   @apply border-cta bg-surface rounded-lg border-l-4 p-6 shadow-sm;
 }
 
-.mdx-content hr {
+:is(.mdx-content, .bn-editor) hr {
   @apply border-border my-8;
 }
 
-.mdx-content img {
+:is(.mdx-content, .bn-editor) img {
   @apply h-auto max-w-full rounded-lg;
 }
 
-.mdx-content table {
+:is(.mdx-content, .bn-editor) table {
   @apply w-full border-collapse text-sm;
 }
 
-.mdx-content th {
+:is(.mdx-content, .bn-editor) th {
   @apply border-b-2 border-gray-200 bg-gray-50 px-4 py-2 text-left font-semibold text-gray-700;
 }
 
-.mdx-content td {
+:is(.mdx-content, .bn-editor) td {
   @apply border-b border-gray-100 px-4 py-2;
 }
 
-.mdx-content tr:last-child td {
+:is(.mdx-content, .bn-editor) tr:last-child td {
   @apply border-b-0;
 }
 

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -14,7 +14,6 @@ import {
 import { BlockNoteView } from "@blocknote/shadcn";
 import "@blocknote/shadcn/style.css";
 
-import { ContentBody } from "@/components/content-body.js";
 import {
   CONTACT_FORM_CARD_CLASSES,
   CONTACT_FORM_DESCRIPTION_CLASSES,
@@ -53,12 +52,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select.js";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs.js";
 import { Textarea } from "@/components/ui/textarea.js";
 import { useHasPermission } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client.js";
@@ -462,15 +455,19 @@ const leagueTableBlock = createReactBlockSpec(
       // One BlockSettings instance across the empty/filled branches:
       // typing the division ID flips the block to the preview, and a
       // separate instance would unmount the open modal mid-keystroke.
+      // min-w-0: BlockNote lays blocks out as flex rows, so without it
+      // the block can't shrink below the table's intrinsic width and
+      // the table's own overflow-x scroll never engages.
       return (
-        <div className="relative my-2 w-full">
+        <div className="relative my-2 w-full min-w-0">
+          {/* Not wrapped in EditorBlockPreview: the table is plain text
+              (no links or buttons to neutralise) and inert would swallow
+              the wheel/scrollbar events its horizontal scroll needs. */}
           {block.props.divisionId !== "" && (
-            <EditorBlockPreview>
-              <mdxComponents.LeagueTable
-                divisionId={block.props.divisionId}
-                name={block.props.name || undefined}
-              />
-            </EditorBlockPreview>
+            <mdxComponents.LeagueTable
+              divisionId={block.props.divisionId}
+              name={block.props.name || undefined}
+            />
           )}
           <BlockSettings
             label="League table settings"
@@ -2571,57 +2568,37 @@ function useRevisionRestore({
 function EditorPane({
   editor,
   slashItems,
-  currentBody,
   onDirty,
 }: {
   editor: Editor;
   slashItems: () => ReturnType<typeof getDefaultReactSlashMenuItems>;
-  currentBody: () => unknown;
   onDirty: () => void;
 }) {
-  const [activeTab, setActiveTab] = useState("edit");
-  const [previewBlocks, setPreviewBlocks] = useState<unknown>([]);
-
+  // No separate preview tab: every block renders its published look in
+  // place, so the canvas IS the preview. It sits on the same creamy
+  // background as the public pages so card-style blocks (league table,
+  // contact form, game/event previews) read exactly like the live site.
   return (
-    <Tabs
-      value={activeTab}
-      onValueChange={(tab) => {
-        if (tab === "preview") setPreviewBlocks(currentBody());
-        setActiveTab(tab);
-      }}
-    >
-      <TabsList>
-        <TabsTrigger value="edit">Edit</TabsTrigger>
-        <TabsTrigger value="preview">Preview</TabsTrigger>
-      </TabsList>
-      <TabsContent value="edit">
-        <div className="rounded-lg border border-stone-200 bg-white py-4">
-          <BlockNoteView
-            editor={editor}
-            theme="light"
-            slashMenu={false}
-            onChange={onDirty}
-          >
-            <SuggestionMenuController
-              triggerCharacter="/"
-              getItems={(query) =>
-                Promise.resolve(
-                  filterSuggestionItems(
-                    [...slashItems(), ...getDefaultReactSlashMenuItems(editor)],
-                    query,
-                  ),
-                )
-              }
-            />
-          </BlockNoteView>
-        </div>
-      </TabsContent>
-      <TabsContent value="preview">
-        <div className="rounded-lg border border-stone-200 bg-white p-4">
-          <ContentBody body={previewBlocks} />
-        </div>
-      </TabsContent>
-    </Tabs>
+    <div className="bg-body rounded-lg border border-stone-200 py-4">
+      <BlockNoteView
+        editor={editor}
+        theme="light"
+        slashMenu={false}
+        onChange={onDirty}
+      >
+        <SuggestionMenuController
+          triggerCharacter="/"
+          getItems={(query) =>
+            Promise.resolve(
+              filterSuggestionItems(
+                [...slashItems(), ...getDefaultReactSlashMenuItems(editor)],
+                query,
+              ),
+            )
+          }
+        />
+      </BlockNoteView>
+    </div>
   );
 }
 
@@ -2908,7 +2885,6 @@ function LoadedEditor({
           <EditorPane
             editor={editor}
             slashItems={slashItems}
-            currentBody={editorBody}
             onDirty={() => {
               dirtyRef.current = true;
             }}


### PR DESCRIPTION
## Summary

With the WYSIWYG block pass (#528, #529) every block edits its rendered output in place, so the separate Edit/Preview tabs no longer earn their keep - the edit view IS the preview. Before removing the tab, this PR closes the visual gaps between the canvas and the published page.

### Canvas/page parity (`app.css`)

- **Headings** (flagged): BlockNote sizes headings on an em scale (h1 = 3em ≈ 48px) via its `--level` variable; the canvas now re-points each level at the site heading scale, including the `md` breakpoint bumps. Verified pixel-equal in the browser (h1 38.54px, h5 19.93px - both identical to the public page).
- **Body text**: Source Sans 3 at the public 1.625 leading and `#444`, replacing BlockNote's Inter at 1.5.
- **League table** (flagged): three compounding bugs fixed -
  - block root gets `min-w-0` (BlockNote lays blocks out as flex rows, so the block refused to shrink and the table's own `overflow-x-auto` never engaged);
  - the `inert` preview wrapper is gone (the table has no links/buttons to neutralise, and inert swallowed the wheel/scrollbar events the horizontal scroll needs);
  - custom blocks reset ProseMirror's editing-text inheritance: `overflow-wrap: break-word` crushed team names mid-word ("Per cy Mai n CC") and `table-layout: fixed` overlapped columns.
- **Quotes**: branded callout card (orange border, white card) instead of BlockNote's plain gray bar.
- **Links/tables**: the `.mdx-content` prose rules now also target `.bn-editor` via `:is()` (selector refactor only - public specificity unchanged), with higher-specificity re-assertions where BlockNote's later-loaded CSS would win. BlockNote's editable-table mechanics (fixed layout, column resize) are deliberately preserved.
- **Canvas background**: creamy `bg-body` like the public pages, so card-style blocks (league table, contact form, game/event previews, person cards) read exactly like the live site.

### Preview tab removal (`content-editor.tsx`)

`EditorPane` drops the Tabs wrapper, the preview snapshot state, and the `currentBody` prop; `ContentBody` and `ui/tabs` imports go with it.

## Verification

Browser-verified against local dev with the real `1st XI` page (headings, body, league table incl. working horizontal scroll) side-by-side with its public render, plus scratch-canvas checks of bullet lists (no marker doubling - BlockNote lists are divs), quotes, native tables, and the slash menu. `tsc`, ESLint, and all 585 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)