### PR TITLE
feat(content): make legal pages migratable to the content API (#517)

### DIFF
--- a/apps/api/scripts/migrate-pages.ts
+++ b/apps/api/scripts/migrate-pages.ts
@@ -3,8 +3,8 @@
  * content API's tables as published items, building parent_id/path from
  * the directory layout (dir/_index.mdx IS the parent item) and pushing
  * each embedded <Image> through the same processing pipeline as editor
- * uploads. pages/legal/** is excluded by design (legal copy stays static
- * and changes via PR review).
+ * uploads. pages/legal/** was initially excluded; #517 migrates it too
+ * so the whole MDX pipeline can be removed.
  *
  * The script inserts rows directly (like migrate-news-events.ts), so it
  * upholds the page-hierarchy invariants itself rather than relying on
@@ -143,9 +143,6 @@ async function main() {
   console.log(`Found ${String(files.length)} pages in ${PAGES_DIR}`);
 
   const tree = buildPageTree(files);
-  for (const exclusion of tree.excluded) {
-    console.log(`  - ${exclusion.file}: ${exclusion.reason}`);
-  }
 
   const counts = {
     inserted: 0,
@@ -496,7 +493,7 @@ async function main() {
   console.log("");
   console.log("=== Migration report ===");
   console.log(
-    `Pages: ${String(counts.inserted)} inserted, ${String(counts.updated)} updated, ${String(counts.unchanged)} unchanged, ${String(counts.skipped)} skipped, ${String(counts.failed)} failed, ${String(tree.excluded.length)} excluded`,
+    `Pages: ${String(counts.inserted)} inserted, ${String(counts.updated)} updated, ${String(counts.unchanged)} unchanged, ${String(counts.skipped)} skipped, ${String(counts.failed)} failed`,
   );
   console.log(
     `Images: ${String(imagesUploaded)} ${dryRun ? "would be uploaded" : "uploaded"}, ${String(imagesReused)} reused`,
@@ -513,10 +510,6 @@ async function main() {
   console.log(`Skipped (${String(skipped.length)}):`);
   for (const item of skipped) {
     console.log(`  ${item.file}: ${item.reason}`);
-  }
-  console.log(`Excluded (${String(tree.excluded.length)}):`);
-  for (const exclusion of tree.excluded) {
-    console.log(`  ${exclusion.file}: ${exclusion.reason}`);
   }
 
   // The before/after nav snapshot artifact: what getPublishedNav would

--- a/apps/api/scripts/page-tree.test.ts
+++ b/apps/api/scripts/page-tree.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from "vitest";
 import {
   buildPageTree,
   filePathToUrlPath,
-  LEGAL_EXCLUSION_REASON,
   parentFailureReason,
   type PageNode,
 } from "./page-tree.ts";
@@ -34,6 +33,7 @@ describe("buildPageTree", () => {
     "cricket/_index.mdx",
     "cricket/ground/_index.mdx",
     "cricket/ground/grounds-team.mdx",
+    "legal/_index.mdx",
     "legal/privacy.mdx",
   ];
 
@@ -72,15 +72,19 @@ describe("buildPageTree", () => {
         path: "/cricket/ground/grounds-team",
         parentPath: "/cricket/ground",
       },
+      {
+        file: "legal/_index.mdx",
+        slug: "legal",
+        path: "/legal",
+        parentPath: null,
+      },
+      {
+        file: "legal/privacy.mdx",
+        slug: "privacy",
+        path: "/legal/privacy",
+        parentPath: "/legal",
+      },
     ]);
-  });
-
-  it("excludes legal/** by design", () => {
-    const tree = buildPageTree(fixture);
-    expect(tree.excluded).toEqual([
-      { file: "legal/privacy.mdx", reason: LEGAL_EXCLUSION_REASON },
-    ]);
-    expect(tree.ordered.some((n) => n.file.startsWith("legal/"))).toBe(false);
   });
 
   it("orders every parent before its children", () => {
@@ -174,13 +178,9 @@ describe("real corpus parity", () => {
     const tree = buildPageTree(files);
 
     // Structure: the real corpus must produce no structural failures -
-    // every non-legal file lands in ordered, legal is excluded.
+    // every file lands in ordered.
     expect(tree.failed).toEqual([]);
-    const nonLegal = files.filter((f) => !f.startsWith("legal/"));
-    expect(tree.ordered.map((n) => n.file).sort()).toEqual(nonLegal);
-    expect(tree.excluded.map((e) => e.file)).toEqual(
-      files.filter((f) => f.startsWith("legal/")),
-    );
+    expect(tree.ordered.map((n) => n.file).sort()).toEqual(files);
 
     // Paths: structural derivation (parent path + slug) agrees with the
     // web app's file-path transform for every single page.

--- a/apps/api/scripts/page-tree.ts
+++ b/apps/api/scripts/page-tree.ts
@@ -32,10 +32,7 @@ export interface PageTree {
   /** Valid nodes, path-ordered: every ancestor precedes its descendants. */
   ordered: PageNode[];
   failed: PageTreeFailure[];
-  excluded: { file: string; reason: string }[];
 }
