### PR TITLE
fix(web): keep opponent club name together when fixture title wraps

### DIFF
--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -174,11 +174,18 @@ function UpcomingStrip() {
     if (games) {
       for (const game of games) {
         if (!game.when || !isAfter(new Date(game.when), now)) continue;
+        // Bind the club name's trailing token (typically "CC") to the word
+        // before it with a non-breaking space, so a wrap moves the whole club
+        // name to the next line rather than orphaning "CC" on its own.
+        const opponent = game.opposition.club.name.replace(
+          / (\S+)$/,
+          "\u00A0$1",
+        );
         upcoming.push({
           id: game.id,
           type: "game",
           when: game.when,
-          displayName: `${game.team.name} vs ${game.opposition.club.name}`,
+          displayName: `${game.team.name} vs ${opponent}`,
           home: game.home,
           href: `/calendar/game/${game.id}`,
         });


### PR DESCRIPTION
## What

On the homepage "What's On" strip, game titles are composed as `<team> vs <opponent club>` (e.g. "2ND XI VS TYNEMOUTH CC"). On narrow mobile widths the title could wrap and leave the club's `CC` suffix orphaned on its own line:

```
2ND XI VS TYNEMOUTH
CC
```

## Fix

Bind the opponent club name's trailing token to the word before it with a non-breaking space (` `), so a wrap moves the whole club name to the next line as a unit:

- `Tynemouth CC` -> `Tynemouth CC` (renders as `2ND XI VS` / `TYNEMOUTH CC`)
- `Seaton Burn CC` -> `Seaton Burn CC` (`Burn CC` stays bound; can still break before `Seaton` on very narrow screens)

## Why this approach

- Pure string-level (HTML), works in every browser - no reliance on `text-wrap: pretty` whose orphan handling is implementation-defined and unevenly supported.
- No overflow risk on variable mobile widths: only one short trailing token is bound, not the whole name (avoids `white-space: nowrap` forcing horizontal scroll on long club names).
- The `CC` is part of the club name from the Play Cricket API, not appended by us; this is keyed to that suffix-last convention.

Events (single editable title field) are untouched.

Verified prettier and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)