### PR TITLE
Add recurrence (repeating events) to events content

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,6 +53,7 @@
     "react-router": "^7.17.0",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
+    "rrule": "^2.8.1",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.0",
     "ts-pattern": "^5.6.0",

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -77,6 +77,7 @@ import {
   CONTENT_KIND_RESOURCES,
   contentBodySchema,
   CUSTOM_BLOCK_TYPES,
+  expandEventOccurrences,
   type ContentKind,
   type WriteContentBlock,
 } from "@percy-main/shared/content";
@@ -88,6 +89,7 @@ import {
 } from "@tanstack/react-query";
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as rruleNs from "rrule";
 import {
   BlockSettings,
   EMPTY_CARD_CLASSES,
@@ -1494,6 +1496,16 @@ interface FormState {
   // event - datetimes are datetime-local values in UK wall-clock time
   when: string;
   finish: string;
+  // event recurrence - a structured builder for an iCal RRULE body. The
+  // assembled rule + exceptions are stored under metadata.recurrence.
+  repeats: "none" | "daily" | "weekly" | "monthly" | "yearly";
+  recurrenceInterval: string;
+  recurrenceByDay: string[]; // weekday codes: MO TU WE TH FR SA SU
+  recurrenceMonthMode: "dayOfMonth" | "nthWeekday";
+  recurrenceEnd: "never" | "until" | "count";
+  recurrenceUntil: string; // yyyy-MM-dd (UK calendar date)
+  recurrenceCount: string;
+  recurrenceExceptions: string[]; // cancelled dates, UK yyyy-MM-dd
   hasLocation: boolean;
   locationName: string;
   locationStreet: string;
@@ -1512,6 +1524,180 @@ interface FormState {
 
 /** Event times are stored as instants but authored as UK wall-clock. */
 const EVENT_TZ = "Europe/London";
+
+// rrule has no "exports" map, so bundlers resolve its ESM build (named
+// exports) while Node resolves its CJS build (members under the interop
+// default). Prefer the named export, fall back to default - works in the
+// browser, in vitest's Node runtime, and in SSR.
+const { RRule } =
+  (rruleNs as typeof rruleNs & { default?: typeof rruleNs }).default ?? rruleNs;
+
+// Weekday codes indexed by rrule's weekday number (MO=0 .. SU=6).
+const WEEKDAY_CODES = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"] as const;
+const WEEKDAY_BY_CODE: Record<string, rruleNs.Weekday> = {
+  MO: RRule.MO,
+  TU: RRule.TU,
+  WE: RRule.WE,
+  TH: RRule.TH,
+  FR: RRule.FR,
+  SA: RRule.SA,
+  SU: RRule.SU,
+};
+const FREQ_BY_REPEATS = {
+  daily: RRule.DAILY,
+  weekly: RRule.WEEKLY,
+  monthly: RRule.MONTHLY,
+  yearly: RRule.YEARLY,
+} as const;
+
+type RepeatsOption = FormState["repeats"];
+
+const REPEATS_LABELS: Array<{ value: RepeatsOption; label: string }> = [
+  { value: "none", label: "Does not repeat" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+  { value: "yearly", label: "Yearly" },
+];
+
+/** The Nth weekday-in-month a date falls on (1-based), e.g. 9th -> 2. */
+function weekOfMonth(dayOfMonth: number): number {
+  return Math.floor((dayOfMonth - 1) / 7) + 1;
+}
+
+/**
+ * Assemble the stored RRULE body (no DTSTART line) from the builder fields.
+ * Returns null when the event does not repeat or the start is unset. Mirrors
+ * the shared eventMetadataSchema.recurrence shape on the way out.
+ */
+function buildEventRecurrence(
+  form: FormState,
+): { rrule: string; exceptions?: string[] } | null {
+  if (form.repeats === "none" || !form.when) return null;
+
+  const interval = Math.max(1, Number(form.recurrenceInterval) || 1);
+  const options: Partial<rruleNs.Options> = {
+    freq: FREQ_BY_REPEATS[form.repeats],
+    interval,
+  };
+
+  if (form.repeats === "weekly" && form.recurrenceByDay.length > 0) {
+    options.byweekday = form.recurrenceByDay.map((c) => WEEKDAY_BY_CODE[c]);
+  }
+
+  if (form.repeats === "monthly") {
+    // The day the series starts drives both monthly modes.
+    const start = new Date(ukLocalToIso(form.when));
+    const dayOfMonth = Number(formatInTimeZone(start, EVENT_TZ, "d"));
+    const weekday = Number(formatInTimeZone(start, EVENT_TZ, "i")) - 1; // 1..7 -> 0..6
+    if (form.recurrenceMonthMode === "nthWeekday") {
+      options.byweekday = [WEEKDAY_BY_CODE[WEEKDAY_CODES[weekday]]];
+      options.bysetpos = [weekOfMonth(dayOfMonth)];
+    } else {
+      options.bymonthday = [dayOfMonth];
+    }
+  }
+
+  if (form.recurrenceEnd === "count") {
+    options.count = Math.max(1, Number(form.recurrenceCount) || 1);
+  } else if (form.recurrenceEnd === "until" && form.recurrenceUntil) {
+    // End of the chosen UK day, encoded in the floating space the shared
+    // expander compares against (see packages/shared .../recurrence.ts).
+    const [y, m, d] = form.recurrenceUntil.split("-").map(Number);
+    options.until = new Date(Date.UTC(y, m - 1, d, 23, 59, 59));
+  }
+
+  // optionsToString emits "RRULE:FREQ=..."; store the body only.
+  const body = RRule.optionsToString(options).replace(/^RRULE:/, "");
+  return {
+    rrule: body,
+    ...(form.recurrenceExceptions.length > 0
+      ? { exceptions: form.recurrenceExceptions }
+      : {}),
+  };
+}
+
+/** Hydrate the recurrence builder fields from stored metadata.recurrence. */
+function recurrenceFormFields(recurrence: unknown): {
+  repeats: RepeatsOption;
+  recurrenceInterval: string;
+  recurrenceByDay: string[];
+  recurrenceMonthMode: "dayOfMonth" | "nthWeekday";
+  recurrenceEnd: "never" | "until" | "count";
+  recurrenceUntil: string;
+  recurrenceCount: string;
+  recurrenceExceptions: string[];
+} {
+  const defaults = {
+    repeats: "none" as RepeatsOption,
+    recurrenceInterval: "1",
+    recurrenceByDay: [] as string[],
+    recurrenceMonthMode: "dayOfMonth" as "dayOfMonth" | "nthWeekday",
+    recurrenceEnd: "never" as "never" | "until" | "count",
+    recurrenceUntil: "",
+    recurrenceCount: "",
+    recurrenceExceptions: [] as string[],
+  };
+  const rule =
+    typeof recurrence === "object" &&
+    recurrence !== null &&
+    typeof (recurrence as Record<string, unknown>).rrule === "string"
+      ? (recurrence as { rrule: string; exceptions?: unknown })
+      : null;
+  if (!rule) return defaults;
+
+  let options: Partial<rruleNs.Options>;
+  try {
+    options = RRule.parseString(rule.rrule);
+  } catch {
+    return defaults;
+  }
+
+  const repeats: RepeatsOption =
+    options.freq === RRule.DAILY
+      ? "daily"
+      : options.freq === RRule.WEEKLY
+        ? "weekly"
+        : options.freq === RRule.MONTHLY
+          ? "monthly"
+          : options.freq === RRule.YEARLY
+            ? "yearly"
+            : "none";
+
+  // byweekday entries may be Weekday instances or plain numbers.
+  const byDayNums = toArray(options.byweekday).map((w) =>
+    typeof w === "number" ? w : (w as rruleNs.Weekday).weekday,
+  );
+  const bysetpos = toArray(options.bysetpos);
+
+  return {
+    repeats,
+    recurrenceInterval: String(options.interval ?? 1),
+    recurrenceByDay:
+      repeats === "weekly"
+        ? byDayNums.flatMap((n) => (WEEKDAY_CODES[n] ? [WEEKDAY_CODES[n]] : []))
+        : [],
+    recurrenceMonthMode: bysetpos.length > 0 ? "nthWeekday" : "dayOfMonth",
+    recurrenceEnd:
+      options.count != null
+        ? "count"
+        : options.until != null
+          ? "until"
+          : "never",
+    recurrenceUntil: options.until
+      ? `${pad4(options.until.getUTCFullYear())}-${pad2(options.until.getUTCMonth() + 1)}-${pad2(options.until.getUTCDate())}`
+      : "",
+    recurrenceCount: options.count != null ? String(options.count) : "",
+    recurrenceExceptions: Array.isArray(rule.exceptions)
+      ? rule.exceptions.filter((d): d is string => typeof d === "string")
+      : [],
+  };
+}
+
+const toArray = <T,>(value: T | T[] | null | undefined): T[] =>
+  value == null ? [] : Array.isArray(value) ? value : [value];
+const pad2 = (n: number) => String(n).padStart(2, "0");
+const pad4 = (n: number) => String(n).padStart(4, "0");
 
 const asString = (value: unknown): string =>
   typeof value === "string" ? value : "";
@@ -1575,6 +1761,7 @@ function metadataFormFields(
     authorSlug: asString(metadata.authorSlug),
     when: isoToUkLocal(metadata.when),
     finish: isoToUkLocal(metadata.finish),
+    ...recurrenceFormFields(metadata.recurrence),
     hasLocation: location !== null,
     locationName: asString(location?.name),
     locationStreet: asString(location?.street),
@@ -1642,6 +1829,19 @@ function metadataProblem(kind: ContentKind, form: FormState): string | null {
   }
   if (kind === "event") {
     if (!form.when) return "Set the event start time first";
+    if (form.repeats !== "none") {
+      if (form.recurrenceEnd === "until" && !form.recurrenceUntil) {
+        return "Set the date the repeat ends on (or choose another end option)";
+      }
+      if (
+        form.recurrenceEnd === "count" &&
+        !(Number(form.recurrenceCount) >= 1)
+      ) {
+        return "Set how many times the event repeats";
+      }
+      const recurrence = buildEventRecurrence(form);
+      if (!recurrence) return "The recurrence rule is incomplete";
+    }
     if (form.hasLocation) {
       if (
         !form.locationName.trim() ||
@@ -1687,9 +1887,11 @@ function buildMetadata(
     };
   }
   if (kind === "event") {
+    const recurrence = buildEventRecurrence(form);
     return {
       when: ukLocalToIso(form.when),
       ...(form.finish ? { finish: ukLocalToIso(form.finish) } : {}),
+      ...(recurrence ? { recurrence } : {}),
       ...(form.hasLocation
         ? {
             location: {
@@ -2148,6 +2350,246 @@ function PersonMetadataFields({
   );
 }
 
+const ordinal = (n: number): string => {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
+};
+
+/**
+ * Structured recurrence builder for events. Drives the iCal RRULE body and
+ * exception list under metadata.recurrence via the shared expander, so the
+ * preview here matches exactly what every public surface will render.
+ */
+function EventRecurrenceFields({
+  form,
+  onChange,
+}: {
+  form: FormState;
+  onChange: (updates: Partial<FormState>) => void;
+}) {
+  const exceptions = new Set(form.recurrenceExceptions);
+
+  // Preview the next handful of occurrences, ignoring exceptions so cancelled
+  // dates still show (struck-through) with a Restore action.
+  const preview = useMemo(() => {
+    if (form.repeats === "none" || !form.when) return [];
+    const rule = buildEventRecurrence({ ...form, recurrenceExceptions: [] });
+    if (!rule) return [];
+    const start = new Date(ukLocalToIso(form.when));
+    const horizonDays =
+      { daily: 1, weekly: 7, monthly: 31, yearly: 366 }[form.repeats] ?? 31;
+    const interval = Math.max(1, Number(form.recurrenceInterval) || 1);
+    const to = new Date(
+      start.getTime() + horizonDays * interval * 9 * 24 * 60 * 60 * 1000,
+    );
+    return expandEventOccurrences(
+      { when: start.toISOString(), recurrence: rule },
+      { from: new Date(start.getTime() - 1000), to },
+    ).slice(0, 8);
+  }, [form]);
+
+  const toggleException = (date: string) => {
+    onChange({
+      recurrenceExceptions: exceptions.has(date)
+        ? form.recurrenceExceptions.filter((d) => d !== date)
+        : [...form.recurrenceExceptions, date].sort(),
+    });
+  };
+
+  const toggleWeekday = (code: string) => {
+    const selected = new Set(form.recurrenceByDay);
+    if (selected.has(code)) selected.delete(code);
+    else selected.add(code);
+    onChange({
+      recurrenceByDay: WEEKDAY_CODES.filter((c) => selected.has(c)),
+    });
+  };
+
+  // Monthly mode labels reflect the start date the rule anchors on.
+  const start = form.when ? new Date(ukLocalToIso(form.when)) : null;
+  const monthlyDayLabel = start
+    ? `On day ${formatInTimeZone(start, EVENT_TZ, "d")} of the month`
+    : "On day-of-month";
+  const monthlyNthLabel = start
+    ? `On the ${ordinal(weekOfMonth(Number(formatInTimeZone(start, EVENT_TZ, "d"))))} ${formatInTimeZone(start, EVENT_TZ, "EEEE")}`
+    : "On the Nth weekday";
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 p-3">
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="event-repeats">Repeats</Label>
+        <Select
+          value={form.repeats}
+          onValueChange={(value) => {
+            onChange({ repeats: value as RepeatsOption });
+          }}
+        >
+          <SelectTrigger id="event-repeats">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {REPEATS_LABELS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {form.repeats !== "none" && (
+        <>
+          <div className="flex items-center gap-2">
+            <Label htmlFor="event-recurrence-interval">Every</Label>
+            <Input
+              id="event-recurrence-interval"
+              type="number"
+              min={1}
+              className="w-20"
+              value={form.recurrenceInterval}
+              onChange={(e) => {
+                onChange({ recurrenceInterval: e.target.value });
+              }}
+            />
+            <span className="text-sm text-stone-600">
+              {{
+                daily: "day(s)",
+                weekly: "week(s)",
+                monthly: "month(s)",
+                yearly: "year(s)",
+                none: "",
+              }[form.repeats] ?? ""}
+            </span>
+          </div>
+
+          {form.repeats === "weekly" && (
+            <div className="flex flex-col gap-1">
+              <Label>On days</Label>
+              <div className="flex flex-wrap gap-3">
+                {WEEKDAY_CODES.map((code) => (
+                  <label key={code} className="flex items-center gap-1">
+                    <Checkbox
+                      checked={form.recurrenceByDay.includes(code)}
+                      onCheckedChange={() => {
+                        toggleWeekday(code);
+                      }}
+                    />
+                    <span className="text-sm">{code}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {form.repeats === "monthly" && (
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="event-recurrence-month-mode">Monthly on</Label>
+              <Select
+                value={form.recurrenceMonthMode}
+                onValueChange={(value) => {
+                  onChange({
+                    recurrenceMonthMode: value as "dayOfMonth" | "nthWeekday",
+                  });
+                }}
+              >
+                <SelectTrigger id="event-recurrence-month-mode">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="dayOfMonth">{monthlyDayLabel}</SelectItem>
+                  <SelectItem value="nthWeekday">{monthlyNthLabel}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="event-recurrence-end">Ends</Label>
+            <Select
+              value={form.recurrenceEnd}
+              onValueChange={(value) => {
+                onChange({
+                  recurrenceEnd: value as "never" | "until" | "count",
+                });
+              }}
+            >
+              <SelectTrigger id="event-recurrence-end">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="never">Never</SelectItem>
+                <SelectItem value="until">On date</SelectItem>
+                <SelectItem value="count">After N times</SelectItem>
+              </SelectContent>
+            </Select>
+            {form.recurrenceEnd === "until" && (
+              <Input
+                type="date"
+                className="mt-1"
+                value={form.recurrenceUntil}
+                onChange={(e) => {
+                  onChange({ recurrenceUntil: e.target.value });
+                }}
+              />
+            )}
+            {form.recurrenceEnd === "count" && (
+              <Input
+                type="number"
+                min={1}
+                className="mt-1 w-24"
+                value={form.recurrenceCount}
+                onChange={(e) => {
+                  onChange({ recurrenceCount: e.target.value });
+                }}
+              />
+            )}
+          </div>
+
+          {preview.length > 0 && (
+            <div className="flex flex-col gap-1">
+              <Label>Upcoming occurrences</Label>
+              <ul className="flex flex-col gap-1">
+                {preview.map((occ) => {
+                  const cancelled = exceptions.has(occ.date);
+                  return (
+                    <li
+                      key={occ.date}
+                      className="flex items-center justify-between gap-2"
+                    >
+                      <span
+                        className={cn(
+                          "text-sm",
+                          cancelled && "text-stone-400 line-through",
+                        )}
+                      >
+                        {formatInTimeZone(
+                          new Date(occ.start),
+                          EVENT_TZ,
+                          "EEE d MMM yyyy, HH:mm",
+                        )}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          toggleException(occ.date);
+                        }}
+                      >
+                        {cancelled ? "Restore" : "Skip"}
+                      </Button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 function MetadataFields({
   kind,
   form,
@@ -2287,6 +2729,7 @@ function MetadataFields({
               )}
             </div>
           </div>
+          <EventRecurrenceFields form={form} onChange={onChange} />
           <div className="flex items-center gap-2">
             <Checkbox
               id="event-has-location"

--- a/apps/web/src/pages/calendar/calendar-event.tsx
+++ b/apps/web/src/pages/calendar/calendar-event.tsx
@@ -6,12 +6,17 @@ import {
   eventQueryOptions,
   parseEventMetadata,
 } from "@/lib/content-queries.js";
+import {
+  expandEventOccurrences,
+  recurrenceSummary,
+  viewedOccurrence,
+} from "@percy-main/shared/content";
 import { useQuery } from "@tanstack/react-query";
 import { AddToCalendarButton } from "add-to-calendar-button-react";
 import { formatInTimeZone } from "date-fns-tz";
 import type { ReactNode } from "react";
 import { IoCalendar, IoChevronForward } from "react-icons/io5";
-import { Link, useParams } from "react-router";
+import { Link, useParams, useSearchParams } from "react-router";
 
 function When({ start, end }: { start: string; end?: string }) {
   return (
@@ -61,12 +66,16 @@ function EventLayout({
   when,
   finish,
   venue,
+  repeats,
+  upcoming,
   children,
 }: {
   name: string;
   when: string;
   finish?: string;
   venue?: EventVenue;
+  repeats?: string;
+  upcoming?: Array<{ date: string; href: string; label: string }>;
   children: ReactNode;
 }) {
   const year = formatInTimeZone(new Date(when), "Europe/London", "yyyy");
@@ -136,6 +145,32 @@ function EventLayout({
             <When start={when} end={finish} />
           </div>
         </div>
+
+        {repeats && (
+          <div className="flex w-full flex-col gap-2 rounded-xl bg-white p-4">
+            <p>
+              <span className="font-semibold">Repeats: </span>
+              {repeats}
+            </p>
+            {upcoming && upcoming.length > 0 && (
+              <div className="flex flex-col gap-1">
+                <span className="font-semibold">Upcoming dates</span>
+                <ul className="flex flex-wrap gap-x-4 gap-y-1">
+                  {upcoming.map((o) => (
+                    <li key={o.date}>
+                      <Link
+                        to={o.href}
+                        className="hover:text-primary text-stone-600 hover:underline"
+                      >
+                        {o.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {venue?.lat != null && venue?.lon != null && (
@@ -160,6 +195,8 @@ function EventLayout({
 export function Component() {
   const { id } = useParams<{ id: string }>();
   const slug = id ?? "";
+  const [searchParams] = useSearchParams();
+  const on = searchParams.get("on");
 
   const {
     data: apiEvent,
@@ -172,12 +209,45 @@ export function Component() {
   useDocumentMeta(apiEvent?.title ?? "Event");
 
   if (apiEvent && meta) {
+    // Resolve which occurrence to show: the ?on date, else the next upcoming,
+    // else the most recent past one. Non-recurring events resolve to their
+    // single date. Add-to-calendar and the breadcrumb follow this occurrence.
+    const now = new Date();
+    const occ = viewedOccurrence(meta, { on, now }) ?? {
+      start: meta.when,
+      finish: meta.finish,
+      date: formatInTimeZone(
+        new Date(meta.when),
+        "Europe/London",
+        "yyyy-MM-dd",
+      ),
+    };
+    const repeats = recurrenceSummary(meta);
+    const upcoming = meta.recurrence
+      ? expandEventOccurrences(meta, {
+          from: now,
+          to: new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000),
+        })
+          .slice(0, 8)
+          .map((o) => ({
+            date: o.date,
+            href: `/calendar/event/${slug}?on=${o.date}`,
+            label: formatInTimeZone(
+              new Date(o.start),
+              "Europe/London",
+              "EEE d MMM",
+            ),
+          }))
+      : undefined;
+
     return (
       <EventLayout
         name={apiEvent.title}
-        when={meta.when}
-        finish={meta.finish}
+        when={occ.start}
+        finish={occ.finish}
         venue={meta.location}
+        repeats={repeats}
+        upcoming={upcoming}
       >
         <ContentBody body={apiEvent.body} className="w-full" />
       </EventLayout>

--- a/apps/web/src/pages/calendar/calendar-month.tsx
+++ b/apps/web/src/pages/calendar/calendar-month.tsx
@@ -9,9 +9,11 @@ import {
   parseEventMetadata,
 } from "@/lib/content-queries.js";
 import { cn } from "@/lib/utils.js";
+import { expandEventOccurrences } from "@percy-main/shared/content";
 import { useQuery } from "@tanstack/react-query";
 import {
   addMonths,
+  endOfMonth,
   format,
   getDay,
   getDaysInMonth,
@@ -63,6 +65,8 @@ type CalendarItem =
       category: "event";
       when: string;
       eventName: string;
+      slug: string;
+      occurrenceDate: string;
     };
 
 // --- Constants ---
@@ -344,8 +348,8 @@ function EventCard({ item }: { item: CalendarItem & { type: "event" } }) {
 
   return (
     <PrefetchLink
-      query={eventQueryOptions(item.id)}
-      to={`/calendar/event/${item.id}`}
+      query={eventQueryOptions(item.slug)}
+      to={`/calendar/event/${item.slug}?on=${item.occurrenceDate}`}
       className="group mb-2 flex items-center gap-3 rounded-lg border-2 border-dashed border-orange-300/50 bg-orange-50/50 p-3 transition-all hover:translate-x-1 hover:shadow-md sm:gap-4 sm:p-4"
     >
       <div className="flex shrink-0 flex-col items-center gap-1">
@@ -498,27 +502,34 @@ export function Component() {
       }
     }
 
-    const events = (eventsData?.items ?? []).flatMap((item) => {
+    // Expand each event (recurring or not) into the concrete occurrences that
+    // fall within the displayed month. Recurrence expansion is DST-correct and
+    // skips cancelled dates; non-recurring events yield their single date.
+    const monthStart = startOfMonth(date);
+    const monthEnd = endOfMonth(date);
+    for (const item of eventsData?.items ?? []) {
       const meta = parseEventMetadata(item.metadata);
-      return meta
-        ? [{ slug: item.slug, name: item.title, when: meta.when }]
-        : [];
-    });
-    for (const event of events) {
-      const eventDate = new Date(event.when);
-      if (
-        eventDate.getFullYear() !== date.getFullYear() ||
-        eventDate.getMonth() !== date.getMonth()
-      )
-        continue;
-
-      items.push({
-        id: event.slug,
-        type: "event",
-        category: "event",
-        when: event.when,
-        eventName: event.name,
-      });
+      if (!meta) continue;
+      for (const occ of expandEventOccurrences(meta, {
+        from: monthStart,
+        to: monthEnd,
+      })) {
+        items.push({
+          id: `${item.slug}#${occ.date}`,
+          type: "event",
+          category: "event",
+          // London-local ISO so the agenda groups it under the right day
+          // (groupItemsByDate keys off the leading date portion of `when`).
+          when: formatInTimeZone(
+            new Date(occ.start),
+            "Europe/London",
+            "yyyy-MM-dd'T'HH:mm:ssXXX",
+          ),
+          eventName: item.title,
+          slug: item.slug,
+          occurrenceDate: occ.date,
+        });
+      }
     }
 
     return sortCalendarItems(items);

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/content-queries.js";
 import { getPriceId } from "@/lib/stripe-env.js";
 import { usePeople, type PersonSummary } from "@/lib/use-people.js";
+import { nextOccurrence } from "@percy-main/shared/content";
 import { useQuery } from "@tanstack/react-query";
 import { format, isAfter } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
@@ -184,20 +185,19 @@ function UpcomingStrip() {
       }
     }
 
-    const events = (eventsData?.items ?? []).flatMap((item) => {
+    for (const item of eventsData?.items ?? []) {
       const meta = parseEventMetadata(item.metadata);
-      return meta
-        ? [{ slug: item.slug, name: item.title, when: meta.when }]
-        : [];
-    });
-    for (const event of events) {
-      if (!isAfter(new Date(event.when), now)) continue;
+      if (!meta) continue;
+      // The next non-cancelled occurrence (the single future date for
+      // one-off events, or nothing once a series has elapsed).
+      const occ = nextOccurrence(meta, now);
+      if (!occ) continue;
       upcoming.push({
-        id: event.slug,
+        id: item.slug,
         type: "event",
-        when: event.when,
-        displayName: event.name,
-        href: `/calendar/event/${event.slug}`,
+        when: occ.start,
+        displayName: item.title,
+        href: `/calendar/event/${item.slug}?on=${occ.date}`,
       });
     }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "better-auth": "^1.6.14",
     "date-fns": "^4.4.0",
+    "date-fns-tz": "^3.2.0",
+    "rrule": "^2.8.1",
     "ts-pattern": "^5.6.0",
     "zod": "^4.4.3"
   },

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { Resource } from "../auth/permissions.ts";
 import { blockPropValueSchema } from "./block-types.ts";
+import { rrulestr } from "./rrule-compat.ts";
 
 // ── Content kinds + statuses ────────────────────────────────────────────
 //
@@ -186,6 +187,26 @@ export type NewsMetadata = z.infer<typeof newsMetadataSchema>;
 export const eventMetadataSchema = z.object({
   when: z.iso.datetime({ offset: true }),
   finish: z.iso.datetime({ offset: true }).optional(),
+  // Optional iCal recurrence. `when` is the series DTSTART; each occurrence
+  // keeps the same finish-minus-when duration. Expansion (DST-correct, in
+  // Europe/London) lives in ./recurrence.ts and is shared by every consumer.
+  recurrence: z
+    .object({
+      // RRULE body only (no DTSTART line); DTSTART is the event's `when`.
+      // e.g. "FREQ=WEEKLY;BYDAY=TU".
+      rrule: z.string().min(1),
+      // Europe/London calendar dates (yyyy-MM-dd) of occurrences to cancel.
+      exceptions: z.array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)).optional(),
+    })
+    .refine((r) => {
+      try {
+        rrulestr(`RRULE:${r.rrule}`);
+        return true;
+      } catch {
+        return false;
+      }
+    }, "Invalid recurrence rule")
+    .optional(),
   // Inline venue embed, deliberately minimal: no county/country fields.
   location: z
     .object({
@@ -265,6 +286,19 @@ export const CONTENT_METADATA_SCHEMAS: Partial<
   game_report: gameReportMetadataSchema,
   person: personMetadataSchema,
 };
+
+// ── Recurrence expansion ────────────────────────────────────────────────
+export {
+  EVENT_TIME_ZONE,
+  expandEventOccurrences,
+  latestOccurrenceBefore,
+  nextOccurrence,
+  occurrenceOnDate,
+  recurrenceSummary,
+  viewedOccurrence,
+  type DateRange,
+  type Occurrence,
+} from "./recurrence.ts";
 
 // ── Block-type primitives ───────────────────────────────────────────────
 //

--- a/packages/shared/src/content/recurrence.test.ts
+++ b/packages/shared/src/content/recurrence.test.ts
@@ -1,0 +1,236 @@
+import { formatInTimeZone } from "date-fns-tz";
+import { describe, expect, it } from "vitest";
+import { eventMetadataSchema, type EventMetadata } from "./index.ts";
+import {
+  expandEventOccurrences,
+  latestOccurrenceBefore,
+  nextOccurrence,
+  occurrenceOnDate,
+  recurrenceSummary,
+  viewedOccurrence,
+} from "./recurrence.ts";
+
+const londonTime = (iso: string) =>
+  formatInTimeZone(new Date(iso), "Europe/London", "HH:mm");
+
+describe("expandEventOccurrences - non-recurring", () => {
+  const event: EventMetadata = {
+    when: "2024-06-01T18:00:00+01:00",
+    finish: "2024-06-01T20:00:00+01:00",
+  };
+
+  it("returns the single date when in range", () => {
+    const got = expandEventOccurrences(event, {
+      from: new Date("2024-05-01T00:00:00Z"),
+      to: new Date("2024-07-01T00:00:00Z"),
+    });
+    expect(got).toEqual([
+      {
+        start: "2024-06-01T18:00:00+01:00",
+        finish: "2024-06-01T20:00:00+01:00",
+        date: "2024-06-01",
+      },
+    ]);
+  });
+
+  it("returns nothing when out of range", () => {
+    const got = expandEventOccurrences(event, {
+      from: new Date("2024-07-01T00:00:00Z"),
+      to: new Date("2024-08-01T00:00:00Z"),
+    });
+    expect(got).toEqual([]);
+  });
+});
+
+describe("expandEventOccurrences - weekly across the BST->GMT boundary", () => {
+  // UK clocks go back on 2024-10-27. 18:00 London must hold on both sides.
+  const event: EventMetadata = {
+    when: "2024-10-22T18:00:00+01:00", // Tuesday, BST
+    finish: "2024-10-22T19:30:00+01:00",
+    recurrence: { rrule: "FREQ=WEEKLY;BYDAY=TU" },
+  };
+
+  it("keeps wall-clock 18:00 across the switch", () => {
+    const got = expandEventOccurrences(event, {
+      from: new Date("2024-10-20T00:00:00Z"),
+      to: new Date("2024-11-06T00:00:00Z"),
+    });
+    expect(got.map((o) => o.date)).toEqual([
+      "2024-10-22",
+      "2024-10-29",
+      "2024-11-05",
+    ]);
+    for (const o of got) expect(londonTime(o.start)).toBe("18:00");
+    // The GMT-side instant is a real UTC hour later than the BST-side one.
+    expect(got[0]?.start).toBe("2024-10-22T17:00:00.000Z");
+    expect(got[1]?.start).toBe("2024-10-29T18:00:00.000Z");
+    // Duration is preserved.
+    expect(got[1]?.finish).toBe("2024-10-29T19:30:00.000Z");
+  });
+});
+
+describe("expandEventOccurrences - monthly nth weekday", () => {
+  it("expands the 2nd Tuesday of each month", () => {
+    const event: EventMetadata = {
+      when: "2024-01-09T19:00:00+00:00", // 2nd Tuesday of Jan 2024
+      recurrence: { rrule: "FREQ=MONTHLY;BYDAY=TU;BYSETPOS=2" },
+    };
+    const got = expandEventOccurrences(event, {
+      from: new Date("2024-01-01T00:00:00Z"),
+      to: new Date("2024-04-01T00:00:00Z"),
+    });
+    expect(got.map((o) => o.date)).toEqual([
+      "2024-01-09",
+      "2024-02-13",
+      "2024-03-12",
+    ]);
+  });
+});
+
+describe("expandEventOccurrences - termination", () => {
+  it("stops after COUNT occurrences", () => {
+    const event: EventMetadata = {
+      when: "2024-01-02T18:00:00+00:00",
+      recurrence: { rrule: "FREQ=WEEKLY;COUNT=3" },
+    };
+    const got = expandEventOccurrences(event, {
+      from: new Date("2024-01-01T00:00:00Z"),
+      to: new Date("2024-12-31T00:00:00Z"),
+    });
+    expect(got.map((o) => o.date)).toEqual([
+      "2024-01-02",
+      "2024-01-09",
+      "2024-01-16",
+    ]);
+  });
+
+  it("stops at UNTIL", () => {
+    const event: EventMetadata = {
+      when: "2024-01-02T18:00:00+00:00",
+      recurrence: { rrule: "FREQ=WEEKLY;UNTIL=20240116T235959Z" },
+    };
+    const got = expandEventOccurrences(event, {
+      from: new Date("2024-01-01T00:00:00Z"),
+      to: new Date("2024-12-31T00:00:00Z"),
+    });
+    expect(got.map((o) => o.date)).toEqual([
+      "2024-01-02",
+      "2024-01-09",
+      "2024-01-16",
+    ]);
+  });
+});
+
+describe("expandEventOccurrences - exceptions", () => {
+  it("skips cancelled dates", () => {
+    const event: EventMetadata = {
+      when: "2024-10-22T18:00:00+01:00",
+      recurrence: {
+        rrule: "FREQ=WEEKLY;BYDAY=TU",
+        exceptions: ["2024-10-29"],
+      },
+    };
+    const got = expandEventOccurrences(event, {
+      from: new Date("2024-10-20T00:00:00Z"),
+      to: new Date("2024-11-06T00:00:00Z"),
+    });
+    expect(got.map((o) => o.date)).toEqual(["2024-10-22", "2024-11-05"]);
+  });
+});
+
+describe("nextOccurrence / occurrenceOnDate / latestOccurrenceBefore", () => {
+  const event: EventMetadata = {
+    when: "2024-01-02T18:00:00+00:00",
+    recurrence: { rrule: "FREQ=WEEKLY;BYDAY=TU" },
+  };
+
+  it("finds the next occurrence after a given instant", () => {
+    const next = nextOccurrence(event, new Date("2024-01-10T00:00:00Z"));
+    expect(next?.date).toBe("2024-01-16");
+  });
+
+  it("finds the occurrence on a specific London date", () => {
+    expect(occurrenceOnDate(event, "2024-01-16")?.date).toBe("2024-01-16");
+    expect(occurrenceOnDate(event, "2024-01-17")).toBeUndefined();
+  });
+
+  it("finds the most recent past occurrence", () => {
+    const prev = latestOccurrenceBefore(
+      event,
+      new Date("2024-01-17T00:00:00Z"),
+    );
+    expect(prev?.date).toBe("2024-01-16");
+  });
+});
+
+describe("viewedOccurrence", () => {
+  const event: EventMetadata = {
+    when: "2024-01-02T18:00:00+00:00",
+    recurrence: { rrule: "FREQ=WEEKLY;BYDAY=TU;COUNT=4" }, // last is 2024-01-23
+  };
+
+  it("uses the ?on date when valid", () => {
+    expect(
+      viewedOccurrence(event, { on: "2024-01-16", now: new Date("2024-01-01") })
+        ?.date,
+    ).toBe("2024-01-16");
+  });
+
+  it("falls back to the next upcoming occurrence", () => {
+    expect(
+      viewedOccurrence(event, {
+        on: null,
+        now: new Date("2024-01-10T00:00:00Z"),
+      })?.date,
+    ).toBe("2024-01-16");
+  });
+
+  it("falls back to the most recent past occurrence once the series is over", () => {
+    expect(
+      viewedOccurrence(event, { on: null, now: new Date("2024-06-01") })?.date,
+    ).toBe("2024-01-23");
+  });
+});
+
+describe("eventMetadataSchema - recurrence validation", () => {
+  it("accepts a valid recurrence", () => {
+    const result = eventMetadataSchema.safeParse({
+      when: "2024-01-02T18:00:00+00:00",
+      recurrence: { rrule: "FREQ=WEEKLY;BYDAY=TU", exceptions: ["2024-01-09"] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unparseable rrule", () => {
+    const result = eventMetadataSchema.safeParse({
+      when: "2024-01-02T18:00:00+00:00",
+      recurrence: { rrule: "this is not a rule" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a malformed exception date", () => {
+    const result = eventMetadataSchema.safeParse({
+      when: "2024-01-02T18:00:00+00:00",
+      recurrence: { rrule: "FREQ=WEEKLY", exceptions: ["09/01/2024"] },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("recurrenceSummary", () => {
+  it("returns human text for a recurring event", () => {
+    expect(
+      recurrenceSummary({
+        when: "2024-01-02T18:00:00+00:00",
+        recurrence: { rrule: "FREQ=WEEKLY;BYDAY=TU" },
+      }),
+    ).toBe("every week on Tuesday");
+  });
+
+  it("returns undefined for a non-recurring event", () => {
+    expect(
+      recurrenceSummary({ when: "2024-01-02T18:00:00+00:00" }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/shared/src/content/recurrence.ts
+++ b/packages/shared/src/content/recurrence.ts
@@ -1,0 +1,204 @@
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
+import type { EventMetadata } from "./index.ts";
+import { RRule } from "./rrule-compat.ts";
+
+/**
+ * Recurring-event expansion — the single source of truth shared by every
+ * consumer (calendar month, event detail, home "What's On", and the admin
+ * editor preview).
+ *
+ * Events store an iCal RRULE body in metadata.recurrence; `when` is the
+ * series DTSTART and each occurrence keeps the same finish-minus-when
+ * duration. Authors cancel individual dates via metadata.recurrence.exceptions
+ * (Europe/London yyyy-MM-dd calendar dates).
+ *
+ * DST correctness is the tricky part: "every Tuesday 18:00 London" must stay
+ * 18:00 across the BST/GMT switch, so we never let rrule.js generate at a
+ * fixed UTC instant. Instead we generate in a *floating* space (the rule's
+ * wall-clock, carried in the UTC fields of throwaway Dates) and re-localize
+ * each instance back to a real instant in Europe/London.
+ */
+
+export const EVENT_TIME_ZONE = "Europe/London";
+
+export interface Occurrence {
+  /** Real instant, ISO-8601 with offset. */
+  start: string;
+  /** Real instant, ISO-8601 with offset. Present iff the event has a finish. */
+  finish?: string;
+  /** Europe/London calendar date (yyyy-MM-dd) — keys, links, exception match. */
+  date: string;
+}
+
+export interface DateRange {
+  from: Date;
+  to: Date;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function pad(n: number, width = 2): string {
+  return String(n).padStart(width, "0");
+}
+
+/** London calendar date (yyyy-MM-dd) of a real instant. */
+function londonDate(instant: Date): string {
+  return formatInTimeZone(instant, EVENT_TIME_ZONE, "yyyy-MM-dd");
+}
+
+/**
+ * A real instant -> a throwaway Date whose UTC fields hold the instant's
+ * London wall-clock. This is the "floating" representation rrule.js operates
+ * on (it reads getUTC* with no tzid).
+ */
+function toFloating(instant: Date): Date {
+  const [y, mo, d, h, mi, s] = formatInTimeZone(
+    instant,
+    EVENT_TIME_ZONE,
+    "yyyy-MM-dd-HH-mm-ss",
+  )
+    .split("-")
+    .map(Number);
+  return new Date(Date.UTC(y, mo - 1, d, h, mi, s));
+}
+
+/**
+ * A floating instance produced by rrule.js -> the real instant of that
+ * wall-clock in Europe/London.
+ */
+function fromFloating(floating: Date): Date {
+  const wall =
+    `${pad(floating.getUTCFullYear(), 4)}-${pad(floating.getUTCMonth() + 1)}-` +
+    `${pad(floating.getUTCDate())} ${pad(floating.getUTCHours())}:` +
+    `${pad(floating.getUTCMinutes())}:${pad(floating.getUTCSeconds())}`;
+  return fromZonedTime(wall, EVENT_TIME_ZONE);
+}
+
+function buildRule(rruleBody: string, dtstart: Date) {
+  return new RRule({ ...RRule.parseString(rruleBody), dtstart });
+}
+
+/**
+ * Expand an event into concrete occurrences whose real start falls within
+ * [from, to] (inclusive). Non-recurring events yield their single date if it
+ * is in range; recurring events expand the RRULE, drop exception dates, and
+ * sort ascending.
+ */
+export function expandEventOccurrences(
+  meta: EventMetadata,
+  range: DateRange,
+): Occurrence[] {
+  const when = new Date(meta.when);
+
+  if (!meta.recurrence) {
+    if (when < range.from || when > range.to) return [];
+    return [
+      {
+        start: meta.when,
+        ...(meta.finish ? { finish: meta.finish } : {}),
+        date: londonDate(when),
+      },
+    ];
+  }
+
+  const durationMs = meta.finish
+    ? new Date(meta.finish).getTime() - when.getTime()
+    : undefined;
+  const rule = buildRule(meta.recurrence.rrule, toFloating(when));
+  const exceptions = new Set(meta.recurrence.exceptions ?? []);
+
+  // Generate in the floating space over a buffered window (±1 day covers the
+  // worst-case BST/GMT offset shift at the range edges), then re-localize.
+  const floatingFrom = toFloating(new Date(range.from.getTime() - DAY_MS));
+  const floatingTo = toFloating(new Date(range.to.getTime() + DAY_MS));
+
+  const occurrences: Occurrence[] = [];
+  for (const floating of rule.between(floatingFrom, floatingTo, true)) {
+    const start = fromFloating(floating);
+    if (start < range.from || start > range.to) continue;
+    const date = londonDate(start);
+    if (exceptions.has(date)) continue;
+    occurrences.push({
+      start: start.toISOString(),
+      ...(durationMs !== undefined
+        ? { finish: new Date(start.getTime() + durationMs).toISOString() }
+        : {}),
+      date,
+    });
+  }
+
+  occurrences.sort((a, b) => a.start.localeCompare(b.start));
+  return occurrences;
+}
+
+/** The first occurrence on or after `after`, within `horizonDays`. */
+export function nextOccurrence(
+  meta: EventMetadata,
+  after: Date,
+  horizonDays = 365,
+): Occurrence | undefined {
+  const to = new Date(after.getTime() + horizonDays * DAY_MS);
+  return expandEventOccurrences(meta, { from: after, to })[0];
+}
+
+/** The occurrence falling on a given Europe/London calendar date, if any. */
+export function occurrenceOnDate(
+  meta: EventMetadata,
+  date: string,
+): Occurrence | undefined {
+  const from = fromZonedTime(`${date} 00:00:00`, EVENT_TIME_ZONE);
+  const to = fromZonedTime(`${date} 23:59:59`, EVENT_TIME_ZONE);
+  return expandEventOccurrences(meta, { from, to }).find(
+    (o) => o.date === date,
+  );
+}
+
+/** The most recent occurrence strictly before `before`, within `lookbackDays`. */
+export function latestOccurrenceBefore(
+  meta: EventMetadata,
+  before: Date,
+  lookbackDays = 730,
+): Occurrence | undefined {
+  const from = new Date(before.getTime() - lookbackDays * DAY_MS);
+  const occurrences = expandEventOccurrences(meta, { from, to: before });
+  return occurrences[occurrences.length - 1];
+}
+
+/**
+ * The occurrence the event-detail page should display: the one matching the
+ * `on` query param if valid, else the next upcoming one, else the most recent
+ * past one. Non-recurring events always resolve to their single date.
+ */
+export function viewedOccurrence(
+  meta: EventMetadata,
+  options: { on?: string | null; now: Date },
+): Occurrence | undefined {
+  if (!meta.recurrence) {
+    return {
+      start: meta.when,
+      ...(meta.finish ? { finish: meta.finish } : {}),
+      date: londonDate(new Date(meta.when)),
+    };
+  }
+  if (options.on && /^\d{4}-\d{2}-\d{2}$/.test(options.on)) {
+    const match = occurrenceOnDate(meta, options.on);
+    if (match) return match;
+  }
+  return (
+    nextOccurrence(meta, options.now) ??
+    latestOccurrenceBefore(meta, options.now)
+  );
+}
+
+/** Human-readable recurrence summary, e.g. "every week on Tuesday". */
+export function recurrenceSummary(meta: EventMetadata): string | undefined {
+  if (!meta.recurrence) return undefined;
+  try {
+    return buildRule(
+      meta.recurrence.rrule,
+      toFloating(new Date(meta.when)),
+    ).toText();
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/shared/src/content/rrule-compat.ts
+++ b/packages/shared/src/content/rrule-compat.ts
@@ -1,0 +1,15 @@
+import * as rruleNs from "rrule";
+
+// rrule ships no "exports" map in its package.json, so module resolvers
+// disagree: bundlers (Vite) load its ESM build, which has named exports and
+// NO default, while Node loads its CJS build, whose members are reachable
+// only through the interop `default`. A plain `import rrule from "rrule"`
+// therefore link-errors in the browser, and `import { RRule }` fails under
+// raw Node ESM. Resolve both at runtime by preferring the named export and
+// falling back to the interop default.
+const lib =
+  (rruleNs as typeof rruleNs & { default?: typeof rruleNs }).default ?? rruleNs;
+
+export const RRule = lib.RRule;
+export const rrulestr = lib.rrulestr;
+export type { Options, Weekday } from "rrule";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      rrule:
+        specifier: ^2.8.1
+        version: 2.8.1
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -747,6 +750,12 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@4.4.0)
+      rrule:
+        specifier: ^2.8.1
+        version: 2.8.1
       ts-pattern:
         specifier: ^5.6.0
         version: 5.9.0
@@ -7704,6 +7713,9 @@ packages:
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
+  rrule@2.8.1:
+    resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
 
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
@@ -16755,6 +16767,10 @@ snapshots:
   rope-sequence@1.3.4: {}
 
   rou3@0.7.12: {}
+
+  rrule@2.8.1:
+    dependencies:
+      tslib: 2.8.1
 
   safe-array-concat@1.1.4:
     dependencies:


### PR DESCRIPTION
## What

Events can now repeat. An author marks an event recurring via a structured builder (not a raw RRULE box), can **skip/cancel** individual dates, and every public surface expands the series into concrete dated occurrences.

- **Full iCal RRULE** recurrence stored in `metadata.recurrence` (`{ rrule, exceptions }`), validated by the shared `eventMetadataSchema` (`rrulestr` parse on write).
- **DST-correct expander** in `packages/shared/src/content/recurrence.ts` (Europe/London): "every Tuesday 18:00" stays 18:00 across the BST/GMT switch. Single source of truth reused by all consumers.
- **Calendar month**: one item per occurrence (cancelled dates omitted), links to `?on=<date>`.
- **Event detail**: resolves the viewed occurrence from `?on` (else next upcoming, else most recent past), shows a "Repeats…" summary + upcoming-dates list, single-occurrence "Add to calendar".
- **Home "What's On"**: next non-cancelled occurrence per event.
- **Admin editor**: Repeats / interval / weekdays / monthly mode / end (Never·On date·After N) with a live, skip-able occurrence preview.

## No API changes

Metadata is validated by the shared schema on write and returned verbatim (opaque `z.record` at transport), so the OpenAPI contract is unchanged (`openapi:generate` is a no-op).

## Note on the rrule interop shim

`rrule` ships no `exports` map, so bundlers load its ESM build (named exports, no default) while Node loads its CJS build (members under the interop default). `packages/shared/src/content/rrule-compat.ts` normalizes this so the same import works in the browser bundler, vitest's Node runtime, and the API's raw-Node prod runtime.

## Verification

- `pnpm --filter @percy-main/shared test` — 38 tests incl. DST boundary, monthly nth-weekday, COUNT/UNTIL, exception skipping, schema validation.
- Typecheck (shared/web/api), `pnpm lint`, `pnpm format`, full suite (1238 tests) all green.
- `pnpm --filter web build` succeeds (bundler resolves rrule).
- `pnpm run openapi:generate` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)