-
-export const LEGAL_EXCLUSION_REASON = "excluded by design (legal stays static)";
 
 /**
  * Byte-for-byte mirror of the web app's transform (apps/web
@@ -101,21 +98,16 @@ function deriveNode(file: string): PageNode {
 }
 
 /**
- * Build the page tree from the corpus file list. legal/** is excluded by
- * design; structural failures (bad slug, missing parent _index.mdx, root
- * _index.mdx) fail the file AND - because a page cannot be inserted
- * without its parent row - every descendant of a failed file fails too.
+ * Build the page tree from the corpus file list. Structural failures
+ * (bad slug, missing parent _index.mdx, root _index.mdx) fail the file
+ * AND - because a page cannot be inserted without its parent row - every
+ * descendant of a failed file fails too.
  */
 export function buildPageTree(files: string[]): PageTree {
   const failed: PageTreeFailure[] = [];
-  const excluded: PageTree["excluded"] = [];
 
   const candidates: PageNode[] = [];
   for (const file of [...files].sort()) {
-    if (file.startsWith("legal/")) {
-      excluded.push({ file, reason: LEGAL_EXCLUSION_REASON });
-      continue;
-    }
     try {
       candidates.push(deriveNode(file));
     } catch (err) {
@@ -147,7 +139,7 @@ export function buildPageTree(files: string[]): PageTree {
     ordered.push(node);
   }
 
-  return { ordered, failed, excluded };
+  return { ordered, failed };
 }
 
 /**

--- a/apps/web/content/pages/legal/_index.mdx
+++ b/apps/web/content/pages/legal/_index.mdx
@@ -1,0 +1,8 @@
+---
+title: Legal
+description: Legal documents and policies for Percy Main Community Sports Club.
+---
+
+Documents covering how Percy Main Community Sports Club handles personal data and meets its legal obligations:
+
+- [Privacy Policy](/legal/privacy)

--- a/apps/web/content/pages/legal/privacy.mdx
+++ b/apps/web/content/pages/legal/privacy.mdx
@@ -7,24 +7,24 @@ description: Percy Main Community Sports Club privacy policy and data protection
 
 This privacy notice tells you what to expect us to do with your personal information.
 
-- [Contact details](#contact)
-- [What information we collect, use, and why](#collect)
-- [Service communications vs direct marketing](#service-vs-marketing)
-- [Lawful bases and data protection rights](#lawful)
-- [Cookies and Google tagging](#cookies)
-- [Where we get personal information from](#infofrom)
-- [How long we keep information](#retention)
-- [Who we share information with](#share)
-- [Accident and incident reports](#incidents)
-- [How to complain](#complain)
+- [Contact details](#contact-details)
+- [What information we collect, use, and why](#what-information-we-collect-use-and-why)
+- [Service communications vs direct marketing](#service-communications-vs-direct-marketing)
+- [Lawful bases and data protection rights](#lawful-bases-and-data-protection-rights)
+- [Cookies and Google tagging](#cookies-and-google-tagging)
+- [Where we get personal information from](#where-we-get-personal-information-from)
+- [How long we keep information](#how-long-we-keep-information)
+- [Who we share information with](#who-we-share-information-with)
+- [Accident and incident reports](#accident-and-incident-reports)
+- [How to complain](#how-to-complain)
 
-<h2 id="contact">Contact details</h2>
+## Contact details
 
 ### Email
 
 [trustees@percymain.org](mailto:trustees@percymain.org)
 
-<h2 id="collect">What information we collect, use, and why</h2>
+## What information we collect, use, and why
 
 We collect or use the following information to **receive donations or funding and organise fundraising activities**:
 
@@ -67,7 +67,7 @@ We collect or use the following personal information for **dealing with queries,
 
 - Names and contact details
 
-<h2 id="service-vs-marketing">Service communications vs direct marketing</h2>
+## Service communications vs direct marketing
 
 We treat these two categories differently, and we want you to know the difference.
 
@@ -75,7 +75,7 @@ We treat these two categories differently, and we want you to know the differenc
 
 **Direct marketing** means newsletters, fundraising asks, seasonal recruitment reminders, sponsor promotions, and anything else we send without a specific prior request from you. We do not currently operate a marketing list. If we ever do, it will be separate from any enquiry you've made, it will be opt-in, and every message will include a one-click unsubscribe.
 
-<h2 id="lawful">Lawful bases and data protection rights</h2>
+## Lawful bases and data protection rights
 
 Under UK data protection law, we must have a "lawful basis" for collecting and using your personal information. There is a list of possible lawful bases in the UK GDPR. You can find out more about lawful bases on the ICO's website.
 
@@ -115,7 +115,7 @@ Our lawful bases for collecting or using personal information for **dealing with
 
 - **Consent**: we have permission from you after we gave you all the relevant information. All of your data protection rights may apply, except the right to object. To be clear, you do have the right to withdraw your consent at any time.
 
-<h2 id="cookies">Cookies and Google tagging</h2>
+## Cookies and Google tagging
 
 We use a small number of cookies. Two are ours, the rest are set by Google when we load their tag.
 
@@ -139,22 +139,26 @@ Google's tag (`gtag.js`) is loaded on every page of this site, regardless of whe
 
 ### Changing your mind
 
-You can change your choice at any time. Click <CookieSettingsLink /> here, or use the "Cookie settings" link in the site footer. The banner will re-open and your new choice takes effect immediately, no page reload required.
+You can change your choice at any time using the link below, or the "Cookie settings" link in the site footer. The banner will re-open and your new choice takes effect immediately, no page reload required.
 
-This notice version: <ConsentVersion />. If we change what we send to Google in a way that materially affects this notice, we bump the version and the banner re-appears so you can re-decide.
+<CookieSettingsLink>Open cookie settings</CookieSettingsLink>
 
-<h2 id="infofrom">Where we get personal information from</h2>
+<ConsentVersion />
+
+If we change what we send to Google in a way that materially affects this notice, we bump the version and the banner re-appears so you can re-decide.
+
+## Where we get personal information from
 
 - Directly from you
 - Through Google Ads click identifiers when you arrive via one of our adverts, only after you have accepted cookies
 
-<h2 id="retention">How long we keep information</h2>
+## How long we keep information
 
 Personal information relating to a member is kept for the duration of a person's membership, and for 36 months thereafter.
 
 Lead records (name, email, phone, notes and the associated events) for people who submit a trial or enquiry form but do not go on to become members are kept for 3 years from the date of submission, then automatically deleted.
 
-<h2 id="share">Who we share information with</h2>
+## Who we share information with
 
 ### Data processors
 
@@ -182,7 +186,7 @@ Application performance monitoring, helps us spot and fix errors on the site.
 
 Receives operational notifications when someone submits a contact, enquiry, trial, or payment. Slack is used by a small number of club volunteers; lead information is not posted publicly.
 
-<h2 id="incidents">Accident and incident reports</h2>
+## Accident and incident reports
 
 The club provides a form for reporting accidents, injuries, near misses and safety concerns at [/report-incident](/report-incident). Information submitted through this form is used to record, review and respond to the incident, and to demonstrate responsible health and safety governance.
 
@@ -194,7 +198,7 @@ Reports may include health-related information (for example details of an injury
 
 **Who we may share them with:** where necessary and lawful, we may share information from accident and incident reports with third parties including our insurers, relevant sport governing bodies (for example the England and Wales Cricket Board or the Northumberland & Tyneside Cricket League), emergency services, local authorities, safeguarding agencies and regulators such as the Health and Safety Executive.
 
-<h2 id="complain">How to complain</h2>
+## How to complain
 
 If you have any concerns about our use of your personal data, you can make a complaint to us using the contact details at the top of this privacy notice.
 
@@ -215,4 +219,6 @@ Website: [https://www.ico.org.uk/make-a-complaint](https://ico.org.uk/make-a-com
 
 ## Last updated
 
-25 April 2026. Notice version <ConsentVersion />. Signed off by the tech lead (Alex Young).
+25 April 2026. Signed off by the tech lead (Alex Young).
+
+<ConsentVersion />

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -113,6 +113,43 @@ describe("ContentBody", () => {
     expect(html).toContain("&lt;script&gt;");
   });
 
+  it("gives headings slugified anchor ids", () => {
+    const html = renderBody([
+      block("heading", {
+        props: { level: 2 },
+        content: [text("What information we collect, use, and why")],
+      }),
+      block("heading", {
+        props: { level: 3 },
+        content: [text("How our consent banner works (Consent Mode v2)")],
+      }),
+    ]);
+    expect(html).toContain('id="what-information-we-collect-use-and-why"');
+    expect(html).toContain('id="how-our-consent-banner-works-consent-mode-v2"');
+  });
+
+  it("omits the heading id when the text slugifies to nothing", () => {
+    const html = renderBody([
+      block("heading", { props: { level: 2 }, content: [text("???")] }),
+    ]);
+    expect(html).not.toContain("id=");
+  });
+
+  it("renders #fragment links for in-page anchors", () => {
+    const html = renderBody([
+      block("paragraph", {
+        content: [
+          {
+            type: "link",
+            href: "#contact-details",
+            content: [text("Contact details")],
+          },
+        ],
+      }),
+    ]);
+    expect(html).toContain('href="#contact-details"');
+  });
+
   it("drops unsafe link protocols but keeps the text", () => {
     const html = renderBody([
       block("paragraph", {
@@ -449,8 +486,8 @@ describe("ContentBody", () => {
     expect(html).toContain("Cookie settings");
   });
 
-  it("renders consentVersion as the current version string", () => {
+  it("renders consentVersion as a self-contained sentence", () => {
     const html = renderBody([block("consentVersion", {})]);
-    expect(html).toContain("v3");
+    expect(html).toContain("This notice is version v3.");
   });
 });

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -54,10 +54,15 @@ function isInlineLink(node: unknown): node is InlineLink {
 
 /**
  * Only protocols/paths we trust ever become anchors. Anything else (e.g.
- * javascript:) renders as its text content with no link.
+ * javascript:) renders as its text content with no link. Fragments are
+ * in-page jumps to heading anchors - they never navigate.
  */
 function isSafeHref(href: string): boolean {
-  return /^(https?:|mailto:|tel:)/i.test(href) || /^\/(?!\/)/.test(href);
+  return (
+    /^(https?:|mailto:|tel:)/i.test(href) ||
+    /^\/(?!\/)/.test(href) ||
+    href.startsWith("#")
+  );
 }
 
 /**
@@ -140,6 +145,20 @@ function alignClass(block: ContentBlock): string | undefined {
 function stringProp(block: ContentBlock, name: string): string | undefined {
   const value = block.props[name];
   return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/**
+ * GitHub-style anchor slug for a heading, so prose can link to sections
+ * with plain #fragment links. Ids are not deduped: duplicate heading
+ * text yields duplicate anchors and the browser jumps to the first.
+ */
+function headingAnchor(content: unknown): string | undefined {
+  const slug = inlineToText(content)
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, "")
+    .trim()
+    .replace(/\s+/g, "-");
+  return slug === "" ? undefined : slug;
 }
 
 /**
@@ -276,7 +295,7 @@ function BlockView({ block }: { block: ContentBlock }) {
         <div>
           {createElement(
             `h${level}`,
-            { className: alignClass(block) },
+            { className: alignClass(block), id: headingAnchor(block.content) },
             <InlineContent content={block.content} />,
           )}
           <BlockChildren block={block} />

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -19,7 +19,7 @@ import { usePeople } from "@/lib/use-people.js";
 import { cn } from "@/lib/utils.js";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { formatInTimeZone } from "date-fns-tz";
-import { type ReactNode, useState } from "react";
+import { createElement, isValidElement, type ReactNode, useState } from "react";
 import { IoCalendar, IoChevronForward } from "react-icons/io5";
 import { Link, useLocation } from "react-router";
 
@@ -528,8 +528,45 @@ function CookieSettingsLink({ children }: { children?: ReactNode }) {
   );
 }
 
+/**
+ * A complete sentence rather than the bare version string: the block
+ * pipeline only supports block-level components, so this has to read as
+ * a standalone paragraph wherever it lands.
+ */
 function ConsentVersion() {
-  return <>{CURRENT_CONSENT_VERSION}</>;
+  return <p>This notice is version {CURRENT_CONSENT_VERSION}.</p>;
+}
+
+/** Plain-text projection of rendered children (for anchor slugs). */
+function nodeText(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(nodeText).join("");
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return nodeText(node.props.children);
+  }
+  return "";
+}
+
+/**
+ * TRANSITION FALLBACK (#517): markdown headings in the bundled MDX get
+ * the same anchor ids ContentBody generates, so #fragment TOC links keep
+ * working between this deploy and the legal pages migration. Deleted
+ * with the MDX pipeline in the cleanup PR.
+ */
+function anchoredHeading(level: 2 | 3) {
+  return function AnchoredHeading({ children }: { children?: ReactNode }) {
+    const slug = nodeText(children)
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\s-]/gu, "")
+      .trim()
+      .replace(/\s+/g, "-");
+    return createElement(
+      `h${String(level)}`,
+      { id: slug === "" ? undefined : slug },
+      children,
+    );
+  };
 }
 
 export const mdxComponents = {
@@ -545,4 +582,6 @@ export const mdxComponents = {
   ConsentVersion,
   Image: ContentImage,
   img: MdxImg,
+  h2: anchoredHeading(2),
+  h3: anchoredHeading(3),
 };


### PR DESCRIPTION
Part 1 of 2 for #517. The cleanup PR (which deletes all static MDX content, loaders and the MDX toolchain) follows, stacked on this branch.

## What

Removes the last blocker to deleting the MDX pipeline: `legal/privacy.mdx` was excluded from the pages migration by design ("legal stays static, changes via PR review"). Per the open question on #517, legal migrates too so the whole toolchain can go.

- **ContentBody**: heading blocks emit GitHub-style slugified anchor `id`s; `#fragment` hrefs are accepted by the safe-link check. The privacy notice's table of contents needs both.
- **mdxComponents**: matching `h2`/`h3` anchor ids for the static MDX render (transition-only - keeps TOC links working between this deploy and the prod migration; deleted with the MDX pipeline in the cleanup PR). `ConsentVersion` now renders "This notice is version 2026-04-25." as a complete sentence, because the block pipeline only supports block-level components. The editor preview reuses the same component so WYSIWYG stays in sync.
- **privacy.mdx**: raw `<h2 id="...">` HTML converted to markdown headings (the converter rejects raw HTML), TOC links repointed at the generated slugs, and the two inline `<ConsentVersion />` / `<CookieSettingsLink />` usages restructured to block-level. **Legal copy is otherwise byte-identical** - the only prose changes are in the "Changing your mind" section (sentence restructure around the now-block-level link/version) and the "Last updated" section (version sentence moved to its own line).
- **New `legal/_index.mdx`**: the DB page hierarchy requires `/legal/privacy` to hang off a `/legal` parent row. Thin landing page, not in the main menu.
- **page-tree.ts**: legal exclusion and the now-empty `excluded[]` mechanism removed.

## Anchor id changes

The old anchors (`#contact`, `#collect`, ...) were hand-written ids; the new ones derive from heading text (`#contact-details`, `#what-information-we-collect-use-and-why`, ...). They are only used by the page's own TOC, which is updated to match.

## Verification

- `migrate-pages.ts --dry-run` against the local DB: `legal/_index.mdx` + `legal/privacy.mdx` convert cleanly (2 + 124 blocks, 0 failures); real run + idempotent re-run pass.
- Browser-checked the DB-backed render: all 10 TOC anchors resolve and jump, cookie-settings button reopens the consent banner, both consent-version sentences and the cookies table render.
- Browser-checked the static-fallback render (legal rows deleted locally): TOC anchors resolve via the transitional h2/h3 override.
- Full monorepo typecheck, lint, tests, format pass.

## After merge

Once this deploys, the prod migration runs (standard prod-script pattern, `--dry-run` first, expecting 31 unchanged + 2 inserted), then the cleanup PR becomes mergeable.

Closes nothing on its own - #517 closes with the cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)