### PR TITLE
Extend the poster design language across public pages

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -870,26 +870,28 @@
 .fc-riso-back {
   color: var(--fc-riso-back);
   mix-blend-mode: var(--fc-riso-blend);
-  transform: translate(20px, 15px);
+  /* Offsets are in em so the off-register shift stays proportional at every
+     heading size: a fixed px shift that reads as a tight registration on the
+     168px hero looks loosely overlapped on a small section title. */
+  transform: translate(0.12em, 0.09em);
   transition: transform 0.9s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .fc-riso.in .fc-riso-back {
-  transform: translate(6px, 5px);
+  transform: translate(0.04em, 0.03em);
 }
 .fc-riso.in:hover .fc-riso-back {
-  transform: translate(13px, 11px) rotate(0.4deg);
+  transform: translate(0.08em, 0.065em) rotate(0.4deg);
 }
 .fc-riso.in:hover .fc-riso-front {
-  transform: translate(-3px, -2px);
+  transform: translate(-0.02em, -0.013em);
 }
-/* Headings are smaller on phones, so the off-register ink shift is dialled down
-   to stay legible rather than reading as a smudge. */
+/* A touch tighter on phones so the smaller headings never read as a smudge. */
 @media (max-width: 640px) {
   .fc-riso-back {
-    transform: translate(9px, 7px);
+    transform: translate(0.08em, 0.06em);
   }
   .fc-riso.in .fc-riso-back {
-    transform: translate(3px, 3px);
+    transform: translate(0.03em, 0.025em);
   }
 }
 

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1059,17 +1059,28 @@
   max-width: 26ch;
   text-align: right;
 }
