### PR TITLE
fix(cricket): correct wagon wheel vertical axis and per-batter runs

### DIFF
--- a/apps/web/src/components/wagon-wheel-geometry.test.ts
+++ b/apps/web/src/components/wagon-wheel-geometry.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { polar, shotRadius } from "./wagon-wheel-geometry";
+
+describe("polar", () => {
+  // SVG coordinates: +x is right, +y is DOWN. The wagon wheel labels Legside
+  // on the right and Offside on the left, with the pitch pointing down. These
+  // cases pin the orientation so the vertical axis can't silently flip again
+  // (the bug where leg-side shots rendered mirrored top-to-bottom).
+  const cases: Array<[string, number, [number, number]]> = [
+    ["0deg points straight up (behind the wicket)", 0, [0, -100]],
+    ["90deg points right (legside)", 90, [100, 0]],
+    ["180deg points straight down (down the ground)", 180, [0, 100]],
+    ["270deg points left (offside)", 270, [-100, 0]],
+  ];
+
+  it.each(cases)("%s", (_label, deg, [ex, ey]) => {
+    const [x, y] = polar(deg, 100);
+    expect(x).toBeCloseTo(ex, 6);
+    expect(y).toBeCloseTo(ey, 6);
+  });
+
+  it("sends a leg-side drive (135deg) down and to the right", () => {
+    const [x, y] = polar(135, 100);
+    expect(x).toBeGreaterThan(0); // legside (right)
+    expect(y).toBeGreaterThan(0); // lower half (down)
+  });
+
+  it("sends an off-side cut (225deg) down and to the left", () => {
+    const [x, y] = polar(225, 100);
+    expect(x).toBeLessThan(0); // offside (left)
+    expect(y).toBeGreaterThan(0); // lower half (down)
+  });
+});
+
+describe("shotRadius", () => {
+  it("pins sixes and fours to fixed boundary radii", () => {
+    expect(shotRadius({ runsBat: 6, shotLength: null })).toBe(278);
+    expect(shotRadius({ runsBat: 4, shotLength: null })).toBe(256);
+  });
+
+  it("scales other shots by shot length", () => {
+    expect(shotRadius({ runsBat: 2, shotLength: 50 })).toBe(210);
+    expect(shotRadius({ runsBat: 1, shotLength: 25 })).toBe(105);
+  });
+
+  it("returns 0 when there is no shot length (e.g. a dot)", () => {
+    expect(shotRadius({ runsBat: 0, shotLength: null })).toBe(0);
+  });
+});

--- a/apps/web/src/components/wagon-wheel-geometry.ts
+++ b/apps/web/src/components/wagon-wheel-geometry.ts
@@ -1,0 +1,31 @@
+// Pure geometry helpers for the wagon wheel, kept separate from the React
+// component so the angle/radius conventions can be unit-tested without pulling
+// in the component graph (Dialog, hooks, etc.).
+
+export const ROPE = 240;
+// Must be > the maximum shotRadius (278 for sixes) plus marker padding so
+// dismissal rings on boundaries don't clip against the viewBox edge.
+export const VIEW = 295;
+export const MAX_LEN = 50;
+
+export function shotRadius(b: {
+  runsBat: number;
+  shotLength: number | null;
+}): number {
+  if (b.runsBat >= 6) return 278;
+  if (b.runsBat >= 4) return 256;
+  if (b.shotLength == null) return 0;
+  return (b.shotLength / MAX_LEN) * 210;
+}
+
+// Maps a shot angle (degrees) and radius to SVG [x, y] coordinates.
+//
+// SVG's y-axis points down, so we negate cos to keep the shot_angle convention
+// upright: 0deg points up (behind the wicket) and the angle sweeps clockwise
+// through legside (90deg, right) to straight (180deg, down the ground) to
+// offside (270deg, left). Without the negation the vertical axis is flipped
+// and shots render mirrored top-to-bottom versus Play-Cricket.
+export function polar(deg: number, r: number): [number, number] {
+  const a = (deg * Math.PI) / 180;
+  return [Math.sin(a) * r, -Math.cos(a) * r];
+}

