### PR TITLE
fix(sponsorship): restrict public game-sponsor endpoint to a public projection

### DIFF
--- a/apps/api/src/features/sponsorship/integration.test.ts
+++ b/apps/api/src/features/sponsorship/integration.test.ts
@@ -86,7 +86,9 @@ describe("sponsorship service (integration)", () => {
       const result = await getGameSponsorByGameId(ctx.db)(gameId);
       expect(result).not.toBeNull();
       expect(result?.game_id).toBe(gameId);
-      expect(result?.approved).toBe(true);
+      // approved/paid are filter predicates, not projected fields (public
+      // projection) - a returned row is necessarily the approved+paid one.
+      expect(result?.sponsor_name).toBe("Test Sponsor");
     });
   });
 

--- a/apps/api/src/features/sponsorship/schemas.ts
+++ b/apps/api/src/features/sponsorship/schemas.ts
@@ -165,12 +165,36 @@ export const publicPlayerSponsorColumns = [
   "sponsor_message",
 ] as const;
 
+// Public projection of a game sponsorship - same rationale as the player
+// one above: this route is unauthenticated, so omit sponsor_email,
+// amount_pence, paid_at, notes and stripe_payment_intent_id.
+const publicGameSponsorSchema = z.object({
+  game_id: z.string(),
+  sponsor_name: z.string(),
+  display_name: z.string().nullable(),
+  sponsor_website: z.string().nullable(),
+  sponsor_phone: z.string().nullable(),
+  sponsor_logo_url: z.string().nullable(),
+  sponsor_message: z.string().nullable(),
+});
+
+/** Columns the public projection selects - keep in sync with the schema. */
+export const publicGameSponsorColumns = [
+  "game_id",
+  "sponsor_name",
+  "display_name",
+  "sponsor_website",
+  "sponsor_phone",
+  "sponsor_logo_url",
+  "sponsor_message",
+] as const;
+
 export const approvedPlayerSponsorsResponseSchema = z.object({
   sponsors: z.array(publicPlayerSponsorSchema),
 });
 
 export const gameSponsorResponseSchema = z.object({
-  sponsor: gameSponsorshipRowSchema.nullable(),
+  sponsor: publicGameSponsorSchema.nullable(),
 });
 
 export const playerSponsorResponseSchema = z.object({

--- a/apps/api/src/features/sponsorship/service.ts
+++ b/apps/api/src/features/sponsorship/service.ts
@@ -10,7 +10,10 @@ import type {
   SponsorshipList,
   SponsorshipUpdate,
 } from "./schemas.ts";
-import { publicPlayerSponsorColumns } from "./schemas.ts";
+import {
+  publicGameSponsorColumns,
+  publicPlayerSponsorColumns,
+} from "./schemas.ts";
 
 /**
  * Cancel a Stripe payment intent, swallowing the expected
@@ -70,12 +73,14 @@ export async function getPlayerSponsorshipPrice(
 
 export function getGameSponsorByGameId(db: Kysely<DB>) {
   return async (gameId: string) => {
+    // Public projection only - this route is unauthenticated (see
+    // publicGameSponsorColumns).
     const sponsor = await db
       .selectFrom("game_sponsorship")
       .where("game_id", "=", gameId)
       .where("approved", "=", true)
       .where("paid_at", "is not", null)
-      .selectAll()
+      .select(publicGameSponsorColumns)
       .executeTakeFirst();
 
     return sponsor ?? null;

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -3226,21 +3226,13 @@ export interface paths {
                     content: {
                         "application/json": {
                             sponsor: {
-                                id: string;
                                 game_id: string;
                                 sponsor_name: string;
-                                sponsor_email: string;
+                                display_name: string | null;
                                 sponsor_website: string | null;
                                 sponsor_phone: string | null;
                                 sponsor_logo_url: string | null;
                                 sponsor_message: string | null;
-                                amount_pence: number;
-                                approved: boolean;
-                                paid_at: string | null;
-                                created_at: string;
-                                display_name: string | null;
-                                notes: string | null;
-                                stripe_payment_intent_id: string | null;
                             } | null;
                         };
                     };

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -5764,16 +5764,14 @@
                       "nullable": true,
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string"
-                        },
                         "game_id": {
                           "type": "string"
                         },
                         "sponsor_name": {
                           "type": "string"
                         },
-                        "sponsor_email": {
+                        "display_name": {
+                          "nullable": true,
                           "type": "string"
                         },
                         "sponsor_website": {
@@ -5791,49 +5789,16 @@
                         "sponsor_message": {
                           "nullable": true,
                           "type": "string"
-                        },
-                        "amount_pence": {
-                          "type": "number"
-                        },
-                        "approved": {
-                          "type": "boolean"
-                        },
-                        "paid_at": {
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "created_at": {
-                          "type": "string"
-                        },
-                        "display_name": {
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "notes": {
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "stripe_payment_intent_id": {
-                          "nullable": true,
-                          "type": "string"
                         }
                       },
                       "required": [
-                        "id",
                         "game_id",
                         "sponsor_name",
-                        "sponsor_email",
+                        "display_name",
                         "sponsor_website",
                         "sponsor_phone",
                         "sponsor_logo_url",
-                        "sponsor_message",
-                        "amount_pence",
-                        "approved",
-                        "paid_at",
-                        "created_at",
-                        "display_name",
-                        "notes",
-                        "stripe_payment_intent_id"
+                        "sponsor_message"
                       ],
                       "additionalProperties": false
                     }

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -3226,21 +3226,13 @@ export interface paths {
                     content: {
                         "application/json": {
                             sponsor: {
-                                id: string;
                                 game_id: string;
                                 sponsor_name: string;
-                                sponsor_email: string;
+                                display_name: string | null;
                                 sponsor_website: string | null;
                                 sponsor_phone: string | null;
                                 sponsor_logo_url: string | null;
                                 sponsor_message: string | null;
-                                amount_pence: number;
-                                approved: boolean;
-                                paid_at: string | null;
-                                created_at: string;
-                                display_name: string | null;
-                                notes: string | null;
-                                stripe_payment_intent_id: string | null;
                             } | null;
                         };
                     };

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -5764,16 +5764,14 @@
                       "nullable": true,
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string"
-                        },
                         "game_id": {
                           "type": "string"
                         },
                         "sponsor_name": {
                           "type": "string"
                         },
-                        "sponsor_email": {
+                        "display_name": {
+                          "nullable": true,
                           "type": "string"
                         },
                         "sponsor_website": {
@@ -5791,49 +5789,16 @@
                         "sponsor_message": {
                           "nullable": true,
                           "type": "string"
-                        },
-                        "amount_pence": {
-                          "type": "number"
-                        },
-                        "approved": {
-                          "type": "boolean"
-                        },
-                        "paid_at": {
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "created_at": {
-                          "type": "string"
-                        },
-                        "display_name": {
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "notes": {
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "stripe_payment_intent_id": {
-                          "nullable": true,
-                          "type": "string"
                         }
                       },
                       "required": [
-                        "id",
                         "game_id",
                         "sponsor_name",
-                        "sponsor_email",
+                        "display_name",
                         "sponsor_website",
                         "sponsor_phone",
                         "sponsor_logo_url",
-                        "sponsor_message",
-                        "amount_pence",
-                        "approved",
-                        "paid_at",
-                        "created_at",
-                        "display_name",
-                        "notes",
-                        "stripe_payment_intent_id"
+                        "sponsor_message"
                       ],
                       "additionalProperties": false
                     }


### PR DESCRIPTION
## What

Follow-up to #538. The public, unauthenticated `GET /api/sponsorship/game/{gameId}` route returned the **full** `game_sponsorship` row - including `sponsor_email`, `amount_pence`, `paid_at`, `notes` and `stripe_payment_intent_id`. Same class of over-exposure as the player endpoints fixed in #538.

## How

- Add a `publicGameSponsorSchema` projection (`game_id`, `sponsor_name`, `display_name`, `sponsor_website`, `sponsor_phone`, `sponsor_logo_url`, `sponsor_message`) and `publicGameSponsorColumns`, shared between the response schema and the service select.
- Repoint `gameSponsorResponseSchema` to the projection and narrow `getGameSponsorByGameId`'s `SELECT` to those columns.
- Admin game routes (`gameSponsorshipListResponseSchema`, behind `requirePermission("finance","manage")`) keep the full row.

The games feature already projected sponsor fields safely when embedding them into `/api/games` responses (`game.sponsor` = `{name, website, logoUrl, phone, message}`), so the public display surface is unaffected; this just closes the remaining direct leak. The bare `/sponsorship/game/{gameId}` route has no current frontend consumer.

## Test plan

- [x] `tsc --noEmit` clean (api + web)
- [x] eslint clean
- [x] sponsorship unit tests pass (5)
- [x] sponsorship integration tests pass (7, real Postgres) - updated the `getGameSponsorByGameId` test to assert on a projected field (`sponsor_name`) instead of the now-omitted `approved` predicate
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)