+/* Fallbacks (brand orange/cream/navy + the display face) keep the stamp
+   self-sufficient where the fc-theme vars are absent — e.g. the admin
+   content editor preview, which renders the same shared components but is
+   not a First-Class route, so the editor stamp stays identical to public. */
 .fc-stamp {
   display: inline-flex;
   align-items: center;
   gap: 12px;
-  font-family: var(--fc-display);
+  font-family: var(
+    --fc-display,
+    "Anton",
+    "Haettenschweiler",
+    "Impact",
+    "Arial Narrow",
+    sans-serif
+  );
   text-transform: uppercase;
   font-size: 26px;
   letter-spacing: 0.04em;
   line-height: 1;
-  color: var(--fc-paper);
-  background: var(--fc-orange);
+  color: var(--fc-paper, #f1e5c9);
+  background: var(--fc-orange, #ef4a1e);
   padding: 14px 34px;
   border: none;
   text-decoration: none;
@@ -1080,10 +1091,25 @@
 }
 .fc-stamp:hover {
   transform: rotate(-2.5deg) scale(1.04);
-  color: var(--fc-paper);
+  color: var(--fc-paper, #f1e5c9);
 }
 .fc-stamp--navy {
-  background: var(--fc-navy);
+  background: var(--fc-navy, #1b2a55);
+}
+/* Tighter size for inline form submits (Send Message, Pay, ...). */
+.fc-stamp--sm {
+  font-size: 18px;
+  letter-spacing: 0.03em;
+  gap: 9px;
+  padding: 10px 24px;
+}
+/* A pending/disabled submit must not invite a click. */
+.fc-stamp:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.fc-stamp:disabled:hover {
+  transform: rotate(-2.5deg);
 }
 .fc-rv {
   opacity: 0;
@@ -1371,57 +1397,77 @@
   border-radius: 0;
 }
 
-/* ---- Scoreboard stat lines (home "The Numbers", on a navy plate) ---- */
-.fc-statlines {
-  color: var(--fc-paper);
+/* ============================================================
+   Editorial stat table — the reusable scoreboard treatment. Wrap any
+   table (incl. a shadcn <Table>) in .fc-stat and it reads as a printed
+   stat sheet: blocky display face, orange uppercase headers, hairline
+   rules. Default ink is navy-on-paper (for cream pages: leaderboards,
+   player stats, scorecards, records). Add .fc-stat--invert for cream-on-
+   navy on a dark plate (home "The Numbers"). The ink set is driven by
+   custom properties so both variants share one rule set.
+   ============================================================ */
+.fc-theme .fc-stat {
+  --fc-stat-ink: var(--fc-navy);
+  --fc-stat-head: var(--fc-orange);
+  --fc-stat-rule: rgb(27 42 85 / 16%);
+  --fc-stat-rule-strong: var(--fc-navy);
+  --fc-stat-row-hover: rgb(239 74 30 / 10%);
+  color: var(--fc-stat-ink);
 }
-.fc-statlines :is(h3, h4) {
-  color: var(--fc-paper);
+.fc-theme .fc-stat--invert {
+  --fc-stat-ink: var(--fc-paper);
+  --fc-stat-head: var(--fc-orange);
+  --fc-stat-rule: rgb(241 229 201 / 16%);
+  --fc-stat-rule-strong: rgb(241 229 201 / 45%);
+  --fc-stat-row-hover: rgb(239 74 30 / 16%);
 }
-.fc-statlines table {
+.fc-theme .fc-stat :is(h3, h4) {
+  color: var(--fc-stat-ink);
+}
+.fc-theme .fc-stat table {
   width: 100%;
   border-collapse: collapse;
 }
-.fc-statlines tr {
+.fc-theme .fc-stat tr {
   border: 0;
 }
-/* The shadcn row hover/selected fill is light and bleached the cream text —
+/* The shadcn row hover/selected fill is light and bleaches the ink —
    replace it with a faint orange wash that keeps the text legible. */
-.fc-statlines tbody tr:hover,
-.fc-statlines tbody tr[data-state="selected"] {
-  background-color: rgb(239 74 30 / 16%);
+.fc-theme .fc-stat tbody tr:hover,
+.fc-theme .fc-stat tbody tr[data-state="selected"] {
+  background-color: var(--fc-stat-row-hover);
 }
 /* Blocky display face throughout — the scoreboard reads in one voice. */
-.fc-statlines th {
+.fc-theme .fc-stat th {
   font-family: var(--fc-display);
   font-weight: 400;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 13px;
-  color: var(--fc-orange);
+  color: var(--fc-stat-head);
   padding: 8px 10px;
-  border-bottom: 2px solid rgb(241 229 201 / 45%);
+  border-bottom: 2px solid var(--fc-stat-rule-strong);
 }
-.fc-statlines td {
+.fc-theme .fc-stat td {
   font-family: var(--fc-display);
   font-weight: 400;
   text-transform: uppercase;
   letter-spacing: 0.01em;
   font-size: 19px;
-  color: var(--fc-paper);
+  color: var(--fc-stat-ink);
   padding: 7px 10px;
-  border-bottom: 1px solid rgb(241 229 201 / 16%);
+  border-bottom: 1px solid var(--fc-stat-rule);
 }
-.fc-statlines :is(td.font-bold, .font-bold) {
+.fc-theme .fc-stat :is(td.font-bold, .font-bold) {
   font-size: 23px;
-  color: var(--fc-paper);
+  color: var(--fc-stat-ink);
 }
-.fc-statlines a {
-  color: var(--fc-paper);
+.fc-theme .fc-stat a {
+  color: var(--fc-stat-ink);
   text-decoration: underline;
   text-decoration-color: rgb(239 74 30 / 80%);
   text-underline-offset: 3px;
 }
-.fc-statlines a:hover {
+.fc-theme .fc-stat a:hover {
   color: var(--fc-orange);
 }

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -23,6 +23,10 @@
      Used for text/icons on the always-orange header so they stay light on the
      standard dark-mode routes too. */
   --color-paper: #f1e5c9;
+  /* The brand navy as a fixed token (matches --fc-navy, which only exists under
+     .fc-theme). Lets shared components reach the navy in any theme - e.g. the
+     person-card masthead, which also renders in the standard-themed editor. */
+  --color-navy: #1b2a55;
   --color-surface: #ffffff;
   --color-surface-raised: #f9fafb;
   --color-border: #e5e7eb;

--- a/apps/web/src/components/leaderboard-content.tsx
+++ b/apps/web/src/components/leaderboard-content.tsx
@@ -139,7 +139,7 @@ function SkeletonRows({ cols }: { cols: number }) {
         <TableRow key={i}>
           {Array.from({ length: cols }).map((_, j) => (
             <TableCell key={j}>
-              <div className="h-4 w-12 animate-pulse rounded bg-stone-200" />
+              <div className="bg-primary/10 h-4 w-12 animate-pulse rounded" />
             </TableCell>
           ))}
         </TableRow>
@@ -162,7 +162,7 @@ function PlayerName({
   const nameElement = slug ? (
     <Link
       to={`/person/${slug}`}
-      className="font-medium text-green-800 underline decoration-green-800/30 underline-offset-2 hover:decoration-green-800"
+      className="text-primary decoration-cta/70 hover:text-cta font-medium underline underline-offset-2"
     >
       {name}
     </Link>
@@ -174,7 +174,7 @@ function PlayerName({
     <div>
       {nameElement}
       {sponsor && (
-        <span className="block text-xs text-stone-500">
+        <span className="text-muted block text-xs">
           {sponsor.display_name ?? sponsor.sponsor_name}
         </span>
       )}
@@ -195,14 +195,14 @@ function BattingTable({
 }) {
   if (error) {
     return (
-      <p className="py-4 text-center text-red-600">
+      <p className="py-4 text-center text-red-700">
         Failed to load batting leaderboard.
       </p>
     );
   }
 
   return (
-    <div>
+    <div className="fc-stat">
       <Table>
         <caption className="sr-only">Season batting leaderboard</caption>
         <TableHeader>
@@ -247,17 +247,14 @@ function BattingTable({
           {isPending && <SkeletonRows cols={12} />}
           {entries?.length === 0 && (
             <TableRow>
-              <TableCell
-                colSpan={12}
-                className="py-8 text-center text-stone-500"
-              >
+              <TableCell colSpan={12} className="text-muted py-8 text-center">
                 No batting data available yet.
               </TableCell>
             </TableRow>
           )}
           {entries?.map((e, i) => (
             <TableRow key={e.playerId}>
-              <TableCell className="text-stone-500">{i + 1}</TableCell>
+              <TableCell className="text-muted">{i + 1}</TableCell>
               <TableCell>
                 <PlayerName
                   name={e.playerName}
@@ -294,7 +291,7 @@ function BattingTable({
         </TableBody>
       </Table>
       {entries && entries.length > 0 && (
-        <p className="mt-2 text-xs text-stone-500">
+        <p className="text-muted mt-2 text-xs">
           Averages shown for players with 3+ innings.
         </p>
       )}
@@ -315,14 +312,14 @@ function BowlingTable({
 }) {
   if (error) {
     return (
-      <p className="py-4 text-center text-red-600">
+      <p className="py-4 text-center text-red-700">
         Failed to load bowling leaderboard.
       </p>
     );
   }
 
   return (
-    <div>
+    <div className="fc-stat">
       <Table>
         <caption className="sr-only">Season bowling leaderboard</caption>
         <TableHeader>
@@ -361,17 +358,14 @@ function BowlingTable({
           {isPending && <SkeletonRows cols={10} />}
           {entries?.length === 0 && (
             <TableRow>
-              <TableCell
-                colSpan={10}
-                className="py-8 text-center text-stone-500"
-              >
+              <TableCell colSpan={10} className="text-muted py-8 text-center">
                 No bowling data available yet.
               </TableCell>
             </TableRow>
           )}
           {entries?.map((e, i) => (
             <TableRow key={e.playerId}>
-              <TableCell className="text-stone-500">{i + 1}</TableCell>
+              <TableCell className="text-muted">{i + 1}</TableCell>
               <TableCell>
                 <PlayerName
                   name={e.playerName}
@@ -404,7 +398,7 @@ function BowlingTable({
         </TableBody>
       </Table>
       {entries && entries.length > 0 && (
-        <p className="mt-2 text-xs text-stone-500">
+        <p className="text-muted mt-2 text-xs">
           Averages and strike rates shown for bowlers with 10+ overs.
         </p>
       )}
@@ -484,13 +478,13 @@ export function LeaderboardContent() {
   return (
     <div>
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="text-2xl font-semibold">
+        <h2 className="fc-two-tone text-2xl font-semibold">
           {season !== null ? `${season} Season` : "All Time"} Leaderboard
         </h2>
         <select
           value={season !== null ? String(season) : "all"}
           onChange={(e) => handleSeasonChange(e.target.value)}
-          className="rounded border border-stone-300 px-3 py-1.5 text-sm"
+          className="border-primary bg-surface text-primary border-2 px-3 py-1.5 text-sm"
         >
           <option value="all">All Time</option>
           {seasons.map((y) => (
@@ -504,18 +498,18 @@ export function LeaderboardContent() {
       {/* Filters */}
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center">
         {/* Category toggle */}
-        <div className="inline-flex rounded-md bg-stone-100 p-1">
+        <div className="border-primary bg-surface inline-flex border-2 p-1">
           <button
-            className={`rounded px-3 py-1 text-sm font-medium ${
-              !isJunior ? "bg-white text-stone-900 shadow-sm" : "text-stone-500"
+            className={`px-3 py-1 text-sm font-medium ${
+              !isJunior ? "bg-primary text-paper" : "text-muted"
             }`}
             onClick={() => handleCategoryChange(false)}
           >
             Seniors
           </button>
           <button
-            className={`rounded px-3 py-1 text-sm font-medium ${
-              isJunior ? "bg-white text-stone-900 shadow-sm" : "text-stone-500"
+            className={`px-3 py-1 text-sm font-medium ${
+              isJunior ? "bg-primary text-paper" : "text-muted"
             }`}
             onClick={() => handleCategoryChange(true)}
           >
@@ -527,7 +521,7 @@ export function LeaderboardContent() {
         <select
           value={teamId}
           onChange={(e) => setTeamId(e.target.value)}
-          className="rounded border border-stone-300 px-3 py-1.5 text-sm"
+          className="border-primary bg-surface text-primary border-2 px-3 py-1.5 text-sm"
         >
           <option value="">All teams</option>
           {filteredTeams.map((t) => (
@@ -545,7 +539,7 @@ export function LeaderboardContent() {
                 type="checkbox"
                 checked={competitionTypes.includes(type)}
                 onChange={() => toggleCompetitionType(type)}
-                className="rounded border-stone-300"
+                className="border-border"
               />
               {type}
             </label>
@@ -586,7 +580,7 @@ export function LeaderboardContent() {
         {season !== null && season > FIRST_SEASON && (
           <button
             onClick={() => handleSeasonChange(String(season - 1))}
-            className="rounded border border-stone-300 px-4 py-2 text-sm hover:bg-stone-50"
+            className="border-primary bg-surface text-primary hover:bg-cta/10 border-2 px-4 py-2 text-sm"
           >
             {season - 1}
           </button>
@@ -594,7 +588,7 @@ export function LeaderboardContent() {
         {season !== null && season < seasons[0] && (
           <button
             onClick={() => handleSeasonChange(String(season + 1))}
-            className="rounded border border-stone-300 px-4 py-2 text-sm hover:bg-stone-50"
+            className="border-primary bg-surface text-primary hover:bg-cta/10 border-2 px-4 py-2 text-sm"
           >
             {season + 1}
           </button>
@@ -602,7 +596,7 @@ export function LeaderboardContent() {
         {season !== null && (
           <button
             onClick={() => handleSeasonChange("all")}
-            className="rounded border border-stone-300 px-4 py-2 text-sm hover:bg-stone-50"
+            className="border-primary bg-surface text-primary hover:bg-cta/10 border-2 px-4 py-2 text-sm"
           >
             All Time
           </button>

--- a/apps/web/src/components/marketing/lead-form.tsx
+++ b/apps/web/src/components/marketing/lead-form.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { StampButton } from "@/components/theme/bits.js";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -63,7 +63,6 @@ function emptyToUndefined(value: string): string | undefined {
   return trimmed.length === 0 ? undefined : trimmed;
 }
 
-// eslint-disable-next-line react-doctor/no-giant-component -- single conversion form whose adult/junior variants share submit logic, validation, attribution capture and analytics; splitting would just thread props between halves of one cohesive form.
 export const LeadForm: FC<LeadFormProps> = ({
   campaignId,
   segment,
@@ -340,7 +339,7 @@ export const LeadForm: FC<LeadFormProps> = ({
       {mutation.isError && (
         <div
           role="alert"
-          className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800"
+          className="bg-surface border-2 border-red-700 p-3 text-sm text-red-800"
         >
           <p className="font-medium">Something went wrong.</p>
           <p className="mt-1">
@@ -356,15 +355,9 @@ export const LeadForm: FC<LeadFormProps> = ({
         </div>
       )}
 
-      <Button
-        type="submit"
-        variant="cta"
-        size="lg"
-        className="w-full"
-        disabled={isPending}
-      >
-        {isPending ? "Sending…" : "Get in touch"}
-      </Button>
+      <StampButton type="submit" size="sm" disabled={isPending}>
+        {isPending ? "Sending…" : "Get in touch →"}
+      </StampButton>
     </form>
   );
 };
@@ -381,7 +374,7 @@ const Field: FC<FieldProps> = ({ id, label, required, hint, children }) => (
   <div className="space-y-1.5">
     <Label htmlFor={id}>
       {label}
-      {required && <span className="text-red-600"> *</span>}
+      {required && <span className="text-red-700"> *</span>}
     </Label>
     {children}
     {hint && <p className="text-muted text-xs">{hint}</p>}
@@ -399,7 +392,7 @@ const SuccessMessage: FC<SuccessMessageProps> = ({ variant, displayName }) => {
     <div
       role="status"
       aria-live="polite"
-      className="rounded-lg border border-green-200 bg-green-50 p-5 text-sm text-green-900"
+      className="border-primary bg-surface text-primary border-2 p-5 text-sm"
     >
       {variant === "junior" ? (
         <>

--- a/apps/web/src/components/marketing/recruit-page-sections.tsx
+++ b/apps/web/src/components/marketing/recruit-page-sections.tsx
@@ -1,4 +1,6 @@
 import { OptimisedImage } from "@/components/optimised-image.js";
+import { StampLink } from "@/components/theme/bits.js";
+import { RisoHeading } from "@/components/theme/riso-heading.js";
 import { getPicture } from "@/lib/image-map.js";
 import type { FC, ReactNode } from "react";
 import { Link } from "react-router";
@@ -42,19 +44,21 @@ export const RecruitHero: FC<RecruitHeroProps> = ({
       <div className="absolute inset-0 bg-black/55" />
       <div className="absolute inset-0 flex items-center">
         <div className="container mx-auto px-6">
-          <div className="max-w-2xl text-white">
-            <h1 className="text-h2 md:text-h1 mb-4 leading-tight font-semibold tracking-tight text-white">
+          <div className="flex max-w-2xl flex-col text-white">
+            <RisoHeading
+              as="h1"
+              front="var(--fc-paper, #f1e5c9)"
+              back="var(--fc-orange, #ef4a1e)"
+              className="text-h2 md:text-h1 mb-4 leading-tight"
+            >
               {title}
-            </h1>
+            </RisoHeading>
             <p className="mb-6 text-lg text-balance text-white/90 md:text-xl">
               {description}
             </p>
-            <a
-              href={`#${FORM_ANCHOR_ID}`}
-              className="bg-cta hover:bg-cta-dark inline-block rounded px-6 py-3 text-base font-semibold text-white shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-            >
-              I&rsquo;m interested
-            </a>
+            <StampLink href={`#${FORM_ANCHOR_ID}`} className="self-start">
+              I&rsquo;m interested &rarr;
+            </StampLink>
           </div>
         </div>
       </div>
@@ -72,18 +76,18 @@ interface ReassuranceListProps {
 }
 
 export const ReassuranceList: FC<ReassuranceListProps> = ({ items }) => (
-  <section className="bg-white py-10">
+  <section className="bg-body py-10">
     <div className="container mx-auto px-6">
       <div className="grid gap-6 md:grid-cols-2">
         {items.map((item) => (
           <div
             key={item.heading}
-            className="rounded-lg border border-stone-200 bg-white p-5 shadow-sm"
+            className="border-primary bg-surface border-2 p-5 transition-transform hover:-translate-y-[3px]"
           >
-            <h2 className="text-dark mb-2 text-lg font-semibold">
+            <h2 className="text-primary mb-2 text-lg font-semibold">
               {item.heading}
             </h2>
-            <div className="text-sm text-stone-700">{item.body}</div>
+            <div className="text-muted text-sm">{item.body}</div>
           </div>
         ))}
       </div>
@@ -110,12 +114,15 @@ interface SafeguardingLineProps {
 export const SafeguardingLine: FC<SafeguardingLineProps> = ({
   href = "/cricket/safeguarding",
 }) => (
-  <section className="bg-white py-6">
+  <section className="bg-body py-6">
     <div className="container mx-auto px-6">
-      <p className="mx-auto max-w-3xl text-center text-sm text-stone-700">
+      <p className="text-muted mx-auto max-w-3xl text-center text-sm">
         All junior sessions are run by DBS-checked coaches and a Level 3 Club
         Safeguarding Officer.{" "}
-        <Link to={href} className="text-blue-900 underline">
+        <Link
+          to={href}
+          className="text-primary decoration-cta/70 hover:text-cta underline underline-offset-2"
+        >
           Read our safeguarding policy
         </Link>
         .
@@ -130,10 +137,10 @@ interface FormSectionProps {
 }
 
 export const FormSection: FC<FormSectionProps> = ({ headline, children }) => (
-  <section id={FORM_ANCHOR_ID} className="scroll-mt-16 bg-white py-12">
+  <section id={FORM_ANCHOR_ID} className="bg-body scroll-mt-16 py-12">
     <div className="container mx-auto px-6">
       <div className="mx-auto max-w-xl">
-        <h2 className="text-h4 mb-6 text-center">{headline}</h2>
+        <h2 className="fc-two-tone text-h4 mb-6 text-center">{headline}</h2>
         {children}
       </div>
     </div>

--- a/apps/web/src/components/marketing/segment-picker.tsx
+++ b/apps/web/src/components/marketing/segment-picker.tsx
@@ -44,7 +44,7 @@ export const SegmentPicker: FC<SegmentPickerProps> = ({
         name={id}
         value={value}
         onChange={selectSegment}
-        className="border-border bg-surface text-dark ring-offset-surface flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-stone-400 focus-visible:ring-offset-2 focus-visible:outline-none"
+        className="border-border bg-surface text-dark ring-offset-surface flex h-10 w-full border-2 px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-stone-400 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         <option value="" disabled>
           Choose one…

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/optimised-image.js";
 import { OutcomeBadge } from "@/components/outcome-badge.js";
 import { RecordsWall as RecordsWallComponent } from "@/components/records-wall.js";
-import { StampButton } from "@/components/theme/bits.js";
+import { PosterLink, StampButton } from "@/components/theme/bits.js";
 import { Input } from "@/components/ui/input.js";
 import { Textarea } from "@/components/ui/textarea.js";
 import { WagonWheel as WagonWheelView } from "@/components/wagon-wheel-modal.js";
@@ -59,7 +59,7 @@ export function PersonCardShell({
   const resolvedPicture = picture ?? ANON_PICTURE;
   return (
     <div className="person h-full rounded-lg bg-white pb-4 text-stone-900 shadow-md">
-      <div className="bg-cta rounded-t-lg px-4 py-3 text-center">
+      <div className="bg-navy rounded-t-lg px-4 py-3 text-center">
         <h5 className="text-paper m-0 font-semibold tracking-wide uppercase">
           {name}
         </h5>
@@ -138,12 +138,9 @@ function Person({ slug, role }: { slug: string; role?: string }) {
   return (
     <PersonCardShell name={name} picture={person?.picture}>
       {role && <p className="text-sm text-stone-600">{role}</p>}
-      <Link
-        to={`/person/${slug}`}
-        className="text-primary mt-2 inline-block px-2 text-sm font-medium hover:underline"
-      >
+      <PosterLink to={`/person/${slug}`} className="mt-2 text-[15px]">
         Profile
-      </Link>
+      </PosterLink>
       {sponsor && <PersonSponsor sponsor={sponsor} />}
     </PersonCardShell>
   );

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/optimised-image.js";
 import { OutcomeBadge } from "@/components/outcome-badge.js";
 import { RecordsWall as RecordsWallComponent } from "@/components/records-wall.js";
-import { Button } from "@/components/ui/button.js";
+import { StampButton } from "@/components/theme/bits.js";
 import { Input } from "@/components/ui/input.js";
 import { Textarea } from "@/components/ui/textarea.js";
 import { WagonWheel as WagonWheelView } from "@/components/wagon-wheel-modal.js";
@@ -525,9 +525,14 @@ export function ContactFormBody({ description }: { description?: string }) {
               value={message}
               onChange={(e) => setMessage(e.target.value)}
             />
-            <Button type="submit" disabled={mutation.isPending}>
-              {mutation.isPending ? "Sending…" : "Send Message"}
-            </Button>
+            <StampButton
+              type="submit"
+              size="sm"
+              disabled={mutation.isPending}
+              className="mt-1 self-start"
+            >
+              {mutation.isPending ? "Sending…" : "Send Message →"}
+            </StampButton>
           </form>
           {mutation.isError ? (
             <p className="mt-3 text-sm text-red-600">

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -42,9 +42,10 @@ function RecordsWall() {
 
 /**
  * Presentational person card, shared with the personGrid editor block so
- * the in-editor cards stay pixel-identical to the public ones (#527).
- * `children` fills the slot under the name (public: role text + profile
- * link; editor: an inline role input).
+ * the in-editor cards stay pixel-identical to the public ones (#527). The
+ * name rides a printed orange masthead at the top (cream ink); `children`
+ * fills the slot beneath the photo (public: role text + profile link;
+ * editor: an inline role input).
  */
 export function PersonCardShell({
   name,
@@ -58,7 +59,11 @@ export function PersonCardShell({
   const resolvedPicture = picture ?? ANON_PICTURE;
   return (
     <div className="person h-full rounded-lg bg-white pb-4 text-stone-900 shadow-md">
-      <div className="bg-cta h-2 rounded-t-lg" />
+      <div className="bg-cta rounded-t-lg px-4 py-3 text-center">
+        <h5 className="text-paper m-0 font-semibold tracking-wide uppercase">
+          {name}
+        </h5>
+      </div>
       <div className="mx-auto mt-4 size-24 overflow-hidden rounded-full border-4 border-stone-100">
         {resolvedPicture ? (
           <OptimisedImage
@@ -75,10 +80,7 @@ export function PersonCardShell({
           />
         )}
       </div>
-      <div className="mt-3 text-center">
-        <h5 className="pb-1 font-semibold">{name}</h5>
-        {children}
-      </div>
+      <div className="mt-3 text-center">{children}</div>
     </div>
   );
 }

--- a/apps/web/src/components/records-wall.tsx
+++ b/apps/web/src/components/records-wall.tsx
@@ -1,10 +1,4 @@
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card.js";
-import {
   Table,
   TableBody,
   TableCell,
@@ -44,7 +38,7 @@ function PlayerLink({ name, slug }: { name: string; slug: string | null }) {
     return (
       <Link
         to={`/person/${slug}`}
-        className="font-medium text-green-800 underline decoration-green-800/30 underline-offset-2 hover:decoration-green-800"
+        className="text-primary decoration-cta/70 hover:text-cta font-medium underline underline-offset-2"
       >
         {name}
       </Link>
@@ -61,22 +55,16 @@ type HonourEntry = NonNullable<HonoursData>["centuries"][number];
 
 function RecordCard({ record }: { record: RecordItem }) {
   return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-sm font-medium text-stone-500">
-          {record.title}
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="text-3xl font-bold text-green-800">{record.value}</div>
-        <div className="mt-1">
-          <PlayerLink name={record.playerName} slug={record.slug} />
-        </div>
-        {record.season > 0 && (
-          <div className="mt-0.5 text-sm text-stone-500">{record.season}</div>
-        )}
-      </CardContent>
-    </Card>
+    <div className="border-primary bg-surface border-2 p-4">
+      <div className="text-muted pb-2 text-sm font-medium">{record.title}</div>
+      <div className="text-primary text-3xl font-bold">{record.value}</div>
+      <div className="mt-1">
+        <PlayerLink name={record.playerName} slug={record.slug} />
+      </div>
+      {record.season > 0 && (
+        <div className="text-muted mt-0.5 text-sm">{record.season}</div>
+      )}
+    </div>
   );
 }
 
@@ -84,15 +72,11 @@ function RecordsSkeleton() {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {Array.from({ length: 7 }).map((_, i) => (
-        <Card key={i}>
-          <CardHeader className="pb-2">
-            <div className="h-4 w-24 animate-pulse rounded bg-stone-200" />
-          </CardHeader>
-          <CardContent>
-            <div className="h-8 w-16 animate-pulse rounded bg-stone-200" />
-            <div className="mt-2 h-4 w-32 animate-pulse rounded bg-stone-200" />
-          </CardContent>
-        </Card>
+        <div key={i} className="border-primary bg-surface border-2 p-4">
+          <div className="bg-primary/10 h-4 w-24 animate-pulse rounded" />
+          <div className="bg-primary/10 mt-2 h-8 w-16 animate-pulse rounded" />
+          <div className="bg-primary/10 mt-2 h-4 w-32 animate-pulse rounded" />
+        </div>
       ))}
     </div>
   );
@@ -107,7 +91,7 @@ function HonoursTable({
 }) {
   if (entries.length === 0) {
     return (
-      <p className="py-8 text-center text-stone-500">
+      <p className="text-muted py-8 text-center">
         {type === "batting"
           ? "No centuries recorded yet."
           : "No five-wicket hauls recorded yet."}
@@ -116,37 +100,39 @@ function HonoursTable({
   }
 
   return (
-    <Table>
-      <caption className="sr-only">
-        {type === "batting" ? "Centuries" : "Five-wicket hauls"}
-      </caption>
-      <TableHeader>
-        <TableRow>
-          <TableHead scope="col">Player</TableHead>
-          <TableHead scope="col" className="text-right">
-            {type === "batting" ? "Score" : "Figures"}
-          </TableHead>
-          <TableHead scope="col" className="text-right">
-            Season
-          </TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {entries.map((entry) => (
-          <TableRow
-            key={`${entry.playerName}-${entry.matchDate}-${entry.value}`}
-          >
-            <TableCell>
-              <PlayerLink name={entry.playerName} slug={entry.slug} />
-            </TableCell>
-            <TableCell className="text-right font-bold">
-              {entry.value}
-            </TableCell>
-            <TableCell className="text-right">{entry.season}</TableCell>
+    <div className="fc-stat">
+      <Table>
+        <caption className="sr-only">
+          {type === "batting" ? "Centuries" : "Five-wicket hauls"}
+        </caption>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">Player</TableHead>
+            <TableHead scope="col" className="text-right">
+              {type === "batting" ? "Score" : "Figures"}
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Season
+            </TableHead>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody>
+          {entries.map((entry) => (
+            <TableRow
+              key={`${entry.playerName}-${entry.matchDate}-${entry.value}`}
+            >
+              <TableCell>
+                <PlayerLink name={entry.playerName} slug={entry.slug} />
+              </TableCell>
+              <TableCell className="text-right font-bold">
+                {entry.value}
+              </TableCell>
+              <TableCell className="text-right">{entry.season}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 
@@ -160,7 +146,7 @@ export function RecordsWall() {
 
   if (recordsQuery.error || honoursQuery.error) {
     return (
-      <p className="py-4 text-center text-red-600">Failed to load records.</p>
+      <p className="py-4 text-center text-red-700">Failed to load records.</p>
     );
   }
 
@@ -168,7 +154,9 @@ export function RecordsWall() {
     <div className="space-y-10">
       {/* All-Time Records */}
       <section>
-        <h2 className="mb-4 text-2xl font-semibold">All-Time Records</h2>
+        <h2 className="fc-two-tone mb-4 text-2xl font-semibold">
+          All-Time Records
+        </h2>
         {recordsQuery.isPending ? (
           <RecordsSkeleton />
         ) : records ? (
@@ -182,13 +170,15 @@ export function RecordsWall() {
 
       {/* Honours Board */}
       <section>
-        <h2 className="mb-4 text-2xl font-semibold">Honours Board</h2>
+        <h2 className="fc-two-tone mb-4 text-2xl font-semibold">
+          Honours Board
+        </h2>
         {honoursQuery.isPending ? (
           <div className="space-y-2">
             {Array.from({ length: 5 }).map((_, i) => (
               <div
                 key={i}
-                className="h-10 animate-pulse rounded bg-stone-200"
+                className="bg-primary/10 h-10 animate-pulse rounded"
               />
             ))}
           </div>

--- a/apps/web/src/components/scorecard.tsx
+++ b/apps/web/src/components/scorecard.tsx
@@ -598,7 +598,9 @@ function InningsCard({
         />
         <FallOfWickets fow={innings.fallOfWickets} />
         <div className="border-border border-t pt-4">
-          <Kicker className="mb-2">Bowling</Kicker>
+          <Kicker level={5} className="mb-2">
+            Bowling
+          </Kicker>
           <BowlingCard bowling={innings.bowling} />
         </div>
       </div>

--- a/apps/web/src/components/scorecard.tsx
+++ b/apps/web/src/components/scorecard.tsx
@@ -1,9 +1,4 @@
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card.js";
+import { Kicker } from "@/components/theme/bits.js";
 import {
   Table,
   TableBody,
@@ -358,7 +353,7 @@ function PlayerName({
   return (
     <Link
       to={`/person/${slug}`}
-      className={`${className ?? ""} text-primary inline-flex items-center gap-0.5 underline decoration-dotted decoration-1 underline-offset-2 hover:decoration-solid`}
+      className={`${className ?? ""} text-primary decoration-cta/70 hover:text-cta inline-flex items-center gap-0.5 underline underline-offset-2`}
       title="View player profile"
     >
       {name}
@@ -390,7 +385,7 @@ function BattingCard({
   const totalColSpan = isPairs ? 5 : 5;
 
   return (
-    <div>
+    <div className="fc-stat">
       <Table>
         <caption className="sr-only">Batting scorecard</caption>
         <TableHeader>
@@ -425,9 +420,7 @@ function BattingCard({
                     slug={b.memberSlug}
                     className="font-medium"
                   />
-                  <div className="text-xs text-stone-500">
-                    {formatDismissal(b)}
-                  </div>
+                  <div className="text-muted text-xs">{formatDismissal(b)}</div>
                 </div>
               </TableCell>
               <TableCell className="text-right font-mono font-semibold tabular-nums">
@@ -453,7 +446,7 @@ function BattingCard({
           ))}
           <TableRow>
             <TableCell>
-              <span className="text-sm text-stone-600">
+              <span className="text-muted text-sm">
                 Extras ({formatExtrasBreakdown(extras)})
               </span>
             </TableCell>
@@ -474,7 +467,7 @@ function BattingCard({
         </TableBody>
       </Table>
       {didNotBat.length > 0 && (
-        <p className="mt-2 text-xs text-stone-500">
+        <p className="text-muted mt-2 text-xs">
           <strong>Did not bat:</strong>{" "}
           {didNotBat.map((b, i) => (
             <span key={b.position}>
@@ -490,71 +483,73 @@ function BattingCard({
 
 function BowlingCard({ bowling }: { bowling: BowlingEntry[] }) {
   return (
-    <Table>
-      <caption className="sr-only">Bowling scorecard</caption>
-      <TableHeader>
-        <TableRow>
-          <TableHead scope="col" className="w-full">
-            Bowler
-          </TableHead>
-          <TableHead scope="col" className="text-right">
-            O
-          </TableHead>
-          <TableHead scope="col" className="text-right">
-            M
-          </TableHead>
-          <TableHead scope="col" className="text-right">
-            R
-          </TableHead>
-          <TableHead scope="col" className="text-right">
-            W
-          </TableHead>
-          <TableHead scope="col" className="text-right">
-            Econ
-          </TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {bowling.map((b) => {
-          const decimalOvers = oversToDecimal(b.overs);
-          const economy =
-            decimalOvers > 0 ? (b.runs / decimalOvers).toFixed(1) : "-";
-          return (
-            <TableRow key={b.memberSlug ?? b.name}>
-              <TableCell>
-                <PlayerName
-                  name={b.name}
-                  slug={b.memberSlug}
-                  className="font-medium"
-                />
-              </TableCell>
-              <TableCell className="text-right font-mono tabular-nums">
-                {b.overs}
-              </TableCell>
-              <TableCell className="text-right font-mono tabular-nums">
-                {b.maidens}
-              </TableCell>
-              <TableCell className="text-right font-mono tabular-nums">
-                {b.runs}
-              </TableCell>
-              <TableCell className="text-right font-mono font-semibold tabular-nums">
-                {b.wickets}
-              </TableCell>
-              <TableCell className="text-right font-mono tabular-nums">
-                {economy}
-              </TableCell>
-            </TableRow>
-          );
-        })}
-      </TableBody>
-    </Table>
+    <div className="fc-stat">
+      <Table>
+        <caption className="sr-only">Bowling scorecard</caption>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col" className="w-full">
+              Bowler
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              O
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              M
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              R
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              W
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Econ
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {bowling.map((b) => {
+            const decimalOvers = oversToDecimal(b.overs);
+            const economy =
+              decimalOvers > 0 ? (b.runs / decimalOvers).toFixed(1) : "-";
+            return (
+              <TableRow key={b.memberSlug ?? b.name}>
+                <TableCell>
+                  <PlayerName
+                    name={b.name}
+                    slug={b.memberSlug}
+                    className="font-medium"
+                  />
+                </TableCell>
+                <TableCell className="text-right font-mono tabular-nums">
+                  {b.overs}
+                </TableCell>
+                <TableCell className="text-right font-mono tabular-nums">
+                  {b.maidens}
+                </TableCell>
+                <TableCell className="text-right font-mono tabular-nums">
+                  {b.runs}
+                </TableCell>
+                <TableCell className="text-right font-mono font-semibold tabular-nums">
+                  {b.wickets}
+                </TableCell>
+                <TableCell className="text-right font-mono tabular-nums">
+                  {economy}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 
 function FallOfWickets({ fow }: { fow: FoWEntry[] }) {
   if (fow.length === 0) return null;
   return (
-    <p className="text-xs text-stone-600">
+    <p className="text-muted text-xs">
       <strong>Fall of wickets:</strong>{" "}
       {fow.map((f, i) => (
         <span key={f.wicketNumber}>
@@ -580,19 +575,21 @@ function InningsCard({
   const showNetScore =
     isPairs && startingRuns !== null && dismissalPenalty !== null;
   return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-lg">{innings.teamBattingName}</CardTitle>
-        <div className="text-sm font-semibold text-stone-700">
+    <div className="border-primary bg-surface border-2">
+      <div className="border-border border-b p-4 pb-2">
+        <div className="text-primary text-lg font-semibold">
+          {innings.teamBattingName}
+        </div>
+        <div className="text-muted text-sm font-semibold">
           {formatTotalScore(innings.total)}
         </div>
         {showNetScore && (
-          <div className="text-base font-bold text-stone-800">
+          <div className="text-primary text-base font-bold">
             Net Score {netScore(innings.total, startingRuns, dismissalPenalty)}
           </div>
         )}
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
+      </div>
+      <div className="flex flex-col gap-4 p-4">
         <BattingCard
           batting={innings.batting}
           extras={innings.extras}
@@ -600,34 +597,34 @@ function InningsCard({
           isPairs={isPairs}
         />
         <FallOfWickets fow={innings.fallOfWickets} />
-        <div className="border-t pt-4">
-          <h5 className="mb-2 text-sm font-semibold text-stone-700">Bowling</h5>
+        <div className="border-border border-t pt-4">
+          <Kicker className="mb-2">Bowling</Kicker>
           <BowlingCard bowling={innings.bowling} />
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 
 function ScorecardSkeleton() {
   return (
     <div className="flex flex-col gap-4">
-      <h4 className="text-lg font-semibold md:text-xl">Scorecard</h4>
+      <h4 className="fc-two-tone text-lg font-semibold md:text-xl">
+        Scorecard
+      </h4>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         {["innings-1", "innings-2"].map((k) => (
-          <Card key={k}>
-            <CardHeader>
-              <div className="h-5 w-40 animate-pulse rounded bg-stone-200" />
-            </CardHeader>
-            <CardContent className="space-y-3">
+          <div key={k} className="border-primary bg-surface border-2 p-4">
+            <div className="bg-primary/10 h-5 w-40 animate-pulse rounded" />
+            <div className="mt-4 space-y-3">
               {["r1", "r2", "r3", "r4", "r5", "r6"].map((row) => (
                 <div
                   key={`${k}-${row}`}
-                  className="h-4 animate-pulse rounded bg-stone-100"
+                  className="bg-primary/10 h-4 animate-pulse rounded"
                 />
               ))}
-            </CardContent>
-          </Card>
+            </div>
+          </div>
         ))}
       </div>
     </div>
@@ -639,9 +636,11 @@ function ScorecardDisplay({ data }: { data: MatchDetailData }) {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-2">
-        <h4 className="text-lg font-semibold md:text-xl">Scorecard</h4>
+        <h4 className="fc-two-tone text-lg font-semibold md:text-xl">
+          Scorecard
+        </h4>
         {isPairs && (
-          <span className="rounded-full bg-stone-700 px-2 py-0.5 text-xs font-semibold text-white">
+          <span className="bg-primary text-paper px-2 py-0.5 text-xs font-semibold">
             Women&apos;s Softball
           </span>
         )}

--- a/apps/web/src/components/season-leaders.tsx
+++ b/apps/web/src/components/season-leaders.tsx
@@ -43,7 +43,7 @@ function PlayerLink({
     return (
       <Link
         to={`/person/${slug}`}
-        className="font-medium text-green-800 underline decoration-green-800/30 underline-offset-2 hover:decoration-green-800"
+        className="text-primary decoration-cta/70 hover:text-cta font-medium underline underline-offset-2"
       >
         {name}
       </Link>
@@ -65,7 +65,7 @@ function MiniTable({
 }) {
   return (
     <div className="min-w-0 flex-1">
-      <h4 className="mb-3 text-sm font-semibold tracking-wide text-stone-600 uppercase">
+      <h4 className="text-muted mb-3 text-sm font-semibold tracking-wide uppercase">
         {title}
       </h4>
       <Table>
@@ -138,11 +138,11 @@ export function SeasonLeaders() {
         <div className="grid gap-6 md:grid-cols-2">
           {["batting", "bowling"].map((col) => (
             <div key={col} className="space-y-3">
-              <div className="h-4 w-24 animate-pulse rounded bg-stone-200" />
+              <div className="bg-primary/10 h-4 w-24 animate-pulse rounded" />
               {["row1", "row2", "row3"].map((row) => (
                 <div
                   key={`${col}-${row}`}
-                  className="h-8 animate-pulse rounded bg-stone-100"
+                  className="bg-primary/10 h-8 animate-pulse rounded"
                 />
               ))}
             </div>
@@ -182,7 +182,7 @@ export function SeasonLeaders() {
                 <TableRow
                   key={entry.slug ?? `${entry.playerName ?? "unknown"}-${idx}`}
                 >
-                  <TableCell className="text-stone-400">{idx + 1}</TableCell>
+                  <TableCell className="text-muted">{idx + 1}</TableCell>
                   <TableCell>
                     <PlayerLink name={entry.playerName} slug={entry.slug} />
                   </TableCell>
@@ -232,7 +232,7 @@ export function SeasonLeaders() {
                 <TableRow
                   key={entry.slug ?? `${entry.playerName ?? "unknown"}-${idx}`}
                 >
-                  <TableCell className="text-stone-400">{idx + 1}</TableCell>
+                  <TableCell className="text-muted">{idx + 1}</TableCell>
                   <TableCell>
                     <PlayerLink name={entry.playerName} slug={entry.slug} />
                   </TableCell>
@@ -255,7 +255,7 @@ export function SeasonLeaders() {
       <div className="mt-4 text-center">
         <Link
           to={`/cricket/records/leaderboards?season=${effectiveSeason}`}
-          className="text-primary hover:text-primary-light text-sm font-medium transition"
+          className="text-primary decoration-cta/70 hover:text-cta text-sm font-medium underline underline-offset-2 transition"
         >
           View full {effectiveSeason} leaderboard &rarr;
         </Link>

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -10,20 +10,20 @@ export const SiteFooter: FC = () => {
   const now = useClientDate();
 
   return (
-    <footer className="bg-primary text-white">
+    <footer className="bg-primary text-paper">
       <div className="container mx-auto px-8 py-12">
         <div className="grid gap-10 md:grid-cols-3">
           {/* Column 1: About */}
           <div>
             <Logo size="md" />
-            <p className="mt-4 text-sm leading-relaxed text-white/80">
+            <p className="text-paper/80 mt-4 text-sm leading-relaxed">
               Community sports club providing facilities for cricket, football,
               boxing, and running in Percy Main and surrounding areas.
             </p>
-            <p className="mt-3 text-sm text-white/60">
+            <p className="text-paper/70 mt-3 text-sm">
               <a
                 href="https://register-of-charities.charitycommission.gov.uk/en/charity-search/-/charity-details/5231516/charity-overview"
-                className="text-cta transition hover:text-[#f7864f]"
+                className="text-cta hover:text-paper transition"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -34,14 +34,14 @@ export const SiteFooter: FC = () => {
 
           {/* Column 2: Quick Links */}
           <div>
-            <h4 className="mb-4 text-sm font-semibold tracking-wider text-white uppercase">
+            <h4 className="text-cta mb-4 text-xs font-bold tracking-[0.2em] uppercase">
               Quick Links
             </h4>
             <ul className="space-y-2 text-sm">
               <li>
                 <Link
                   to="/calendar"
-                  className="text-white/80 transition hover:text-white max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
+                  className="text-paper/80 hover:text-paper transition max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
                 >
                   Calendar
                 </Link>
@@ -49,7 +49,7 @@ export const SiteFooter: FC = () => {
               <li>
                 <Link
                   to="/news/1"
-                  className="text-white/80 transition hover:text-white max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
+                  className="text-paper/80 hover:text-paper transition max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
                 >
                   News
                 </Link>
@@ -57,7 +57,7 @@ export const SiteFooter: FC = () => {
               <li>
                 <Link
                   to="/person"
-                  className="text-white/80 transition hover:text-white max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
+                  className="text-paper/80 hover:text-paper transition max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
                 >
                   People
                 </Link>
@@ -65,7 +65,7 @@ export const SiteFooter: FC = () => {
               <li>
                 <Link
                   to="/cricket"
-                  className="text-white/80 transition hover:text-white max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
+                  className="text-paper/80 hover:text-paper transition max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
                 >
                   Cricket
                 </Link>
@@ -73,7 +73,7 @@ export const SiteFooter: FC = () => {
               <li>
                 <Link
                   to="/report-incident"
-                  className="text-white/80 transition hover:text-white max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
+                  className="text-paper/80 hover:text-paper transition max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
                 >
                   Report an accident or incident
                 </Link>
@@ -81,7 +81,7 @@ export const SiteFooter: FC = () => {
               <li>
                 <Link
                   to="/legal/privacy"
-                  className="text-white/80 transition hover:text-white max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
+                  className="text-paper/80 hover:text-paper transition max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
                 >
                   Privacy Policy
                 </Link>
@@ -89,7 +89,7 @@ export const SiteFooter: FC = () => {
               <li>
                 <Link
                   to="/cricket/safeguarding"
-                  className="text-white/80 transition hover:text-white max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
+                  className="text-paper/80 hover:text-paper transition max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
                 >
                   Safeguarding
                 </Link>
@@ -98,7 +98,7 @@ export const SiteFooter: FC = () => {
                 <button
                   type="button"
                   onClick={openCookieSettings}
-                  className="text-left text-white/80 transition hover:text-white max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
+                  className="text-paper/80 hover:text-paper text-left transition max-lg:inline-flex max-lg:min-h-6 max-lg:items-center max-lg:py-1"
                 >
                   Cookie settings
                 </button>
@@ -108,17 +108,17 @@ export const SiteFooter: FC = () => {
 
           {/* Column 3: Contact */}
           <div>
-            <h4 className="mb-4 text-sm font-semibold tracking-wider text-white uppercase">
+            <h4 className="text-cta mb-4 text-xs font-bold tracking-[0.2em] uppercase">
               Contact
             </h4>
-            <address className="space-y-1 text-sm text-white/80 not-italic">
+            <address className="text-paper/80 space-y-1 text-sm not-italic">
               <p>St. Johns Terrace</p>
               <p>North Shields</p>
               <p>NE29 6HS</p>
             </address>
             <a
               href="mailto:trustees@percymain.org"
-              className="text-cta mt-3 inline-block text-sm transition hover:text-[#f7864f]"
+              className="text-cta hover:text-paper mt-3 inline-block text-sm transition"
             >
               trustees@percymain.org
             </a>
@@ -128,8 +128,8 @@ export const SiteFooter: FC = () => {
       </div>
 
       {/* Bottom bar */}
-      <div className="border-t border-white/10">
-        <div className="container mx-auto flex flex-col items-center justify-between gap-3 px-8 py-4 text-sm text-white/60 md:flex-row">
+      <div className="border-paper/15 border-t">
+        <div className="text-paper/60 container mx-auto flex flex-col items-center justify-between gap-3 px-8 py-4 text-sm md:flex-row">
           <p>
             &copy; {now?.getFullYear() ?? ""} Percy Main Community Sports Club
           </p>

--- a/apps/web/src/components/theme/bits.tsx
+++ b/apps/web/src/components/theme/bits.tsx
@@ -4,15 +4,32 @@ import type { ReactNode } from "react";
 import { Link } from "react-router";
 import { RisoHeading } from "./riso-heading.js";
 
-/** A small uppercase, heavily letterspaced label — the "No. 03" kicker. */
+/**
+ * A small uppercase, heavily letterspaced label — the "No. 03" kicker.
+ * Pass `level` when the kicker stands in for a real section heading (it then
+ * exposes `role="heading"` at that aria-level so screen-reader heading
+ * navigation still works); omit it for a purely decorative eyebrow sitting
+ * above its own heading. Kept as a <div> either way so the print styling is
+ * not overridden by the global heading rules.
+ */
 export function Kicker({
   children,
+  level,
   className,
 }: {
   children: ReactNode;
+  level?: 2 | 3 | 4 | 5 | 6;
   className?: string;
 }) {
-  return <div className={cn("fc-kicker", className)}>{children}</div>;
+  return (
+    <div
+      className={cn("fc-kicker", className)}
+      role={level ? "heading" : undefined}
+      aria-level={level}
+    >
+      {children}
+    </div>
+  );
 }
 
 /**

--- a/apps/web/src/components/theme/bits.tsx
+++ b/apps/web/src/components/theme/bits.tsx
@@ -70,6 +70,45 @@ export function StampLink({
   );
 }
 
+/**
+ * The stamped CTA as a real <button> — the action-triggering twin of
+ * StampLink, for form submits and onClick handlers. `size="sm"` is the
+ * tighter form-field size; `variant="navy"` swaps the orange ink for navy.
+ */
+export function StampButton({
+  type = "button",
+  variant,
+  size,
+  disabled,
+  onClick,
+  children,
+  className,
+}: {
+  type?: "button" | "submit" | "reset";
+  variant?: "navy";
+  size?: "sm";
+  disabled?: boolean;
+  onClick?: () => void;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "fc-stamp",
+        variant === "navy" && "fc-stamp--navy",
+        size === "sm" && "fc-stamp--sm",
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
 /** Fades + lifts its children once they scroll into view. */
 export function Reveal({
   children,

--- a/apps/web/src/components/theme/bits.tsx
+++ b/apps/web/src/components/theme/bits.tsx
@@ -126,6 +126,42 @@ export function StampButton({
   );
 }
 
+/**
+ * The underlined poster link from the homepage hero ("Our redevelopment
+ * plans"): condensed uppercase, navy with a navy rule, flipping to orange on
+ * hover. Renders an internal Link or an external anchor. The text-colour
+ * importants assert the navy over `.mdx-content a` (which paints every
+ * editorial anchor orange) so it reads the same in content as in chrome.
+ */
+export function PosterLink({
+  to,
+  href,
+  children,
+  className,
+}: {
+  to?: string;
+  href?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const cls = cn(
+    "font-secondary border-navy hover:border-cta inline-block border-b-2 pb-1 tracking-wide text-navy! uppercase transition hover:text-cta! hover:no-underline!",
+    className,
+  );
+  if (href) {
+    return (
+      <a className={cls} href={href}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link className={cls} to={to ?? "#"}>
+      {children}
+    </Link>
+  );
+}
+
 /** Fades + lifts its children once they scroll into view. */
 export function Reveal({
   children,

--- a/apps/web/src/components/theme/fixture-strip.tsx
+++ b/apps/web/src/components/theme/fixture-strip.tsx
@@ -1,0 +1,47 @@
+import { formatInTimeZone } from "date-fns-tz";
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+
+/** One row of the fixture strip. */
+export interface FixtureStripItem {
+  /** Stable key + used for nothing else. */
+  id: string;
+  /** Where the row links to. */
+  href: string;
+  /** ISO datetime; the date block + any time in `meta` derive from it. */
+  when: string;
+  /** The headline of the row, e.g. "1st XI vs Tynemouth CC". */
+  title: ReactNode;
+  /** Secondary line under the title, e.g. "Match · 2:00 PM". */
+  meta: ReactNode;
+  /** Right-hand stamp, e.g. "Home" / "Away" / "Event". */
+  tag: ReactNode;
+}
+
+/**
+ * The poster fixture strip: a date block, the fixture, and a Home/Away tag,
+ * with an orange (or navy, on an orange plate) sweep on hover. Extracted from
+ * the homepage "What's On" so every fixture list across the site reads in one
+ * voice. Renders navy-on-paper by default; drop it inside a `Plate variant=
+ * "orange"` and the `.fc-plate--orange .fc-frow` rules invert it to cream.
+ */
+export function FixtureStrip({ items }: { items: FixtureStripItem[] }) {
+  return (
+    <div className="fc-fixtures">
+      {items.map((item) => (
+        <Link key={item.id} to={item.href} className="fc-frow">
+          <div className="fc-frow-date">
+            {formatInTimeZone(new Date(item.when), "Europe/London", "EEE dd")}
+            <br />
+            {formatInTimeZone(new Date(item.when), "Europe/London", "MMM")}
+          </div>
+          <div>
+            <div className="fc-frow-opp">{item.title}</div>
+            <div className="fc-frow-meta">{item.meta}</div>
+          </div>
+          <div className="fc-frow-tag">{item.tag}</div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/theme/fixture-strip.tsx
+++ b/apps/web/src/components/theme/fixture-strip.tsx
@@ -8,14 +8,20 @@ export interface FixtureStripItem {
   id: string;
   /** Where the row links to. */
   href: string;
-  /** ISO datetime; the date block + any time in `meta` derive from it. */
+  /** ISO datetime; the date block derives from it unless `lead` overrides it. */
   when: string;
   /** The headline of the row, e.g. "1st XI vs Tynemouth CC". */
   title: ReactNode;
-  /** Secondary line under the title, e.g. "Match · 2:00 PM". */
-  meta: ReactNode;
+  /** Secondary line under the title, e.g. "Match · 2:00 PM". Omitted if absent. */
+  meta?: ReactNode;
   /** Right-hand stamp, e.g. "Home" / "Away" / "Event". */
   tag: ReactNode;
+  /**
+   * Overrides the left block. The default is the date derived from `when`;
+   * pass e.g. a time when rows are already grouped under a date heading, so
+   * the date is not printed twice.
+   */
+  lead?: ReactNode;
 }
 
 /**
@@ -31,13 +37,23 @@ export function FixtureStrip({ items }: { items: FixtureStripItem[] }) {
       {items.map((item) => (
         <Link key={item.id} to={item.href} className="fc-frow">
           <div className="fc-frow-date">
-            {formatInTimeZone(new Date(item.when), "Europe/London", "EEE dd")}
-            <br />
-            {formatInTimeZone(new Date(item.when), "Europe/London", "MMM")}
+            {item.lead ?? (
+              <>
+                {formatInTimeZone(
+                  new Date(item.when),
+                  "Europe/London",
+                  "EEE dd",
+                )}
+                <br />
+                {formatInTimeZone(new Date(item.when), "Europe/London", "MMM")}
+              </>
+            )}
           </div>
           <div>
             <div className="fc-frow-opp">{item.title}</div>
-            <div className="fc-frow-meta">{item.meta}</div>
+            {item.meta != null && (
+              <div className="fc-frow-meta">{item.meta}</div>
+            )}
           </div>
           <div className="fc-frow-tag">{item.tag}</div>
         </Link>

--- a/apps/web/src/lib/fc-theme.ts
+++ b/apps/web/src/lib/fc-theme.ts
@@ -6,8 +6,8 @@
  * RootLayout). Everything under that class re-points the core design tokens to
  * the paper/orange/navy palette and switches headings to the condensed display
  * face, so existing components shift palette without per-file edits. Admin,
- * members, membership, auth, scout and the junior-manager tools keep the
- * standard club theme and are deliberately excluded.
+ * members, auth, scout and the junior-manager tools keep the standard club
+ * theme and are deliberately excluded.
  *
  * This single predicate is the source of truth, shared by the class toggle and
  * by the chrome (header / footer) that render theme-aware variants.
@@ -17,7 +17,6 @@
 const NON_THEMED_PREFIXES = [
   "/auth",
   "/members",
-  "/membership",
   "/admin",
   "/scout",
   "/junior-manager",

--- a/apps/web/src/pages/calendar/calendar-event.tsx
+++ b/apps/web/src/pages/calendar/calendar-event.tsx
@@ -20,7 +20,7 @@ import { Link, useParams, useSearchParams } from "react-router";
 
 function When({ start, end }: { start: string; end?: string }) {
   return (
-    <div className="flex flex-row items-center justify-between gap-4 rounded-xl bg-white p-4">
+    <div className="border-primary bg-surface text-primary flex flex-row items-center justify-between gap-4 border-2 p-4">
       <IoCalendar fontSize={32} />
       <div className="flex flex-col gap-4">
         <p>
@@ -84,18 +84,18 @@ function EventLayout({
   return (
     <div className="container mx-auto px-4 py-6">
       <div className="text-h4 mb-4 flex items-center gap-2">
-        <Link to="/calendar" className="hover:text-primary text-stone-600">
+        <Link to="/calendar" className="hover:text-primary text-muted">
           Calendar
         </Link>
-        <IoChevronForward className="text-stone-400" size={14} />
+        <IoChevronForward className="text-muted" size={14} />
         <Link
           to={`/calendar/${year}/${month.toLowerCase()}`}
-          className="hover:text-primary text-stone-600"
+          className="hover:text-primary text-muted"
         >
           {month} {year}
         </Link>
-        <IoChevronForward className="text-stone-400" size={14} />
-        <span className="text-dark font-medium">{name}</span>
+        <IoChevronForward className="text-muted" size={14} />
+        <span className="fc-two-tone font-medium">{name}</span>
       </div>
 
       <div className="flex flex-col items-start gap-4">
@@ -147,7 +147,7 @@ function EventLayout({
         </div>
 
         {repeats && (
-          <div className="flex w-full flex-col gap-2 rounded-xl bg-white p-4">
+          <div className="border-primary bg-surface text-primary flex w-full flex-col gap-2 border-2 p-4">
             <p>
               <span className="font-semibold">Repeats: </span>
               {repeats}
@@ -160,7 +160,7 @@ function EventLayout({
                     <li key={o.date}>
                       <Link
                         to={o.href}
-                        className="hover:text-primary text-stone-600 hover:underline"
+                        className="hover:text-cta text-muted hover:underline"
                       >
                         {o.label}
                       </Link>
@@ -178,7 +178,7 @@ function EventLayout({
           center={{ lat: venue.lat, lon: venue.lon }}
           infoWindow={{ header: venue.name }}
         >
-          <div className="flex flex-col gap-2 bg-white p-4 text-lg sm:text-sm">
+          <div className="border-primary bg-surface text-primary flex flex-col gap-2 border-2 p-4 text-lg sm:text-sm">
             <h4 className="text-h6 md:text-h5">{venue.name}</h4>
             {venue.street && <p>{venue.street}</p>}
             {venue.city && <p>{venue.city}</p>}
@@ -278,8 +278,8 @@ export function Component() {
 
   return (
     <div className="container mx-auto px-4 py-12">
-      <h1 className="text-2xl font-semibold">Event Not Found</h1>
-      <p className="mt-2 text-stone-600">This event could not be found.</p>
+      <h1 className="fc-two-tone text-2xl font-semibold">Event Not Found</h1>
+      <p className="text-muted mt-2">This event could not be found.</p>
       <Link
         to="/calendar"
         className="text-primary mt-4 inline-block hover:underline"

--- a/apps/web/src/pages/calendar/calendar-month.lib.test.ts
+++ b/apps/web/src/pages/calendar/calendar-month.lib.test.ts
@@ -24,6 +24,12 @@ describe("categoriseTeam", () => {
     expect(categoriseTeam("midweek")).toBe("mid");
   });
 
+  it("recognises women's sides (but not 'girls', which stay junior)", () => {
+    expect(categoriseTeam("Womens Softball")).toBe("wxi");
+    expect(categoriseTeam("Women's XI")).toBe("wxi");
+    expect(categoriseTeam("Ladies")).toBe("wxi");
+  });
+
   it("recognises juniors via 'under', 'junior', 'colts', and U-codes", () => {
     expect(categoriseTeam("Under 13s")).toBe("jun");
     expect(categoriseTeam("Junior Dynamos")).toBe("jun");

--- a/apps/web/src/pages/calendar/calendar-month.lib.ts
+++ b/apps/web/src/pages/calendar/calendar-month.lib.ts
@@ -7,7 +7,7 @@
 
 import { isBefore } from "date-fns";
 
-export type TeamCategory = "1xi" | "2xi" | "mid" | "jun";
+export type TeamCategory = "1xi" | "2xi" | "mid" | "wxi" | "jun";
 export type Filter = "all" | TeamCategory | "event";
 
 export const MONTH_NAMES = [
@@ -34,6 +34,9 @@ export function categoriseTeam(teamName: string): TeamCategory {
   if (/1st/i.test(teamName)) return "1xi";
   if (/2nd/i.test(teamName)) return "2xi";
   if (/midweek/i.test(teamName)) return "mid";
+  // Women's / ladies sides (e.g. "Womens Softball"). "Girls" stays a junior
+  // side and is intentionally not matched here.
+  if (/wom(a|e)n|ladies/i.test(teamName)) return "wxi";
   if (/under|junior|colts|\bU\d{2}\b/i.test(teamName)) return "jun";
   return "1xi";
 }

--- a/apps/web/src/pages/calendar/calendar-month.tsx
+++ b/apps/web/src/pages/calendar/calendar-month.tsx
@@ -23,7 +23,7 @@ import {
   startOfMonth,
 } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { IoChevronForward } from "react-icons/io5";
 import { Link, useLocation, useNavigate, useParams } from "react-router";
 import {
@@ -467,7 +467,6 @@ export function Component() {
   const [selectedDay, setSelectedDay] = useState<number | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
-  const todayScrolledRef = useRef(false);
   const locationPathname = location.pathname;
   const locationState: unknown = location.state;
 
@@ -595,8 +594,9 @@ export function Component() {
   };
 
   // Arriving via the Today button from another month: scroll once the agenda
-  // for the current month has rendered, then clear the one-shot nav flag so a
-  // later re-render or back-navigation does not re-trigger it.
+  // for the current month has rendered, then clear the nav flag. Clearing the
+  // flag (not a one-shot ref) is what stops a re-fire, so a later
+  // "other month -> Today" on this still-mounted page scrolls again.
   const navState: unknown = locationState;
   const wantsTodayScroll =
     typeof navState === "object" &&
@@ -604,9 +604,7 @@ export function Component() {
     "scrollToToday" in navState &&
     navState.scrollToToday === true;
   useEffect(() => {
-    if (!wantsTodayScroll || todayScrolledRef.current || todayTargetDay == null)
-      return;
-    todayScrolledRef.current = true;
+    if (!wantsTodayScroll || todayTargetDay == null) return;
     document
       .getElementById(`agenda-day-${todayTargetDay}`)
       ?.scrollIntoView({ behavior: "smooth", block: "start" });

--- a/apps/web/src/pages/calendar/calendar-month.tsx
+++ b/apps/web/src/pages/calendar/calendar-month.tsx
@@ -1,10 +1,12 @@
-import { OutcomeBadge } from "@/components/outcome-badge.js";
-import { PrefetchLink } from "@/components/prefetch-link.js";
+import { Kicker } from "@/components/theme/bits.js";
+import {
+  FixtureStrip,
+  type FixtureStripItem,
+} from "@/components/theme/fixture-strip.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client.js";
 import type { paths } from "@/lib/api.gen.js";
 import {
-  eventQueryOptions,
   eventsListQueryOptions,
   parseEventMetadata,
 } from "@/lib/content-queries.js";
@@ -80,11 +82,14 @@ const FILTER_LABELS: Array<{ key: Filter; label: string }> = [
   { key: "event", label: "Events" },
 ];
 
-const TEAM_BORDER_CLASSES: Record<string, string> = {
-  "1xi": "border-l-green-800",
-  "2xi": "border-l-blue-600",
-  mid: "border-l-violet-600",
-  jun: "border-l-amber-600",
+const OUTCOME_LABELS: Record<Outcome, string> = {
+  W: "Won",
+  L: "Lost",
+  D: "Draw",
+  T: "Tied",
+  A: "Abandoned",
+  C: "Cancelled",
+  N: "No result",
 };
 
 // --- Mini Calendar ---
@@ -119,15 +124,15 @@ function MiniCalendar({
     cells.push({ key: `day-${d}`, day: d });
 
   return (
-    <div className="rounded-xl border border-stone-200 bg-white p-4 shadow-sm">
-      <div className="mb-3 text-sm font-bold text-stone-900">
+    <div className="border-primary bg-surface border-2 p-4">
+      <div className="text-primary mb-3 text-sm font-bold">
         {format(date, "MMMM yyyy")}
       </div>
       <div className="mb-1 grid grid-cols-7 text-center">
         {dayHeaders.map((d) => (
           <div
             key={d.key}
-            className="py-1 text-[11px] font-semibold tracking-wider text-stone-400 uppercase"
+            className="text-muted py-1 text-[11px] font-semibold tracking-wider uppercase"
           >
             {d.label}
           </div>
@@ -137,7 +142,7 @@ function MiniCalendar({
         {cells.map((cell) => {
           if (cell.day === null) {
             return (
-              <span key={cell.key} className="py-1.5 text-xs text-stone-300" />
+              <span key={cell.key} className="text-muted/40 py-1.5 text-xs" />
             );
           }
           const day = cell.day;
@@ -148,19 +153,19 @@ function MiniCalendar({
           const isTodayDay = isToday(cellDate);
 
           const classes = cn(
-            "relative rounded py-1.5 text-xs transition-colors",
-            !hasItems && "text-stone-500",
+            "relative py-1.5 text-xs transition-colors",
+            !hasItems && "text-muted",
             hasItems &&
-              "cursor-pointer font-semibold text-stone-900 hover:bg-green-50",
-            isSelected && "!bg-green-800 !text-white",
-            isTodayDay && !isSelected && "ring-1 ring-green-800/40",
+              "text-primary hover:bg-primary/10 cursor-pointer font-semibold",
+            isSelected && "!bg-primary !text-paper",
+            isTodayDay && !isSelected && "ring-primary/40 ring-1",
           );
 
           const dot = hasItems && (
             <span
               className={cn(
                 "mx-auto mt-0.5 block rounded-full",
-                isSelected ? "bg-white" : "bg-green-800",
+                isSelected ? "bg-paper" : "bg-cta",
                 hasMultiple ? "h-[5px] w-2 rounded-sm" : "h-[5px] w-[5px]",
               )}
             />
@@ -199,28 +204,26 @@ function MonthSummary({
   stats: { won: number; lost: number; upcoming: number };
 }) {
   return (
-    <div className="mt-4 rounded-xl border border-stone-200 bg-white p-4 shadow-sm">
-      <h4 className="mb-2 text-xs font-semibold tracking-wider text-stone-400 uppercase">
+    <div className="border-primary bg-surface mt-4 border-2 p-4">
+      <h4 className="text-muted mb-2 text-xs font-semibold tracking-wider uppercase">
         Month Summary
       </h4>
       <div className="grid grid-cols-3 gap-2">
-        <div className="rounded-lg bg-green-50 p-2 text-center">
-          <div className="text-lg font-bold text-green-700">{stats.won}</div>
-          <div className="text-[10px] font-semibold text-green-600 uppercase">
+        <div className="border-border bg-surface border p-2 text-center">
+          <div className="text-primary text-lg font-bold">{stats.won}</div>
+          <div className="text-primary text-[10px] font-semibold uppercase">
             Won
           </div>
         </div>
-        <div className="rounded-lg bg-red-50 p-2 text-center">
+        <div className="border-border bg-surface border p-2 text-center">
           <div className="text-lg font-bold text-red-700">{stats.lost}</div>
-          <div className="text-[10px] font-semibold text-red-600 uppercase">
+          <div className="text-[10px] font-semibold text-red-700 uppercase">
             Lost
           </div>
         </div>
-        <div className="rounded-lg bg-stone-100 p-2 text-center">
-          <div className="text-lg font-bold text-stone-600">
-            {stats.upcoming}
-          </div>
-          <div className="text-[10px] font-semibold text-stone-400 uppercase">
+        <div className="border-border bg-surface border p-2 text-center">
+          <div className="text-cta text-lg font-bold">{stats.upcoming}</div>
+          <div className="text-cta text-[10px] font-semibold uppercase">
             Upcoming
           </div>
         </div>
@@ -248,10 +251,10 @@ function FilterPills({
             type="button"
             onClick={() => onChange(key)}
             className={cn(
-              "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+              "px-4 py-1.5 text-sm font-medium transition-colors",
               isActive
-                ? "bg-green-800 text-white shadow-md"
-                : "border-2 border-stone-200 text-stone-700 hover:border-stone-300",
+                ? "bg-primary text-paper"
+                : "border-border text-muted hover:border-primary border-2",
             )}
           >
             {label}
@@ -262,127 +265,52 @@ function FilterPills({
   );
 }
 
-// --- Fixture Card ---
+// --- Fixture strip mapping ---
 
-function FixtureCard({ item }: { item: CalendarItem & { type: "game" } }) {
-  const when = new Date(item.when);
-  const time = formatInTimeZone(when, "Europe/London", "HH:mm");
-  const borderClass = TEAM_BORDER_CLASSES[item.category] ?? "";
-  const hasResultStripe = item.outcome === "W" || item.outcome === "L";
+/**
+ * Map a calendar item (game or event) into a poster fixture-strip row. Games
+ * link to the game page with a Home/Away tag; events link to the event page
+ * with an "Event" tag. The result word (W/L/D ...) and any sponsor note ride
+ * along in the meta line so the strip stays a single, consistent voice.
+ */
+function toFixtureStripItem(item: CalendarItem): FixtureStripItem {
+  const time = formatInTimeZone(new Date(item.when), "Europe/London", "HH:mm");
 
-  return (
-    <Link
-      to={`/calendar/game/${item.id}`}
-      className={cn(
-        "group relative mb-2 flex items-center gap-3 overflow-hidden rounded-lg border-l-4 bg-white p-3 shadow-sm transition-all hover:translate-x-1 hover:shadow-md sm:gap-4 sm:p-4",
-        borderClass,
-      )}
-    >
-      {hasResultStripe && (
-        <span
-          className={cn(
-            "absolute top-0 right-0 bottom-0 w-[3px]",
-            item.outcome === "W" ? "bg-green-600" : "bg-red-600",
-          )}
-        />
-      )}
+  if (item.type === "event") {
+    return {
+      id: item.id,
+      href: `/calendar/event/${item.slug}?on=${item.occurrenceDate}`,
+      when: item.when,
+      title: item.eventName,
+      meta: time,
+      tag: "Event",
+    };
+  }
 
-      <div className="flex shrink-0 flex-col items-center gap-1">
-        <span
-          className={cn(
-            "flex size-7 items-center justify-center rounded-md text-xs font-semibold",
-            item.home
-              ? "bg-green-100 text-green-800"
-              : "bg-blue-100 text-blue-800",
-          )}
-        >
-          {item.home ? "H" : "A"}
-        </span>
-        <span className="text-[10px] font-bold tracking-wider text-stone-400 uppercase">
-          {time}
-        </span>
-      </div>
+  const competition = item.leagueName || item.competitionName;
+  const outcomeLabel = item.outcome
+    ? (OUTCOME_LABELS[item.outcome] ?? null)
+    : null;
 
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-1 sm:gap-2">
-          <span className="text-sm font-bold text-stone-900 sm:text-base">
-            {item.teamName}
-          </span>
-          <span className="text-sm text-stone-400">vs.</span>
-          <span className="text-sm font-semibold text-stone-900 sm:text-base">
-            {item.oppositionClub} {item.oppositionTeam}
-          </span>
-        </div>
-        <div className="mt-0.5 flex flex-wrap items-center gap-2">
-          <span className="text-xs text-stone-400">
-            {item.leagueName || item.competitionName}
-          </span>
-          {item.sponsorName && (
-            <>
-              <span className="mx-1 size-1 rounded-full bg-stone-200" />
-              <span className="text-xs font-medium text-orange-600">
-                Sponsored by {item.sponsorName}
-              </span>
-            </>
-          )}
-        </div>
-      </div>
-
-      {item.outcome && (
-        <OutcomeBadge
-          outcome={item.outcome}
-          scoreDescription={item.scoreDescription ?? undefined}
-        />
-      )}
-
-      <IoChevronForward className="size-5 shrink-0 text-stone-300" />
-    </Link>
-  );
-}
-
-// --- Event Card ---
-
-function EventCard({ item }: { item: CalendarItem & { type: "event" } }) {
-  const when = new Date(item.when);
-  const time = formatInTimeZone(when, "Europe/London", "HH:mm");
-
-  return (
-    <PrefetchLink
-      query={eventQueryOptions(item.slug)}
-      to={`/calendar/event/${item.slug}?on=${item.occurrenceDate}`}
-      className="group mb-2 flex items-center gap-3 rounded-lg border-2 border-dashed border-orange-300/50 bg-orange-50/50 p-3 transition-all hover:translate-x-1 hover:shadow-md sm:gap-4 sm:p-4"
-    >
-      <div className="flex shrink-0 flex-col items-center gap-1">
-        <span className="flex size-7 items-center justify-center rounded-md bg-orange-100 text-orange-600">
-          <svg
-            className="size-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-          </svg>
-        </span>
-        <span className="text-[10px] font-bold tracking-wider text-stone-400 uppercase">
-          {time}
-        </span>
-      </div>
-
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded bg-orange-100 px-1.5 py-0.5 text-[10px] font-bold tracking-wider text-orange-600 uppercase">
-            Event
-          </span>
-          <span className="text-sm font-bold text-stone-900 sm:text-base">
-            {item.eventName}
-          </span>
-        </div>
-      </div>
-
-      <IoChevronForward className="size-5 shrink-0 text-stone-300" />
-    </PrefetchLink>
-  );
+  return {
+    id: item.id,
+    href: `/calendar/game/${item.id}`,
+    when: item.when,
+    title: (
+      <>
+        {item.teamName} vs {item.oppositionClub} {item.oppositionTeam}
+      </>
+    ),
+    meta: (
+      <>
+        {[competition, time].filter(Boolean).join(" · ")}
+        {outcomeLabel ? ` · ${outcomeLabel}` : ""}
+        {item.scoreDescription ? ` · ${item.scoreDescription}` : ""}
+        {item.sponsorName ? ` · Sponsored by ${item.sponsorName}` : ""}
+      </>
+    ),
+    tag: item.home ? "Home" : "Away",
+  };
 }
 
 // --- Date Group ---
@@ -398,19 +326,11 @@ function DateGroup({
   const heading = format(date, "EEEE d MMMM");
 
   return (
-    <div className="mb-6" id={`agenda-day-${date.getDate()}`}>
-      <div className="mb-3">
-        <h3 className="mb-0 text-base font-semibold text-stone-900 sm:text-lg">
-          {heading}
-        </h3>
+    <div className="mb-8" id={`agenda-day-${date.getDate()}`}>
+      <div className="mb-2">
+        <Kicker>{heading}</Kicker>
       </div>
-      {items.map((item) =>
-        item.type === "event" ? (
-          <EventCard key={item.id} item={item} />
-        ) : (
-          <FixtureCard key={item.id} item={item} />
-        ),
-      )}
+      <FixtureStrip items={items.map(toFixtureStripItem)} />
     </div>
   );
 }
@@ -420,11 +340,11 @@ function DateGroup({
 function PastUpcomingDivider() {
   return (
     <div className="relative my-8 flex items-center">
-      <div className="flex-1 border-t-2 border-dashed border-green-800/20" />
-      <span className="mx-4 shrink-0 rounded-full bg-green-800 px-4 py-1 text-xs font-bold tracking-wider text-white uppercase">
+      <div className="border-primary/30 flex-1 border-t-2 border-dashed" />
+      <span className="bg-cta text-paper mx-4 shrink-0 px-4 py-1 text-xs font-bold tracking-wider uppercase">
         Upcoming
       </span>
-      <div className="flex-1 border-t-2 border-dashed border-green-800/20" />
+      <div className="border-primary/30 flex-1 border-t-2 border-dashed" />
     </div>
   );
 }
@@ -576,11 +496,11 @@ export function Component() {
     <div className="container mx-auto px-4 py-6">
       {/* Breadcrumbs */}
       <div className="text-h4 mb-4 flex items-center gap-2">
-        <Link to="/calendar" className="hover:text-primary text-stone-600">
+        <Link to="/calendar" className="hover:text-primary text-muted">
           Calendar
         </Link>
-        <IoChevronForward className="text-stone-400" size={14} />
-        <span className="text-dark font-medium">
+        <IoChevronForward className="text-muted" size={14} />
+        <span className="text-primary font-medium">
           {monthDisplay} {yearDisplay}
         </span>
       </div>
@@ -590,7 +510,7 @@ export function Component() {
         <div className="flex items-center gap-4 sm:gap-8">
           <Link
             to={prevPath}
-            className="flex size-10 items-center justify-center rounded-lg border-2 border-green-800/20 text-green-800 transition-colors hover:bg-green-800 hover:text-white"
+            className="border-primary text-primary hover:bg-primary hover:text-paper flex size-10 items-center justify-center border-2 transition-colors"
           >
             <svg
               className="size-5"
@@ -603,10 +523,10 @@ export function Component() {
             </svg>
           </Link>
           <div>
-            <h1 className="mb-0 text-2xl font-semibold text-stone-900 sm:text-3xl">
+            <h1 className="fc-two-tone mb-0 text-2xl font-semibold sm:text-3xl">
               {monthDisplay} {yearDisplay}
             </h1>
-            <p className="text-sm text-stone-500">
+            <p className="text-muted text-sm">
               {totalFixtures} fixture{totalFixtures !== 1 ? "s" : ""}
               {totalResults > 0 && (
                 <>
@@ -619,7 +539,7 @@ export function Component() {
           </div>
           <Link
             to={nextPath}
-            className="flex size-10 items-center justify-center rounded-lg border-2 border-green-800/20 text-green-800 transition-colors hover:bg-green-800 hover:text-white"
+            className="border-primary text-primary hover:bg-primary hover:text-paper flex size-10 items-center justify-center border-2 transition-colors"
           >
             <svg
               className="size-5"
@@ -635,7 +555,7 @@ export function Component() {
 
         <Link
           to={todayPath}
-          className="hidden items-center gap-1.5 rounded-lg bg-green-800 px-4 py-2 text-sm font-semibold text-white transition hover:bg-green-700 sm:flex"
+          className="border-primary text-primary hover:bg-primary hover:text-paper hidden items-center gap-1.5 border-2 px-4 py-2 text-sm font-semibold transition sm:flex"
         >
           <svg
             className="size-4"
@@ -673,9 +593,9 @@ export function Component() {
         {/* Main Agenda */}
         <div className="min-w-0 flex-1">
           {grouped.length === 0 ? (
-            <div className="flex flex-col items-center justify-center rounded-lg bg-white p-8 text-center shadow-sm">
+            <div className="border-primary bg-surface flex flex-col items-center justify-center border-2 p-8 text-center">
               <svg
-                className="mb-3 size-12 text-stone-300"
+                className="text-primary/30 mb-3 size-12"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -683,7 +603,7 @@ export function Component() {
               >
                 <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
-              <p className="font-medium text-stone-600">
+              <p className="text-muted font-medium">
                 {activeFilter === "all"
                   ? `No events scheduled for ${monthDisplay}`
                   : `No ${FILTER_LABELS.find((f) => f.key === activeFilter)?.label ?? ""} fixtures for ${monthDisplay}`}

--- a/apps/web/src/pages/calendar/calendar-month.tsx
+++ b/apps/web/src/pages/calendar/calendar-month.tsx
@@ -328,7 +328,7 @@ function DateGroup({
   return (
     <div className="mb-8" id={`agenda-day-${date.getDate()}`}>
       <div className="mb-2">
-        <Kicker>{heading}</Kicker>
+        <Kicker level={3}>{heading}</Kicker>
       </div>
       <FixtureStrip items={items.map(toFixtureStripItem)} />
     </div>

--- a/apps/web/src/pages/calendar/calendar-month.tsx
+++ b/apps/web/src/pages/calendar/calendar-month.tsx
@@ -23,9 +23,9 @@ import {
   startOfMonth,
 } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { IoChevronForward } from "react-icons/io5";
-import { Link, useParams } from "react-router";
+import { Link, useLocation, useNavigate, useParams } from "react-router";
 import {
   categoriseTeam,
   filterItemsByCategory,
@@ -266,6 +266,105 @@ function FilterPills({
   );
 }
 
+// --- Month Navigation Header ---
+
+function MonthNavHeader({
+  prevPath,
+  nextPath,
+  todayPath,
+  monthDisplay,
+  yearDisplay,
+  totalFixtures,
+  totalResults,
+  isCurrentMonth,
+  onToday,
+}: {
+  prevPath: string;
+  nextPath: string;
+  todayPath: string;
+  monthDisplay: string;
+  yearDisplay: string;
+  totalFixtures: number;
+  totalResults: number;
+  isCurrentMonth: boolean;
+  onToday: () => void;
+}) {
+  return (
+    <div className="mb-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
+      <div className="flex items-center gap-4 sm:gap-8">
+        <Link
+          to={prevPath}
+          className="border-primary text-primary hover:bg-primary hover:text-paper flex size-10 items-center justify-center border-2 transition-colors"
+        >
+          <svg
+            className="size-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2.5}
+          >
+            <path d="M15 19l-7-7 7-7" />
+          </svg>
+        </Link>
+        <div>
+          <h1 className="fc-two-tone mb-0 text-2xl font-semibold sm:text-3xl">
+            {monthDisplay} {yearDisplay}
+          </h1>
+          <p className="text-muted text-sm">
+            {totalFixtures} fixture{totalFixtures !== 1 ? "s" : ""}
+            {totalResults > 0 && (
+              <>
+                {" "}
+                &middot; {totalResults} result{totalResults !== 1 ? "s" : ""}
+              </>
+            )}
+          </p>
+        </div>
+        <Link
+          to={nextPath}
+          className="border-primary text-primary hover:bg-primary hover:text-paper flex size-10 items-center justify-center border-2 transition-colors"
+        >
+          <svg
+            className="size-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2.5}
+          >
+            <path d="M9 5l7 7-7 7" />
+          </svg>
+        </Link>
+      </div>
+
+      <Link
+        to={todayPath}
+        state={{ scrollToToday: true }}
+        onClick={(e) => {
+          // Already on the current month: no navigation needed, just scroll
+          // the agenda to today. Other months fall through to the Link's
+          // navigation, and the effect scrolls once it lands.
+          if (isCurrentMonth) {
+            e.preventDefault();
+            onToday();
+          }
+        }}
+        className="border-primary text-primary hover:bg-primary hover:text-paper hidden items-center gap-1.5 border-2 px-4 py-2 text-sm font-semibold transition sm:flex"
+      >
+        <svg
+          className="size-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+        Today
+      </Link>
+    </div>
+  );
+}
+
 // --- Fixture strip mapping ---
 
 /**
@@ -330,7 +429,7 @@ function DateGroup({
   const heading = format(date, "EEEE d MMMM");
 
   return (
-    <div className="mb-8" id={`agenda-day-${date.getDate()}`}>
+    <div className="mb-8 scroll-mt-24" id={`agenda-day-${date.getDate()}`}>
       <div className="mb-2">
         <Kicker level={3}>{heading}</Kicker>
       </div>
@@ -366,6 +465,11 @@ export function Component() {
 
   const [activeFilter, setActiveFilter] = useState<Filter>("all");
   const [selectedDay, setSelectedDay] = useState<number | null>(null);
+  const location = useLocation();
+  const navigate = useNavigate();
+  const todayScrolledRef = useRef(false);
+  const locationPathname = location.pathname;
+  const locationState: unknown = location.state;
 
   const date = parsed
     ? new Date(parsed.year, parsed.monthIndex, 1)
@@ -465,6 +569,50 @@ export function Component() {
   const stats = summariseMonth(allItems, new Date());
   const dividerIndex = findDividerIndex(grouped, new Date());
 
+  // "Today" scrolling. The day-of-month to land on is today itself if it has
+  // fixtures, otherwise the next group on/after today (falling back to the
+  // last group). Null when the displayed month is not the current month, or
+  // before the agenda has rendered.
+  const isCurrentMonth =
+    date.getFullYear() === new Date().getFullYear() &&
+    date.getMonth() === new Date().getMonth();
+  const todayStr = format(new Date(), "yyyy-MM-dd");
+  const todayTargetDay =
+    isCurrentMonth && grouped.length > 0
+      ? new Date(
+          (
+            grouped.find((g) => g.dateStr >= todayStr) ??
+            grouped[grouped.length - 1]
+          ).dateStr,
+        ).getDate()
+      : null;
+
+  const scrollToToday = () => {
+    if (todayTargetDay == null) return;
+    document
+      .getElementById(`agenda-day-${todayTargetDay}`)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  // Arriving via the Today button from another month: scroll once the agenda
+  // for the current month has rendered, then clear the one-shot nav flag so a
+  // later re-render or back-navigation does not re-trigger it.
+  const navState: unknown = locationState;
+  const wantsTodayScroll =
+    typeof navState === "object" &&
+    navState !== null &&
+    "scrollToToday" in navState &&
+    navState.scrollToToday === true;
+  useEffect(() => {
+    if (!wantsTodayScroll || todayScrolledRef.current || todayTargetDay == null)
+      return;
+    todayScrolledRef.current = true;
+    document
+      .getElementById(`agenda-day-${todayTargetDay}`)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    void navigate(locationPathname, { replace: true, state: null });
+  }, [wantsTodayScroll, todayTargetDay, navigate, locationPathname]);
+
   // Navigation
   const prevDate = addMonths(date, -1);
   const nextDate = addMonths(date, 1);
@@ -509,70 +657,17 @@ export function Component() {
         </span>
       </div>
 
-      {/* Month Navigation Header */}
-      <div className="mb-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
-        <div className="flex items-center gap-4 sm:gap-8">
-          <Link
-            to={prevPath}
-            className="border-primary text-primary hover:bg-primary hover:text-paper flex size-10 items-center justify-center border-2 transition-colors"
-          >
-            <svg
-              className="size-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2.5}
-            >
-              <path d="M15 19l-7-7 7-7" />
-            </svg>
-          </Link>
-          <div>
-            <h1 className="fc-two-tone mb-0 text-2xl font-semibold sm:text-3xl">
-              {monthDisplay} {yearDisplay}
-            </h1>
-            <p className="text-muted text-sm">
-              {totalFixtures} fixture{totalFixtures !== 1 ? "s" : ""}
-              {totalResults > 0 && (
-                <>
-                  {" "}
-                  &middot; {totalResults} result
-                  {totalResults !== 1 ? "s" : ""}
-                </>
-              )}
-            </p>
-          </div>
-          <Link
-            to={nextPath}
-            className="border-primary text-primary hover:bg-primary hover:text-paper flex size-10 items-center justify-center border-2 transition-colors"
-          >
-            <svg
-              className="size-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2.5}
-            >
-              <path d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div>
-
-        <Link
-          to={todayPath}
-          className="border-primary text-primary hover:bg-primary hover:text-paper hidden items-center gap-1.5 border-2 px-4 py-2 text-sm font-semibold transition sm:flex"
-        >
-          <svg
-            className="size-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-          </svg>
-          Today
-        </Link>
-      </div>
+      <MonthNavHeader
+        prevPath={prevPath}
+        nextPath={nextPath}
+        todayPath={todayPath}
+        monthDisplay={monthDisplay}
+        yearDisplay={yearDisplay}
+        totalFixtures={totalFixtures}
+        totalResults={totalResults}
+        isCurrentMonth={isCurrentMonth}
+        onToday={scrollToToday}
+      />
 
       {/* Filter Pills */}
       <FilterPills active={activeFilter} onChange={handleFilterChange} />

--- a/apps/web/src/pages/calendar/calendar-month.tsx
+++ b/apps/web/src/pages/calendar/calendar-month.tsx
@@ -49,7 +49,7 @@ type CalendarItem =
   | {
       id: string;
       type: "game";
-      category: "1xi" | "2xi" | "mid" | "jun";
+      category: "1xi" | "2xi" | "mid" | "wxi" | "jun";
       when: string;
       home: boolean;
       teamName: string;
@@ -78,6 +78,7 @@ const FILTER_LABELS: Array<{ key: Filter; label: string }> = [
   { key: "1xi", label: "1st XI" },
   { key: "2xi", label: "2nd XI" },
   { key: "mid", label: "Midweek XI" },
+  { key: "wxi", label: "Women's XI" },
   { key: "jun", label: "Juniors" },
   { key: "event", label: "Events" },
 ];
@@ -276,13 +277,15 @@ function FilterPills({
 function toFixtureStripItem(item: CalendarItem): FixtureStripItem {
   const time = formatInTimeZone(new Date(item.when), "Europe/London", "HH:mm");
 
+  // The day heading already prints the date, so the row's left block carries
+  // the time instead (no duplicated date), and the time is dropped from meta.
   if (item.type === "event") {
     return {
       id: item.id,
       href: `/calendar/event/${item.slug}?on=${item.occurrenceDate}`,
       when: item.when,
+      lead: time,
       title: item.eventName,
-      meta: time,
       tag: "Event",
     };
   }
@@ -296,6 +299,7 @@ function toFixtureStripItem(item: CalendarItem): FixtureStripItem {
     id: item.id,
     href: `/calendar/game/${item.id}`,
     when: item.when,
+    lead: time,
     title: (
       <>
         {item.teamName} vs {item.oppositionClub} {item.oppositionTeam}
@@ -303,7 +307,7 @@ function toFixtureStripItem(item: CalendarItem): FixtureStripItem {
     ),
     meta: (
       <>
-        {[competition, time].filter(Boolean).join(" · ")}
+        {competition}
         {outcomeLabel ? ` · ${outcomeLabel}` : ""}
         {item.scoreDescription ? ` · ${item.scoreDescription}` : ""}
         {item.sponsorName ? ` · Sponsored by ${item.sponsorName}` : ""}
@@ -577,7 +581,9 @@ export function Component() {
       <div className="flex gap-6 lg:gap-8">
         {/* Left Sidebar: Mini Calendar (desktop only) */}
         <aside className="hidden w-64 shrink-0 lg:block">
-          <div className="sticky top-4 space-y-4">
+          {/* Offset clears the sticky site header (top-0) so the pinned widget
+              is not tucked underneath it. */}
+          <div className="sticky top-20 space-y-4">
             <MiniCalendar
               date={date}
               itemsByDay={itemsByDay}

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -2,9 +2,7 @@ import { ContentBody } from "@/components/content-body.js";
 import { Map } from "@/components/map.js";
 import { OutcomeBadge } from "@/components/outcome-badge.js";
 import { Scorecard } from "@/components/scorecard.js";
-import { Badge } from "@/components/ui/badge.js";
-import { Button, buttonVariants } from "@/components/ui/button.js";
-import { Card, CardContent } from "@/components/ui/card.js";
+import { StampButton, StampLink } from "@/components/theme/bits.js";
 import { WagonWheelModal } from "@/components/wagon-wheel-modal.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { hasWagonWheel, useWagonWheelQuery } from "@/hooks/use-wagon-wheel.js";
@@ -52,14 +50,11 @@ function SponsorThisGame({ gameId, when }: { gameId: string; when: string }) {
   if (!isFuture || pendingData?.hasPending) return null;
 
   return (
-    <div className="flex w-full flex-col items-center gap-2 rounded-lg border border-orange-200 bg-orange-50 px-4 py-3">
-      <p className="text-sm text-orange-600">No match sponsor… yet</p>
-      <Link
-        to={`/calendar/game/${gameId}/sponsor`}
-        className={buttonVariants({ variant: "default", size: "sm" })}
-      >
-        Sponsor This Game
-      </Link>
+    <div className="border-cta bg-surface text-primary flex w-full flex-col items-center gap-2 border-2 px-4 py-3">
+      <p className="text-cta text-sm">No match sponsor… yet</p>
+      <StampLink to={`/calendar/game/${gameId}/sponsor`}>
+        Sponsor This Game →
+      </StampLink>
     </div>
   );
 }
@@ -79,7 +74,7 @@ function formatInningsScore(inn: {
 
 function When({ start, end }: { start: string; end?: string }) {
   return (
-    <div className="flex w-full flex-row items-center justify-between gap-4 rounded-lg border border-orange-200 bg-orange-50 p-4 md:w-auto">
+    <div className="border-cta bg-surface text-primary flex w-full flex-row items-center justify-between gap-4 border-2 p-4 md:w-auto">
       <IoCalendar fontSize={32} />
       <div className="flex flex-col gap-4">
         <p>
@@ -112,39 +107,37 @@ function ResultSummary({
 }) {
   const isPairs = result.gameType === "Pairs";
   return (
-    <Card>
-      <CardContent className="flex flex-col gap-3 p-4">
-        <div className="flex flex-wrap items-center gap-2">
-          {result.outcome && <OutcomeBadge outcome={result.outcome} />}
-          {isPairs && (
-            <span className="rounded-full bg-stone-700 px-2 py-0.5 text-xs font-semibold text-white">
-              Women&apos;s Softball
+    <div className="border-primary bg-surface flex flex-col gap-3 border-2 p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        {result.outcome && <OutcomeBadge outcome={result.outcome} />}
+        {isPairs && (
+          <span className="bg-primary text-paper rounded-full px-2 py-0.5 text-xs font-semibold">
+            Women&apos;s Softball
+          </span>
+        )}
+        {result.toss && (
+          <span className="text-muted text-sm">{result.toss}</span>
+        )}
+      </div>
+      <div className="flex flex-col gap-2">
+        {result.innings.map((inn) => (
+          <div
+            key={`${inn.teamBattingId}-${inn.runs}-${inn.wickets}-${inn.overs}`}
+            className="flex items-baseline justify-between gap-4"
+          >
+            <span className="text-sm font-medium">{inn.teamName}</span>
+            <span className="flex items-baseline gap-2 font-mono text-sm font-semibold tabular-nums">
+              <span>{formatInningsScore(inn)}</span>
+              {inn.netScore !== null && (
+                <span className="border-border bg-surface text-primary rounded border px-1.5 py-0.5 text-xs font-bold">
+                  Net {inn.netScore}
+                </span>
+              )}
             </span>
-          )}
-          {result.toss && (
-            <span className="text-sm text-stone-600">{result.toss}</span>
-          )}
-        </div>
-        <div className="flex flex-col gap-2">
-          {result.innings.map((inn) => (
-            <div
-              key={`${inn.teamBattingId}-${inn.runs}-${inn.wickets}-${inn.overs}`}
-              className="flex items-baseline justify-between gap-4"
-            >
-              <span className="text-sm font-medium">{inn.teamName}</span>
-              <span className="flex items-baseline gap-2 font-mono text-sm font-semibold tabular-nums">
-                <span>{formatInningsScore(inn)}</span>
-                {inn.netScore !== null && (
-                  <span className="rounded bg-green-50 px-1.5 py-0.5 text-xs font-bold text-green-800">
-                    Net {inn.netScore}
-                  </span>
-                )}
-              </span>
-            </div>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -157,7 +150,7 @@ function SponsorBadge({
     !!sponsor.website && /^https?:\/\//i.test(sponsor.website);
 
   const content = (
-    <div className="flex w-full flex-col items-center gap-2 rounded-lg border border-orange-200 bg-orange-50 px-4 py-3">
+    <div className="border-cta bg-surface flex w-full flex-col items-center gap-2 border-2 px-4 py-3">
       {sponsor.logoUrl && (
         <img
           src={sponsor.logoUrl}
@@ -166,10 +159,10 @@ function SponsorBadge({
         />
       )}
       <div className="text-center">
-        <p className="text-xs text-orange-600">Match sponsored by</p>
+        <p className="text-cta text-xs">Match sponsored by</p>
         <p
           className={cn(
-            "text-lg font-semibold text-orange-800",
+            "text-cta text-lg font-semibold",
             hasValidWebsite && "underline decoration-dotted underline-offset-2",
           )}
         >
@@ -178,16 +171,14 @@ function SponsorBadge({
         {sponsor.phone && (
           <a
             href={`tel:${sponsor.phone}`}
-            className="mt-1 block text-sm text-orange-700 underline decoration-dotted underline-offset-2"
+            className="text-cta mt-1 block text-sm underline decoration-dotted underline-offset-2"
             onClick={(e) => e.stopPropagation()}
           >
             {sponsor.phone}
           </a>
         )}
       </div>
-      {sponsor.message && (
-        <p className="text-sm text-orange-600">{sponsor.message}</p>
-      )}
+      {sponsor.message && <p className="text-cta text-sm">{sponsor.message}</p>}
     </div>
   );
 
@@ -231,14 +222,9 @@ function BallByBallTrigger({ game }: { game: GameData }) {
   return (
     <>
       {available && (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => setOpen(true)}
-        >
-          Ball by ball viewer
-        </Button>
+        <StampButton variant="navy" size="sm" onClick={() => setOpen(true)}>
+          Ball by ball viewer →
+        </StampButton>
       )}
       <WagonWheelModal
         matchId={game.id}
@@ -302,22 +288,22 @@ function GameDetailContent({ game }: { game: GameData }) {
   return (
     <div className="container mx-auto px-4 py-6">
       <div className="text-h4 mb-4 flex items-center gap-2">
-        <Link to="/calendar" className="hover:text-primary text-stone-600">
+        <Link to="/calendar" className="hover:text-primary text-muted">
           Calendar
         </Link>
-        <IoChevronForward className="text-stone-400" size={14} />
+        <IoChevronForward className="text-muted" size={14} />
         {year && month && (
           <>
             <Link
               to={`/calendar/${year}/${month.toLowerCase()}`}
-              className="hover:text-primary text-stone-600"
+              className="hover:text-primary text-muted"
             >
               {month} {year}
             </Link>
-            <IoChevronForward className="text-stone-400" size={14} />
+            <IoChevronForward className="text-muted" size={14} />
           </>
         )}
-        <span className="text-dark font-medium">{title}</span>
+        <span className="fc-two-tone font-medium">{title}</span>
       </div>
 
       <div className="flex flex-col items-start gap-6">
@@ -408,9 +394,16 @@ function GameDetailContent({ game }: { game: GameData }) {
               {game.home !== undefined && (
                 <li>
                   <strong>Venue:</strong>{" "}
-                  <Badge variant={game.home ? "default" : "secondary"}>
+                  <span
+                    className={cn(
+                      "inline-flex items-center border-2 px-2 py-0.5 text-xs font-bold tracking-wider uppercase",
+                      game.home
+                        ? "border-primary text-primary"
+                        : "border-cta text-cta",
+                    )}
+                  >
                     {game.home ? "Home" : "Away"}
-                  </Badge>
+                  </span>
                 </li>
               )}
             </ul>
@@ -422,20 +415,18 @@ function GameDetailContent({ game }: { game: GameData }) {
 
         {/* Team lineup — hidden once Play Cricket has a result (scorecard shows actual teams) */}
         {!game.result && game.lineup && game.lineup.players.length > 0 && (
-          <Card>
-            <CardContent className="flex flex-col gap-3 p-4">
-              <h4 className="text-lg font-semibold">
-                {game.lineup.confirmed ? "Team" : "Selected Team"}
-              </h4>
-              <ol className="list-inside list-decimal space-y-1">
-                {game.lineup.players.map((player, pos) => (
-                  <li key={`${pos}-${player.name}`} className="text-sm">
-                    {player.name}
-                  </li>
-                ))}
-              </ol>
-            </CardContent>
-          </Card>
+          <div className="border-primary bg-surface flex flex-col gap-3 border-2 p-4">
+            <h4 className="fc-two-tone text-lg font-semibold">
+              {game.lineup.confirmed ? "Team" : "Selected Team"}
+            </h4>
+            <ol className="list-inside list-decimal space-y-1">
+              {game.lineup.players.map((player, pos) => (
+                <li key={`${pos}-${player.name}`} className="text-sm">
+                  {player.name}
+                </li>
+              ))}
+            </ol>
+          </div>
         )}
 
         {/* Result summary — full card if Play Cricket has data, badge-only for manual result */}
@@ -443,14 +434,10 @@ function GameDetailContent({ game }: { game: GameData }) {
           <ResultSummary result={game.result} />
         ) : (
           game.outcome && (
-            <Card>
-              <CardContent className="flex items-center gap-2 p-4">
-                <OutcomeBadge outcome={game.outcome} />
-                <span className="text-sm text-stone-600">
-                  Full scorecard pending
-                </span>
-              </CardContent>
-            </Card>
+            <div className="border-primary bg-surface flex items-center gap-2 border-2 p-4">
+              <OutcomeBadge outcome={game.outcome} />
+              <span className="text-muted text-sm">Full scorecard pending</span>
+            </div>
           )
         )}
 
@@ -476,7 +463,7 @@ function GameDetailContent({ game }: { game: GameData }) {
           center={{ lat: location.lat, lon: location.lon }}
           infoWindow={{ header: location.name }}
         >
-          <div className="flex flex-col gap-2 bg-white p-4 text-lg sm:text-sm">
+          <div className="border-primary bg-surface text-primary flex flex-col gap-2 border-2 p-4 text-lg sm:text-sm">
             <h4 className="text-lg font-semibold md:text-xl">
               {location.name}
             </h4>
@@ -516,9 +503,9 @@ export function Component() {
     return (
       <div className="container mx-auto px-4 py-12">
         <div className="flex flex-col gap-4">
-          <div className="h-6 w-64 animate-pulse rounded bg-stone-200" />
-          <div className="h-4 w-48 animate-pulse rounded bg-stone-100" />
-          <div className="h-32 animate-pulse rounded bg-stone-100" />
+          <div className="bg-primary/10 h-6 w-64 animate-pulse rounded" />
+          <div className="bg-primary/10 h-4 w-48 animate-pulse rounded" />
+          <div className="bg-primary/10 h-32 animate-pulse rounded" />
         </div>
       </div>
     );
@@ -527,8 +514,8 @@ export function Component() {
   if (!game) {
     return (
       <div className="container mx-auto px-4 py-12">
-        <h1 className="text-2xl font-semibold">Game Not Found</h1>
-        <p className="mt-2 text-stone-600">This game could not be found.</p>
+        <h1 className="fc-two-tone text-2xl font-semibold">Game Not Found</h1>
+        <p className="text-muted mt-2">This game could not be found.</p>
         <Link
           to="/calendar"
           className="text-primary mt-4 inline-block hover:underline"

--- a/apps/web/src/pages/calendar/game-sponsor-checkout.tsx
+++ b/apps/web/src/pages/calendar/game-sponsor-checkout.tsx
@@ -1,13 +1,6 @@
 import { PaymentForm } from "@/components/payment-form";
+import { StampButton } from "@/components/theme/bits.js";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
@@ -140,7 +133,7 @@ export function Component() {
   if (gameLoading) {
     return (
       <div className="container mx-auto max-w-md px-4 py-12">
-        <div className="h-6 w-48 animate-pulse rounded bg-stone-200" />
+        <div className="bg-primary/10 h-6 w-48 animate-pulse rounded" />
       </div>
     );
   }
@@ -148,8 +141,8 @@ export function Component() {
   if (!game) {
     return (
       <div className="container mx-auto max-w-md px-4 py-12">
-        <h1>Game Not Found</h1>
-        <Link to="/calendar" className="text-primary hover:underline">
+        <h1 className="fc-two-tone">Game Not Found</h1>
+        <Link to="/calendar" className="text-cta hover:underline">
           Back to Calendar
         </Link>
       </div>
@@ -159,29 +152,22 @@ export function Component() {
   if (step === "success") {
     return (
       <div className="container mx-auto max-w-md px-4 py-12">
-        <Card>
-          <CardHeader>
-            <CardTitle>Thank You!</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p>
-              Thank you for sponsoring this game! Your sponsorship details will
-              be reviewed by our team and displayed on the game page once
-              approved.
-            </p>
-            <p className="text-sm text-stone-600">
-              A confirmation email has been sent to {sponsorEmail}.
-            </p>
-          </CardContent>
-          <CardFooter>
-            <Link
-              to={`/calendar/game/${id}`}
-              className="text-primary text-sm hover:underline"
-            >
-              Back to game
-            </Link>
-          </CardFooter>
-        </Card>
+        <div className="border-primary bg-surface flex flex-col gap-3 border-2 p-6">
+          <h2 className="fc-two-tone text-xl font-semibold">Thank You!</h2>
+          <p>
+            Thank you for sponsoring this game! Your sponsorship details will be
+            reviewed by our team and displayed on the game page once approved.
+          </p>
+          <p className="text-muted text-sm">
+            A confirmation email has been sent to {sponsorEmail}.
+          </p>
+          <Link
+            to={`/calendar/game/${id}`}
+            className="text-cta self-start text-sm hover:underline"
+          >
+            Back to game
+          </Link>
+        </div>
       </div>
     );
   }
@@ -204,33 +190,35 @@ export function Component() {
     <div className="container mx-auto max-w-md px-4 py-6">
       {/* Breadcrumbs */}
       <div className="text-h4 mb-4 flex items-center gap-2">
-        <Link to="/calendar" className="hover:text-primary text-stone-600">
+        <Link to="/calendar" className="hover:text-primary text-muted">
           Calendar
         </Link>
-        <IoChevronForward className="text-stone-400" size={14} />
+        <IoChevronForward className="text-muted" size={14} />
         <Link
           to={`/calendar/game/${id}`}
-          className="hover:text-primary text-stone-600"
+          className="hover:text-primary text-muted"
         >
           {gameTitle}
         </Link>
-        <IoChevronForward className="text-stone-400" size={14} />
-        <span className="text-dark font-medium">Sponsor</span>
+        <IoChevronForward className="text-muted" size={14} />
+        <span className="text-primary font-medium">Sponsor</span>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Sponsor This Game</CardTitle>
-          <p className="text-sm text-stone-600">{gameTitle}</p>
-          <p className="text-sm text-stone-600">
+      <div className="border-primary bg-surface border-2 p-6">
+        <div className="space-y-1">
+          <h2 className="fc-two-tone text-xl font-semibold">
+            Sponsor This Game
+          </h2>
+          <p className="text-muted text-sm">{gameTitle}</p>
+          <p className="text-muted text-sm">
             Sponsor this game and your details will be displayed on the match
             page.
           </p>
-        </CardHeader>
+        </div>
 
-        <CardContent className="space-y-4">
+        <div className="mt-4 space-y-4">
           {priceData && (
-            <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+            <div className="border-primary bg-surface text-primary border-2 px-4 py-3 text-sm">
               Game sponsorship:{" "}
               <strong>
                 {currencyFormatter.format(priceData.amountPence / 100)}
@@ -292,7 +280,7 @@ export function Component() {
                 onChange={(e) => void handleLogoChange(e)}
               />
               {logoError && (
-                <p className="mt-1 text-xs text-red-600">{logoError}</p>
+                <p className="mt-1 text-xs text-red-700">{logoError}</p>
               )}
               {logoDataUrl && (
                 <img
@@ -312,7 +300,7 @@ export function Component() {
                 placeholder='e.g. "Good luck lads!" or "In memory of…"'
                 maxLength={MAX_MESSAGE_CHARS}
               />
-              <p className="mt-1 text-xs text-stone-400">
+              <p className="text-muted mt-1 text-xs">
                 {sponsorMessage.length}/{MAX_MESSAGE_CHARS}
               </p>
             </div>
@@ -325,23 +313,26 @@ export function Component() {
               </AlertDescription>
             </Alert>
           )}
-        </CardContent>
+        </div>
 
-        <CardFooter className="flex justify-between">
+        <div className="mt-6 flex items-center justify-between">
           <Link
             to={`/calendar/game/${id}`}
-            className="text-sm text-stone-500 hover:underline"
+            className="text-muted text-sm hover:underline"
           >
             Cancel
           </Link>
-          <Button
+          <StampButton
+            size="sm"
             onClick={() => paymentMutation.mutate()}
             disabled={!isFormValid || paymentMutation.isPending}
           >
-            {paymentMutation.isPending ? "Processing…" : "Continue to Payment"}
-          </Button>
-        </CardFooter>
-      </Card>
+            {paymentMutation.isPending
+              ? "Processing…"
+              : "Continue to Payment →"}
+          </StampButton>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/pages/content-page.tsx
+++ b/apps/web/src/pages/content-page.tsx
@@ -14,6 +14,7 @@ import {
   type NavNode,
   type NavPage,
 } from "@/lib/nav.js";
+import { cn } from "@/lib/utils.js";
 import { contentPathSchema } from "@percy-main/shared/content";
 import { useQuery } from "@tanstack/react-query";
 import { Fragment, useEffect, useState, type ReactNode } from "react";
@@ -36,35 +37,40 @@ function SidebarNav({
         const isActive = currentPath.startsWith(child.page.path);
         return (
           <Fragment key={child.page.path}>
+            {/* Top-level items read as printed section labels: condensed
+                display face, uppercase, with an orange registration bar
+                marking the active section. */}
             <Link
               to={child.page.path}
-              className={`py-1 ${
+              className={cn(
+                "font-secondary py-1.5 text-[15px] leading-tight tracking-wide uppercase transition-colors",
                 isActive
-                  ? "border-primary text-primary ml-[-0.76rem] border-l-4 pl-2 font-medium"
-                  : "hover:text-primary text-stone-700"
-              }`}
+                  ? "border-cta text-primary ml-[-0.85rem] border-l-4 pl-3"
+                  : "text-primary/70 hover:text-cta",
+              )}
             >
               {child.page.title}
             </Link>
             {child.children.length > 0 && (
-              <div className="ml-4 flex flex-col">
+              <div className="mt-1 mb-1 flex flex-col">
                 {child.children.map((grandchild) => {
                   const isChildActive =
                     currentPath === grandchild.page.path ||
                     currentPath.startsWith(grandchild.page.path + "/");
+                  // Each child carries its own left rule; the rules stack into
+                  // one continuous hairline, and the active child inks it orange.
                   return (
                     <Link
                       key={grandchild.page.path}
                       to={grandchild.page.path}
-                      className={`py-1 ${
+                      className={cn(
+                        "ml-1 border-l-2 py-1 pl-3 text-sm transition-colors",
                         isChildActive
-                          ? "border-primary text-primary ml-[-1.76rem] border-l-4 pl-4 font-medium"
-                          : "hover:text-primary text-stone-600"
-                      }`}
+                          ? "border-cta text-primary font-semibold"
+                          : "border-border text-muted hover:text-cta",
+                      )}
                     >
-                      <span className={isChildActive ? "pl-2" : ""}>
-                        {grandchild.page.title}
-                      </span>
+                      {grandchild.page.title}
                     </Link>
                   );
                 })}
@@ -90,18 +96,19 @@ function MobileSidebarNav({
 
   return (
     <nav className="text-sm md:hidden">
-      <div className="flex flex-col overflow-hidden rounded-lg border border-stone-200 bg-white shadow-md">
+      <div className="border-primary bg-surface flex flex-col overflow-hidden border-2">
         {tree.children.map((child) => {
           const isActive = currentPath.startsWith(child.page.path);
           return (
             <div key={child.page.path}>
               <Link
                 to={child.page.path}
-                className={`block border-b border-stone-100 px-4 py-2.5 font-medium transition-colors last:border-b-0 ${
+                className={cn(
+                  "font-secondary border-border block border-b px-4 py-2.5 tracking-wide uppercase transition-colors last:border-b-0",
                   isActive
-                    ? "bg-primary/5 text-primary"
-                    : "hover:text-primary text-stone-800 hover:bg-stone-50"
-                }`}
+                    ? "bg-cta/10 text-primary"
+                    : "text-primary/80 hover:bg-cta/10 hover:text-cta",
+                )}
               >
                 {child.page.title}
               </Link>
@@ -113,11 +120,12 @@ function MobileSidebarNav({
                   <Link
                     key={grandchild.page.path}
                     to={grandchild.page.path}
-                    className={`block border-b border-stone-100 py-2.5 pr-4 pl-9 transition-colors last:border-b-0 ${
+                    className={cn(
+                      "border-border block border-b py-2.5 pr-4 pl-9 transition-colors last:border-b-0",
                       isChildActive
-                        ? "bg-primary/5 text-primary font-medium"
-                        : "hover:text-primary text-stone-600 hover:bg-stone-50"
-                    }`}
+                        ? "bg-cta/10 text-primary font-semibold"
+                        : "text-muted hover:bg-cta/10 hover:text-cta",
+                    )}
                   >
                     {grandchild.page.title}
                   </Link>
@@ -154,12 +162,13 @@ function PageChrome({
 
   return (
     <div className="container mx-auto px-4 py-6">
-      {/* Breadcrumbs */}
-      <div className="text-h4 mb-4 flex items-center gap-2">
+      {/* Breadcrumbs: a compact letterspaced trail, the same kicker voice as
+          the rest of the print system. */}
+      <div className="mb-5 flex items-center gap-2 text-xs font-semibold tracking-wide uppercase">
         {hasSidebar && (
           <button
             onClick={() => setMobileNavOpen(!mobileNavOpen)}
-            className="text-dark flex cursor-pointer items-center p-1 md:hidden"
+            className="text-primary flex cursor-pointer items-center p-1 md:hidden"
             aria-label="Toggle section menu"
           >
             <svg className="size-5 fill-current" viewBox="0 0 20 20">
@@ -169,14 +178,13 @@ function PageChrome({
         )}
         {breadcrumbs.map((crumb, i) => (
           <span key={crumb.path} className="flex items-center gap-2">
-            {i > 0 && <IoChevronForward className="text-stone-400" size={14} />}
+            {i > 0 && (
+              <IoChevronForward className="text-primary/40" size={12} />
+            )}
             {i === breadcrumbs.length - 1 ? (
-              <span className="text-dark font-medium">{crumb.title}</span>
+              <span className="text-primary">{crumb.title}</span>
             ) : (
-              <Link
-                to={crumb.path}
-                className="hover:text-primary text-stone-600"
-              >
+              <Link to={crumb.path} className="text-muted hover:text-cta">
                 {crumb.title}
               </Link>
             )}

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -2,6 +2,7 @@ import { OptimisedImage } from "@/components/optimised-image.js";
 import { SeasonLeaders } from "@/components/season-leaders.js";
 import {
   Kicker,
+  PosterLink,
   Reveal,
   SectionMast,
   StampLink,
@@ -364,12 +365,9 @@ export function Component() {
             </div>
             <div className="mt-9 flex flex-wrap items-center gap-5">
               <StampLink to="/auth/register">Join the Club &rarr;</StampLink>
-              <Link
-                to="/charity/redevelopment"
-                className="font-secondary border-b-2 border-[#1b2a55] pb-1 text-[18px] tracking-wide text-[#1b2a55] uppercase transition hover:border-[#ef4a1e] hover:text-[#ef4a1e]"
-              >
+              <PosterLink to="/charity/redevelopment" className="text-[18px]">
                 Our redevelopment plans
-              </Link>
+              </PosterLink>
             </div>
           </div>
         </div>

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -6,6 +6,7 @@ import {
   SectionMast,
   StampLink,
 } from "@/components/theme/bits.js";
+import { FixtureStrip } from "@/components/theme/fixture-strip.js";
 import { Plate } from "@/components/theme/plate.js";
 import { RisoHeading } from "@/components/theme/riso-heading.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
@@ -239,31 +240,20 @@ function UpcomingStrip() {
         back="var(--fc-navy)"
         blend="normal"
       />
-      <div className="fc-fixtures">
-        {items.map((item) => (
-          <Link key={item.id} to={item.href} className="fc-frow">
-            <div className="fc-frow-date">
-              {formatInTimeZone(new Date(item.when), "Europe/London", "EEE dd")}
-              <br />
-              {formatInTimeZone(new Date(item.when), "Europe/London", "MMM")}
-            </div>
-            <div>
-              <div className="fc-frow-opp">{item.displayName}</div>
-              <div className="fc-frow-meta">
-                {item.type === "game" ? "Match" : "Club Event"} ·{" "}
-                {formatInTimeZone(
-                  new Date(item.when),
-                  "Europe/London",
-                  "h:mm a",
-                )}
-              </div>
-            </div>
-            <div className="fc-frow-tag">
-              {item.type === "game" ? (item.home ? "Home" : "Away") : "Event"}
-            </div>
-          </Link>
-        ))}
-      </div>
+      <FixtureStrip
+        items={items.map((item) => ({
+          id: item.id,
+          href: item.href,
+          when: item.when,
+          title: item.displayName,
+          meta: `${item.type === "game" ? "Match" : "Club Event"} · ${formatInTimeZone(
+            new Date(item.when),
+            "Europe/London",
+            "h:mm a",
+          )}`,
+          tag: item.type === "game" ? (item.home ? "Home" : "Away") : "Event",
+        }))}
+      />
       <div className="mt-7">
         <Link
           to="/calendar"
@@ -396,7 +386,7 @@ export function Component() {
           back="var(--fc-orange)"
           blend="normal"
         />
-        <div className="fc-statlines">
+        <div className="fc-stat fc-stat--invert">
           <SeasonLeaders />
         </div>
       </Plate>

--- a/apps/web/src/pages/membership/membership-join.tsx
+++ b/apps/web/src/pages/membership/membership-join.tsx
@@ -2,7 +2,7 @@ import {
   MemberDetails,
   useMemberDetails,
 } from "@/components/members/member-details";
-import { buttonVariants } from "@/components/ui/button";
+import { StampLink } from "@/components/theme/bits.js";
 import {
   Card,
   CardContent,
@@ -12,7 +12,6 @@ import {
 } from "@/components/ui/card";
 import { useDocumentMeta } from "@/hooks/use-document-meta";
 import { useSession } from "@/lib/auth-client";
-import { Link } from "react-router";
 
 function JoinWizardInner() {
   const session = useSession();
@@ -27,11 +26,13 @@ function JoinWizardInner() {
     <div className="mx-auto max-w-2xl">
       <Card>
         <CardHeader>
-          <CardTitle>Join Percy Main Community Sports Club</CardTitle>
+          <CardTitle className="fc-two-tone">
+            Join Percy Main Community Sports Club
+          </CardTitle>
         </CardHeader>
         <CardContent>
           {hasDetails ? (
-            <div className="rounded border border-green-300 bg-green-50 p-3 text-sm text-green-800">
+            <div className="border-primary bg-surface text-primary border-2 p-3 text-sm">
               Your details are already on file. You can proceed to payment.
             </div>
           ) : (
@@ -39,12 +40,9 @@ function JoinWizardInner() {
           )}
         </CardContent>
         <CardFooter className="flex justify-between">
-          <Link
-            to={`/membership/pay?email=${encodeURIComponent(email)}`}
-            className={buttonVariants()}
-          >
-            Choose Membership
-          </Link>
+          <StampLink to={`/membership/pay?email=${encodeURIComponent(email)}`}>
+            Choose Membership →
+          </StampLink>
         </CardFooter>
       </Card>
     </div>

--- a/apps/web/src/pages/membership/membership-junior.tsx
+++ b/apps/web/src/pages/membership/membership-junior.tsx
@@ -1,7 +1,8 @@
 import { PaymentForm } from "@/components/payment-form";
 import { RadioButtons } from "@/components/radio-buttons";
+import { Kicker, StampButton, StampLink } from "@/components/theme/bits.js";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -63,17 +64,17 @@ function StepIndicator({ currentStep }: { currentStep: Step }) {
   const currentIndex = STEPS.indexOf(currentStep);
   return (
     <nav className="mb-6">
-      <ol className="flex items-center text-xs font-medium text-stone-500 sm:text-sm">
+      <ol className="text-muted flex items-center text-xs font-medium sm:text-sm">
         {STEPS.map((step, i) => {
           const isActive = i === currentIndex;
           const isComplete = i < currentIndex;
           return (
             <li
               key={step}
-              className={`flex items-center ${i < STEPS.length - 1 ? "after:mx-2 after:inline-block after:h-px after:w-4 after:bg-stone-300 after:content-[''] sm:after:w-8" : ""}`}
+              className={`flex items-center ${i < STEPS.length - 1 ? "after:bg-border after:mx-2 after:inline-block after:h-px after:w-4 after:content-[''] sm:after:w-8" : ""}`}
             >
               <span
-                className={`flex items-center gap-1 whitespace-nowrap ${isActive ? "font-semibold text-blue-700" : ""} ${isComplete ? "text-green-600" : ""}`}
+                className={`flex items-center gap-1 whitespace-nowrap ${isActive ? "text-cta font-semibold" : ""} ${isComplete ? "text-primary" : ""}`}
               >
                 {isComplete && (
                   <svg
@@ -110,12 +111,12 @@ function StepNav({
 }) {
   return (
     <div className="mb-8 flex flex-wrap gap-3">
-      <Button type="button" variant="outline" onClick={onBack}>
+      <StampButton variant="navy" size="sm" onClick={onBack}>
         Back
-      </Button>
-      <Button type="button" onClick={onNext}>
-        {nextLabel}
-      </Button>
+      </StampButton>
+      <StampButton size="sm" onClick={onNext}>
+        {nextLabel} →
+      </StampButton>
     </div>
   );
 }
@@ -191,18 +192,15 @@ function SocialMembershipUpsell() {
   if (membership) return null;
 
   return (
-    <div className="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-4">
+    <div className="border-primary bg-surface text-primary mt-8 border-2 p-4">
       <p className="mb-2 text-sm font-semibold">Support the club?</p>
-      <p className="mb-3 text-sm text-stone-600">
+      <p className="text-muted mb-3 text-sm">
         As a parent you don&apos;t need a membership, but if you&apos;d like to
         support the club you can become a social member.
       </p>
-      <Link
-        to="/membership/pay"
-        className={buttonVariants({ variant: "outline" })}
-      >
-        Become a Social Member
-      </Link>
+      <StampLink to="/membership/pay" className="fc-stamp--navy fc-stamp--sm">
+        Become a Social Member →
+      </StampLink>
     </div>
   );
 }
@@ -255,7 +253,7 @@ function JuniorRegistrationInner() {
 
   const payMutation = useMutation({
     // Junior registration pays only the charge just created for these
-    // dependents — passing chargeIds prevents bundling unrelated
+    // dependents - passing chargeIds prevents bundling unrelated
     // outstanding charges (#93) like a parent's own membership fee.
     mutationFn: (chargeIds: string[]) =>
       callApi(
@@ -303,15 +301,13 @@ function JuniorRegistrationInner() {
   if (step === "done") {
     return (
       <div className="mx-auto max-w-2xl">
-        <div className="rounded-lg border border-green-200 bg-green-50 p-6 text-center">
-          <h4 className="mb-2">Registration & Payment Complete</h4>
-          <p className="mb-4 text-sm text-stone-600">
+        <div className="border-primary bg-surface flex flex-col items-center border-2 p-6 text-center">
+          <h4 className="fc-two-tone mb-2">Registration & Payment Complete</h4>
+          <p className="text-muted mb-4 text-sm">
             Your junior members have been registered and payment has been
             received. You can view your payment history in the members area.
           </p>
-          <Link to="/members?tab=payments" className={buttonVariants()}>
-            Go to Members Area
-          </Link>
+          <StampLink to="/members?tab=payments">Go to Members Area →</StampLink>
         </div>
         <SocialMembershipUpsell />
       </div>
@@ -320,8 +316,11 @@ function JuniorRegistrationInner() {
 
   return (
     <div className="mx-auto max-w-2xl">
-      <h4 className="mb-2">Junior Membership Registration</h4>
-      <p className="mb-4 text-sm text-stone-600">
+      <Kicker className="mb-1">
+        Step {STEPS.indexOf(step) + 1} of {STEPS.length} - {STEP_LABELS[step]}
+      </Kicker>
+      <h4 className="fc-two-tone mb-2">Junior Membership Registration</h4>
+      <p className="text-muted mb-4 text-sm">
         Register your children as junior members of Percy Main Cricket Club.
       </p>
 
@@ -333,7 +332,7 @@ function JuniorRegistrationInner() {
           {dependents.map((dep, i) => (
             <div
               key={dep.clientId}
-              className="mb-6 rounded-lg border border-stone-200 bg-white p-4 shadow-sm"
+              className="border-primary bg-surface mb-6 border-2 p-4"
             >
               <div className="mb-2 flex items-center justify-between">
                 <h5 className="text-sm font-semibold">
@@ -385,18 +384,21 @@ function JuniorRegistrationInner() {
               />
 
               {errors[i] && (
-                <p className="mt-1 text-sm text-red-600">{errors[i]}</p>
+                <p className="mt-1 text-sm text-red-700">{errors[i]}</p>
               )}
             </div>
           ))}
 
           <div className="mb-8 flex flex-wrap gap-3">
-            <Button type="button" variant="outline" onClick={addChild}>
+            <StampButton variant="navy" size="sm" onClick={addChild}>
               + Add Another Child
-            </Button>
-            <Button type="button" onClick={() => validateAndAdvance("cricket")}>
-              Next: Cricket Experience
-            </Button>
+            </StampButton>
+            <StampButton
+              size="sm"
+              onClick={() => validateAndAdvance("cricket")}
+            >
+              Next: Cricket Experience →
+            </StampButton>
           </div>
         </>
       )}
@@ -407,11 +409,11 @@ function JuniorRegistrationInner() {
           {dependents.map((dep, i) => (
             <div
               key={dep.clientId}
-              className="mb-6 rounded-lg border border-stone-200 bg-white p-4 shadow-sm"
+              className="border-primary bg-surface mb-6 border-2 p-4"
             >
               <h5 className="mb-3 text-sm font-semibold">{dep.name}</h5>
 
-              <p className="mb-2 text-sm font-medium text-stone-700">
+              <p className="text-primary mb-2 text-sm font-medium">
                 Has your child played cricket before?
               </p>
               <RadioButtons
@@ -437,7 +439,7 @@ function JuniorRegistrationInner() {
 
               {dep.played_before && (
                 <>
-                  <p className="mb-2 text-sm font-medium text-stone-700">
+                  <p className="text-primary mb-2 text-sm font-medium">
                     Where have they played cricket?
                   </p>
                   <RadioButtons
@@ -455,7 +457,7 @@ function JuniorRegistrationInner() {
               )}
 
               {errors[i] && (
-                <p className="mt-1 text-sm text-red-600">{errors[i]}</p>
+                <p className="mt-1 text-sm text-red-700">{errors[i]}</p>
               )}
             </div>
           ))}
@@ -474,11 +476,11 @@ function JuniorRegistrationInner() {
           {dependents.map((dep, i) => (
             <div
               key={dep.clientId}
-              className="mb-6 rounded-lg border border-stone-200 bg-white p-4 shadow-sm"
+              className="border-primary bg-surface mb-6 border-2 p-4"
             >
               <h5 className="mb-3 text-sm font-semibold">{dep.name}</h5>
 
-              <p className="mb-2 text-sm font-medium text-stone-700">
+              <p className="text-primary mb-2 text-sm font-medium">
                 Do you give permission for your mobile phone number to be added
                 to this child&apos;s team WhatsApp groups?
               </p>
@@ -500,7 +502,7 @@ function JuniorRegistrationInner() {
                 ]}
               />
 
-              <h6 className="mt-4 mb-2 text-sm font-semibold text-stone-700">
+              <h6 className="text-primary mt-4 mb-2 text-sm font-semibold">
                 Alternative Contact
               </h6>
               {i > 0 && (
@@ -540,7 +542,7 @@ function JuniorRegistrationInner() {
                   updateDependent(i, { alt_contact_phone: val })
                 }
               />
-              <p className="mb-2 text-sm font-medium text-stone-700">
+              <p className="text-primary mb-2 text-sm font-medium">
                 Would you like the alternative contact phone number to be added
                 to team WhatsApp groups?
               </p>
@@ -565,7 +567,7 @@ function JuniorRegistrationInner() {
               />
 
               {errors[i] && (
-                <p className="mt-1 text-sm text-red-600">{errors[i]}</p>
+                <p className="mt-1 text-sm text-red-700">{errors[i]}</p>
               )}
             </div>
           ))}
@@ -584,7 +586,7 @@ function JuniorRegistrationInner() {
           {dependents.map((dep, i) => (
             <div
               key={dep.clientId}
-              className="mb-6 rounded-lg border border-stone-200 bg-white p-4 shadow-sm"
+              className="border-primary bg-surface mb-6 border-2 p-4"
             >
               <h5 className="mb-3 text-sm font-semibold">{dep.name}</h5>
 
@@ -621,7 +623,7 @@ function JuniorRegistrationInner() {
                 onChange={(val) => updateDependent(i, { gp_phone: val })}
               />
 
-              <p className="mb-2 text-sm font-medium text-stone-700">
+              <p className="text-primary mb-2 text-sm font-medium">
                 Do you consider your child to have a disability?
               </p>
               <RadioButtons
@@ -647,7 +649,7 @@ function JuniorRegistrationInner() {
 
               {dep.has_disability && (
                 <>
-                  <p className="mb-2 text-sm font-medium text-stone-700">
+                  <p className="text-primary mb-2 text-sm font-medium">
                     What is the nature of the disability?
                   </p>
                   <RadioButtons
@@ -679,8 +681,8 @@ function JuniorRegistrationInner() {
                 />
               </div>
 
-              <div className="mt-4 rounded border border-amber-200 bg-amber-50 p-3">
-                <p className="mb-2 text-sm font-medium text-stone-700">
+              <div className="border-cta bg-surface mt-4 border-2 p-3">
+                <p className="text-primary mb-2 text-sm font-medium">
                   I give my consent that in an emergency situation, the Club may
                   act in loco parentis to seek emergency medical treatment,
                   including anaesthetic if required.
@@ -706,8 +708,8 @@ function JuniorRegistrationInner() {
                 />
               </div>
 
-              <div className="mt-4 rounded border border-amber-200 bg-amber-50 p-3">
-                <p className="mb-2 text-sm font-medium text-stone-700">
+              <div className="border-cta bg-surface mt-4 border-2 p-3">
+                <p className="text-primary mb-2 text-sm font-medium">
                   I confirm that to the best of my knowledge, my child does not
                   suffer from any medical condition other than those listed
                   above.
@@ -734,7 +736,7 @@ function JuniorRegistrationInner() {
               </div>
 
               {errors[i] && (
-                <p className="mt-1 text-sm text-red-600">{errors[i]}</p>
+                <p className="mt-1 text-sm text-red-700">{errors[i]}</p>
               )}
             </div>
           ))}
@@ -750,9 +752,9 @@ function JuniorRegistrationInner() {
       {/* Step 5: Consents */}
       {step === "consents" && (
         <>
-          <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
+          <div className="border-primary bg-surface text-primary mb-6 border-2 p-4">
             <h5 className="mb-2 text-sm font-semibold">Data Protection</h5>
-            <p className="text-sm text-stone-600">
+            <p className="text-muted text-sm">
               Percy Main Cricket Club collects personal data to administer
               membership, organise cricket activities, and communicate with
               members. Your data is processed in accordance with our{" "}
@@ -760,7 +762,7 @@ function JuniorRegistrationInner() {
                 to="/legal/privacy"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-700 underline hover:text-blue-900"
+                className="text-primary decoration-cta/70 hover:text-cta underline underline-offset-2"
               >
                 Privacy Policy
               </Link>
@@ -773,12 +775,12 @@ function JuniorRegistrationInner() {
           {dependents.map((dep, i) => (
             <div
               key={dep.clientId}
-              className="mb-6 rounded-lg border border-stone-200 bg-white p-4 shadow-sm"
+              className="border-primary bg-surface mb-6 border-2 p-4"
             >
               <h5 className="mb-3 text-sm font-semibold">{dep.name}</h5>
 
-              <div className="mb-4 rounded border border-amber-200 bg-amber-50 p-3">
-                <p className="mb-2 text-sm font-medium text-stone-700">
+              <div className="border-cta bg-surface mb-4 border-2 p-3">
+                <p className="text-primary mb-2 text-sm font-medium">
                   I confirm I have read the Privacy Policy and consent to the
                   processing of my child&apos;s personal data as described.
                 </p>
@@ -803,8 +805,8 @@ function JuniorRegistrationInner() {
                 />
               </div>
 
-              <div className="rounded border border-amber-200 bg-amber-50 p-3">
-                <p className="mb-2 text-sm font-medium text-stone-700">
+              <div className="border-cta bg-surface border-2 p-3">
+                <p className="text-primary mb-2 text-sm font-medium">
                   I give my consent to my child being photographed and/or
                   videoed for the purposes of coaching and/or publicity.
                 </p>
@@ -830,7 +832,7 @@ function JuniorRegistrationInner() {
               </div>
 
               {errors[i] && (
-                <p className="mt-1 text-sm text-red-600">{errors[i]}</p>
+                <p className="mt-1 text-sm text-red-700">{errors[i]}</p>
               )}
             </div>
           ))}
@@ -849,7 +851,7 @@ function JuniorRegistrationInner() {
           {dependents.map((dep, i) => (
             <div
               key={dep.clientId}
-              className="mb-6 rounded-lg border border-stone-200 bg-white p-4 shadow-sm"
+              className="border-primary bg-surface mb-6 border-2 p-4"
             >
               <div className="mb-2 flex items-center justify-between">
                 <h5 className="font-semibold">
@@ -857,27 +859,27 @@ function JuniorRegistrationInner() {
                 </h5>
               </div>
               <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-                <dt className="font-medium text-stone-500">Date of Birth</dt>
+                <dt className="text-muted font-medium">Date of Birth</dt>
                 <dd>{format(new Date(dep.dob), "dd/MM/yyyy")}</dd>
-                <dt className="font-medium text-stone-500">Gender</dt>
+                <dt className="text-muted font-medium">Gender</dt>
                 <dd className="capitalize">{dep.sex}</dd>
-                <dt className="font-medium text-stone-500">School Year</dt>
+                <dt className="text-muted font-medium">School Year</dt>
                 <dd>{dep.school_year}</dd>
-                <dt className="font-medium text-stone-500">Played Before</dt>
+                <dt className="text-muted font-medium">Played Before</dt>
                 <dd>{dep.played_before ? "Yes" : "No"}</dd>
                 {dep.played_before && dep.previous_cricket && (
                   <>
-                    <dt className="font-medium text-stone-500">Where</dt>
+                    <dt className="text-muted font-medium">Where</dt>
                     <dd>{dep.previous_cricket}</dd>
                   </>
                 )}
-                <dt className="font-medium text-stone-500">Photo Consent</dt>
+                <dt className="text-muted font-medium">Photo Consent</dt>
                 <dd>{dep.photo_consent ? "Yes" : "No"}</dd>
               </dl>
             </div>
           ))}
 
-          <div className="mb-6 rounded-lg border border-stone-200 bg-white p-4 shadow-sm">
+          <div className="border-primary bg-surface mb-6 border-2 p-4">
             <h5 className="mb-2 font-semibold">Payment Summary</h5>
             <table className="w-full text-left text-sm">
               <thead>
@@ -907,14 +909,14 @@ function JuniorRegistrationInner() {
             </table>
           </div>
 
-          <p className="mb-4 text-sm text-stone-600">
+          <p className="text-muted mb-4 text-sm">
             This is a one-off payment for junior membership valid until the end
             of {new Date().getFullYear()}. You will not be automatically charged
             when it expires.
           </p>
 
           {addDependentsMutation.error && (
-            <p className="mb-4 text-sm text-red-600">
+            <p className="mb-4 text-sm text-red-700">
               {addDependentsMutation.error instanceof Error
                 ? addDependentsMutation.error.message
                 : "Registration failed. Please try again."}
@@ -922,22 +924,22 @@ function JuniorRegistrationInner() {
           )}
 
           <div className="mb-8 flex flex-wrap gap-3">
-            <Button
-              type="button"
-              variant="outline"
+            <StampButton
+              variant="navy"
+              size="sm"
               onClick={() => setStep("consents")}
             >
               Back
-            </Button>
-            <Button
-              type="button"
+            </StampButton>
+            <StampButton
+              size="sm"
               disabled={addDependentsMutation.isPending}
               onClick={() => void handleSubmit()}
             >
               {addDependentsMutation.isPending
                 ? "Registering…"
-                : "Confirm & Continue to Payment"}
-            </Button>
+                : "Confirm & Continue to Payment →"}
+            </StampButton>
           </div>
         </>
       )}
@@ -946,8 +948,8 @@ function JuniorRegistrationInner() {
       {step === "payment" && (
         <div>
           {payMutation.isPending && !paymentData && (
-            <div className="rounded-lg border border-stone-200 bg-white p-6 text-center">
-              <p className="text-sm text-stone-600">Setting up payment…</p>
+            <div className="border-primary bg-surface border-2 p-6 text-center">
+              <p className="text-muted text-sm">Setting up payment…</p>
             </div>
           )}
 
@@ -956,9 +958,9 @@ function JuniorRegistrationInner() {
               <Alert variant="destructive">
                 <AlertDescription>{paymentError}</AlertDescription>
               </Alert>
-              <div className="flex flex-wrap gap-3">
-                <Button
-                  type="button"
+              <div className="flex flex-wrap items-center gap-3">
+                <StampButton
+                  size="sm"
                   disabled={!addDependentsMutation.data?.chargeId}
                   onClick={() => {
                     const chargeId = addDependentsMutation.data?.chargeId;
@@ -967,11 +969,11 @@ function JuniorRegistrationInner() {
                     payMutation.mutate([chargeId]);
                   }}
                 >
-                  Try Again
-                </Button>
+                  Try Again →
+                </StampButton>
                 <Link
                   to="/members?tab=payments"
-                  className={buttonVariants({ variant: "outline" })}
+                  className="text-primary decoration-cta/70 hover:text-cta text-sm underline underline-offset-2"
                 >
                   Pay Later
                 </Link>
@@ -993,7 +995,7 @@ function JuniorRegistrationInner() {
                       },
                     }),
                   ).catch(() => {
-                    // Payment succeeded at Stripe but confirmation failed — the
+                    // Payment succeeded at Stripe but confirmation failed - the
                     // webhook will reconcile, so still show success.
                   });
                   setStep("done");
@@ -1002,11 +1004,11 @@ function JuniorRegistrationInner() {
                   window.location.href = "/members?tab=payments";
                 }}
               />
-              <p className="text-center text-sm text-stone-500">
+              <p className="text-muted text-center text-sm">
                 Or{" "}
                 <Link
                   to="/members?tab=payments"
-                  className="text-blue-700 underline hover:text-blue-900"
+                  className="text-primary decoration-cta/70 hover:text-cta underline underline-offset-2"
                 >
                   pay later in the members area
                 </Link>

--- a/apps/web/src/pages/membership/membership-pay.tsx
+++ b/apps/web/src/pages/membership/membership-pay.tsx
@@ -1,10 +1,10 @@
 import { RadioButtons } from "@/components/radio-buttons";
-import { buttonVariants } from "@/components/ui/button";
+import { StampLink } from "@/components/theme/bits.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta";
 import { api, callApi } from "@/lib/api-client";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { Link, useSearchParams } from "react-router";
+import { useSearchParams } from "react-router";
 
 type MembershipType =
   | "senior_player"
@@ -28,7 +28,7 @@ function PayMembershipInner() {
 
   if (isLoading || !options) {
     return (
-      <div className="text-center text-sm text-stone-500">Loading prices…</div>
+      <div className="text-muted text-center text-sm">Loading prices…</div>
     );
   }
 
@@ -58,7 +58,7 @@ function PayMembershipInner() {
 
   return (
     <div className="mx-auto max-w-2xl">
-      <h4>Choose Your Membership</h4>
+      <h4 className="fc-two-tone">Choose Your Membership</h4>
 
       <div className="mt-8">
         <section className="mb-12">
@@ -128,12 +128,11 @@ function PayMembershipInner() {
           </section>
           {selectedPrice && (
             <section className="mb-12">
-              <Link
+              <StampLink
                 to={`/purchase/${selectedPrice.id}?${purchaseParams.toString()}`}
-                className={buttonVariants()}
               >
-                Pay Online
-              </Link>
+                Pay Online →
+              </StampLink>
             </section>
           )}
         </>

--- a/apps/web/src/pages/news/news-list-view.tsx
+++ b/apps/web/src/pages/news/news-list-view.tsx
@@ -1,6 +1,8 @@
 import { OptimisedImage } from "@/components/optimised-image.js";
 import { PageLoading } from "@/components/page-loading.js";
 import { PrefetchLink } from "@/components/prefetch-link.js";
+import { Kicker } from "@/components/theme/bits.js";
+import { RisoHeading } from "@/components/theme/riso-heading.js";
 import type { paths } from "@/lib/api.gen.js";
 import { getCategoryColor } from "@/lib/category-colors.js";
 import {
@@ -100,12 +102,12 @@ function FeaturedArticleCard({ article }: { article: NewsListItem }) {
     <PrefetchLink
       query={newsArticleQueryOptions(article.slug)}
       to={`/news/article/${article.slug}`}
-      className="featured-card relative mb-7 block cursor-pointer overflow-hidden rounded-2xl bg-white"
+      className="group border-primary bg-surface relative mb-7 block cursor-pointer overflow-hidden border-2 transition-transform duration-200 hover:-translate-y-[3px]"
     >
-      <div className="from-primary via-primary-light to-cta h-1 bg-gradient-to-r" />
+      <div className="bg-cta h-1.5" />
       <div className="flex flex-col gap-3.5 p-5 pb-6 sm:p-7">
         <div className="flex items-center gap-3">
-          <span className="bg-primary inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-[11px] font-bold tracking-wider text-white uppercase">
+          <span className="bg-primary text-paper inline-flex items-center gap-1.5 px-3 py-1 text-[11px] font-bold tracking-wider uppercase">
             <svg
               className="size-3"
               viewBox="0 0 24 24"
@@ -119,16 +121,16 @@ function FeaturedArticleCard({ article }: { article: NewsListItem }) {
             </svg>
             Latest
           </span>
-          <span className="text-[13px] text-stone-500">
+          <span className="text-muted text-[13px]">
             {format(article.date, "d MMMM yyyy")}
           </span>
         </div>
 
-        <h2 className="font-secondary text-dark m-0 text-[22px] leading-snug font-semibold sm:text-[28px]">
+        <h2 className="font-secondary text-primary group-hover:text-cta m-0 text-[26px] leading-[0.95] tracking-wide uppercase transition-colors duration-150 sm:text-[32px]">
           {article.title}
         </h2>
 
-        <div className="flex items-center justify-between border-t border-black/5 pt-4">
+        <div className="border-primary/15 flex items-center justify-between border-t pt-4">
           <div className="flex items-center gap-2.5">
             {article.author?.picture ? (
               <OptimisedImage
@@ -138,29 +140,27 @@ function FeaturedArticleCard({ article }: { article: NewsListItem }) {
                 sizes="32px"
               />
             ) : (
-              <div className="bg-home-bg text-primary flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-bold">
+              <div className="bg-primary text-paper flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-bold">
                 {initials}
               </div>
             )}
-            <span className="text-dark text-sm font-semibold">
+            <span className="text-primary text-sm font-semibold">
               {article.author?.name}
             </span>
           </div>
-          <span className="text-primary inline-flex items-center gap-2 text-sm font-semibold">
+          <span className="text-primary group-hover:text-cta inline-flex items-center gap-2 text-sm font-semibold transition-colors duration-150">
             Read article
-            <span className="bg-home-bg flex size-7 items-center justify-center rounded-full transition-all duration-200">
-              <svg
-                className="size-3.5"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <polyline points="9 18 15 12 9 6" />
-              </svg>
-            </span>
+            <svg
+              className="size-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
           </span>
         </div>
       </div>
@@ -175,7 +175,7 @@ function ArticleCard({ article }: { article: NewsListItem }) {
     <PrefetchLink
       query={newsArticleQueryOptions(article.slug)}
       to={`/news/article/${article.slug}`}
-      className="article-card relative mb-3.5 block cursor-pointer overflow-hidden rounded-[14px] bg-white shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)] transition-all duration-[250ms] hover:-translate-y-[3px] hover:shadow-[0_12px_32px_rgba(27,61,47,0.08),0_4px_8px_rgba(0,0,0,0.04)]"
+      className="group border-primary bg-surface relative mb-3.5 block cursor-pointer overflow-hidden border-2 transition-transform duration-200 hover:-translate-y-[3px]"
     >
       <div className="flex flex-col gap-3 p-5 sm:px-6">
         <div className="flex items-center justify-between gap-3">
@@ -185,7 +185,7 @@ function ArticleCard({ article }: { article: NewsListItem }) {
               return (
                 <span
                   key={tag}
-                  className="inline-flex items-center gap-1 rounded-md px-2.5 py-0.5 text-[11px] font-semibold tracking-wide"
+                  className="inline-flex items-center gap-1 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide"
                   style={{ background: c.bg, color: c.text }}
                 >
                   {tag}
@@ -193,16 +193,16 @@ function ArticleCard({ article }: { article: NewsListItem }) {
               );
             })}
           </div>
-          <span className="shrink-0 text-[13px] whitespace-nowrap text-stone-500 max-md:hidden">
+          <span className="text-muted shrink-0 text-[13px] whitespace-nowrap max-md:hidden">
             {format(article.date, "EEEE, d MMMM yyyy")}
           </span>
         </div>
 
-        <h3 className="font-secondary text-dark m-0 text-[20px] leading-snug font-semibold transition-colors duration-150">
+        <h3 className="font-secondary text-primary group-hover:text-cta m-0 text-[24px] leading-[0.95] tracking-wide uppercase transition-colors duration-150">
           {article.title}
         </h3>
 
-        <div className="mt-0.5 flex items-center justify-between border-t border-black/[0.04] pt-3">
+        <div className="border-primary/15 mt-0.5 flex items-center justify-between border-t pt-3">
           <div className="flex items-center gap-2.5">
             {article.author?.picture ? (
               <OptimisedImage
@@ -212,15 +212,15 @@ function ArticleCard({ article }: { article: NewsListItem }) {
                 sizes="28px"
               />
             ) : (
-              <div className="bg-home-bg text-primary flex size-7 shrink-0 items-center justify-center rounded-full text-[11px] font-bold">
+              <div className="bg-primary text-paper flex size-7 shrink-0 items-center justify-center rounded-full text-[11px] font-bold">
                 {initials}
               </div>
             )}
-            <span className="text-dark text-[13px] font-semibold">
+            <span className="text-primary text-[13px] font-semibold">
               {article.author?.name}
             </span>
           </div>
-          <span className="text-primary inline-flex items-center gap-1.5 text-[13px] font-semibold">
+          <span className="text-primary group-hover:text-cta inline-flex items-center gap-1.5 text-[13px] font-semibold transition-colors duration-150">
             Read article
             <svg
               width="16"
@@ -263,7 +263,7 @@ function Pagination({
       {currentPage > 1 ? (
         <Link
           to={`${basePath}/${String(currentPage - 1)}`}
-          className="text-text hover:border-primary hover:text-primary flex size-9 items-center justify-center rounded-full border-[1.5px] border-stone-200 bg-white transition-all duration-150"
+          className="border-border bg-surface text-primary hover:bg-primary hover:text-paper hover:border-primary flex size-9 items-center justify-center border-2 transition-colors duration-150"
         >
           <svg
             width="16"
@@ -279,7 +279,7 @@ function Pagination({
           </svg>
         </Link>
       ) : (
-        <span className="text-text pointer-events-none flex size-9 items-center justify-center rounded-full border-[1.5px] border-stone-200 bg-white opacity-30">
+        <span className="border-border bg-surface text-primary pointer-events-none flex size-9 items-center justify-center border-2 opacity-30">
           <svg
             width="16"
             height="16"
@@ -294,13 +294,13 @@ function Pagination({
           </svg>
         </span>
       )}
-      <span className="text-text min-w-[60px] px-2 text-center text-[13px] opacity-50">
+      <span className="text-muted min-w-[60px] px-2 text-center text-[13px] font-semibold">
         {currentPage} / {lastPage}
       </span>
       {currentPage < lastPage ? (
         <Link
           to={`${basePath}/${String(currentPage + 1)}`}
-          className="text-text hover:border-primary hover:text-primary flex size-9 items-center justify-center rounded-full border-[1.5px] border-stone-200 bg-white transition-all duration-150"
+          className="border-border bg-surface text-primary hover:bg-primary hover:text-paper hover:border-primary flex size-9 items-center justify-center border-2 transition-colors duration-150"
         >
           <svg
             width="16"
@@ -316,7 +316,7 @@ function Pagination({
           </svg>
         </Link>
       ) : (
-        <span className="text-text pointer-events-none flex size-9 items-center justify-center rounded-full border-[1.5px] border-stone-200 bg-white opacity-30">
+        <span className="border-border bg-surface text-primary pointer-events-none flex size-9 items-center justify-center border-2 opacity-30">
           <svg
             width="16"
             height="16"
@@ -349,38 +349,42 @@ function NewsSidebar({
   return (
     <aside className="hidden w-[260px] shrink-0 lg:block">
       <div className="sticky top-4 flex flex-col gap-4">
-        <div className="rounded-xl border border-black/[0.06] bg-white p-4 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
-          <h3 className="mb-3 text-sm font-semibold">Overview</h3>
+        <div className="border-primary bg-surface border-2 p-4">
+          <h3 className="font-secondary text-primary mb-3 text-base tracking-wide uppercase">
+            Overview
+          </h3>
           <div className="grid grid-cols-2 gap-2">
-            <div className="bg-home-bg text-primary rounded-lg p-2.5 text-center">
-              <div className="font-secondary text-xl leading-none font-bold">
+            <div className="border-border bg-surface text-primary border p-2.5 text-center">
+              <div className="font-secondary text-2xl leading-none">
                 {totalArticleCount}
               </div>
-              <div className="mt-1 text-[10px] font-semibold tracking-wide uppercase">
+              <div className="text-muted mt-1 text-[10px] font-semibold tracking-wide uppercase">
                 Articles
               </div>
             </div>
-            <div className="rounded-lg bg-[#fef3c7] p-2.5 text-center text-[#d97706]">
-              <div className="font-secondary text-xl leading-none font-bold">
+            <div className="border-border bg-surface text-cta border p-2.5 text-center">
+              <div className="font-secondary text-2xl leading-none">
                 {uniqueAuthorCount}
               </div>
-              <div className="mt-1 text-[10px] font-semibold tracking-wide uppercase">
+              <div className="text-muted mt-1 text-[10px] font-semibold tracking-wide uppercase">
                 Authors
               </div>
             </div>
           </div>
         </div>
 
-        <div className="rounded-xl border border-black/[0.06] bg-white p-4 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
-          <h3 className="mb-3 text-sm font-semibold">Archive</h3>
+        <div className="border-primary bg-surface border-2 p-4">
+          <h3 className="font-secondary text-primary mb-3 text-base tracking-wide uppercase">
+            Archive
+          </h3>
           <div className="flex flex-col">
             {archiveMonths.map((m) => (
               <div
                 key={m.label}
-                className="text-text flex items-center justify-between border-b border-black/[0.04] py-1.5 text-[13px] last:border-b-0"
+                className="text-muted border-border/40 flex items-center justify-between border-b py-1.5 text-[13px] last:border-b-0"
               >
                 <span>{m.label}</span>
-                <span className="rounded-full bg-black/5 px-2 py-0.5 text-[11px] font-semibold">
+                <span className="bg-primary text-paper px-2 py-0.5 text-[11px] font-semibold">
                   {m.count}
                 </span>
               </div>
@@ -411,10 +415,10 @@ function FilterPills({
     <div className="mb-5 flex flex-wrap items-center gap-2">
       <Link
         to="/news/1"
-        className={`inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-[13px] font-semibold transition-all ${
+        className={`inline-flex items-center gap-1.5 border-2 px-3.5 py-1.5 text-[13px] font-semibold tracking-wide uppercase transition-colors ${
           activeTag === null
-            ? "bg-primary text-white"
-            : "text-text bg-white hover:bg-stone-50"
+            ? "border-primary bg-primary text-paper"
+            : "border-border bg-surface text-primary hover:bg-cta/10"
         }`}
       >
         All <span className="text-[11px] opacity-70">{totalCount}</span>
@@ -426,8 +430,10 @@ function FilterPills({
           <Link
             key={tag}
             to={isActive ? "/news/1" : `/news/tag/${encodeURIComponent(tag)}/1`}
-            className={`inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-[13px] font-medium transition-all ${
-              isActive ? "ring-primary/30 ring-2" : "bg-white hover:bg-stone-50"
+            className={`inline-flex items-center gap-1.5 border-2 px-3.5 py-1.5 text-[13px] font-semibold tracking-wide uppercase transition-colors ${
+              isActive
+                ? "border-primary bg-primary text-paper"
+                : "border-border bg-surface text-primary hover:bg-cta/10"
             }`}
           >
             <span
@@ -435,7 +441,7 @@ function FilterPills({
               style={{ background: c.dot }}
             />
             {tag}
-            <span className="text-[11px] opacity-50">{count}</span>
+            <span className="text-[11px] opacity-60">{count}</span>
           </Link>
         );
       })}
@@ -460,10 +466,8 @@ export function NewsListView({
   if (isPending) {
     return (
       <div className="container mx-auto px-4 py-6">
-        <div className="text-h4 mb-4 flex items-center gap-2">
-          <span className="text-dark font-medium">News</span>
-        </div>
-        <h1 className="mb-1 text-[2rem] leading-tight">News</h1>
+        <Kicker className="mb-3">From the club</Kicker>
+        <RisoHeading as="h1">News</RisoHeading>
         <PageLoading />
       </div>
     );
@@ -511,16 +515,12 @@ export function NewsListView({
 
   return (
     <div className="container mx-auto px-4 py-6">
-      {/* Breadcrumbs */}
-      <div className="text-h4 mb-4 flex items-center gap-2">
-        <span className="text-dark font-medium">News</span>
-      </div>
-
       {/* Page header */}
-      <div className="mb-5 flex flex-col items-start justify-between gap-3 sm:flex-row">
+      <div className="mb-5 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
         <div>
-          <h1 className="mb-1 text-[2rem] leading-tight">News</h1>
-          <div className="text-text text-sm opacity-60">
+          <Kicker className="mb-3">From the club</Kicker>
+          <RisoHeading as="h1">News</RisoHeading>
+          <div className="text-muted mt-2 text-sm font-semibold tracking-wide uppercase">
             {vm.totalArticles} articles &middot; {vm.tags.length} tags
           </div>
         </div>
@@ -553,7 +553,7 @@ export function NewsListView({
 
           {[...byMonth.entries()].map(([month, articles]) => (
             <div key={month} className="mb-7">
-              <div className="font-secondary border-primary text-dark mb-3.5 inline-block border-b-2 pb-2 text-base font-bold">
+              <div className="font-secondary border-cta text-primary mb-3.5 inline-block border-b-2 pb-2 text-lg tracking-wide uppercase">
                 {month}
               </div>
               {articles.map((article) => (
@@ -563,7 +563,7 @@ export function NewsListView({
           ))}
 
           {vm.items.length === 0 && (
-            <p className="py-8 text-center text-stone-500">
+            <p className="text-muted py-8 text-center">
               No articles found for this tag.
             </p>
           )}

--- a/apps/web/src/pages/person/player-stats.tsx
+++ b/apps/web/src/pages/person/player-stats.tsx
@@ -40,7 +40,11 @@ function FormatSection({
 
   return (
     <section className="mb-8 last:mb-0">
-      {showHeading && <Kicker className="mb-3">{format.label}</Kicker>}
+      {showHeading && (
+        <Kicker level={3} className="mb-3">
+          {format.label}
+        </Kicker>
+      )}
 
       <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
         <StatCard label="Matches" value={String(career.batting.matches)} />

--- a/apps/web/src/pages/person/player-stats.tsx
+++ b/apps/web/src/pages/person/player-stats.tsx
@@ -1,3 +1,4 @@
+import { Kicker } from "@/components/theme/bits.js";
 import {
   Table,
   TableBody,
@@ -18,9 +19,9 @@ type FormatStats = CareerStats["formats"][number];
 
 function StatCard({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-lg border border-stone-200 bg-stone-50 px-3 py-2 text-center">
-      <div className="text-lg font-bold text-green-800">{value}</div>
-      <div className="text-xs text-stone-500">{label}</div>
+    <div className="border-primary bg-surface border-2 px-3 py-2 text-center">
+      <div className="text-primary text-lg font-bold">{value}</div>
+      <div className="text-muted text-xs">{label}</div>
     </div>
   );
 }
@@ -39,11 +40,7 @@ function FormatSection({
 
   return (
     <section className="mb-8 last:mb-0">
-      {showHeading && (
-        <h3 className="mb-3 text-base font-semibold text-stone-700">
-          {format.label}
-        </h3>
-      )}
+      {showHeading && <Kicker className="mb-3">{format.label}</Kicker>}
 
       <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
         <StatCard label="Matches" value={String(career.batting.matches)} />
@@ -65,8 +62,8 @@ function FormatSection({
 
       {battingSeasons.length > 0 && (
         <div>
-          <p className="mb-1 text-xs font-medium text-stone-500">Batting</p>
-          <div className="overflow-x-auto">
+          <Kicker className="mb-1">Batting</Kicker>
+          <div className="fc-stat overflow-x-auto">
             <Table>
               <caption className="sr-only">
                 Batting statistics by season
@@ -159,8 +156,8 @@ function FormatSection({
 
       {bowlingSeasons.length > 0 && (
         <div className="mt-4">
-          <p className="mb-1 text-xs font-medium text-stone-500">Bowling</p>
-          <div className="overflow-x-auto">
+          <Kicker className="mb-1">Bowling</Kicker>
+          <div className="fc-stat overflow-x-auto">
             <Table>
               <caption className="sr-only">
                 Bowling statistics by season
@@ -256,13 +253,10 @@ export function PlayerStats({ slug }: { slug: string }) {
   if (careerPending) {
     return (
       <div className="mt-6 space-y-3">
-        <div className="h-6 w-32 animate-pulse rounded bg-stone-200" />
+        <div className="bg-primary/10 h-6 w-32 animate-pulse rounded" />
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
           {["s1", "s2", "s3", "s4", "s5"].map((k) => (
-            <div
-              key={k}
-              className="h-16 animate-pulse rounded-lg bg-stone-100"
-            />
+            <div key={k} className="bg-primary/10 h-16 animate-pulse" />
           ))}
         </div>
       </div>
@@ -282,7 +276,7 @@ export function PlayerStats({ slug }: { slug: string }) {
 
   return (
     <div className="mt-6">
-      <h2 className="mb-4 text-lg font-semibold">Statistics</h2>
+      <h2 className="fc-two-tone mb-4 text-lg font-semibold">Statistics</h2>
 
       {formats.map((format) => (
         <FormatSection
@@ -293,11 +287,11 @@ export function PlayerStats({ slug }: { slug: string }) {
       ))}
 
       {hardballSeasons.length > 0 && (
-        <p className="mt-4 text-xs text-stone-400">
+        <p className="text-muted mt-4 text-xs">
           View the full{" "}
           <Link
             to={`/cricket/records/leaderboards?season=${hardballSeasons[0].season}`}
-            className="text-green-800 underline decoration-green-800/30 underline-offset-2 hover:decoration-green-800"
+            className="text-primary decoration-cta/70 hover:text-cta underline underline-offset-2"
           >
             {hardballSeasons[0].season} season leaderboard
           </Link>

--- a/apps/web/src/pages/report-incident.tsx
+++ b/apps/web/src/pages/report-incident.tsx
@@ -261,7 +261,7 @@ export function Component() {
         </div>
 
         <section className="flex flex-col gap-3">
-          <Kicker>About you</Kicker>
+          <Kicker level={2}>About you</Kicker>
           <FieldRow>
             <Field>
               <Label htmlFor="reporterName">Your name *</Label>
@@ -337,7 +337,7 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <Kicker>Details of the injured / affected person</Kicker>
+          <Kicker level={2}>Details of the injured / affected person</Kicker>
           <FieldRow>
             <Field>
               <Label htmlFor="affectedName">
@@ -394,7 +394,7 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <Kicker>Accident / incident details</Kicker>
+          <Kicker level={2}>Accident / incident details</Kicker>
           <FieldRow>
             <Field>
               <Label htmlFor="occurredAt">When did it happen? *</Label>
@@ -465,7 +465,7 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <Kicker>Injury or ill health details</Kicker>
+          <Kicker level={2}>Injury or ill health details</Kicker>
           <div className="flex items-center gap-2">
             <Checkbox
               id="injuryOccurred"
@@ -570,7 +570,7 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <Kicker>Immediate actions and witnesses</Kicker>
+          <Kicker level={2}>Immediate actions and witnesses</Kicker>
           <Field>
             <Label htmlFor="immediateActions">
               Details of any immediate actions taken
@@ -596,7 +596,7 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <Kicker>Declaration</Kicker>
+          <Kicker level={2}>Declaration</Kicker>
           <div className="border-primary bg-surface flex items-start gap-3 border-2 p-4">
             <Checkbox
               id="declarationConfirmed"

--- a/apps/web/src/pages/report-incident.tsx
+++ b/apps/web/src/pages/report-incident.tsx
@@ -1,5 +1,6 @@
+import { Kicker, StampButton } from "@/components/theme/bits.js";
+import { RisoHeading } from "@/components/theme/riso-heading.js";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -190,14 +191,17 @@ export function Component() {
   if (submit.isSuccess) {
     return (
       <div className="container mx-auto max-w-2xl px-4 py-8">
-        <h1>Thank you</h1>
+        <h1 className="fc-two-tone">Thank you</h1>
         <p className="mt-4">
           Your report has been received. We&rsquo;ve sent a confirmation to the
           email address you provided. The club trustees will review it and, if
           needed, be in touch using the contact details you gave us.
         </p>
         <p className="mt-4">
-          <Link className="text-blue-900 underline" to="/">
+          <Link
+            className="text-primary decoration-cta/70 hover:text-cta underline underline-offset-2"
+            to="/"
+          >
             Back to the home page
           </Link>
         </p>
@@ -207,7 +211,7 @@ export function Component() {
 
   return (
     <div className="container mx-auto max-w-2xl px-4 py-8">
-      <h1>Report an accident or incident</h1>
+      <RisoHeading as="h1">Report an accident or incident</RisoHeading>
 
       <Alert variant="destructive" className="mt-4">
         <AlertDescription>
@@ -217,12 +221,15 @@ export function Component() {
         </AlertDescription>
       </Alert>
 
-      <p className="mt-4 text-sm text-stone-700">
+      <p className="text-muted mt-4 text-sm">
         This form is for reporting something that has already happened at, or in
         connection with, the club. The information you submit will be used by
         the club to record, review and respond to accidents, incidents and
         safety concerns. See our{" "}
-        <Link className="text-blue-900 underline" to="/legal/privacy">
+        <Link
+          className="text-primary decoration-cta/70 hover:text-cta underline underline-offset-2"
+          to="/legal/privacy"
+        >
           privacy policy
         </Link>{" "}
         for how we handle this information.
@@ -254,7 +261,7 @@ export function Component() {
         </div>
 
         <section className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">About you</h2>
+          <Kicker>About you</Kicker>
           <FieldRow>
             <Field>
               <Label htmlFor="reporterName">Your name *</Label>
@@ -330,9 +337,7 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">
-            Details of the injured / affected person
-          </h2>
+          <Kicker>Details of the injured / affected person</Kicker>
           <FieldRow>
             <Field>
               <Label htmlFor="affectedName">
@@ -389,7 +394,7 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">Accident / incident details</h2>
+          <Kicker>Accident / incident details</Kicker>
           <FieldRow>
             <Field>
               <Label htmlFor="occurredAt">When did it happen? *</Label>
@@ -460,9 +465,7 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">
-            Injury or ill health details
-          </h2>
+          <Kicker>Injury or ill health details</Kicker>
           <div className="flex items-center gap-2">
             <Checkbox
               id="injuryOccurred"
@@ -567,9 +570,7 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">
-            Immediate actions and witnesses
-          </h2>
+          <Kicker>Immediate actions and witnesses</Kicker>
           <Field>
             <Label htmlFor="immediateActions">
               Details of any immediate actions taken
@@ -595,8 +596,8 @@ export function Component() {
         </section>
 
         <section className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold">Declaration</h2>
-          <div className="border-border bg-muted/30 flex items-start gap-3 rounded border p-4">
+          <Kicker>Declaration</Kicker>
+          <div className="border-primary bg-surface flex items-start gap-3 border-2 p-4">
             <Checkbox
               id="declarationConfirmed"
               className="mt-1"
@@ -633,12 +634,13 @@ export function Component() {
         )}
 
         <div className="flex justify-end">
-          <Button
+          <StampButton
             type="submit"
+            size="sm"
             disabled={submit.isPending || !declarationConfirmed}
           >
-            {submit.isPending ? "Submitting…" : "Submit report"}
-          </Button>
+            {submit.isPending ? "Submitting…" : "Submit report →"}
+          </StampButton>
         </div>
       </form>
     </div>

--- a/apps/web/src/pages/tell-me-about/index.tsx
+++ b/apps/web/src/pages/tell-me-about/index.tsx
@@ -87,9 +87,9 @@ export function Component() {
       <TrialIsFree />
 
       {/* Dedicated segment links — secondary navigation option */}
-      <section className="bg-white py-10">
+      <section className="bg-body py-10">
         <div className="container mx-auto px-6">
-          <h2 className="text-h4 mb-6 text-center">
+          <h2 className="fc-two-tone text-h4 mb-6 text-center">
             Or jump straight to a dedicated page
           </h2>
           <div className="mx-auto grid max-w-4xl gap-4 sm:grid-cols-2">
@@ -97,12 +97,12 @@ export function Component() {
               <Link
                 key={link.segment}
                 to={link.href}
-                className="rounded-lg border border-stone-200 bg-white p-5 shadow-sm transition hover:shadow-md"
+                className="border-primary bg-surface border-2 p-5 transition-transform hover:-translate-y-[3px]"
               >
-                <h3 className="text-dark mb-1 text-lg font-semibold">
+                <h3 className="text-primary mb-1 text-lg font-semibold">
                   {link.label}
                 </h3>
-                <p className="text-sm text-stone-700">{link.description}</p>
+                <p className="text-muted text-sm">{link.description}</p>
               </Link>
             ))}
           </div>
@@ -123,7 +123,7 @@ export function Component() {
               variant={variant}
             />
           ) : (
-            <p className="text-sm text-stone-600">
+            <p className="text-muted text-sm">
               Pick a group above to see the form.
             </p>
           )}


### PR DESCRIPTION
Carries the homepage "First-Class" print / riso language across the rest of the public site so pages read in one voice instead of generic shadcn. Covers all of P1 + P2 from the design review, the footer, and the sidebar subnav.

## New shared primitives
- **`StampButton`** (`theme/bits.tsx`) - the rotated orange stamp CTA as a `<button>` twin of `StampLink` (with `size="sm"` / `variant="navy"` / disabled states). `.fc-stamp` got brand-colour fallbacks so it also renders correctly in the admin editor preview.
- **`FixtureStrip`** (`theme/fixture-strip.tsx`) - the home "What's On" fixture row, extracted for reuse. Navy-on-cream by default, auto-inverts on an orange plate.
- **`.fc-stat`** - the editorial stat-table treatment, promoted off the homepage into a reusable wrapper with `--invert` for dark plates. Home now consumes it via `.fc-stat--invert` (single source of truth).

## Applied across
- **Editorial stat tables**: leaderboard, player stats, scorecard, records wall.
- **Fixtures**: calendar month + game pages reuse `FixtureStrip` (was three different bespoke treatments).
- **Membership funnel** brought into the theme (removed `/membership` from `NON_THEMED_PREFIXES`) so the join flow stops being a white/serif break at conversion.
- **CTAs**: contact form, lead form, report-incident, recruitment hero, game sponsor flow now use the stamp.
- **News list** restyled from soft SaaS cards to printed panels.
- **Footer** re-inked to the paper palette with orange kicker headings; removed a rogue `#f7864f`.
- **Content-page sidebar / breadcrumb / mobile nav** re-skinned: condensed display section labels, orange active registration bar, palette tokens.

Swept hardcoded off-palette colours (green / blue / amber / stone + rogue oranges) to palette tokens. Genuine error states keep a red for clarity.

## Verification
- `pnpm typecheck`, `pnpm lint` (zero warnings), `pnpm format`, `pnpm build` all pass.
- Visually spot-checked against the live local stack: contact form stamp, leaderboard editorial table (12-col, confirmed no overflow), calendar fixture strip, footer, subnav active bar, and home (no regression).

## Notes / decisions to confirm
- **be-the-keeper** (game canvas + its leaderboard) and the dark cricket data-viz were left as intentional separate palettes, per your steer. The global header was left alone, also per your steer.
- **Membership pages are auth-gated**, so they were verified via build/typecheck rather than a screenshot.
- Errors keep a red (`text-red-700`) - the one allowed off-palette colour.
- Scorecard dismissal sub-text now inherits the Anton/uppercase stat voice (a visible change from the previous serif).

🤖 Generated with [Claude Code](https://claude.com/claude-code)