--- a/apps/web/src/components/wagon-wheel-modal.tsx
+++ b/apps/web/src/components/wagon-wheel-modal.tsx
@@ -1,5 +1,11 @@
 import { Dialog, DialogContent } from "@/components/ui/dialog.js";
 import {
+  polar,
+  ROPE,
+  shotRadius,
+  VIEW,
+} from "@/components/wagon-wheel-geometry.js";
+import {
   hasWagonWheel,
   useWagonWheelQuery,
   type WagonWheelData,
@@ -205,7 +211,11 @@ function InningsView({
     [balls, selectedOver, selectedBatter, selectedBowler],
   );
 
-  const stats = computeStats(filtered, dismissalPenalty);
+  const stats = computeStats(
+    filtered,
+    dismissalPenalty,
+    selectedBatter !== null,
+  );
 
   return (
     <>
@@ -341,9 +351,19 @@ interface Stats {
   wickets: number;
 }
 
-function computeStats(balls: Ball[], dismissalPenalty: number): Stats {
+function computeStats(
+  balls: Ball[],
+  dismissalPenalty: number,
+  batterSelected: boolean,
+): Stats {
   const wickets = balls.filter((b) => b.dismissed).length;
-  const gross = balls.reduce((a, b) => a + b.runsBat + b.runsExtra, 0);
+  // With a single batter filtered, "Runs" is that batter's own score (off the
+  // bat only) so it matches the scorecard. Otherwise it's the total runs on
+  // these balls, including extras (the innings / over / bowler views).
+  const gross = balls.reduce(
+    (a, b) => a + b.runsBat + (batterSelected ? 0 : b.runsExtra),
+    0,
+  );
   return {
     runs: gross - wickets * dismissalPenalty,
     balls: balls.length,
@@ -874,24 +894,6 @@ function CumulativeChart({
 }
 
 // --- Wheel ---
-
-const ROPE = 240;
-// Must be > the maximum shotRadius (278 for sixes) plus marker padding so
-// dismissal rings on boundaries don't clip against the viewBox edge.
-const VIEW = 295;
-const MAX_LEN = 50;
-
-function shotRadius(b: Pick<Ball, "runsBat" | "shotLength">): number {
-  if (b.runsBat >= 6) return 278;
-  if (b.runsBat >= 4) return 256;
-  if (b.shotLength == null) return 0;
-  return (b.shotLength / MAX_LEN) * 210;
-}
-
-function polar(deg: number, r: number): [number, number] {
-  const a = (deg * Math.PI) / 180;
-  return [Math.sin(a) * r, Math.cos(a) * r];
-}
 
 function ballKey(b: Pick<Ball, "over" | "ball">): string {
   return `${b.over}-${b.ball}`;


### PR DESCRIPTION
## What

Two fixes to the ball-by-ball wagon wheel viewer, found while comparing C Beever's 1st XI innings vs Monkseaton (2026-06-13) against the Play-Cricket render.

### 1. Vertical axis was flipped

`polar()` mapped a shot's angle to SVG coordinates as `[sin*r, cos*r]`. SVG's y-axis points **down**, but the `+cos` term put 0deg at the bottom, so the angle swept the wrong way vertically and every shot rendered mirrored top-to-bottom. The horizontal (off/leg) axis was already correct.

Confirmed against the real prod data: of Beever's 55 shots with an angle, the old formula put **41 in the top half / 14 in the bottom**, whereas Play-Cricket shows the bulk in the **bottom** half (leg-side heavy on the right). The fix negates cos, which flips only the vertical axis and leaves off/leg untouched.

### 2. "Runs" stat counted extras for a single batter

`computeStats` summed `runsBat + runsExtra`. With a batter filtered that showed team runs accrued while they were on strike (**118** for Beever) rather than their own score (**108**, matching the scorecard). Extras are now excluded when a single batter is selected; the innings / over / bowler views are unchanged (still include extras as an innings total should).

## How

- Extracted `polar()`, `shotRadius()` and the wheel constants into a pure `wagon-wheel-geometry.ts` so the conventions can be unit-tested without the React component graph.
- Added `wagon-wheel-geometry.test.ts` pinning the angle convention (0deg up, 90deg legside/right, 180deg down, 270deg offside/left) so the axis can't silently flip again.
- `computeStats` takes a `batterSelected` flag and excludes extras when set.

## Testing

- New unit tests pass (9 tests).
- prettier, eslint, and `tsc --noEmit` clean.
- Verified visually in the running app against prod data pulled into the local DB: Beever's wheel now matches Play-Cricket (down/leg-side heavy, six down-right, near-vertical four straight down) and RUNS reads 108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)