### PR TITLE
Expenses reimbursement + Stripe Global Payouts

### DIFF
--- a/EXPENSES.md
+++ b/EXPENSES.md
@@ -47,18 +47,18 @@ aggregated totals.
 
 ## 3. Repo patterns to reuse
 
-| Concern | Existing asset | Notes |
-| --- | --- | --- |
-| Approve/deny + email-on-decision template | `apps/api/src/features/financial-relief/` (CRUD, status transitions, decision email, DI deps) | Primary template for the workflow + notify lifecycle. |
-| Roles | `packages/shared/src/auth/permissions.ts` (`statements`, `roles`, `ALL_PERMS`, `ASSIGNABLE_ROLES`, `ROLE_LABELS`). Existing `finance_viewer` / `finance_admin`. | Roles persist as a comma-separated string in `user.role`. `checkPermission()` shared FE/BE. |
-| Route auth | `requirePermission(resource, action)` preHandler + `getAuthSession(request)` in `apps/api/src/features/auth/middleware.ts` | 401 / 403 handled for us. |
-| Receipt upload | `app.s3.uploadReceipt(...)` in `apps/api/src/lib/s3-upload.ts` (base64 data-URL in JSON body, 5MB cap, jpeg/png/webp/heic). Config `S3_RECEIPT_PREFIX`. | Generic infra; reuse directly. Retain images indefinitely (decision 13.9). |
-| Email to a user | `app.send({ to, subject, html })` + React Email templates in `packages/email/src/templates/`. Model on `FinancialReliefDecision.tsx`. | SES via `createSesSend`; dev viewer on port 5174. |
-| Stripe v1 client | `createStripe({ stripeSecretKey })` in `apps/api/src/features/payments/stripe.ts`. `stripe@^22.2.1` (Basil, v1). Clients created per-plugin, injected into curried services. | The v2 Global Payouts client must be a SEPARATE instance (section 7). |
-| Stripe v1 webhooks | `apps/api/src/features/payments/webhook.ts` + `stripe_webhook_event` idempotency table + encapsulated raw-body parser + `StripeWebhookTerminalError` | The v2 money-movement events use a DIFFERENT delivery mechanism (section 7). |
-| Money | integer `*_amount_pence` columns, currency hardcoded `"gbp"`. | Format with `Intl.NumberFormat("en-GB", { currency: "GBP" })`. |
-| Admin UI | React Router v7 + react-query + typed client (`apps/web/src/lib/api-client.ts`). Tabs in `apps/web/src/pages/admin/admin-panel.tsx` (`SECTIONS`). Model the page on `apps/web/src/pages/admin/expense-history-tab.tsx`. | Finance section already exists. |
-| Migrations | `pnpm db:migration` -> write `up()` -> `pnpm db:up` -> `pnpm db:types` -> `pnpm openapi:generate`. Skills: `add-migration`, `add-endpoint`, `write-tests`. | Clean create-table template: `packages/db/src/migrations/2026-05-21T21:13:05.080Z.ts`. |
+| Concern                                   | Existing asset                                                                                                                                                                                                          | Notes                                                                                       |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Approve/deny + email-on-decision template | `apps/api/src/features/financial-relief/` (CRUD, status transitions, decision email, DI deps)                                                                                                                           | Primary template for the workflow + notify lifecycle.                                       |
+| Roles                                     | `packages/shared/src/auth/permissions.ts` (`statements`, `roles`, `ALL_PERMS`, `ASSIGNABLE_ROLES`, `ROLE_LABELS`). Existing `finance_viewer` / `finance_admin`.                                                         | Roles persist as a comma-separated string in `user.role`. `checkPermission()` shared FE/BE. |
+| Route auth                                | `requirePermission(resource, action)` preHandler + `getAuthSession(request)` in `apps/api/src/features/auth/middleware.ts`                                                                                              | 401 / 403 handled for us.                                                                   |
+| Receipt upload                            | `app.s3.uploadReceipt(...)` in `apps/api/src/lib/s3-upload.ts` (base64 data-URL in JSON body, 5MB cap, jpeg/png/webp/heic). Config `S3_RECEIPT_PREFIX`.                                                                 | Generic infra; reuse directly. Retain images indefinitely (decision 13.9).                  |
+| Email to a user                           | `app.send({ to, subject, html })` + React Email templates in `packages/email/src/templates/`. Model on `FinancialReliefDecision.tsx`.                                                                                   | SES via `createSesSend`; dev viewer on port 5174.                                           |
+| Stripe v1 client                          | `createStripe({ stripeSecretKey })` in `apps/api/src/features/payments/stripe.ts`. `stripe@^22.2.1` (Basil, v1). Clients created per-plugin, injected into curried services.                                            | The v2 Global Payouts client must be a SEPARATE instance (section 7).                       |
+| Stripe v1 webhooks                        | `apps/api/src/features/payments/webhook.ts` + `stripe_webhook_event` idempotency table + encapsulated raw-body parser + `StripeWebhookTerminalError`                                                                    | The v2 money-movement events use a DIFFERENT delivery mechanism (section 7).                |
+| Money                                     | integer `*_amount_pence` columns, currency hardcoded `"gbp"`.                                                                                                                                                           | Format with `Intl.NumberFormat("en-GB", { currency: "GBP" })`.                              |
+| Admin UI                                  | React Router v7 + react-query + typed client (`apps/web/src/lib/api-client.ts`). Tabs in `apps/web/src/pages/admin/admin-panel.tsx` (`SECTIONS`). Model the page on `apps/web/src/pages/admin/expense-history-tab.tsx`. | Finance section already exists.                                                             |
+| Migrations                                | `pnpm db:migration` -> write `up()` -> `pnpm db:up` -> `pnpm db:types` -> `pnpm openapi:generate`. Skills: `add-migration`, `add-endpoint`, `write-tests`.                                                              | Clean create-table template: `packages/db/src/migrations/2026-05-21T21:13:05.080Z.ts`.      |
 
 New standalone feature folder: `apps/api/src/features/expense/`
 (`routes.ts`, `service.ts`, `schemas.ts`, `service.test.ts`, `integration.test.ts`).
@@ -68,6 +68,7 @@ New standalone feature folder: `apps/api/src/features/expense/`
 New tables via Kysely migration. All money as integer pence.
 
 ### `expense`
+
 - `id` uuid pk
 - `created_by` -> `user.id` (submitter)
 - `claimant_name` text (display name at submit time)
@@ -88,6 +89,7 @@ Indexes: `status`, `created_by`. Receipt-required rule enforced in the submit
 service/schema, not as a pure column check (it depends on amount).
 
 ### `expense_approval` (enforces the two-approver rule + separation of duties)
+
 - `id` uuid pk
 - `expense_id` -> `expense.id` on delete cascade
 - `approver_user_id` -> `user.id`
@@ -101,6 +103,7 @@ Status is derived from approvals + the threshold (section 9). The submitter is
 never permitted a row here.
 
 ### `expense_category` (admin-editable tag vocabulary, decision 13.4)
+
 - `id` uuid pk
 - `name` citext unique (case-insensitive dedupe)
 - `created_by` -> `user.id` null
@@ -108,6 +111,7 @@ never permitted a row here.
 - `created_at` timestamptz not null default now()
 
 ### `expense_category_link` (many-to-many: an expense has one or more tags)
+
 - `expense_id` -> `expense.id` on delete cascade
 - `category_id` -> `expense_category.id`
 - composite pk `(expense_id, category_id)`
@@ -118,6 +122,7 @@ the approver can add/remove at decision; creating a "new" tag upserts into
 least one tag is required to reach `approved`.
 
 ### `expense_event` (append-only audit log)
+
 - `id` uuid pk
 - `expense_id` -> `expense.id` on delete cascade
 - `actor_user_id` -> `user.id` null (null for Stripe-system events)
@@ -137,6 +142,7 @@ Add an `expenses` resource to `packages/shared/src/auth/permissions.ts`
 Actions: `submit`, `view_own`, `view`, `approve`, `pay`, `manage_tags`.
 
 Roles:
+
 - `expense_submitter` -> `expenses: ["submit", "view_own"]`.
 - `expense_approver` -> `expenses: ["view", "approve"]`.
 - `pay` and the full dashboard granted to the existing `finance_admin` /
@@ -145,6 +151,7 @@ Roles:
   Submitters/approvers can still create new tags inline via proposal.
 
 Controls / separation of duties:
+
 - An approver cannot approve their own submission (no `expense_approval` row
   where `approver_user_id == created_by`).
 - The two required approvals (for GBP 50+) must come from two distinct users
@@ -208,7 +215,9 @@ product is in preview.
   integration time rather than assuming the field set.
 
 ### New config (`apps/api/src/config.ts`)
+
 Required env vars (Terraform threads placeholders, per repo convention):
+
 - `STRIPE_FINANCIAL_ACCOUNT_ID`
 - `STRIPE_PAYOUTS_API_VERSION` (preview version string)
 
@@ -239,6 +248,7 @@ pending --1st approve--> ------------------> approved --pay--> paid
 ## 9. Notifications
 
 Reuse `app.send` + new React Email templates in `packages/email/src/templates/`:
+
 - On submit: email every user holding `expense_approver` (decision 13.3).
 - On first approval of a GBP 50+ expense: email the approver pool that a second
   approval is needed.
@@ -252,6 +262,7 @@ All sends are best-effort (try/catch + log), matching `financial-relief`.
 
 Via the `add-endpoint` skill (Zod schemas, curried services, OpenAPI regen,
 typed client):
+
 - `POST /api/expenses` - submit (`expenses:submit`). description, amount,
   optional `receiptImage` data-URL (required when amount > GBP 10), proposed
   tag names/ids.
@@ -281,6 +292,7 @@ typed client):
 ## 12. Testing
 
 This is a money-movement feature, so coverage is expected, not optional:
+
 - Unit tests (mocked DB) for the status machine: single vs two-approver paths,
   self-approval rejection, distinct-approver enforcement, receipt-required rule,
   tag-required-on-approval, payout idempotency.

--- a/EXPENSES.md
+++ b/EXPENSES.md
@@ -1,0 +1,351 @@
+# Expenses + Stripe Payouts - Implementation Plan
+
+Status: DECISIONS RESOLVED / ready to build. Author: planning pass, 2026-06-18.
+
+All open questions from the first draft have been answered by Alex and are folded
+into the design below. The resolved answers are recorded in section 13.
+
+## 1. Goal and use case
+
+Let approved club volunteers submit out-of-pocket expenses and get reimbursed,
+with a fully auditable approval workflow and an admin dashboard.
+
+Flow:
+
+1. **Submit** - a user with the `expense_submitter` role adds an expense:
+   description, amount, optional receipt image (mandatory over GBP 10), proposed
+   tags, and their payout details (entered directly into Stripe, see section 6).
+2. **Decide** - users with the `expense_approver` role are notified by email,
+   approve or deny, and finalise the tags. Expenses of GBP 50 or more need two
+   distinct approvers.
+3. **Notify** - the submitter is notified by email of the decision.
+4. **Pay** - once fully approved, the submitter is paid via Stripe Global
+   Payouts using the bank details Stripe is holding for them.
+
+Hard requirements: auditable, controlled (separation of duties + two-approver
+threshold), admin dashboard showing pending / approved / denied / paid plus
+aggregated totals.
+
+## 2. TL;DR
+
+- **Chosen payout rail: Stripe Global Payouts** (recipients + OutboundPayments).
+  Stripe "Payouts" only pays your own bank account; paying a club member needs
+  Global Payouts. The account is already eligible and activated (decision 13.2).
+- **Stripe holds the bank details.** The payee enters their bank account into a
+  Stripe-hosted form; we persist only token IDs
+  (`stripe_recipient_account_id`, `stripe_payout_method_id`), never a sort code
+  or account number. This is the data-minimising answer to the legal question
+  (decision 13.1).
+- **Build in phases.** Phase 1 ships the full audited workflow (tags,
+  two-approver rule, notifications, dashboard) with a manual "mark paid"
+  fallback. Phase 2 wires the one-click Global Payouts payout. Phasing is kept
+  because Global Payouts is still on Stripe's **public-preview v2 API**, a
+  different surface and SDK channel from the v1 (Basil) integration this repo
+  uses today (section 7).
+- **Matchday expenses are out of scope** (decision 13.8). This is a brand new,
+  standalone feature.
+
+## 3. Repo patterns to reuse
+
+| Concern | Existing asset | Notes |
+| --- | --- | --- |
+| Approve/deny + email-on-decision template | `apps/api/src/features/financial-relief/` (CRUD, status transitions, decision email, DI deps) | Primary template for the workflow + notify lifecycle. |
+| Roles | `packages/shared/src/auth/permissions.ts` (`statements`, `roles`, `ALL_PERMS`, `ASSIGNABLE_ROLES`, `ROLE_LABELS`). Existing `finance_viewer` / `finance_admin`. | Roles persist as a comma-separated string in `user.role`. `checkPermission()` shared FE/BE. |
+| Route auth | `requirePermission(resource, action)` preHandler + `getAuthSession(request)` in `apps/api/src/features/auth/middleware.ts` | 401 / 403 handled for us. |
+| Receipt upload | `app.s3.uploadReceipt(...)` in `apps/api/src/lib/s3-upload.ts` (base64 data-URL in JSON body, 5MB cap, jpeg/png/webp/heic). Config `S3_RECEIPT_PREFIX`. | Generic infra; reuse directly. Retain images indefinitely (decision 13.9). |
+| Email to a user | `app.send({ to, subject, html })` + React Email templates in `packages/email/src/templates/`. Model on `FinancialReliefDecision.tsx`. | SES via `createSesSend`; dev viewer on port 5174. |
+| Stripe v1 client | `createStripe({ stripeSecretKey })` in `apps/api/src/features/payments/stripe.ts`. `stripe@^22.2.1` (Basil, v1). Clients created per-plugin, injected into curried services. | The v2 Global Payouts client must be a SEPARATE instance (section 7). |
+| Stripe v1 webhooks | `apps/api/src/features/payments/webhook.ts` + `stripe_webhook_event` idempotency table + encapsulated raw-body parser + `StripeWebhookTerminalError` | The v2 money-movement events use a DIFFERENT delivery mechanism (section 7). |
+| Money | integer `*_amount_pence` columns, currency hardcoded `"gbp"`. | Format with `Intl.NumberFormat("en-GB", { currency: "GBP" })`. |
+| Admin UI | React Router v7 + react-query + typed client (`apps/web/src/lib/api-client.ts`). Tabs in `apps/web/src/pages/admin/admin-panel.tsx` (`SECTIONS`). Model the page on `apps/web/src/pages/admin/expense-history-tab.tsx`. | Finance section already exists. |
+| Migrations | `pnpm db:migration` -> write `up()` -> `pnpm db:up` -> `pnpm db:types` -> `pnpm openapi:generate`. Skills: `add-migration`, `add-endpoint`, `write-tests`. | Clean create-table template: `packages/db/src/migrations/2026-05-21T21:13:05.080Z.ts`. |
+
+New standalone feature folder: `apps/api/src/features/expense/`
+(`routes.ts`, `service.ts`, `schemas.ts`, `service.test.ts`, `integration.test.ts`).
+
+## 4. Data model
+
+New tables via Kysely migration. All money as integer pence.
+
+### `expense`
+- `id` uuid pk
+- `created_by` -> `user.id` (submitter)
+- `claimant_name` text (display name at submit time)
+- `description` text not null
+- `amount_pence` integer not null (check > 0)
+- `currency` text not null default `'gbp'`
+- `status` text not null - one of
+  `pending` / `awaiting_second_approval` / `approved` / `denied` / `paid` / `payout_failed`
+- `receipt_image_url` text null (required at submit when `amount_pence > 1000`, decision 13.9)
+- payout linkage (Phase 2, nullable in Phase 1):
+  - `stripe_recipient_account_id` text null
+  - `stripe_payout_method_id` text null
+  - `stripe_outbound_payment_id` text null (unique - guards double-pay)
+  - `paid_at` timestamptz null
+- `created_at` / `updated_at` timestamptz not null default now()
+
+Indexes: `status`, `created_by`. Receipt-required rule enforced in the submit
+service/schema, not as a pure column check (it depends on amount).
+
+### `expense_approval` (enforces the two-approver rule + separation of duties)
+- `id` uuid pk
+- `expense_id` -> `expense.id` on delete cascade
+- `approver_user_id` -> `user.id`
+- `decision` text - `approved` / `denied`
+- `note` text null
+- `created_at` timestamptz not null default now()
+- unique `(expense_id, approver_user_id)` - one decision per approver, so the
+  same person cannot supply both required approvals.
+
+Status is derived from approvals + the threshold (section 9). The submitter is
+never permitted a row here.
+
+### `expense_category` (admin-editable tag vocabulary, decision 13.4)
+- `id` uuid pk
+- `name` citext unique (case-insensitive dedupe)
+- `created_by` -> `user.id` null
+- `archived_at` timestamptz null (soft-retire; keeps historical links valid)
+- `created_at` timestamptz not null default now()
+
+### `expense_category_link` (many-to-many: an expense has one or more tags)
+- `expense_id` -> `expense.id` on delete cascade
+- `category_id` -> `expense_category.id`
+- composite pk `(expense_id, category_id)`
+
+Tags: the claimant proposes one or more at submit (pick existing or create new);
+the approver can add/remove at decision; creating a "new" tag upserts into
+`expense_category` by name so the vocabulary grows but stays deduplicated. At
+least one tag is required to reach `approved`.
+
+### `expense_event` (append-only audit log)
+- `id` uuid pk
+- `expense_id` -> `expense.id` on delete cascade
+- `actor_user_id` -> `user.id` null (null for Stripe-system events)
+- `type` text - `submitted` / `approved` / `denied` / `edited` / `tags_changed` / `payout_initiated` / `payout_paid` / `payout_failed`
+- `from_status` text null, `to_status` text null
+- `metadata` jsonb null (amounts, notes, tag ids, stripe ids, failure reason)
+- `created_at` timestamptz not null default now()
+
+Every transition writes one `expense_event` in the same DB transaction as the
+`expense`/`expense_approval` write. The log is never updated or deleted.
+
+## 5. Roles and permissions
+
+Add an `expenses` resource to `packages/shared/src/auth/permissions.ts`
+(`statements`, `roles`, `ALL_PERMS`, `ASSIGNABLE_ROLES`, `ROLE_LABELS`).
+
+Actions: `submit`, `view_own`, `view`, `approve`, `pay`, `manage_tags`.
+
+Roles:
+- `expense_submitter` -> `expenses: ["submit", "view_own"]`.
+- `expense_approver` -> `expenses: ["view", "approve"]`.
+- `pay` and the full dashboard granted to the existing `finance_admin` /
+  treasurer role (decision 13.6 reuses the existing key; no fourth role needed).
+- `manage_tags` (rename/archive the canonical tag list) -> `finance_admin`.
+  Submitters/approvers can still create new tags inline via proposal.
+
+Controls / separation of duties:
+- An approver cannot approve their own submission (no `expense_approval` row
+  where `approver_user_id == created_by`).
+- The two required approvals (for GBP 50+) must come from two distinct users
+  (enforced by the unique `(expense_id, approver_user_id)`).
+- `pay` is a distinct permission from `approve`.
+- Amount and description are immutable after the first approval; editing them
+  resets the expense to `pending`, clears existing approvals, and logs an
+  `edited` event.
+
+## 6. Payout mechanism and the bank-details question (Option A, decided)
+
+Decision 13.1: **Stripe Global Payouts, with Stripe holding the bank details.**
+
+- On (full) approval, the submitter completes a Stripe-hosted recipient /
+  payout-method form. **Stripe stores the bank details.** We persist only the
+  recipient account id and payout method id.
+- Reimbursement is an OutboundPayment from a Stripe-managed Financial Account,
+  funded from the club's existing Stripe GBP balance (donations / membership /
+  charges already settle there).
+- Repeat claimants reuse their stored recipient, so they enter bank details once.
+- We never hold the sort code / account number, which is the data-minimising
+  outcome the brief wanted.
+- Cost: GBP 0.50 per domestic payout, no monthly fee, free FPS top-up.
+
+Rejected alternatives (recorded for the ADR): storing bank details ourselves
+(needless GDPR/encryption/retention burden) and a pure manual-transfer model
+(kept only as the Phase 1 fallback, below).
+
+## 7. Stripe Global Payouts integration specifics (Phase 2)
+
+Verified against Stripe docs during planning; re-confirm at build time as the
+product is in preview.
+
+- **Product:** Global Payouts. Pay third parties with no Stripe account. UK
+  platform paying GBP to UK recipients is supported. Account already eligible +
+  activated (decision 13.2).
+- **API surface (v2, preview):**
+  - Recipient: `POST /v2/core/accounts` (Accounts v2) with
+    `identity.entity_type = "individual"`, `identity.country = "gb"`,
+    `contact_email`, `display_name`, and
+    `configuration.recipient.capabilities.bank_accounts.local.requested = true`.
+  - Payout methods: `/v2/money_management/payout_methods` (Stripe stores the
+    bank account; default via
+    `configuration.recipient.default_outbound_destination`).
+  - Payout: `POST /v2/money_management/outbound_payments` with
+    `from.financial_account`, `to.recipient`, `amount.value` (pence),
+    `amount.currency = "gbp"`, `description`.
+- **Financial Account:** activated. Funded from the Stripe payments balance / FPS.
+- **SDK / client isolation:** the repo pins `stripe@^22` on v1 Basil and does
+  not set `apiVersion`. Global Payouts needs the public-preview SDK channel and a
+  preview `Stripe-Version` header. Introduce a SEPARATE dedicated v2 client (e.g.
+  `createStripePayouts(...)`) so live v1 payments flows are untouched. The same
+  `STRIPE_SECRET_KEY` carries the capability (decision 13.6).
+- **Webhooks (decision 13.7):** handle OutboundPayment status via a v2 event
+  destination, developed locally with the Stripe CLI webhook forwarder
+  (`stripe listen`). This is a different mechanism (thin events) from the v1
+  `/api/stripe/webhook` handler, so it gets its own small endpoint. The unique
+  `stripe_outbound_payment_id` column plus the `expense_event` log give us
+  idempotency regardless of delivery.
+- **Identity / KYC:** read the live `requirements.summary` per recipient at
+  integration time rather than assuming the field set.
+
+### New config (`apps/api/src/config.ts`)
+Required env vars (Terraform threads placeholders, per repo convention):
+- `STRIPE_FINANCIAL_ACCOUNT_ID`
+- `STRIPE_PAYOUTS_API_VERSION` (preview version string)
+
+`STRIPE_SECRET_KEY` is reused.
+
+## 8. State machine and controls
+
+Threshold: `TWO_APPROVAL_THRESHOLD_PENCE = 5000` (GBP 50, decision 13.5).
+
+```
+                         amount < 5000
+pending --1st approve--> ------------------> approved --pay--> paid
+   |                |                            ^               |
+   |                | amount >= 5000             |               +--(error)--> payout_failed --retry--> paid
+   |                v                            |
+   |        awaiting_second_approval --2nd approve (distinct user)--+
+   |                |
+   +---deny---------+--> denied
+```
+
+- A single `deny` from any approver moves the expense to `denied` (with note).
+- At least one tag and (for amounts over GBP 10) a receipt are required before
+  approval can complete.
+- Payout is idempotent: only `approved` (or `payout_failed` for retry) may be
+  paid, guarded by the unique `stripe_outbound_payment_id`.
+- Every transition writes an `expense_event` in the same transaction.
+
+## 9. Notifications
+
+Reuse `app.send` + new React Email templates in `packages/email/src/templates/`:
+- On submit: email every user holding `expense_approver` (decision 13.3).
+- On first approval of a GBP 50+ expense: email the approver pool that a second
+  approval is needed.
+- On final decision (approved/denied + note): email the submitter. Model on
+  `FinancialReliefDecision.tsx`.
+- On paid (Phase 2): email the submitter that the payout is on its way.
+
+All sends are best-effort (try/catch + log), matching `financial-relief`.
+
+## 10. API endpoints (`apps/api/src/features/expense/`)
+
+Via the `add-endpoint` skill (Zod schemas, curried services, OpenAPI regen,
+typed client):
+- `POST /api/expenses` - submit (`expenses:submit`). description, amount,
+  optional `receiptImage` data-URL (required when amount > GBP 10), proposed
+  tag names/ids.
+- `GET /api/expenses` - list; own only for `view_own`, all for `view`. Filters:
+  status, tag, date range, search; pagination. URL-driven filter state on the web.
+- `GET /api/expenses/:id` - detail + approvals + event history.
+- `POST /api/expenses/:id/decision` - approve or deny + note + final tag set
+  (`expenses:approve`; not self; enforces distinct second approver for GBP 50+).
+- `POST /api/expenses/:id/payout` - initiate Global Payouts payout
+  (`expenses:pay`, Phase 2). Phase 1 fallback: `POST /api/expenses/:id/mark-paid`.
+- `GET /api/expenses/summary` - aggregated totals by status / tag / period.
+- `GET /api/expense-categories` - list active tags (for the proposal/edit UI).
+- `POST /api/expense-categories` - create a tag (any submitter/approver).
+- `PATCH /api/expense-categories/:id` - rename/archive (`expenses:manage_tags`).
+
+## 11. Admin dashboard (`apps/web`)
+
+- New "Expenses" sub-tab under the Finance section in
+  `apps/web/src/pages/admin/admin-panel.tsx`, gated by `expenses:view`.
+- List/table modelled on `apps/web/src/pages/admin/expense-history-tab.tsx`
+  (filters incl. tag, debounced search, pagination, detail dialog with approval
+  history, receipt lightbox, CSV export, react-query + typed client).
+- Summary widgets: totals by status and by tag, period filter.
+- Separate lightweight submitter view ("my expenses" + submit form with tag
+  proposal) for users holding only `expense_submitter`.
+
+## 12. Testing
+
+This is a money-movement feature, so coverage is expected, not optional:
+- Unit tests (mocked DB) for the status machine: single vs two-approver paths,
+  self-approval rejection, distinct-approver enforcement, receipt-required rule,
+  tag-required-on-approval, payout idempotency.
+- Integration tests (testcontainers) for submit -> approve -> pay, the audit
+  log, and the category upsert/dedupe.
+- Phase 2: a Stripe payout test against a local test account with the CLI
+  webhook forwarder (decision 13.7).
+
+## 13. Decisions log (resolved open questions)
+
+1. **Legal / data protection:** Option A - Stripe Global Payouts; Stripe holds
+   the bank details, we store only token IDs.
+2. **Global Payouts eligibility:** account is eligible and activated.
+3. **Approver routing:** email every user holding `expense_approver`.
+4. **Tags:** admin-editable vocabulary. Claimant proposes tags, approver can
+   edit; new tags allowed alongside existing ones. (Replaces the original single
+   fixed category.)
+5. **Thresholds:** under GBP 50 = one approver; GBP 50+ = two distinct approvers.
+   Start simple.
+6. **Stripe key:** existing `STRIPE_SECRET_KEY` carries the capability.
+7. **v2 webhook vs polling:** use webhooks (v2 event destination), developed
+   locally with a test account + the Stripe CLI webhook forwarder.
+8. **Matchday expenses:** out of scope; barely used, has not landed. Build new.
+9. **Receipts:** retain indefinitely (low volume); receipt mandatory over GBP 10.
+
+### Phase 0 spike findings (resolved 2026-06-18)
+
+Probed the pinned `stripe@22.2.1` SDK directly:
+
+- It exposes a `v2` namespace with **`v2.core.accounts`** (recipient creation),
+  **`v2.core.eventDestinations`** and **`v2.core.events`** (v2 webhooks). It does
+  NOT bundle the `MoneyManagement` resources (OutboundPayments / PayoutMethods /
+  FinancialAccounts) - those ship only in newer preview SDK releases.
+- It DOES expose **`stripe.rawRequest(method, path, params, options)`** plus
+  `Stripe-Context` header support (`stripeContext` option / `StripeContext`
+  helper) and per-call `apiVersion`.
+
+Decision: **do not bump the SDK.** Phase 2 calls the preview money-movement
+endpoints (`/v2/money_management/payout_methods`,
+`/v2/money_management/outbound_payments`) via `rawRequest` on a dedicated
+`Stripe` instance constructed with the preview `apiVersion`
+(`STRIPE_PAYOUTS_API_VERSION`) and the shared `STRIPE_SECRET_KEY`. Recipient
+creation can use the typed `v2.core.accounts`. This isolates the preview surface
+entirely from the live v1 (Basil) payments client and avoids the dependency-bump
+risk to existing flows. The thin client wrapper lives in
+`apps/api/src/features/expense/payouts.ts`.
+
+Still confirmed only against docs (re-verify against the live test account when
+wiring Phase 2 end to end): the exact preview `Stripe-Version` value, the
+OutboundPayment event names, and the live `requirements` set for a UK individual
+recipient. These are config / mapping details, not architectural blockers.
+
+## 14. Phased delivery
+
+- **Phase 0 (spike, ~0.5 day):** install the preview v2 SDK, create a test
+  recipient + payout method, fire a test OutboundPayment, confirm event names via
+  `stripe listen`, and read the live UK-individual `requirements`. Resolves the
+  residual unknowns above.
+- **Phase 1 (workflow):** roles + permissions; `expense`, `expense_approval`,
+  `expense_category`, `expense_category_link`, `expense_event` tables; submit
+  (with receipt rule + tag proposal); the one/two-approver decision flow; tag
+  management; email notifications; admin dashboard + aggregated totals; manual
+  `mark-paid` fallback; full unit + integration tests.
+- **Phase 2 (Stripe rail):** dedicated v2 client; Stripe-hosted recipient +
+  payout-method collection; OutboundPayment with idempotency; v2 webhook
+  endpoint for payout status; paid notification. Manual path retained as fallback.
+- **ADR:** record Global Payouts vs Connect vs manual, and the "Stripe holds the
+  bank details" data-minimisation choice, via the `add-adr` skill.

--- a/PAYOUT_TEST_PLAN.md
+++ b/PAYOUT_TEST_PLAN.md
@@ -1,0 +1,241 @@
+# Payout test plan (Stripe Global Payouts) - handoff
+
+Status: the Stripe sandbox + Global Payouts Financial Account is being provisioned.
+This is the runbook to verify the **real** v2 payout path once the sandbox keys
+are available. Pick this up when the keys land.
+
+## Why this exists
+
+Phase 1 (submit -> approve/deny -> notify -> manual mark-paid) and the payout
+**state machine** are fully tested (browser walkthrough + 26 integration tests
+with a fake Stripe client). What is NOT yet proven is the actual Stripe v2
+money-movement surface in [`apps/api/src/features/expense/payouts.ts`](apps/api/src/features/expense/payouts.ts):
+the request/response shapes, the preview API version, and the webhook event
+names were written from docs, not exercised against Stripe.
+
+Until the payout env vars are set, `createPayoutsClient` returns `null` and the
+payout endpoint returns `503 Stripe Global Payouts is not configured`. That 503
+is the only thing the "Pay via Stripe" button has actually done so far.
+
+Goal of this plan: drive a real recipient -> bank-details -> OutboundPayment ->
+webhook cycle in the sandbox, and fix any shape mismatches in `payouts.ts` /
+`service.ts` / `routes.ts`.
+
+## 0. Prerequisites
+
+- A Stripe **sandbox** with Global Payouts enabled and a **Financial Account**
+  activated (Dashboard -> Balances -> Financial account -> Get started).
+- The Financial Account funded with test money (Global Payouts pays from the FA
+  balance; an OutboundPayment fails if the balance is 0). Top it up in the
+  sandbox dashboard.
+- Tools: Docker, `pnpm`, and the [Stripe CLI](https://docs.stripe.com/stripe-cli)
+  (`stripe login` against the sandbox).
+
+## 1. Configure env
+
+Edit `apps/api/.env` (gitignored, local only) and set:
+
+| Var                             | Where it comes from                                                             |
+| ------------------------------- | ------------------------------------------------------------------------------- |
+| `STRIPE_SECRET_KEY`             | the sandbox secret key (replaces the old legacy `sk_test_…`)                    |
+| `STRIPE_FINANCIAL_ACCOUNT_ID`   | the `fa_…` id of the activated Financial Account                                |
+| `STRIPE_PAYOUTS_API_VERSION`    | the exact preview version string the sandbox expects, e.g. `2026-05-27.preview` |
+| `STRIPE_PAYOUTS_WEBHOOK_SECRET` | from `stripe listen` in step 2 (set it, then restart the API)                   |
+
+Config lives in [`apps/api/src/config.ts`](apps/api/src/config.ts) (the three
+new vars are placeholder-tolerant, so a wrong/blank value will not crash boot -
+but it WILL make the client null or the calls fail). The client is built in
+[`routes.ts`](apps/api/src/features/expense/routes.ts) via `createPayoutsClient`.
+
+## 2. Start the stack + webhook forwarder
+
+```bash
+docker compose up -d
+pnpm db:up                       # apply migrations to the local DB
+pnpm dev:api                     # API on :3000  (reads apps/api/.env)
+pnpm dev:web                     # web on :5173
+
+# Separate terminal - forward the v2 payout webhook and capture the secret:
+stripe listen --forward-to localhost:3000/api/stripe/payouts-webhook
+#   -> prints "whsec_..."; put it in STRIPE_PAYOUTS_WEBHOOK_SECRET and restart dev:api
+```
+
+Note: `pnpm dev` (scripts/dev.sh) auto-forwards Stripe to the **v1** webhook
+(`/api/stripe/webhook`). The payout webhook is a **separate** endpoint, so run
+the `stripe listen` above explicitly.
+
+## 3. Seed two users (submitter + a distinct approver)
+
+Self-approval is blocked, so you need a submitter and a separate approver who
+also holds `pay` (finance_admin). The local DB has no password-hash seeder, so
+register via the auth API then flip verification + roles in the DB.
+
+```bash
+# Register (creates user + password account; unverified)
+curl -s -X POST http://localhost:3000/api/auth/sign-up/email -H 'Content-Type: application/json' \
+  -d '{"name":"Alice Submitter","email":"alice@test.local","password":"Password123!"}' -o /dev/null -w "%{http_code}\n"
+curl -s -X POST http://localhost:3000/api/auth/sign-up/email -H 'Content-Type: application/json' \
+  -d '{"name":"Bob Approver","email":"bob@test.local","password":"Password123!"}' -o /dev/null -w "%{http_code}\n"
+
+# Verify email + assign roles (bypasses the email link)
+docker compose exec -T postgres psql -U percy -d percy_main -c "
+  UPDATE \"user\" SET \"emailVerified\"=true, role='expense_submitter' WHERE email='alice@test.local';
+  UPDATE \"user\" SET \"emailVerified\"=true, role='expense_approver,finance_admin,expense_submitter' WHERE email='bob@test.local';"
+```
+
+Roles are defined in [`packages/shared/src/auth/permissions.ts`](packages/shared/src/auth/permissions.ts):
+`expense_submitter` (submit), `expense_approver` (approve), `finance_admin`
+(view + **pay** + manage_tags).
+
+## 4. Create an approved claim
+
+```bash
+# Sign in as the submitter and raise a claim (<= GBP 10 so no receipt is needed)
+curl -s -X POST http://localhost:3000/api/auth/sign-in/email -H 'Content-Type: application/json' \
+  -d '{"email":"alice@test.local","password":"Password123!"}' -c /tmp/alice.cookies -o /dev/null -w "%{http_code}\n"
+curl -s -X POST http://localhost:3000/api/expenses -H 'Content-Type: application/json' -b /tmp/alice.cookies \
+  -d '{"description":"Coffees for the umpires","amountPence":850,"tagNames":["hospitality"]}'
+```
+
+Then approve it as Bob in the browser: log in at `http://localhost:5173/auth/login`
+(bob@test.local / Password123!), go to
+`http://localhost:5173/admin?section=finance&sub=reimbursements`, open Alice's
+claim, click **Approve**. Status should become `Approved` and the actions become
+**Pay via Stripe** / **Mark paid (manual)**.
+
+## 5. Drive the real payout (the part that needs verifying)
+
+The flow is in `payoutExpense` ([`service.ts`](apps/api/src/features/expense/service.ts)).
+Keep the API logs visible - failures are caught and written to
+`payout_failure_reason` (surfaced in the dialog) and logged as
+`expense_payout_failed`, so Stripe's error text is your debugging signal.
+
+**Step A - first payout attempt (no bank details yet).** Click **Pay via Stripe**.
+Expected: a recipient is created and, because the recipient has no payout method,
+the response carries an `onboardingUrl` and the dialog shows
+"The claimant needs to add their bank details first". Status stays `Approved`.
+
+- Verifies: `createRecipient` (`POST /v2/core/accounts`) and
+  `createPayoutMethodSetupLink` (`POST /v2/core/account_links`).
+- If it 500s or records a failure instead: the request body or the
+  `account_links` `use_case` shape is wrong - fix in `payouts.ts`.
+
+**Step B - complete Stripe-hosted onboarding.** Open the `onboardingUrl`. Enter
+the GB test identity + bank details Stripe documents for sandboxes (commonly
+sort code `10-88-00`, account `00012345` - confirm against Stripe's current
+testing docs). This is where Stripe collects + stores the bank details, so we
+never do.
+
+- Verifies: the recipient `requirements` we send are sufficient for a GB
+  individual. If onboarding demands fields we did not request, note them; the
+  capability request in `createRecipient` may need expanding.
+
+**Step C - second payout attempt (bank details on file).** Click **Pay via
+Stripe** again. Expected: an OutboundPayment is created, status -> `Paid`,
+`stripe_outbound_payment_id` stored, claimant emailed.
+
+- Verifies: `getDefaultPayoutMethodId`
+  (`GET /v2/money_management/payout_methods` + `Stripe-Context` header) and
+  `createOutboundPayment` (`POST /v2/money_management/outbound_payments`).
+- Check the real `op.status` value returned (logged in the `payout_initiated`
+  event metadata as `stripeStatus`). The code treats `failed`/`returned`/
+  `canceled` as terminal failure and everything else as optimistic paid - adjust
+  the `terminalFailure` set in `service.ts` if the real status vocabulary differs.
+
+**Step D - webhook.** Watch the `stripe listen` terminal and the API logs as the
+OutboundPayment settles. Expected: an event arrives, `applyPayoutWebhook` runs,
+and the status is confirmed (or corrected to `payout_failed`).
+
+- Verifies `mapOutboundPaymentEvent` (event `type` strings) and
+  `outboundPaymentIdFromEvent` (id at `data.object.id` vs `related_object.id`),
+  both in [`payouts.ts`](apps/api/src/features/expense/payouts.ts) /
+  [`routes.ts`](apps/api/src/features/expense/routes.ts).
+- If the webhook arrives but nothing updates: the event `type` did not match
+  (fix the suffix checks) or the id was read from the wrong field. Log the raw
+  event to see the real shape:
+  `stripe listen --print-json` in a scratch terminal, or temporarily log
+  `event.type` + `JSON.stringify(event)` in the webhook handler.
+
+## 6. Verification checklist (what was guessed, confirm each)
+
+- [ ] `STRIPE_PAYOUTS_API_VERSION` value is accepted (a wrong version yields a
+      Stripe error on the first call).
+- [ ] `createRecipient` body shape (`identity`, `configuration.recipient.capabilities`).
+- [ ] Live `requirements` for a GB individual recipient.
+- [ ] `createPayoutMethodSetupLink` `use_case` shape + returned URL.
+- [ ] `getDefaultPayoutMethodId` list response (`data[0].id`) and the
+      `Stripe-Context` header behaviour.
+- [ ] `createOutboundPayment` body (`from`/`to`/`amount`) and the `status`
+      vocabulary it returns.
+- [ ] Webhook event `type` strings and id location.
+- [ ] Idempotency: a double-click on Pay does not create two OutboundPayments
+      (key = expense id); a `payout_failed` retry creates a fresh one.
+
+## 7. Failure-path check
+
+With the FA balance at 0 (or below the claim amount), trigger a payout. Expect
+status -> `payout_failed` with the Stripe error in `payout_failure_reason`, and
+"Pay via Stripe" / "Mark paid (manual)" still available to retry.
+
+## 8. Optional quick probe (validate shapes before the full UI flow)
+
+To sanity-check the recipient call without the whole flow, run this throwaway
+script (delete after). It hits the real sandbox via the same `rawRequest` path
+the client uses and prints the recipient + its `requirements`:
+
+```ts
+// apps/api/scratch-probe.mts  (run: cd apps/api && pnpm exec tsx --env-file=.env scratch-probe.mts)
+import Stripe from "stripe";
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+const v = process.env.STRIPE_PAYOUTS_API_VERSION!;
+try {
+  const acct = await stripe.rawRequest(
+    "POST",
+    "/v2/core/accounts",
+    {
+      display_name: "Probe Recipient",
+      contact_email: "probe@example.com",
+      identity: { country: "gb", entity_type: "individual" },
+      configuration: {
+        recipient: {
+          capabilities: { bank_accounts: { local: { requested: true } } },
+        },
+      },
+      include: ["requirements", "configuration.recipient"],
+    },
+    { apiVersion: v },
+  );
+  console.log(JSON.stringify(acct, null, 2));
+} catch (e) {
+  console.error("PROBE FAILED:", e);
+}
+```
+
+A clean response confirms auth + version + the recipient body. The
+`requirements` block tells you exactly what onboarding will demand.
+
+## 9. Cleanup
+
+```bash
+# stop dev servers
+lsof -ti tcp:3000,tcp:5173 -sTCP:LISTEN | xargs kill
+# remove local test users (optional; local DB only)
+docker compose exec -T postgres psql -U percy -d percy_main -c "
+  DELETE FROM \"user\" WHERE email IN ('alice@test.local','bob@test.local');"
+rm -f apps/api/scratch-probe.mts /tmp/alice.cookies
+```
+
+## Quick reference
+
+- Payout endpoint: `POST /api/expenses/:expenseId/payout` (perm `expenses:pay`).
+- Webhook: `POST /api/stripe/payouts-webhook` (raw body, separate signing secret).
+- Client: [`apps/api/src/features/expense/payouts.ts`](apps/api/src/features/expense/payouts.ts).
+- Orchestration: `payoutExpense` + `applyPayoutWebhook` in
+  [`apps/api/src/features/expense/service.ts`](apps/api/src/features/expense/service.ts).
+- Decisions + residual notes: [`EXPENSES.md`](EXPENSES.md),
+  [ADR 050](docs/adrs/050-reimbursement-payouts-stripe-global-payouts.md),
+  [ADR 051](docs/adrs/051-stripe-global-payouts-raw-request-isolation.md).
+
+When the real shapes are confirmed and any fixes are in, update the "residual"
+note in EXPENSES.md and this file's status line, and consider replacing the
+fake-client payout tests with a sandbox smoke test gated on the env vars.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -50,6 +50,7 @@ import { contentImageRoutes } from "./features/content-images/routes.ts";
 import { contentRoutes } from "./features/content/routes.ts";
 import { cricketLeaderboardRoutes } from "./features/cricket-leaderboard/routes.ts";
 import { documentRoutes } from "./features/documents/routes.ts";
+import { expenseRoutes } from "./features/expense/routes.ts";
 import { fantasyRoutes } from "./features/fantasy/routes.ts";
 import { financialReliefRoutes } from "./features/financial-relief/routes.ts";
 import { gamesRoutes } from "./features/games/routes.ts";
@@ -310,6 +311,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(contactRoutes, { prefix: "/api" });
   await app.register(incidentReportRoutes, { prefix: "/api" });
   await app.register(financialReliefRoutes, { prefix: "/api" });
+  await app.register(expenseRoutes, { prefix: "/api" });
   await app.register(userGroupsRoutes, { prefix: "/api" });
   await app.register(marketingRoutes, { prefix: "/api" });
   await app.register(notifPrefsRoutes, { prefix: "/api" });

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -63,6 +63,19 @@ const configSchema = z.object({
   STRIPE_SECRET_KEY: z.string(),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),
 
+  // Stripe Global Payouts (EXPENSES.md Phase 2). Preview v2 API; see
+  // features/expense/payouts.ts. Deliberately placeholder-tolerant (not hard
+  // required) so the API boots everywhere before the preview Financial Account
+  // is provisioned - the payout endpoint returns a clear "not configured"
+  // error until both are set. Enabling payouts in prod also means wiring these
+  // as SSM params in infra (mirror VAPID_PUBLIC_KEY) and seeding the real
+  // financial account id + preview version string.
+  STRIPE_FINANCIAL_ACCOUNT_ID: optionalPlaceholderString,
+  STRIPE_PAYOUTS_API_VERSION: optionalPlaceholderString,
+  // Separate webhook signing secret for the v2 money-management event
+  // destination (distinct from the v1 STRIPE_WEBHOOK_SECRET).
+  STRIPE_PAYOUTS_WEBHOOK_SECRET: optionalPlaceholderString,
+
   // Email
   EMAIL_PROVIDER: z.enum(["dev", "ses"]).default("dev"),
   SES_REGION: z.string().default("eu-west-2"),

--- a/apps/api/src/features/expense/integration.test.ts
+++ b/apps/api/src/features/expense/integration.test.ts
@@ -632,4 +632,37 @@ describe("expense payouts (integration)", () => {
       .executeTakeFirstOrThrow();
     expect(row.status).toBe("payout_failed");
   });
+
+  it("retries a webhook-failed payout instead of echoing the old failed one", async () => {
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const { id } = await approvedClaim();
+    const firstOp = `op_${crypto.randomUUID()}`;
+    const secondOp = `op_${crypto.randomUUID()}`;
+    const createOutboundPayment = vi
+      .fn()
+      .mockResolvedValueOnce({ id: firstOp, status: "processing" })
+      .mockResolvedValueOnce({ id: secondOp, status: "processing" });
+    const run = () =>
+      payoutExpense(ctx.db, {
+        client: fakeClient({
+          getDefaultPayoutMethodId: vi.fn().mockResolvedValue("pm_test"),
+          createOutboundPayment,
+        }),
+        send: vi.fn(),
+        baseUrl: "https://percymain.org",
+      })(payer.userId, id, log);
+
+    await run();
+    await applyPayoutWebhook(ctx.db)(firstOp, "payout_failed", log);
+
+    // The claim is payout_failed but still carries firstOp's id. A retry must
+    // NOT short-circuit on that id; it should create a fresh payment.
+    const retry = await run();
+    expect(createOutboundPayment).toHaveBeenCalledTimes(2);
+    expect(retry.status).toBe("paid");
+    expect(retry.stripeOutboundPaymentId).toBe(secondOp);
+  });
 });

--- a/apps/api/src/features/expense/integration.test.ts
+++ b/apps/api/src/features/expense/integration.test.ts
@@ -57,10 +57,7 @@ async function submitClaim(
   overrides: { amountPence?: number; tagNames?: string[] } = {},
 ) {
   const send = vi.fn().mockResolvedValue(undefined);
-  const { id } = await submitExpense(
-    ctx.db,
-    deps(send),
-  )(
+  const { id } = await submitExpense(ctx.db, deps(send))(
     submitter.userId,
     submitter.name,
     {
@@ -76,7 +73,9 @@ async function submitClaim(
 describe("expense (integration)", () => {
   it("submit creates a pending expense, tag links and a submitted event", async () => {
     const submitter = await seedSubmitter();
-    const { id } = await submitClaim(submitter, { tagNames: ["Fuel", "Travel"] });
+    const { id } = await submitClaim(submitter, {
+      tagNames: ["Fuel", "Travel"],
+    });
 
     const row = await ctx.db
       .selectFrom("expense")
@@ -115,10 +114,7 @@ describe("expense (integration)", () => {
 
   it("submit stores a receipt url when an image is provided", async () => {
     const submitter = await seedSubmitter();
-    const { id } = await submitExpense(
-      ctx.db,
-      deps(),
-    )(
+    const { id } = await submitExpense(ctx.db, deps())(
       submitter.userId,
       submitter.name,
       {
@@ -140,10 +136,7 @@ describe("expense (integration)", () => {
   it("submit rejects a malformed receipt data url (400)", async () => {
     const submitter = await seedSubmitter();
     await expect(
-      submitExpense(
-        ctx.db,
-        deps(),
-      )(
+      submitExpense(ctx.db, deps())(
         submitter.userId,
         submitter.name,
         {
@@ -237,7 +230,12 @@ describe("expense (integration)", () => {
     });
     const { id } = await submitClaim(both);
     await expect(
-      decideExpense(ctx.db, deps())(both.userId, id, { decision: "approve" }, log),
+      decideExpense(ctx.db, deps())(
+        both.userId,
+        id,
+        { decision: "approve" },
+        log,
+      ),
     ).rejects.toMatchObject({ statusCode: 403 });
   });
 
@@ -329,12 +327,10 @@ describe("expense (integration)", () => {
     );
 
     const send = vi.fn().mockResolvedValue(undefined);
-    const result = await markExpensePaid(ctx.db, { send, baseUrl: "https://x" })(
-      payer.userId,
-      id,
-      { note: "Faster Payment sent" },
-      log,
-    );
+    const result = await markExpensePaid(ctx.db, {
+      send,
+      baseUrl: "https://x",
+    })(payer.userId, id, { note: "Faster Payment sent" }, log);
     expect(result.success).toBe(true);
     expect(send).toHaveBeenCalledOnce();
 

--- a/apps/api/src/features/expense/integration.test.ts
+++ b/apps/api/src/features/expense/integration.test.ts
@@ -1,0 +1,429 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { S3Uploader } from "../../lib/s3-upload.ts";
+import { createNoopLogger } from "../../lib/worker-logger.ts";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import {
+  createCategory,
+  decideExpense,
+  getExpenseDetail,
+  getExpenseSummary,
+  getMyExpenses,
+  listCategories,
+  listExpenses,
+  markExpensePaid,
+  submitExpense,
+  updateCategory,
+} from "./service.ts";
+
+const log = createNoopLogger();
+
+// Not testing email rendering — keep focused on DB state and notification fan-out.
+vi.mock("react-email", () => ({
+  render: vi.fn().mockResolvedValue("<html></html>"),
+}));
+
+let ctx: TestContext;
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+}, 60_000);
+
+afterAll(async () => {
+  await stopTestContainer(ctx);
+});
+
+const fakeS3: S3Uploader = {
+  uploadReceipt: vi.fn().mockResolvedValue("https://s3.example/receipt.jpg"),
+};
+
+function deps(send = vi.fn().mockResolvedValue(undefined)) {
+  return { send, baseUrl: "https://percymain.org", s3: fakeS3 };
+}
+
+async function seedSubmitter() {
+  return seedTestUser(ctx.db, { role: "expense_submitter", withMember: false });
+}
+async function seedApprover() {
+  return seedTestUser(ctx.db, { role: "expense_approver", withMember: false });
+}
+
+async function submitClaim(
+  submitter: { userId: string; name: string },
+  overrides: { amountPence?: number; tagNames?: string[] } = {},
+) {
+  const send = vi.fn().mockResolvedValue(undefined);
+  const { id } = await submitExpense(
+    ctx.db,
+    deps(send),
+  )(
+    submitter.userId,
+    submitter.name,
+    {
+      description: "Petrol to the away game",
+      amountPence: overrides.amountPence ?? 2000,
+      tagNames: overrides.tagNames ?? ["fuel"],
+    },
+    log,
+  );
+  return { id, send };
+}
+
+describe("expense (integration)", () => {
+  it("submit creates a pending expense, tag links and a submitted event", async () => {
+    const submitter = await seedSubmitter();
+    const { id } = await submitClaim(submitter, { tagNames: ["Fuel", "Travel"] });
+
+    const row = await ctx.db
+      .selectFrom("expense")
+      .where("id", "=", id)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("pending");
+    expect(row.created_by).toBe(submitter.userId);
+    expect(row.amount_pence).toBe(2000);
+
+    const tags = await ctx.db
+      .selectFrom("expense_category_link")
+      .where("expense_id", "=", id)
+      .selectAll()
+      .execute();
+    expect(tags).toHaveLength(2);
+
+    const events = await ctx.db
+      .selectFrom("expense_event")
+      .where("expense_id", "=", id)
+      .selectAll()
+      .execute();
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("submitted");
+    expect(events[0].to_status).toBe("pending");
+  });
+
+  it("submit notifies every expense_approver by email", async () => {
+    await seedApprover();
+    await seedApprover();
+    const submitter = await seedSubmitter();
+    const { send } = await submitClaim(submitter);
+    // At least the two approvers we just seeded (other tests may add more).
+    expect(send.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("submit stores a receipt url when an image is provided", async () => {
+    const submitter = await seedSubmitter();
+    const { id } = await submitExpense(
+      ctx.db,
+      deps(),
+    )(
+      submitter.userId,
+      submitter.name,
+      {
+        description: "New stumps",
+        amountPence: 4000,
+        receiptImage: "data:image/png;base64,iVBORw0KGgoAAAANS=",
+        tagNames: ["equipment"],
+      },
+      log,
+    );
+    const row = await ctx.db
+      .selectFrom("expense")
+      .where("id", "=", id)
+      .select(["receipt_image_url"])
+      .executeTakeFirstOrThrow();
+    expect(row.receipt_image_url).toBe("https://s3.example/receipt.jpg");
+  });
+
+  it("submit rejects a malformed receipt data url (400)", async () => {
+    const submitter = await seedSubmitter();
+    await expect(
+      submitExpense(
+        ctx.db,
+        deps(),
+      )(
+        submitter.userId,
+        submitter.name,
+        {
+          description: "x",
+          amountPence: 100,
+          receiptImage: "not-a-data-url",
+          tagNames: [],
+        },
+        log,
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("a single approver approves a sub-GBP-50 claim", async () => {
+    const submitter = await seedSubmitter();
+    const approver = await seedApprover();
+    const { id } = await submitClaim(submitter, { amountPence: 2000 });
+
+    const result = await decideExpense(ctx.db, deps())(
+      approver.userId,
+      id,
+      { decision: "approve", note: "Fine" },
+      log,
+    );
+    expect(result.status).toBe("approved");
+
+    const row = await ctx.db
+      .selectFrom("expense")
+      .where("id", "=", id)
+      .select(["status"])
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("approved");
+  });
+
+  it("a GBP 50+ claim needs two distinct approvers", async () => {
+    const submitter = await seedSubmitter();
+    const approver1 = await seedApprover();
+    const approver2 = await seedApprover();
+    const { id } = await submitClaim(submitter, { amountPence: 5000 });
+
+    const first = await decideExpense(ctx.db, deps())(
+      approver1.userId,
+      id,
+      { decision: "approve" },
+      log,
+    );
+    expect(first.status).toBe("awaiting_second_approval");
+
+    const second = await decideExpense(ctx.db, deps())(
+      approver2.userId,
+      id,
+      { decision: "approve" },
+      log,
+    );
+    expect(second.status).toBe("approved");
+
+    const approvals = await ctx.db
+      .selectFrom("expense_approval")
+      .where("expense_id", "=", id)
+      .selectAll()
+      .execute();
+    expect(approvals).toHaveLength(2);
+  });
+
+  it("the same approver cannot supply both approvals (409)", async () => {
+    const submitter = await seedSubmitter();
+    const approver = await seedApprover();
+    const { id } = await submitClaim(submitter, { amountPence: 8000 });
+
+    await decideExpense(ctx.db, deps())(
+      approver.userId,
+      id,
+      { decision: "approve" },
+      log,
+    );
+    await expect(
+      decideExpense(ctx.db, deps())(
+        approver.userId,
+        id,
+        { decision: "approve" },
+        log,
+      ),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("an approver cannot decide their own claim (403)", async () => {
+    // A user who can both submit and approve.
+    const both = await seedTestUser(ctx.db, {
+      role: "expense_submitter,expense_approver",
+      withMember: false,
+    });
+    const { id } = await submitClaim(both);
+    await expect(
+      decideExpense(ctx.db, deps())(both.userId, id, { decision: "approve" }, log),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("approval requires at least one tag", async () => {
+    const submitter = await seedSubmitter();
+    const approver = await seedApprover();
+    const { id } = await submitClaim(submitter, { tagNames: [] });
+    await expect(
+      decideExpense(ctx.db, deps())(
+        approver.userId,
+        id,
+        { decision: "approve" },
+        log,
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("an approver can replace the tag set when approving", async () => {
+    const submitter = await seedSubmitter();
+    const approver = await seedApprover();
+    const { id } = await submitClaim(submitter, { tagNames: ["wrong-tag"] });
+
+    await decideExpense(ctx.db, deps())(
+      approver.userId,
+      id,
+      { decision: "approve", tagNames: ["umpires fee"] },
+      log,
+    );
+
+    const detail = await getExpenseDetail(ctx.db)(id);
+    expect(detail.tags.map((t) => t.name)).toEqual(["umpires fee"]);
+  });
+
+  it("deny closes the claim, records the approver note, and emails the submitter", async () => {
+    const submitter = await seedSubmitter();
+    const approver = await seedApprover();
+    const { id } = await submitClaim(submitter);
+    const send = vi.fn().mockResolvedValue(undefined);
+
+    const result = await decideExpense(ctx.db, { send, baseUrl: "https://x" })(
+      approver.userId,
+      id,
+      { decision: "deny", note: "Out of policy" },
+      log,
+    );
+    expect(result.status).toBe("denied");
+    expect(send).toHaveBeenCalledOnce();
+
+    const detail = await getExpenseDetail(ctx.db)(id);
+    expect(detail.expense.status).toBe("denied");
+    const denied = detail.approvals.find((a) => a.decision === "denied");
+    expect(denied?.note).toBe("Out of policy");
+  });
+
+  it("a decided claim cannot be decided again (400)", async () => {
+    const submitter = await seedSubmitter();
+    const approver1 = await seedApprover();
+    const approver2 = await seedApprover();
+    const { id } = await submitClaim(submitter, { amountPence: 1000 });
+    await decideExpense(ctx.db, deps())(
+      approver1.userId,
+      id,
+      { decision: "approve" },
+      log,
+    );
+    await expect(
+      decideExpense(ctx.db, deps())(
+        approver2.userId,
+        id,
+        { decision: "approve" },
+        log,
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("mark-paid moves an approved claim to paid and emails the submitter", async () => {
+    const submitter = await seedSubmitter();
+    const approver = await seedApprover();
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const { id } = await submitClaim(submitter, { amountPence: 2000 });
+    await decideExpense(ctx.db, deps())(
+      approver.userId,
+      id,
+      { decision: "approve" },
+      log,
+    );
+
+    const send = vi.fn().mockResolvedValue(undefined);
+    const result = await markExpensePaid(ctx.db, { send, baseUrl: "https://x" })(
+      payer.userId,
+      id,
+      { note: "Faster Payment sent" },
+      log,
+    );
+    expect(result.success).toBe(true);
+    expect(send).toHaveBeenCalledOnce();
+
+    const row = await ctx.db
+      .selectFrom("expense")
+      .where("id", "=", id)
+      .select(["status", "paid_at"])
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("paid");
+    expect(row.paid_at).not.toBeNull();
+  });
+
+  it("mark-paid rejects a claim that is not approved (400)", async () => {
+    const submitter = await seedSubmitter();
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const { id } = await submitClaim(submitter);
+    await expect(
+      markExpensePaid(ctx.db, deps())(payer.userId, id, {}, log),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("getMyExpenses returns only the caller's claims", async () => {
+    const a = await seedSubmitter();
+    const b = await seedSubmitter();
+    const { id: aId } = await submitClaim(a);
+    await submitClaim(b);
+
+    const mine = await getMyExpenses(ctx.db)(a.userId);
+    expect(mine.items.map((i) => i.id)).toEqual([aId]);
+    expect(mine.items[0].needsTwoApprovers).toBe(false);
+    expect(mine.items[0].tags.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("listExpenses filters by status and tag", async () => {
+    const submitter = await seedSubmitter();
+    const approver = await seedApprover();
+    const { id: approvedId } = await submitClaim(submitter, {
+      tagNames: ["filter-unique-tag"],
+    });
+    await decideExpense(ctx.db, deps())(
+      approver.userId,
+      approvedId,
+      { decision: "approve" },
+      log,
+    );
+
+    const approved = await listExpenses(ctx.db)({
+      page: 1,
+      pageSize: 100,
+      status: "approved",
+    });
+    expect(approved.items.some((i) => i.id === approvedId)).toBe(true);
+    expect(approved.items.every((i) => i.status === "approved")).toBe(true);
+  });
+
+  it("summary aggregates counts and totals by status", async () => {
+    const submitter = await seedSubmitter();
+    const approver = await seedApprover();
+    const { id } = await submitClaim(submitter, { amountPence: 3000 });
+    await decideExpense(ctx.db, deps())(
+      approver.userId,
+      id,
+      { decision: "approve" },
+      log,
+    );
+
+    const summary = await getExpenseSummary(ctx.db)({});
+    expect(summary.byStatus.approved.count).toBeGreaterThanOrEqual(1);
+    expect(summary.byStatus.approved.totalPence).toBeGreaterThanOrEqual(3000);
+    expect(summary.totals.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("categories dedupe case-insensitively and can be archived", async () => {
+    const submitter = await seedSubmitter();
+    const first = await createCategory(ctx.db)(submitter.userId, {
+      name: "Ground Hire",
+    });
+    const second = await createCategory(ctx.db)(submitter.userId, {
+      name: "ground hire",
+    });
+    expect(second.id).toBe(first.id);
+
+    await updateCategory(ctx.db)(first.id, { archived: true });
+    const active = await listCategories(ctx.db)(false);
+    expect(active.categories.some((c) => c.id === first.id)).toBe(false);
+    const all = await listCategories(ctx.db)(true);
+    expect(all.categories.some((c) => c.id === first.id)).toBe(true);
+  });
+});

--- a/apps/api/src/features/expense/integration.test.ts
+++ b/apps/api/src/features/expense/integration.test.ts
@@ -7,7 +7,9 @@ import {
   stopTestContainer,
   type TestContext,
 } from "../../test/containers.ts";
+import type { PayoutsClient } from "./payouts.ts";
 import {
+  applyPayoutWebhook,
   createCategory,
   decideExpense,
   getExpenseDetail,
@@ -16,6 +18,7 @@ import {
   listCategories,
   listExpenses,
   markExpensePaid,
+  payoutExpense,
   submitExpense,
   updateCategory,
 } from "./service.ts";
@@ -421,5 +424,216 @@ describe("expense (integration)", () => {
     expect(active.categories.some((c) => c.id === first.id)).toBe(false);
     const all = await listCategories(ctx.db)(true);
     expect(all.categories.some((c) => c.id === first.id)).toBe(true);
+  });
+});
+
+function fakeClient(overrides: Partial<PayoutsClient> = {}): PayoutsClient {
+  return {
+    createRecipient: vi.fn().mockResolvedValue("acct_recipient_test"),
+    createPayoutMethodSetupLink: vi
+      .fn()
+      .mockResolvedValue("https://stripe.test/onboard"),
+    getDefaultPayoutMethodId: vi.fn().mockResolvedValue(null),
+    createOutboundPayment: vi
+      .fn()
+      .mockResolvedValue({
+        id: `op_${crypto.randomUUID()}`,
+        status: "processing",
+      }),
+    parseWebhookEvent: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function approvedClaim(amountPence = 2000) {
+  const submitter = await seedSubmitter();
+  const approver = await seedApprover();
+  const { id } = await submitClaim(submitter, { amountPence });
+  await decideExpense(ctx.db, deps())(
+    approver.userId,
+    id,
+    { decision: "approve" },
+    log,
+  );
+  return { id, submitter };
+}
+
+describe("expense payouts (integration)", () => {
+  it("returns a Stripe onboarding link when the claimant has no payout method", async () => {
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const { id } = await approvedClaim();
+    const client = fakeClient({
+      getDefaultPayoutMethodId: vi.fn().mockResolvedValue(null),
+    });
+
+    const result = await payoutExpense(ctx.db, {
+      client,
+      send: vi.fn(),
+      baseUrl: "https://percymain.org",
+    })(payer.userId, id, log);
+
+    expect(result.onboardingUrl).toBe("https://stripe.test/onboard");
+    expect(result.status).toBe("approved");
+    const row = await ctx.db
+      .selectFrom("expense")
+      .where("id", "=", id)
+      .select(["status", "stripe_recipient_account_id"])
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("approved");
+    expect(row.stripe_recipient_account_id).toBe("acct_recipient_test");
+  });
+
+  it("creates an outbound payment and marks the claim paid", async () => {
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const { id } = await approvedClaim(3000);
+    const opId = `op_${crypto.randomUUID()}`;
+    const send = vi.fn().mockResolvedValue(undefined);
+    const client = fakeClient({
+      getDefaultPayoutMethodId: vi.fn().mockResolvedValue("pm_test"),
+      createOutboundPayment: vi
+        .fn()
+        .mockResolvedValue({ id: opId, status: "processing" }),
+    });
+
+    const result = await payoutExpense(ctx.db, {
+      client,
+      send,
+      baseUrl: "https://percymain.org",
+    })(payer.userId, id, log);
+
+    expect(result.status).toBe("paid");
+    expect(result.stripeOutboundPaymentId).toBe(opId);
+    expect(send).toHaveBeenCalledOnce();
+    const row = await ctx.db
+      .selectFrom("expense")
+      .where("id", "=", id)
+      .select(["status", "stripe_outbound_payment_id", "paid_at"])
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("paid");
+    expect(row.stripe_outbound_payment_id).toBe(opId);
+    expect(row.paid_at).not.toBeNull();
+  });
+
+  it("never pays a claim twice (idempotent)", async () => {
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const { id } = await approvedClaim();
+    const createOutboundPayment = vi
+      .fn()
+      .mockResolvedValue({
+        id: `op_${crypto.randomUUID()}`,
+        status: "processing",
+      });
+    const client = fakeClient({
+      getDefaultPayoutMethodId: vi.fn().mockResolvedValue("pm_test"),
+      createOutboundPayment,
+    });
+    const run = () =>
+      payoutExpense(ctx.db, {
+        client,
+        send: vi.fn(),
+        baseUrl: "https://percymain.org",
+      })(payer.userId, id, log);
+
+    const first = await run();
+    const second = await run();
+    expect(second.stripeOutboundPaymentId).toBe(first.stripeOutboundPaymentId);
+    expect(createOutboundPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it("records payout_failed when the OutboundPayment call throws", async () => {
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const { id } = await approvedClaim();
+    const client = fakeClient({
+      getDefaultPayoutMethodId: vi.fn().mockResolvedValue("pm_test"),
+      createOutboundPayment: vi
+        .fn()
+        .mockRejectedValue(new Error("insufficient funds")),
+    });
+
+    const result = await payoutExpense(ctx.db, {
+      client,
+      send: vi.fn(),
+      baseUrl: "https://percymain.org",
+    })(payer.userId, id, log);
+
+    expect(result.status).toBe("payout_failed");
+    const row = await ctx.db
+      .selectFrom("expense")
+      .where("id", "=", id)
+      .select(["status", "payout_failure_reason"])
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("payout_failed");
+    expect(row.payout_failure_reason).toContain("insufficient funds");
+  });
+
+  it("rejects a payout on a non-approved claim (400)", async () => {
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const submitter = await seedSubmitter();
+    const { id } = await submitClaim(submitter);
+    await expect(
+      payoutExpense(ctx.db, {
+        client: fakeClient(),
+        send: vi.fn(),
+        baseUrl: "https://percymain.org",
+      })(payer.userId, id, log),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("returns 503 when Global Payouts is not configured", async () => {
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const { id } = await approvedClaim();
+    await expect(
+      payoutExpense(ctx.db, {
+        client: null,
+        send: vi.fn(),
+        baseUrl: "https://percymain.org",
+      })(payer.userId, id, log),
+    ).rejects.toMatchObject({ statusCode: 503 });
+  });
+
+  it("webhook flips a paid claim to payout_failed on a failure event", async () => {
+    const payer = await seedTestUser(ctx.db, {
+      role: "finance_admin",
+      withMember: false,
+    });
+    const { id } = await approvedClaim();
+    const opId = `op_${crypto.randomUUID()}`;
+    await payoutExpense(ctx.db, {
+      client: fakeClient({
+        getDefaultPayoutMethodId: vi.fn().mockResolvedValue("pm_test"),
+        createOutboundPayment: vi
+          .fn()
+          .mockResolvedValue({ id: opId, status: "processing" }),
+      }),
+      send: vi.fn(),
+      baseUrl: "https://percymain.org",
+    })(payer.userId, id, log);
+
+    await applyPayoutWebhook(ctx.db)(opId, "payout_failed", log);
+
+    const row = await ctx.db
+      .selectFrom("expense")
+      .where("id", "=", id)
+      .select(["status"])
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("payout_failed");
   });
 });

--- a/apps/api/src/features/expense/integration.test.ts
+++ b/apps/api/src/features/expense/integration.test.ts
@@ -434,12 +434,10 @@ function fakeClient(overrides: Partial<PayoutsClient> = {}): PayoutsClient {
       .fn()
       .mockResolvedValue("https://stripe.test/onboard"),
     getDefaultPayoutMethodId: vi.fn().mockResolvedValue(null),
-    createOutboundPayment: vi
-      .fn()
-      .mockResolvedValue({
-        id: `op_${crypto.randomUUID()}`,
-        status: "processing",
-      }),
+    createOutboundPayment: vi.fn().mockResolvedValue({
+      id: `op_${crypto.randomUUID()}`,
+      status: "processing",
+    }),
     parseWebhookEvent: vi.fn(),
     ...overrides,
   };
@@ -526,12 +524,10 @@ describe("expense payouts (integration)", () => {
       withMember: false,
     });
     const { id } = await approvedClaim();
-    const createOutboundPayment = vi
-      .fn()
-      .mockResolvedValue({
-        id: `op_${crypto.randomUUID()}`,
-        status: "processing",
-      });
+    const createOutboundPayment = vi.fn().mockResolvedValue({
+      id: `op_${crypto.randomUUID()}`,
+      status: "processing",
+    });
     const client = fakeClient({
       getDefaultPayoutMethodId: vi.fn().mockResolvedValue("pm_test"),
       createOutboundPayment,

--- a/apps/api/src/features/expense/payouts.test.ts
+++ b/apps/api/src/features/expense/payouts.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { createPayoutsClient, mapOutboundPaymentEvent } from "./payouts.ts";
+
+describe("mapOutboundPaymentEvent", () => {
+  it("maps posted/paid events to paid", () => {
+    expect(
+      mapOutboundPaymentEvent("v2.money_management.outbound_payment.posted"),
+    ).toBe("paid");
+    expect(
+      mapOutboundPaymentEvent("v2.money_management.outbound_payment.paid"),
+    ).toBe("paid");
+  });
+
+  it("maps failed/returned/canceled events to payout_failed", () => {
+    for (const suffix of ["failed", "returned", "canceled"]) {
+      expect(
+        mapOutboundPaymentEvent(
+          `v2.money_management.outbound_payment.${suffix}`,
+        ),
+      ).toBe("payout_failed");
+    }
+  });
+
+  it("ignores unrelated or non-terminal events", () => {
+    expect(
+      mapOutboundPaymentEvent("v2.money_management.outbound_payment.created"),
+    ).toBeNull();
+    expect(mapOutboundPaymentEvent("v1.payment_intent.succeeded")).toBeNull();
+  });
+});
+
+describe("createPayoutsClient", () => {
+  it("returns null when the financial account or version is missing", () => {
+    expect(createPayoutsClient({ stripeSecretKey: "sk_test_x" })).toBeNull();
+    expect(
+      createPayoutsClient({
+        stripeSecretKey: "sk_test_x",
+        financialAccountId: "fa_123",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns a client when fully configured", () => {
+    expect(
+      createPayoutsClient({
+        stripeSecretKey: "sk_test_x",
+        financialAccountId: "fa_123",
+        apiVersion: "2026-05-27.preview",
+      }),
+    ).not.toBeNull();
+  });
+});

--- a/apps/api/src/features/expense/payouts.ts
+++ b/apps/api/src/features/expense/payouts.ts
@@ -1,0 +1,187 @@
+import Stripe from "stripe";
+
+/**
+ * Stripe Global Payouts client (EXPENSES.md Phase 2).
+ *
+ * Global Payouts is on Stripe's preview v2 API, which the pinned stripe@22 SDK
+ * does NOT bundle as typed `moneyManagement` resources (only v2.core.accounts +
+ * v2.core.eventDestinations ship). So we drive the money-movement endpoints via
+ * `stripe.rawRequest` on a DEDICATED client pinned to the preview apiVersion.
+ * This isolates the preview surface completely from the live v1 (Basil)
+ * payments client used elsewhere - no SDK bump, no risk to existing flows.
+ *
+ * The exact preview request/response shapes and event names still need
+ * verifying against the live preview account when this is wired end to end
+ * (EXPENSES.md, Phase 0 residual notes).
+ */
+
+export interface OutboundPaymentResult {
+  id: string;
+  status: string;
+}
+
+export interface PayoutsClient {
+  /** Create a Global Payouts recipient (Accounts v2). Returns the account id. */
+  createRecipient(args: {
+    name: string;
+    email: string | null;
+  }): Promise<string>;
+  /**
+   * Hosted link the claimant follows to add their bank details directly to
+   * Stripe (so we never hold the sort code / account number). Returns the URL.
+   */
+  createPayoutMethodSetupLink(args: {
+    recipientId: string;
+    returnUrl: string;
+    refreshUrl: string;
+  }): Promise<string>;
+  /** The recipient's default payout method id, or null if none is set yet. */
+  getDefaultPayoutMethodId(recipientId: string): Promise<string | null>;
+  /** Move money from our Financial Account to the recipient. */
+  createOutboundPayment(args: {
+    recipientId: string;
+    payoutMethodId: string;
+    amountPence: number;
+    description: string;
+    idempotencyKey: string;
+  }): Promise<OutboundPaymentResult>;
+  /** Verify + parse a v2 money-management webhook event. */
+  parseWebhookEvent(rawBody: Buffer, signature: string): Stripe.Event;
+}
+
+interface RawAccount {
+  id: string;
+}
+interface RawAccountLink {
+  url: string;
+}
+interface RawPayoutMethodList {
+  data: Array<{ id: string }>;
+}
+interface RawOutboundPayment {
+  id: string;
+  status: string;
+}
+
+/**
+ * Returns a configured client, or null when Global Payouts isn't provisioned
+ * (no financial account id / preview version). Callers must treat null as
+ * "payouts not configured" and surface a clear error.
+ */
+export function createPayoutsClient(config: {
+  stripeSecretKey: string;
+  financialAccountId?: string;
+  apiVersion?: string;
+  webhookSecret?: string;
+}): PayoutsClient | null {
+  if (!config.financialAccountId || !config.apiVersion) return null;
+
+  const financialAccountId = config.financialAccountId;
+  const webhookSecret = config.webhookSecret;
+  const apiVersion = config.apiVersion;
+  const stripe = new Stripe(config.stripeSecretKey);
+
+  // The preview Stripe-Version goes on every request (the constructor's
+  // apiVersion is a closed literal union, but the per-request option is a
+  // plain string). rawRequest returns Promise<any>, which flows to Promise<T>.
+  const raw = <T>(
+    method: "GET" | "POST",
+    path: string,
+    params?: Record<string, unknown>,
+    options?: { stripeContext?: string; idempotencyKey?: string },
+  ): Promise<T> =>
+    stripe.rawRequest(method, path, params, { apiVersion, ...options });
+
+  return {
+    async createRecipient({ name, email }) {
+      const account = await raw<RawAccount>("POST", "/v2/core/accounts", {
+        display_name: name,
+        contact_email: email ?? undefined,
+        identity: { country: "gb", entity_type: "individual" },
+        configuration: {
+          recipient: {
+            capabilities: { bank_accounts: { local: { requested: true } } },
+          },
+        },
+      });
+      return account.id;
+    },
+
+    async createPayoutMethodSetupLink({ recipientId, returnUrl, refreshUrl }) {
+      const link = await raw<RawAccountLink>("POST", "/v2/core/account_links", {
+        account: recipientId,
+        use_case: {
+          type: "account_onboarding",
+          account_onboarding: {
+            configurations: ["recipient"],
+            return_url: returnUrl,
+            refresh_url: refreshUrl,
+          },
+        },
+      });
+      return link.url;
+    },
+
+    async getDefaultPayoutMethodId(recipientId) {
+      const list = await raw<RawPayoutMethodList>(
+        "GET",
+        "/v2/money_management/payout_methods",
+        undefined,
+        { stripeContext: recipientId },
+      );
+      return list.data[0]?.id ?? null;
+    },
+
+    async createOutboundPayment({
+      recipientId,
+      payoutMethodId,
+      amountPence,
+      description,
+      idempotencyKey,
+    }) {
+      const op = await raw<RawOutboundPayment>(
+        "POST",
+        "/v2/money_management/outbound_payments",
+        {
+          from: { financial_account: financialAccountId, currency: "gbp" },
+          to: { recipient: recipientId, payout_method: payoutMethodId },
+          amount: { value: amountPence, currency: "gbp" },
+          description,
+        },
+        { idempotencyKey },
+      );
+      return { id: op.id, status: op.status };
+    },
+
+    parseWebhookEvent(rawBody, signature) {
+      if (!webhookSecret) {
+        throw new Error("STRIPE_PAYOUTS_WEBHOOK_SECRET is not set");
+      }
+      // The v2 thin-event signature scheme matches v1, so constructEvent
+      // verifies it. The parsed event carries `type` + `related_object`.
+      return stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);
+    },
+  };
+}
+
+/**
+ * Map a v2 outbound-payment event type to the expense status it implies, or
+ * null if the event isn't a terminal outcome we act on. Kept pure + exported
+ * so it can be unit-tested without a live Stripe account.
+ */
+export function mapOutboundPaymentEvent(
+  eventType: string,
+): "paid" | "payout_failed" | null {
+  const t = eventType.toLowerCase();
+  if (t.includes("outbound_payment")) {
+    if (t.endsWith(".posted") || t.endsWith(".paid")) return "paid";
+    if (
+      t.endsWith(".failed") ||
+      t.endsWith(".returned") ||
+      t.endsWith(".canceled")
+    ) {
+      return "payout_failed";
+    }
+  }
+  return null;
+}

--- a/apps/api/src/features/expense/routes.ts
+++ b/apps/api/src/features/expense/routes.ts
@@ -1,4 +1,5 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { z } from "zod";
 import {
   getAuthSession,
   requireAnyPermission,
@@ -289,28 +290,39 @@ export const expenseRoutes: FastifyPluginAsyncZod = async (app) => {
 
     const onWebhook = applyPayoutWebhook(app.db);
 
-    webhookScope.post("/stripe/payouts-webhook", async (request, reply) => {
-      const signature = request.headers["stripe-signature"];
-      if (!payoutsClient || typeof signature !== "string") {
-        return reply.status(400).send({ error: "Bad webhook request" });
-      }
-      let event;
-      try {
-        event = payoutsClient.parseWebhookEvent(
-          request.body as Buffer,
-          signature,
-        );
-      } catch (err) {
-        request.log.error({ err }, "expense_payout_webhook_bad_signature");
-        return reply.status(400).send({ error: "Invalid signature" });
-      }
+    webhookScope.post(
+      "/stripe/payouts-webhook",
+      {
+        schema: {
+          response: {
+            200: z.object({ received: z.boolean() }),
+            400: z.object({ error: z.string() }),
+          },
+        },
+      },
+      async (request, reply) => {
+        const signature = request.headers["stripe-signature"];
+        if (!payoutsClient || typeof signature !== "string") {
+          return reply.status(400).send({ error: "Bad webhook request" });
+        }
+        let event;
+        try {
+          event = payoutsClient.parseWebhookEvent(
+            request.body as Buffer,
+            signature,
+          );
+        } catch (err) {
+          request.log.error({ err }, "expense_payout_webhook_bad_signature");
+          return reply.status(400).send({ error: "Invalid signature" });
+        }
 
-      const outcome = mapOutboundPaymentEvent(event.type);
-      if (outcome) {
-        const id = outboundPaymentIdFromEvent(event);
-        if (id) await onWebhook(id, outcome, request.log);
-      }
-      return reply.status(200).send({ received: true });
-    });
+        const outcome = mapOutboundPaymentEvent(event.type);
+        if (outcome) {
+          const id = outboundPaymentIdFromEvent(event);
+          if (id) await onWebhook(id, outcome, request.log);
+        }
+        return reply.status(200).send({ received: true });
+      },
+    );
   });
 };

--- a/apps/api/src/features/expense/routes.ts
+++ b/apps/api/src/features/expense/routes.ts
@@ -1,0 +1,228 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import {
+  getAuthSession,
+  requireAnyPermission,
+  requirePermission,
+} from "../auth/middleware.ts";
+import {
+  categoriesResponseSchema,
+  categoryIdParamSchema,
+  createCategoryResponseSchema,
+  createCategorySchema,
+  decideExpenseResponseSchema,
+  decideExpenseSchema,
+  expenseDetailResponseSchema,
+  expenseIdParamSchema,
+  listExpensesResponseSchema,
+  listExpensesSchema,
+  markPaidExpenseResponseSchema,
+  markPaidExpenseSchema,
+  myExpensesResponseSchema,
+  submitExpenseResponseSchema,
+  submitExpenseSchema,
+  summaryQuerySchema,
+  summaryResponseSchema,
+  updateCategoryResponseSchema,
+  updateCategorySchema,
+} from "./schemas.ts";
+import {
+  createCategory,
+  decideExpense,
+  getExpenseDetail,
+  getExpenseSummary,
+  getMyExpenses,
+  listCategories,
+  listExpenses,
+  markExpensePaid,
+  submitExpense,
+  updateCategory,
+} from "./service.ts";
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const expenseRoutes: FastifyPluginAsyncZod = async (app) => {
+  const notifyDeps = { send: app.send, baseUrl: app.config.BASE_URL };
+
+  const submit = submitExpense(app.db, { ...notifyDeps, s3: app.s3 });
+  const myExpenses = getMyExpenses(app.db);
+  const list = listExpenses(app.db);
+  const detail = getExpenseDetail(app.db);
+  const decide = decideExpense(app.db, notifyDeps);
+  const markPaid = markExpensePaid(app.db, notifyDeps);
+  const summary = getExpenseSummary(app.db);
+  const categories = listCategories(app.db);
+  const addCategory = createCategory(app.db);
+  const editCategory = updateCategory(app.db);
+
+  // --- Submitter-facing ---
+
+  app.post(
+    "/expenses",
+    {
+      preHandler: [requirePermission("expenses", "submit")],
+      schema: {
+        body: submitExpenseSchema,
+        response: { 200: submitExpenseResponseSchema },
+      },
+    },
+    async (request) => {
+      const session = getAuthSession(request);
+      return await submit(
+        session.user.id,
+        session.user.name,
+        request.body,
+        request.log,
+      );
+    },
+  );
+
+  app.get(
+    "/expenses/mine",
+    {
+      preHandler: [requirePermission("expenses", "view_own")],
+      schema: { response: { 200: myExpensesResponseSchema } },
+    },
+    async (request) => {
+      const session = getAuthSession(request);
+      return await myExpenses(session.user.id);
+    },
+  );
+
+  // --- Tag vocabulary (shared by submit form + admin) ---
+
+  app.get(
+    "/expense-categories",
+    {
+      preHandler: [
+        requireAnyPermission(
+          { resource: "expenses", action: "submit" },
+          { resource: "expenses", action: "view" },
+        ),
+      ],
+      schema: { response: { 200: categoriesResponseSchema } },
+    },
+    async () => {
+      return await categories(false);
+    },
+  );
+
+  app.post(
+    "/expense-categories",
+    {
+      preHandler: [
+        requireAnyPermission(
+          { resource: "expenses", action: "submit" },
+          { resource: "expenses", action: "approve" },
+        ),
+      ],
+      schema: {
+        body: createCategorySchema,
+        response: { 200: createCategoryResponseSchema },
+      },
+    },
+    async (request) => {
+      const session = getAuthSession(request);
+      return await addCategory(session.user.id, request.body);
+    },
+  );
+
+  app.patch(
+    "/expense-categories/:categoryId",
+    {
+      preHandler: [requirePermission("expenses", "manage_tags")],
+      schema: {
+        params: categoryIdParamSchema,
+        body: updateCategorySchema,
+        response: { 200: updateCategoryResponseSchema },
+      },
+    },
+    async (request) => {
+      return await editCategory(request.params.categoryId, request.body);
+    },
+  );
+
+  // --- Approver / finance admin ---
+
+  app.get(
+    "/expenses",
+    {
+      preHandler: [requirePermission("expenses", "view")],
+      schema: {
+        querystring: listExpensesSchema,
+        response: { 200: listExpensesResponseSchema },
+      },
+    },
+    async (request) => {
+      return await list(request.query);
+    },
+  );
+
+  app.get(
+    "/expenses/summary",
+    {
+      preHandler: [requirePermission("expenses", "view")],
+      schema: {
+        querystring: summaryQuerySchema,
+        response: { 200: summaryResponseSchema },
+      },
+    },
+    async (request) => {
+      return await summary(request.query);
+    },
+  );
+
+  app.get(
+    "/expenses/:expenseId",
+    {
+      preHandler: [requirePermission("expenses", "view")],
+      schema: {
+        params: expenseIdParamSchema,
+        response: { 200: expenseDetailResponseSchema },
+      },
+    },
+    async (request) => {
+      return await detail(request.params.expenseId);
+    },
+  );
+
+  app.post(
+    "/expenses/:expenseId/decision",
+    {
+      preHandler: [requirePermission("expenses", "approve")],
+      schema: {
+        params: expenseIdParamSchema,
+        body: decideExpenseSchema,
+        response: { 200: decideExpenseResponseSchema },
+      },
+    },
+    async (request) => {
+      const session = getAuthSession(request);
+      return await decide(
+        session.user.id,
+        request.params.expenseId,
+        request.body,
+        request.log,
+      );
+    },
+  );
+
+  app.post(
+    "/expenses/:expenseId/mark-paid",
+    {
+      preHandler: [requirePermission("expenses", "pay")],
+      schema: {
+        params: expenseIdParamSchema,
+        body: markPaidExpenseSchema,
+        response: { 200: markPaidExpenseResponseSchema },
+      },
+    },
+    async (request) => {
+      const session = getAuthSession(request);
+      return await markPaid(
+        session.user.id,
+        request.params.expenseId,
+        request.body,
+        request.log,
+      );
+    },
+  );
+};

--- a/apps/api/src/features/expense/routes.ts
+++ b/apps/api/src/features/expense/routes.ts
@@ -4,6 +4,7 @@ import {
   requireAnyPermission,
   requirePermission,
 } from "../auth/middleware.ts";
+import { createPayoutsClient, mapOutboundPaymentEvent } from "./payouts.ts";
 import {
   categoriesResponseSchema,
   categoryIdParamSchema,
@@ -18,6 +19,7 @@ import {
   markPaidExpenseResponseSchema,
   markPaidExpenseSchema,
   myExpensesResponseSchema,
+  payoutExpenseResponseSchema,
   submitExpenseResponseSchema,
   submitExpenseSchema,
   summaryQuerySchema,
@@ -26,6 +28,7 @@ import {
   updateCategorySchema,
 } from "./schemas.ts";
 import {
+  applyPayoutWebhook,
   createCategory,
   decideExpense,
   getExpenseDetail,
@@ -34,13 +37,35 @@ import {
   listCategories,
   listExpenses,
   markExpensePaid,
+  payoutExpense,
   submitExpense,
   updateCategory,
 } from "./service.ts";
 
-// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+/** Pull the OutboundPayment id from a v2 thin event without unsafe casts. */
+function outboundPaymentIdFromEvent(event: unknown): string | null {
+  if (event && typeof event === "object") {
+    const e = event as {
+      data?: { object?: { id?: unknown } };
+      related_object?: { id?: unknown };
+    };
+    const fromData = e.data?.object?.id;
+    if (typeof fromData === "string") return fromData;
+    const fromRelated = e.related_object?.id;
+    if (typeof fromRelated === "string") return fromRelated;
+  }
+  return null;
+}
+
 export const expenseRoutes: FastifyPluginAsyncZod = async (app) => {
   const notifyDeps = { send: app.send, baseUrl: app.config.BASE_URL };
+
+  const payoutsClient = createPayoutsClient({
+    stripeSecretKey: app.config.STRIPE_SECRET_KEY,
+    financialAccountId: app.config.STRIPE_FINANCIAL_ACCOUNT_ID,
+    apiVersion: app.config.STRIPE_PAYOUTS_API_VERSION,
+    webhookSecret: app.config.STRIPE_PAYOUTS_WEBHOOK_SECRET,
+  });
 
   const submit = submitExpense(app.db, { ...notifyDeps, s3: app.s3 });
   const myExpenses = getMyExpenses(app.db);
@@ -48,6 +73,10 @@ export const expenseRoutes: FastifyPluginAsyncZod = async (app) => {
   const detail = getExpenseDetail(app.db);
   const decide = decideExpense(app.db, notifyDeps);
   const markPaid = markExpensePaid(app.db, notifyDeps);
+  const payout = payoutExpense(app.db, {
+    ...notifyDeps,
+    client: payoutsClient,
+  });
   const summary = getExpenseSummary(app.db);
   const categories = listCategories(app.db);
   const addCategory = createCategory(app.db);
@@ -225,4 +254,63 @@ export const expenseRoutes: FastifyPluginAsyncZod = async (app) => {
       );
     },
   );
+
+  app.post(
+    "/expenses/:expenseId/payout",
+    {
+      preHandler: [requirePermission("expenses", "pay")],
+      schema: {
+        params: expenseIdParamSchema,
+        response: { 200: payoutExpenseResponseSchema },
+      },
+    },
+    async (request) => {
+      const session = getAuthSession(request);
+      return await payout(
+        session.user.id,
+        request.params.expenseId,
+        request.log,
+      );
+    },
+  );
+
+  // Stripe Global Payouts (v2) webhook for OutboundPayment status. v2 thin
+  // events need the raw body for signature verification, so this lives in an
+  // encapsulated sub-plugin with its own buffer content-type parser - exactly
+  // like the v1 payments webhook, but kept separate (different signing secret
+  // and event shape).
+  // eslint-disable-next-line @typescript-eslint/require-await -- Fastify plugin callback must be async
+  await app.register(async (webhookScope) => {
+    webhookScope.addContentTypeParser(
+      "application/json",
+      { parseAs: "buffer" },
+      (_req, body, done) => done(null, body),
+    );
+
+    const onWebhook = applyPayoutWebhook(app.db);
+
+    webhookScope.post("/stripe/payouts-webhook", async (request, reply) => {
+      const signature = request.headers["stripe-signature"];
+      if (!payoutsClient || typeof signature !== "string") {
+        return reply.status(400).send({ error: "Bad webhook request" });
+      }
+      let event;
+      try {
+        event = payoutsClient.parseWebhookEvent(
+          request.body as Buffer,
+          signature,
+        );
+      } catch (err) {
+        request.log.error({ err }, "expense_payout_webhook_bad_signature");
+        return reply.status(400).send({ error: "Invalid signature" });
+      }
+
+      const outcome = mapOutboundPaymentEvent(event.type);
+      if (outcome) {
+        const id = outboundPaymentIdFromEvent(event);
+        if (id) await onWebhook(id, outcome, request.log);
+      }
+      return reply.status(200).send({ received: true });
+    });
+  });
 };

--- a/apps/api/src/features/expense/schemas.test.ts
+++ b/apps/api/src/features/expense/schemas.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { decideExpenseSchema, submitExpenseSchema } from "./schemas.ts";
+
+describe("submitExpenseSchema receipt rule (EXPENSES.md 13.9)", () => {
+  it("rejects a claim over GBP 10 with no receipt", () => {
+    const result = submitExpenseSchema.safeParse({
+      description: "Big spend",
+      amountPence: 1500,
+      tagNames: ["fuel"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a claim over GBP 10 with a receipt", () => {
+    const result = submitExpenseSchema.safeParse({
+      description: "Big spend",
+      amountPence: 1500,
+      receiptImage: "data:image/png;base64,iVBORw0KGgo=",
+      tagNames: ["fuel"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a claim of GBP 10 or under with no receipt", () => {
+    const result = submitExpenseSchema.safeParse({
+      description: "Small spend",
+      amountPence: 1000,
+      tagNames: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-positive amount", () => {
+    const result = submitExpenseSchema.safeParse({
+      description: "x",
+      amountPence: 0,
+      tagNames: [],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("decideExpenseSchema", () => {
+  it("accepts approve with a final tag set", () => {
+    const result = decideExpenseSchema.safeParse({
+      decision: "approve",
+      tagNames: ["umpires fee"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown decision", () => {
+    const result = decideExpenseSchema.safeParse({ decision: "maybe" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/features/expense/schemas.ts
+++ b/apps/api/src/features/expense/schemas.ts
@@ -28,13 +28,19 @@ export type SubmitExpense = z.infer<typeof submitExpenseSchema>;
 
 // --- Params --------------------------------------------------------------
 
-export const expenseIdParamSchema = z.object({ expenseId: z.string().min(1) });
+export const expenseIdParamSchema = z.object({ expenseId: z.uuid() });
 export type ExpenseIdParam = z.infer<typeof expenseIdParamSchema>;
 
 export const categoryIdParamSchema = z.object({
-  categoryId: z.string().min(1),
+  categoryId: z.uuid(),
 });
 export type CategoryIdParam = z.infer<typeof categoryIdParamSchema>;
+
+// Accepts an ISO date ("2026-06-18") or datetime; rejects garbage so a bad
+// filter returns a Zod 400 rather than reaching Postgres as a 500.
+const dateFilter = z
+  .string()
+  .refine((v) => !Number.isNaN(Date.parse(v)), { message: "Invalid date" });
 
 // --- Approver / admin actions -------------------------------------------
 
@@ -75,16 +81,16 @@ export const listExpensesSchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(100).default(20),
   status: z.union([expenseStatusSchema, z.literal("all")]).default("all"),
-  tagId: z.string().optional(),
+  tagId: z.uuid().optional(),
   search: z.string().optional(),
-  dateFrom: z.string().optional(),
-  dateTo: z.string().optional(),
+  dateFrom: dateFilter.optional(),
+  dateTo: dateFilter.optional(),
 });
 export type ListExpenses = z.infer<typeof listExpensesSchema>;
 
 export const summaryQuerySchema = z.object({
-  dateFrom: z.string().optional(),
-  dateTo: z.string().optional(),
+  dateFrom: dateFilter.optional(),
+  dateTo: dateFilter.optional(),
 });
 export type SummaryQuery = z.infer<typeof summaryQuerySchema>;
 

--- a/apps/api/src/features/expense/schemas.ts
+++ b/apps/api/src/features/expense/schemas.ts
@@ -204,6 +204,9 @@ export const markPaidExpenseResponseSchema = successResponseSchema;
 export const payoutExpenseResponseSchema = z.object({
   status: expenseStatusSchema,
   stripeOutboundPaymentId: z.string().nullable(),
+  // Stripe-hosted link the claimant must follow to add bank details before a
+  // payout can run. Null once the payment is created.
+  onboardingUrl: z.string().nullable(),
 });
 export const createCategoryResponseSchema = tagSchema;
 export const updateCategoryResponseSchema = successResponseSchema;

--- a/apps/api/src/features/expense/schemas.ts
+++ b/apps/api/src/features/expense/schemas.ts
@@ -1,4 +1,7 @@
-import { expenseReceiptRequired, expenseStatusSchema } from "@percy-main/shared";
+import {
+  expenseReceiptRequired,
+  expenseStatusSchema,
+} from "@percy-main/shared";
 import { z } from "zod";
 
 const successResponseSchema = z.object({ success: z.boolean() });
@@ -17,13 +20,10 @@ export const submitExpenseSchema = z
     // created. The approver can edit the final set at decision time.
     tagNames: z.array(z.string().trim().min(1).max(60)).max(10).default([]),
   })
-  .refine(
-    (d) => !expenseReceiptRequired(d.amountPence) || !!d.receiptImage,
-    {
-      message: "A receipt is required for claims over GBP 10",
-      path: ["receiptImage"],
-    },
-  );
+  .refine((d) => !expenseReceiptRequired(d.amountPence) || !!d.receiptImage, {
+    message: "A receipt is required for claims over GBP 10",
+    path: ["receiptImage"],
+  });
 export type SubmitExpense = z.infer<typeof submitExpenseSchema>;
 
 // --- Params --------------------------------------------------------------

--- a/apps/api/src/features/expense/schemas.ts
+++ b/apps/api/src/features/expense/schemas.ts
@@ -1,0 +1,209 @@
+import { expenseReceiptRequired, expenseStatusSchema } from "@percy-main/shared";
+import { z } from "zod";
+
+const successResponseSchema = z.object({ success: z.boolean() });
+const idResponseSchema = z.object({ id: z.string() });
+
+// --- Member-facing (submitter) ------------------------------------------
+
+export const submitExpenseSchema = z
+  .object({
+    description: z.string().min(1).max(500),
+    amountPence: z.number().int().positive(),
+    // Receipt image as a base64 data URL (data:image/...;base64,...), matching
+    // the matchday receipt-upload convention. Mandatory over GBP 10.
+    receiptImage: z.string().nullable().optional(),
+    // Tag names the claimant proposes; existing ones are reused, new ones are
+    // created. The approver can edit the final set at decision time.
+    tagNames: z.array(z.string().trim().min(1).max(60)).max(10).default([]),
+  })
+  .refine(
+    (d) => !expenseReceiptRequired(d.amountPence) || !!d.receiptImage,
+    {
+      message: "A receipt is required for claims over GBP 10",
+      path: ["receiptImage"],
+    },
+  );
+export type SubmitExpense = z.infer<typeof submitExpenseSchema>;
+
+// --- Params --------------------------------------------------------------
+
+export const expenseIdParamSchema = z.object({ expenseId: z.string().min(1) });
+export type ExpenseIdParam = z.infer<typeof expenseIdParamSchema>;
+
+export const categoryIdParamSchema = z.object({
+  categoryId: z.string().min(1),
+});
+export type CategoryIdParam = z.infer<typeof categoryIdParamSchema>;
+
+// --- Approver / admin actions -------------------------------------------
+
+export const decideExpenseSchema = z.object({
+  decision: z.enum(["approve", "deny"]),
+  note: z.string().max(2000).nullable().optional(),
+  // Final tag set; when omitted the existing tags are kept. At least one tag
+  // is required to approve (enforced in the service).
+  tagNames: z.array(z.string().trim().min(1).max(60)).max(10).optional(),
+});
+export type DecideExpense = z.infer<typeof decideExpenseSchema>;
+
+export const markPaidExpenseSchema = z.object({
+  note: z.string().max(500).nullable().optional(),
+});
+export type MarkPaidExpense = z.infer<typeof markPaidExpenseSchema>;
+
+// --- Tag vocabulary ------------------------------------------------------
+
+export const createCategorySchema = z.object({
+  name: z.string().trim().min(1).max(60),
+});
+export type CreateCategory = z.infer<typeof createCategorySchema>;
+
+export const updateCategorySchema = z
+  .object({
+    name: z.string().trim().min(1).max(60).optional(),
+    archived: z.boolean().optional(),
+  })
+  .refine((d) => d.name !== undefined || d.archived !== undefined, {
+    message: "Provide a new name or an archived flag",
+  });
+export type UpdateCategory = z.infer<typeof updateCategorySchema>;
+
+// --- Queries -------------------------------------------------------------
+
+export const listExpensesSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+  status: z.union([expenseStatusSchema, z.literal("all")]).default("all"),
+  tagId: z.string().optional(),
+  search: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+});
+export type ListExpenses = z.infer<typeof listExpensesSchema>;
+
+export const summaryQuerySchema = z.object({
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+});
+export type SummaryQuery = z.infer<typeof summaryQuerySchema>;
+
+// --- Response schemas ----------------------------------------------------
+
+const tagSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+const expenseRowSchema = z.object({
+  id: z.string(),
+  claimantUserId: z.string(),
+  claimantName: z.string(),
+  description: z.string(),
+  amountPence: z.number(),
+  currency: z.string(),
+  status: expenseStatusSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  decidedAt: z.string().nullable(),
+  paidAt: z.string().nullable(),
+  approvalCount: z.number(),
+  needsTwoApprovers: z.boolean(),
+  hasReceipt: z.boolean(),
+  tags: z.array(tagSchema),
+});
+
+export const listExpensesResponseSchema = z.object({
+  items: z.array(expenseRowSchema),
+  total: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+
+export const myExpensesResponseSchema = z.object({
+  items: z.array(expenseRowSchema),
+});
+
+const approvalSchema = z.object({
+  id: z.string(),
+  approverUserId: z.string(),
+  approverName: z.string().nullable(),
+  decision: z.enum(["approved", "denied"]),
+  note: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+const eventSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  fromStatus: z.string().nullable(),
+  toStatus: z.string().nullable(),
+  note: z.string().nullable(),
+  actorUserId: z.string().nullable(),
+  actorName: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+export const expenseDetailResponseSchema = z.object({
+  expense: z.object({
+    id: z.string(),
+    claimantUserId: z.string(),
+    claimantName: z.string(),
+    claimantEmail: z.string().nullable(),
+    description: z.string(),
+    amountPence: z.number(),
+    currency: z.string(),
+    status: expenseStatusSchema,
+    receiptImageUrl: z.string().nullable(),
+    payoutFailureReason: z.string().nullable(),
+    stripeOutboundPaymentId: z.string().nullable(),
+    needsTwoApprovers: z.boolean(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    paidAt: z.string().nullable(),
+  }),
+  tags: z.array(tagSchema),
+  approvals: z.array(approvalSchema),
+  events: z.array(eventSchema),
+});
+
+export const categoriesResponseSchema = z.object({
+  categories: z.array(tagSchema),
+});
+
+const statusBucketSchema = z.object({
+  count: z.number(),
+  totalPence: z.number(),
+});
+
+export const summaryResponseSchema = z.object({
+  byStatus: z.object({
+    pending: statusBucketSchema,
+    awaiting_second_approval: statusBucketSchema,
+    approved: statusBucketSchema,
+    denied: statusBucketSchema,
+    paid: statusBucketSchema,
+    payout_failed: statusBucketSchema,
+  }),
+  byTag: z.array(
+    z.object({
+      tagId: z.string(),
+      tagName: z.string(),
+      count: z.number(),
+      totalPence: z.number(),
+    }),
+  ),
+  totals: statusBucketSchema,
+});
+
+export const submitExpenseResponseSchema = idResponseSchema;
+export const decideExpenseResponseSchema = z.object({
+  status: expenseStatusSchema,
+});
+export const markPaidExpenseResponseSchema = successResponseSchema;
+export const payoutExpenseResponseSchema = z.object({
+  status: expenseStatusSchema,
+  stripeOutboundPaymentId: z.string().nullable(),
+});
+export const createCategoryResponseSchema = tagSchema;
+export const updateCategoryResponseSchema = successResponseSchema;

--- a/apps/api/src/features/expense/service.ts
+++ b/apps/api/src/features/expense/service.ts
@@ -1,0 +1,911 @@
+import type { DB } from "@percy-main/db";
+import { ExpenseDecision, ExpenseSubmitted, type Email } from "@percy-main/email";
+import {
+  EXPENSE_STATUSES,
+  expenseNeedsTwoApprovers,
+  type ExpenseStatus,
+} from "@percy-main/shared";
+import type { FastifyBaseLogger } from "fastify";
+import { sql, type Kysely } from "kysely";
+import { createElement } from "react";
+import { render } from "react-email";
+import type { S3Uploader } from "../../lib/s3-upload.ts";
+import type {
+  CreateCategory,
+  DecideExpense,
+  ListExpenses,
+  MarkPaidExpense,
+  SubmitExpense,
+  SummaryQuery,
+  UpdateCategory,
+} from "./schemas.ts";
+
+function httpError(statusCode: number, message: string): never {
+  const err = new Error(message) as Error & { statusCode: number };
+  err.statusCode = statusCode;
+  throw err;
+}
+
+function toIsoString(v: unknown): string {
+  return v instanceof Date ? v.toISOString() : String(v);
+}
+
+type Executor = Kysely<DB>;
+
+const RECEIPT_DATA_URL = /^data:(image\/(?:jpeg|png|webp|heic));base64,(.+)$/;
+
+interface Deps {
+  s3: S3Uploader;
+  send: (email: Email) => Promise<void>;
+  baseUrl: string;
+}
+
+type NotifyDeps = Pick<Deps, "send" | "baseUrl">;
+
+// --- Shared helpers ------------------------------------------------------
+
+/**
+ * Resolve a set of tag names to category ids, creating any that don't exist
+ * yet (case-insensitive dedupe via the lower(name) unique index). Both the
+ * claimant (at submit) and the approver (at decision) grow the shared
+ * vocabulary this way.
+ */
+async function resolveTagIds(
+  exec: Executor,
+  names: string[],
+  actorUserId: string | null,
+): Promise<string[]> {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of names) {
+    const name = raw.trim();
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const existing = await exec
+      .selectFrom("expense_category")
+      .where(sql`lower(name)`, "=", key)
+      .select(["id"])
+      .executeTakeFirst();
+    if (existing) {
+      ids.push(existing.id);
+      continue;
+    }
+    try {
+      const inserted = await exec
+        .insertInto("expense_category")
+        .values({ name, created_by: actorUserId })
+        .returning(["id"])
+        .executeTakeFirstOrThrow();
+      ids.push(inserted.id);
+    } catch (err: unknown) {
+      // Lost a race on the lower(name) unique index — re-read the winner.
+      if (
+        err instanceof Error &&
+        err.message.includes("expense_category_name_lower_uniq")
+      ) {
+        const winner = await exec
+          .selectFrom("expense_category")
+          .where(sql`lower(name)`, "=", key)
+          .select(["id"])
+          .executeTakeFirstOrThrow();
+        ids.push(winner.id);
+      } else {
+        throw err;
+      }
+    }
+  }
+  return ids;
+}
+
+async function setExpenseTags(
+  exec: Executor,
+  expenseId: string,
+  categoryIds: string[],
+): Promise<void> {
+  await exec
+    .deleteFrom("expense_category_link")
+    .where("expense_id", "=", expenseId)
+    .execute();
+  if (categoryIds.length > 0) {
+    await exec
+      .insertInto("expense_category_link")
+      .values(categoryIds.map((id) => ({ expense_id: expenseId, category_id: id })))
+      .execute();
+  }
+}
+
+/** Tags + approval counts for a page of expenses, batched to avoid N+1. */
+async function loadRowExtras(db: Kysely<DB>, expenseIds: string[]) {
+  if (expenseIds.length === 0) {
+    return {
+      tagsByExpense: new Map<string, { id: string; name: string }[]>(),
+      approvalCountByExpense: new Map<string, number>(),
+      decidedAtByExpense: new Map<string, string>(),
+    };
+  }
+
+  const tagRows = await db
+    .selectFrom("expense_category_link as l")
+    .innerJoin("expense_category as c", "c.id", "l.category_id")
+    .where("l.expense_id", "in", expenseIds)
+    .select(["l.expense_id as expenseId", "c.id as id", "c.name as name"])
+    .orderBy("c.name", "asc")
+    .execute();
+  const tagsByExpense = new Map<string, { id: string; name: string }[]>();
+  for (const t of tagRows) {
+    const list = tagsByExpense.get(t.expenseId) ?? [];
+    list.push({ id: t.id, name: t.name });
+    tagsByExpense.set(t.expenseId, list);
+  }
+
+  const approvalRows = await db
+    .selectFrom("expense_approval")
+    .where("expense_id", "in", expenseIds)
+    .where("decision", "=", "approved")
+    .select((eb) => [
+      "expense_id as expenseId",
+      eb.fn.countAll<string>().as("count"),
+      eb.fn.max("created_at").as("latest"),
+    ])
+    .groupBy("expense_id")
+    .execute();
+  const approvalCountByExpense = new Map<string, number>();
+  const decidedAtByExpense = new Map<string, string>();
+  for (const a of approvalRows) {
+    approvalCountByExpense.set(a.expenseId, Number(a.count));
+    if (a.latest) decidedAtByExpense.set(a.expenseId, toIsoString(a.latest));
+  }
+
+  return { tagsByExpense, approvalCountByExpense, decidedAtByExpense };
+}
+
+interface ExpenseBaseRow {
+  id: string;
+  created_by: string;
+  claimant_name: string;
+  description: string;
+  amount_pence: number;
+  currency: string;
+  status: string;
+  receipt_image_url: string | null;
+  paid_at: unknown;
+  created_at: unknown;
+  updated_at: unknown;
+}
+
+function mapRow(
+  row: ExpenseBaseRow,
+  extras: Awaited<ReturnType<typeof loadRowExtras>>,
+) {
+  return {
+    id: row.id,
+    claimantUserId: row.created_by,
+    claimantName: row.claimant_name,
+    description: row.description,
+    amountPence: row.amount_pence,
+    currency: row.currency,
+    status: row.status as ExpenseStatus,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+    decidedAt: extras.decidedAtByExpense.get(row.id) ?? null,
+    paidAt: row.paid_at ? toIsoString(row.paid_at) : null,
+    approvalCount: extras.approvalCountByExpense.get(row.id) ?? 0,
+    needsTwoApprovers: expenseNeedsTwoApprovers(row.amount_pence),
+    hasReceipt: row.receipt_image_url !== null,
+    tags: extras.tagsByExpense.get(row.id) ?? [],
+  };
+}
+
+// --- Notifications -------------------------------------------------------
+
+async function notifyApprovers(
+  db: Kysely<DB>,
+  deps: NotifyDeps,
+  args: {
+    claimantName: string;
+    amountPence: number;
+    description: string;
+    secondApproval: boolean;
+  },
+  log: FastifyBaseLogger,
+): Promise<void> {
+  try {
+    const approvers = await db
+      .selectFrom("user")
+      .where("role", "ilike", "%expense_approver%")
+      .where("email", "is not", null)
+      .select(["email"])
+      .execute();
+    if (approvers.length === 0) return;
+
+    const html = await render(
+      createElement(ExpenseSubmitted.component, {
+        imageBaseUrl: `${deps.baseUrl}/images`,
+        claimantName: args.claimantName,
+        amountPence: args.amountPence,
+        description: args.description,
+        secondApproval: args.secondApproval,
+        reviewUrl: `${deps.baseUrl}/admin?section=finance&tab=expenses`,
+      }),
+    );
+    await Promise.all(
+      approvers.map((a) =>
+        deps.send({
+          to: a.email,
+          subject: ExpenseSubmitted.subject,
+          html,
+        }),
+      ),
+    );
+  } catch (err) {
+    log.error({ err }, "expense_approver_notification_failed");
+  }
+}
+
+async function notifySubmitter(
+  deps: NotifyDeps,
+  args: {
+    to: string;
+    recipientName: string;
+    outcome: "approved" | "denied" | "paid";
+    note: string | null;
+    amountPence: number;
+  },
+  log: FastifyBaseLogger,
+): Promise<void> {
+  try {
+    await deps.send({
+      to: args.to,
+      subject: ExpenseDecision.subject,
+      html: await render(
+        createElement(ExpenseDecision.component, {
+          imageBaseUrl: `${deps.baseUrl}/images`,
+          recipientName: args.recipientName,
+          outcome: args.outcome,
+          note: args.note,
+          amountPence: args.amountPence,
+        }),
+      ),
+    });
+  } catch (err) {
+    log.error({ err }, "expense_submitter_notification_failed");
+  }
+}
+
+// --- Submit --------------------------------------------------------------
+
+export function submitExpense(db: Kysely<DB>, deps: Deps) {
+  return async (
+    userId: string,
+    userName: string,
+    data: SubmitExpense,
+    log: FastifyBaseLogger,
+  ) => {
+    const id = crypto.randomUUID();
+
+    let receiptUrl: string | null = null;
+    if (data.receiptImage) {
+      const match = RECEIPT_DATA_URL.exec(data.receiptImage);
+      if (!match) {
+        httpError(400, "Receipt must be a base64 image data URL");
+      }
+      receiptUrl = await deps.s3.uploadReceipt({
+        imageBytes: Buffer.from(match[2], "base64"),
+        contentType: match[1],
+        expenseId: id,
+      });
+    }
+
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .insertInto("expense")
+        .values({
+          id,
+          created_by: userId,
+          claimant_name: userName,
+          description: data.description,
+          amount_pence: data.amountPence,
+          currency: "gbp",
+          status: "pending",
+          receipt_image_url: receiptUrl,
+        })
+        .execute();
+
+      const tagIds = await resolveTagIds(trx, data.tagNames, userId);
+      await setExpenseTags(trx, id, tagIds);
+
+      await trx
+        .insertInto("expense_event")
+        .values({
+          id: crypto.randomUUID(),
+          expense_id: id,
+          actor_user_id: userId,
+          type: "submitted",
+          from_status: null,
+          to_status: "pending",
+          metadata: { amountPence: data.amountPence },
+        })
+        .execute();
+    });
+
+    await notifyApprovers(
+      db,
+      deps,
+      {
+        claimantName: userName,
+        amountPence: data.amountPence,
+        description: data.description,
+        secondApproval: false,
+      },
+      log,
+    );
+
+    return { id };
+  };
+}
+
+// --- Listing -------------------------------------------------------------
+
+export function getMyExpenses(db: Kysely<DB>) {
+  return async (userId: string) => {
+    const rows = await db
+      .selectFrom("expense")
+      .where("created_by", "=", userId)
+      .selectAll()
+      .orderBy("created_at", "desc")
+      .execute();
+    const extras = await loadRowExtras(
+      db,
+      rows.map((r) => r.id),
+    );
+    return { items: rows.map((r) => mapRow(r, extras)) };
+  };
+}
+
+export function listExpenses(db: Kysely<DB>) {
+  return async (params: ListExpenses) => {
+    const offset = (params.page - 1) * params.pageSize;
+
+    let base = db.selectFrom("expense");
+    if (params.status !== "all") {
+      base = base.where("status", "=", params.status);
+    }
+    if (params.dateFrom) {
+      base = base.where("created_at", ">=", new Date(params.dateFrom));
+    }
+    if (params.dateTo) {
+      base = base.where("created_at", "<=", new Date(params.dateTo));
+    }
+    if (params.search) {
+      const like = `%${params.search}%`;
+      base = base.where((eb) =>
+        eb.or([
+          eb("claimant_name", "ilike", like),
+          eb("description", "ilike", like),
+        ]),
+      );
+    }
+    if (params.tagId) {
+      const tagId = params.tagId;
+      base = base.where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom("expense_category_link as fl")
+            .whereRef("fl.expense_id", "=", "expense.id")
+            .where("fl.category_id", "=", tagId)
+            .select("fl.expense_id"),
+        ),
+      );
+    }
+
+    const [{ total }, rows] = await Promise.all([
+      base
+        .select((eb) => eb.fn.countAll<string>().as("total"))
+        .executeTakeFirstOrThrow(),
+      base
+        .selectAll()
+        .orderBy("created_at", "desc")
+        .limit(params.pageSize)
+        .offset(offset)
+        .execute(),
+    ]);
+
+    const extras = await loadRowExtras(
+      db,
+      rows.map((r) => r.id),
+    );
+
+    return {
+      items: rows.map((r) => mapRow(r, extras)),
+      total: Number(total),
+      page: params.page,
+      pageSize: params.pageSize,
+    };
+  };
+}
+
+export function getExpenseDetail(db: Kysely<DB>) {
+  return async (expenseId: string) => {
+    const expense = await db
+      .selectFrom("expense as e")
+      .leftJoin("user as u", "u.id", "e.created_by")
+      .where("e.id", "=", expenseId)
+      .select([
+        "e.id",
+        "e.created_by as createdBy",
+        "e.claimant_name as claimantName",
+        "u.email as claimantEmail",
+        "e.description",
+        "e.amount_pence as amountPence",
+        "e.currency",
+        "e.status",
+        "e.receipt_image_url as receiptImageUrl",
+        "e.payout_failure_reason as payoutFailureReason",
+        "e.stripe_outbound_payment_id as stripeOutboundPaymentId",
+        "e.paid_at as paidAt",
+        "e.created_at as createdAt",
+        "e.updated_at as updatedAt",
+      ])
+      .executeTakeFirst();
+    if (!expense) httpError(404, "Expense not found");
+
+    const [tags, approvals, events] = await Promise.all([
+      db
+        .selectFrom("expense_category_link as l")
+        .innerJoin("expense_category as c", "c.id", "l.category_id")
+        .where("l.expense_id", "=", expenseId)
+        .select(["c.id", "c.name"])
+        .orderBy("c.name", "asc")
+        .execute(),
+      db
+        .selectFrom("expense_approval as a")
+        .leftJoin("user as u", "u.id", "a.approver_user_id")
+        .where("a.expense_id", "=", expenseId)
+        .select([
+          "a.id",
+          "a.approver_user_id as approverUserId",
+          "u.name as approverName",
+          "a.decision",
+          "a.note",
+          "a.created_at as createdAt",
+        ])
+        .orderBy("a.created_at", "asc")
+        .execute(),
+      db
+        .selectFrom("expense_event as ev")
+        .leftJoin("user as u", "u.id", "ev.actor_user_id")
+        .where("ev.expense_id", "=", expenseId)
+        .select([
+          "ev.id",
+          "ev.type",
+          "ev.from_status as fromStatus",
+          "ev.to_status as toStatus",
+          "ev.metadata",
+          "ev.actor_user_id as actorUserId",
+          "u.name as actorName",
+          "ev.created_at as createdAt",
+        ])
+        .orderBy("ev.created_at", "asc")
+        .execute(),
+    ]);
+
+    return {
+      expense: {
+        id: expense.id,
+        claimantUserId: expense.createdBy,
+        claimantName: expense.claimantName,
+        claimantEmail: expense.claimantEmail,
+        description: expense.description,
+        amountPence: expense.amountPence,
+        currency: expense.currency,
+        status: expense.status as ExpenseStatus,
+        receiptImageUrl: expense.receiptImageUrl,
+        payoutFailureReason: expense.payoutFailureReason,
+        stripeOutboundPaymentId: expense.stripeOutboundPaymentId,
+        needsTwoApprovers: expenseNeedsTwoApprovers(expense.amountPence),
+        createdAt: toIsoString(expense.createdAt),
+        updatedAt: toIsoString(expense.updatedAt),
+        paidAt: expense.paidAt ? toIsoString(expense.paidAt) : null,
+      },
+      tags: tags.map((t) => ({ id: t.id, name: t.name })),
+      approvals: approvals.map((a) => ({
+        id: a.id,
+        approverUserId: a.approverUserId,
+        approverName: a.approverName,
+        decision: a.decision as "approved" | "denied",
+        note: a.note,
+        createdAt: toIsoString(a.createdAt),
+      })),
+      events: events.map((e) => ({
+        id: e.id,
+        type: e.type,
+        fromStatus: e.fromStatus,
+        toStatus: e.toStatus,
+        note: readEventNote(e.metadata),
+        actorUserId: e.actorUserId,
+        actorName: e.actorName,
+        createdAt: toIsoString(e.createdAt),
+      })),
+    };
+  };
+}
+
+function readEventNote(metadata: unknown): string | null {
+  if (
+    metadata &&
+    typeof metadata === "object" &&
+    "note" in metadata &&
+    typeof (metadata as { note: unknown }).note === "string"
+  ) {
+    return (metadata as { note: string }).note;
+  }
+  return null;
+}
+
+// --- Decision (approve / deny + two-approver rule) -----------------------
+
+export function decideExpense(db: Kysely<DB>, deps: NotifyDeps) {
+  return async (
+    approverUserId: string,
+    expenseId: string,
+    data: DecideExpense,
+    log: FastifyBaseLogger,
+  ) => {
+    const expense = await db
+      .selectFrom("expense as e")
+      .leftJoin("user as u", "u.id", "e.created_by")
+      .where("e.id", "=", expenseId)
+      .select([
+        "e.id",
+        "e.created_by as createdBy",
+        "e.status",
+        "e.amount_pence as amountPence",
+        "e.claimant_name as claimantName",
+        "u.email as claimantEmail",
+      ])
+      .executeTakeFirst();
+    if (!expense) httpError(404, "Expense not found");
+
+    if (!["pending", "awaiting_second_approval"].includes(expense.status)) {
+      httpError(400, "This claim has already been decided");
+    }
+    // Separation of duties: an approver can never decide their own claim.
+    if (expense.createdBy === approverUserId) {
+      httpError(403, "You cannot approve your own expense claim");
+    }
+
+    const outcome = await db.transaction().execute(async (trx) => {
+      // Record this approver's decision. The unique (expense_id,
+      // approver_user_id) constraint blocks a second decision from the same
+      // person, which is what makes the two-approver rule require two
+      // distinct people.
+      try {
+        await trx
+          .insertInto("expense_approval")
+          .values({
+            id: crypto.randomUUID(),
+            expense_id: expenseId,
+            approver_user_id: approverUserId,
+            decision: data.decision === "approve" ? "approved" : "denied",
+            note: data.note ?? null,
+          })
+          .execute();
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.message.includes("expense_approval_one_per_approver_uniq")
+        ) {
+          httpError(409, "You have already decided this claim");
+        }
+        throw err;
+      }
+
+      const now = new Date().toISOString();
+
+      if (data.decision === "deny") {
+        await trx
+          .updateTable("expense")
+          .set({ status: "denied", updated_at: now })
+          .where("id", "=", expenseId)
+          .execute();
+        await trx
+          .insertInto("expense_event")
+          .values({
+            id: crypto.randomUUID(),
+            expense_id: expenseId,
+            actor_user_id: approverUserId,
+            type: "denied",
+            from_status: expense.status,
+            to_status: "denied",
+            metadata: data.note ? { note: data.note } : null,
+          })
+          .execute();
+        return { status: "denied" as ExpenseStatus, secondApprovalNeeded: false };
+      }
+
+      // Approve: finalise tags (approver may edit the set), then require at
+      // least one tag before the claim can be approved.
+      if (data.tagNames !== undefined) {
+        const tagIds = await resolveTagIds(trx, data.tagNames, approverUserId);
+        await setExpenseTags(trx, expenseId, tagIds);
+      }
+      const tagCount = await trx
+        .selectFrom("expense_category_link")
+        .where("expense_id", "=", expenseId)
+        .select((eb) => eb.fn.countAll<string>().as("count"))
+        .executeTakeFirstOrThrow();
+      if (Number(tagCount.count) === 0) {
+        httpError(400, "At least one tag is required to approve a claim");
+      }
+
+      const approvedCountRow = await trx
+        .selectFrom("expense_approval")
+        .where("expense_id", "=", expenseId)
+        .where("decision", "=", "approved")
+        .select((eb) => eb.fn.countAll<string>().as("count"))
+        .executeTakeFirstOrThrow();
+      const approvedCount = Number(approvedCountRow.count);
+      const needsTwo = expenseNeedsTwoApprovers(expense.amountPence);
+      const nextStatus: ExpenseStatus =
+        needsTwo && approvedCount < 2 ? "awaiting_second_approval" : "approved";
+
+      await trx
+        .updateTable("expense")
+        .set({ status: nextStatus, updated_at: now })
+        .where("id", "=", expenseId)
+        .execute();
+      await trx
+        .insertInto("expense_event")
+        .values({
+          id: crypto.randomUUID(),
+          expense_id: expenseId,
+          actor_user_id: approverUserId,
+          type: "approved",
+          from_status: expense.status,
+          to_status: nextStatus,
+          metadata: {
+            approvalCount: approvedCount,
+            ...(data.note ? { note: data.note } : {}),
+          },
+        })
+        .execute();
+
+      return {
+        status: nextStatus,
+        secondApprovalNeeded: nextStatus === "awaiting_second_approval",
+      };
+    });
+
+    // Notifications (best-effort).
+    if (outcome.secondApprovalNeeded) {
+      await notifyApprovers(
+        db,
+        deps,
+        {
+          claimantName: expense.claimantName,
+          amountPence: expense.amountPence,
+          description: "",
+          secondApproval: true,
+        },
+        log,
+      );
+    } else if (expense.claimantEmail) {
+      await notifySubmitter(
+        deps,
+        {
+          to: expense.claimantEmail,
+          recipientName: expense.claimantName,
+          outcome: outcome.status === "denied" ? "denied" : "approved",
+          note: data.note ?? null,
+          amountPence: expense.amountPence,
+        },
+        log,
+      );
+    }
+
+    return { status: outcome.status };
+  };
+}
+
+// --- Manual mark-paid (Phase 1 fallback) ---------------------------------
+
+export function markExpensePaid(db: Kysely<DB>, deps: NotifyDeps) {
+  return async (
+    actorUserId: string,
+    expenseId: string,
+    data: MarkPaidExpense,
+    log: FastifyBaseLogger,
+  ) => {
+    const expense = await db
+      .selectFrom("expense as e")
+      .leftJoin("user as u", "u.id", "e.created_by")
+      .where("e.id", "=", expenseId)
+      .select([
+        "e.id",
+        "e.status",
+        "e.amount_pence as amountPence",
+        "e.claimant_name as claimantName",
+        "u.email as claimantEmail",
+      ])
+      .executeTakeFirst();
+    if (!expense) httpError(404, "Expense not found");
+    if (!["approved", "payout_failed"].includes(expense.status)) {
+      httpError(400, "Only an approved claim can be marked paid");
+    }
+
+    const now = new Date().toISOString();
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .updateTable("expense")
+        .set({ status: "paid", paid_at: now, updated_at: now })
+        .where("id", "=", expenseId)
+        .execute();
+      await trx
+        .insertInto("expense_event")
+        .values({
+          id: crypto.randomUUID(),
+          expense_id: expenseId,
+          actor_user_id: actorUserId,
+          type: "payout_paid",
+          from_status: expense.status,
+          to_status: "paid",
+          metadata: {
+            manual: true,
+            ...(data.note ? { note: data.note } : {}),
+          },
+        })
+        .execute();
+    });
+
+    if (expense.claimantEmail) {
+      await notifySubmitter(
+        deps,
+        {
+          to: expense.claimantEmail,
+          recipientName: expense.claimantName,
+          outcome: "paid",
+          note: data.note ?? null,
+          amountPence: expense.amountPence,
+        },
+        log,
+      );
+    }
+
+    return { success: true };
+  };
+}
+
+// --- Summary -------------------------------------------------------------
+
+export function getExpenseSummary(db: Kysely<DB>) {
+  return async (params: SummaryQuery) => {
+    const from = params.dateFrom ? new Date(params.dateFrom) : null;
+    const to = params.dateTo ? new Date(params.dateTo) : null;
+
+    let statusQ = db.selectFrom("expense");
+    if (from) statusQ = statusQ.where("created_at", ">=", from);
+    if (to) statusQ = statusQ.where("created_at", "<=", to);
+    const statusRows = await statusQ
+      .select((eb) => [
+        "status",
+        eb.fn.countAll<string>().as("count"),
+        eb.fn.coalesce(eb.fn.sum("amount_pence"), sql<string>`0`).as("sumPence"),
+      ])
+      .groupBy("status")
+      .execute();
+
+    const emptyBucket = () => ({ count: 0, totalPence: 0 });
+    const byStatus: Record<ExpenseStatus, { count: number; totalPence: number }> =
+      {
+        pending: emptyBucket(),
+        awaiting_second_approval: emptyBucket(),
+        approved: emptyBucket(),
+        denied: emptyBucket(),
+        paid: emptyBucket(),
+        payout_failed: emptyBucket(),
+      };
+    let totalCount = 0;
+    let totalPence = 0;
+    for (const r of statusRows) {
+      if ((EXPENSE_STATUSES as readonly string[]).includes(r.status)) {
+        const bucket = byStatus[r.status as ExpenseStatus];
+        bucket.count = Number(r.count);
+        bucket.totalPence = Number(r.sumPence);
+        totalCount += bucket.count;
+        totalPence += bucket.totalPence;
+      }
+    }
+
+    let tagQ = db
+      .selectFrom("expense_category_link as l")
+      .innerJoin("expense", "expense.id", "l.expense_id")
+      .innerJoin("expense_category as c", "c.id", "l.category_id");
+    if (from) tagQ = tagQ.where("expense.created_at", ">=", from);
+    if (to) tagQ = tagQ.where("expense.created_at", "<=", to);
+    const tagRows = await tagQ
+      .select((eb) => [
+        "c.id as tagId",
+        "c.name as tagName",
+        eb.fn.countAll<string>().as("count"),
+        eb.fn
+          .coalesce(eb.fn.sum("expense.amount_pence"), sql<string>`0`)
+          .as("sumPence"),
+      ])
+      .groupBy(["c.id", "c.name"])
+      .orderBy("c.name", "asc")
+      .execute();
+
+    return {
+      byStatus,
+      byTag: tagRows.map((t) => ({
+        tagId: t.tagId,
+        tagName: t.tagName,
+        count: Number(t.count),
+        totalPence: Number(t.sumPence),
+      })),
+      totals: { count: totalCount, totalPence },
+    };
+  };
+}
+
+// --- Tag vocabulary ------------------------------------------------------
+
+export function listCategories(db: Kysely<DB>) {
+  return async (includeArchived: boolean) => {
+    let q = db.selectFrom("expense_category").select(["id", "name"]);
+    if (!includeArchived) {
+      q = q.where("archived_at", "is", null);
+    }
+    const rows = await q.orderBy("name", "asc").execute();
+    return { categories: rows };
+  };
+}
+
+export function createCategory(db: Kysely<DB>) {
+  return async (actorUserId: string, data: CreateCategory) => {
+    const ids = await resolveTagIds(db, [data.name], actorUserId);
+    const row = await db
+      .selectFrom("expense_category")
+      .where("id", "=", ids[0])
+      .select(["id", "name"])
+      .executeTakeFirstOrThrow();
+    return row;
+  };
+}
+
+export function updateCategory(db: Kysely<DB>) {
+  return async (categoryId: string, data: UpdateCategory) => {
+    const existing = await db
+      .selectFrom("expense_category")
+      .where("id", "=", categoryId)
+      .select(["id"])
+      .executeTakeFirst();
+    if (!existing) httpError(404, "Tag not found");
+
+    const patch: { name?: string; archived_at?: string | null } = {};
+    if (data.name !== undefined) patch.name = data.name;
+    if (data.archived !== undefined) {
+      patch.archived_at = data.archived ? new Date().toISOString() : null;
+    }
+
+    try {
+      await db
+        .updateTable("expense_category")
+        .set(patch)
+        .where("id", "=", categoryId)
+        .execute();
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        err.message.includes("expense_category_name_lower_uniq")
+      ) {
+        httpError(409, "A tag with that name already exists");
+      }
+      throw err;
+    }
+    return { success: true };
+  };
+}

--- a/apps/api/src/features/expense/service.ts
+++ b/apps/api/src/features/expense/service.ts
@@ -14,6 +14,7 @@ import { sql, type Kysely } from "kysely";
 import { createElement } from "react";
 import { render } from "react-email";
 import type { S3Uploader } from "../../lib/s3-upload.ts";
+import type { PayoutsClient } from "./payouts.ts";
 import type {
   CreateCategory,
   DecideExpense,
@@ -920,5 +921,249 @@ export function updateCategory(db: Kysely<DB>) {
       throw err;
     }
     return { success: true };
+  };
+}
+
+// --- Stripe Global Payouts (Phase 2) -------------------------------------
+
+interface PayoutDeps extends NotifyDeps {
+  client: PayoutsClient | null;
+}
+
+/**
+ * Pay an approved claim via Stripe Global Payouts. The first time a claimant is
+ * paid we create their recipient and (if they have no bank details on file)
+ * return a Stripe-hosted setup link instead of paying - so the bank details
+ * live in Stripe, never here. Idempotent: a claim that already has an
+ * OutboundPayment id is never paid twice.
+ */
+export function payoutExpense(db: Kysely<DB>, deps: PayoutDeps) {
+  return async (
+    actorUserId: string,
+    expenseId: string,
+    log: FastifyBaseLogger,
+  ) => {
+    const expense = await db
+      .selectFrom("expense as e")
+      .leftJoin("user as u", "u.id", "e.created_by")
+      .where("e.id", "=", expenseId)
+      .select([
+        "e.id",
+        "e.created_by as createdBy",
+        "e.status",
+        "e.amount_pence as amountPence",
+        "e.claimant_name as claimantName",
+        "e.stripe_recipient_account_id as recipientId",
+        "e.stripe_outbound_payment_id as outboundPaymentId",
+        "u.email as claimantEmail",
+      ])
+      .executeTakeFirst();
+    if (!expense) httpError(404, "Expense not found");
+
+    // Idempotency: never create a second payout for a claim.
+    if (expense.outboundPaymentId) {
+      return {
+        status: expense.status as ExpenseStatus,
+        stripeOutboundPaymentId: expense.outboundPaymentId,
+        onboardingUrl: null,
+      };
+    }
+    if (!["approved", "payout_failed"].includes(expense.status)) {
+      httpError(400, "Only an approved claim can be paid");
+    }
+    if (!deps.client) {
+      httpError(503, "Stripe Global Payouts is not configured");
+    }
+    const client = deps.client;
+
+    // Reuse the claimant's recipient across claims; create one on first payout.
+    let recipientId = expense.recipientId;
+    if (!recipientId) {
+      const prior = await db
+        .selectFrom("expense")
+        .where("created_by", "=", expense.createdBy)
+        .where("stripe_recipient_account_id", "is not", null)
+        .orderBy("created_at", "desc")
+        .select(["stripe_recipient_account_id as recipientId"])
+        .executeTakeFirst();
+      recipientId = prior?.recipientId ?? null;
+    }
+    recipientId ??= await client.createRecipient({
+      name: expense.claimantName,
+      email: expense.claimantEmail,
+    });
+    await db
+      .updateTable("expense")
+      .set({ stripe_recipient_account_id: recipientId })
+      .where("id", "=", expenseId)
+      .execute();
+
+    // Bank details live in Stripe. If the claimant hasn't added them yet, hand
+    // back a hosted setup link rather than paying.
+    const payoutMethodId = await client.getDefaultPayoutMethodId(recipientId);
+    if (!payoutMethodId) {
+      const returnUrl = `${deps.baseUrl}/admin?section=finance&sub=reimbursements`;
+      const onboardingUrl = await client.createPayoutMethodSetupLink({
+        recipientId,
+        returnUrl,
+        refreshUrl: returnUrl,
+      });
+      await db
+        .insertInto("expense_event")
+        .values({
+          id: crypto.randomUUID(),
+          expense_id: expenseId,
+          actor_user_id: actorUserId,
+          type: "payout_setup_required",
+          from_status: expense.status,
+          to_status: expense.status,
+          metadata: { note: "Awaiting the claimant's bank details in Stripe" },
+        })
+        .execute();
+      return {
+        status: expense.status as ExpenseStatus,
+        stripeOutboundPaymentId: null,
+        onboardingUrl,
+      };
+    }
+
+    // Pay. Idempotency key = expense id so a retry returns the same payment.
+    try {
+      const op = await client.createOutboundPayment({
+        recipientId,
+        payoutMethodId,
+        amountPence: expense.amountPence,
+        description: `Percy Main expense reimbursement ${expenseId}`,
+        idempotencyKey: expenseId,
+      });
+      const now = new Date().toISOString();
+      await db.transaction().execute(async (trx) => {
+        await trx
+          .updateTable("expense")
+          .set({
+            status: "paid",
+            paid_at: now,
+            stripe_payout_method_id: payoutMethodId,
+            stripe_outbound_payment_id: op.id,
+            payout_failure_reason: null,
+            updated_at: now,
+          })
+          .where("id", "=", expenseId)
+          .execute();
+        await trx
+          .insertInto("expense_event")
+          .values({
+            id: crypto.randomUUID(),
+            expense_id: expenseId,
+            actor_user_id: actorUserId,
+            type: "payout_initiated",
+            from_status: expense.status,
+            to_status: "paid",
+            metadata: { outboundPaymentId: op.id, stripeStatus: op.status },
+          })
+          .execute();
+      });
+
+      if (expense.claimantEmail) {
+        await notifySubmitter(
+          deps,
+          {
+            to: expense.claimantEmail,
+            recipientName: expense.claimantName,
+            outcome: "paid",
+            note: null,
+            amountPence: expense.amountPence,
+          },
+          log,
+        );
+      }
+      return {
+        status: "paid" as ExpenseStatus,
+        stripeOutboundPaymentId: op.id,
+        onboardingUrl: null,
+      };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "Payout failed";
+      log.error({ err, expenseId }, "expense_payout_failed");
+      const now = new Date().toISOString();
+      await db.transaction().execute(async (trx) => {
+        await trx
+          .updateTable("expense")
+          .set({
+            status: "payout_failed",
+            payout_failure_reason: reason,
+            updated_at: now,
+          })
+          .where("id", "=", expenseId)
+          .execute();
+        await trx
+          .insertInto("expense_event")
+          .values({
+            id: crypto.randomUUID(),
+            expense_id: expenseId,
+            actor_user_id: actorUserId,
+            type: "payout_failed",
+            from_status: expense.status,
+            to_status: "payout_failed",
+            metadata: { note: reason },
+          })
+          .execute();
+      });
+      return {
+        status: "payout_failed" as ExpenseStatus,
+        stripeOutboundPaymentId: null,
+        onboardingUrl: null,
+      };
+    }
+  };
+}
+
+/**
+ * Apply a Stripe webhook outcome for an OutboundPayment to the matching claim.
+ * Idempotent and tolerant of unmatched ids (logs and returns).
+ */
+export function applyPayoutWebhook(db: Kysely<DB>) {
+  return async (
+    outboundPaymentId: string,
+    outcome: "paid" | "payout_failed",
+    log: FastifyBaseLogger,
+  ) => {
+    const expense = await db
+      .selectFrom("expense")
+      .where("stripe_outbound_payment_id", "=", outboundPaymentId)
+      .select(["id", "status"])
+      .executeTakeFirst();
+    if (!expense) {
+      log.warn({ outboundPaymentId }, "expense_payout_webhook_unmatched");
+      return;
+    }
+    if (expense.status === outcome) return;
+
+    const now = new Date().toISOString();
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .updateTable("expense")
+        .set({
+          status: outcome,
+          paid_at: outcome === "paid" ? now : null,
+          payout_failure_reason:
+            outcome === "payout_failed" ? "Reported failed by Stripe" : null,
+          updated_at: now,
+        })
+        .where("id", "=", expense.id)
+        .execute();
+      await trx
+        .insertInto("expense_event")
+        .values({
+          id: crypto.randomUUID(),
+          expense_id: expense.id,
+          actor_user_id: null,
+          type: outcome === "paid" ? "payout_paid" : "payout_failed",
+          from_status: expense.status,
+          to_status: outcome,
+          metadata: { source: "stripe_webhook", outboundPaymentId },
+        })
+        .execute();
+    });
   };
 }

--- a/apps/api/src/features/expense/service.ts
+++ b/apps/api/src/features/expense/service.ts
@@ -235,7 +235,7 @@ async function notifyApprovers(
         amountPence: args.amountPence,
         description: args.description,
         secondApproval: args.secondApproval,
-        reviewUrl: `${deps.baseUrl}/admin?section=finance&tab=expenses`,
+        reviewUrl: `${deps.baseUrl}/admin?section=finance&sub=reimbursements`,
       }),
     );
     await Promise.all(
@@ -585,6 +585,22 @@ export function decideExpense(db: Kysely<DB>, deps: NotifyDeps) {
     }
 
     const outcome = await db.transaction().execute(async (trx) => {
+      // Lock the claim row so concurrent decisions serialise. Without this,
+      // two approvers acting at once on a GBP 50+ claim could each read
+      // "pending", insert an approval, and both land on
+      // awaiting_second_approval (miscounting the two approvals). Re-read the
+      // status under the lock and re-check the guard.
+      const locked = await trx
+        .selectFrom("expense")
+        .where("id", "=", expenseId)
+        .select(["status"])
+        .forUpdate()
+        .executeTakeFirstOrThrow();
+      const fromStatus = locked.status;
+      if (!["pending", "awaiting_second_approval"].includes(fromStatus)) {
+        httpError(400, "This claim has already been decided");
+      }
+
       // Record this approver's decision. The unique (expense_id,
       // approver_user_id) constraint blocks a second decision from the same
       // person, which is what makes the two-approver rule require two
@@ -625,7 +641,7 @@ export function decideExpense(db: Kysely<DB>, deps: NotifyDeps) {
             expense_id: expenseId,
             actor_user_id: approverUserId,
             type: "denied",
-            from_status: expense.status,
+            from_status: fromStatus,
             to_status: "denied",
             metadata: data.note ? { note: data.note } : null,
           })
@@ -674,7 +690,7 @@ export function decideExpense(db: Kysely<DB>, deps: NotifyDeps) {
           expense_id: expenseId,
           actor_user_id: approverUserId,
           type: "approved",
-          from_status: expense.status,
+          from_status: fromStatus,
           to_status: nextStatus,
           metadata: {
             approvalCount: approvedCount,
@@ -748,6 +764,17 @@ export function markExpensePaid(db: Kysely<DB>, deps: NotifyDeps) {
 
     const now = new Date().toISOString();
     await db.transaction().execute(async (trx) => {
+      // Lock + re-check under the row lock so a manual mark-paid can't race a
+      // Stripe payout (or another mark-paid) into a double "paid".
+      const locked = await trx
+        .selectFrom("expense")
+        .where("id", "=", expenseId)
+        .select(["status"])
+        .forUpdate()
+        .executeTakeFirstOrThrow();
+      if (!["approved", "payout_failed"].includes(locked.status)) {
+        httpError(400, "Only an approved claim can be marked paid");
+      }
       await trx
         .updateTable("expense")
         .set({ status: "paid", paid_at: now, updated_at: now })
@@ -760,7 +787,7 @@ export function markExpensePaid(db: Kysely<DB>, deps: NotifyDeps) {
           expense_id: expenseId,
           actor_user_id: actorUserId,
           type: "payout_paid",
-          from_status: expense.status,
+          from_status: locked.status,
           to_status: "paid",
           metadata: {
             manual: true,
@@ -960,10 +987,12 @@ export function payoutExpense(db: Kysely<DB>, deps: PayoutDeps) {
       .executeTakeFirst();
     if (!expense) httpError(404, "Expense not found");
 
-    // Idempotency: never create a second payout for a claim.
-    if (expense.outboundPaymentId) {
+    // A paid claim is terminal - never pay it again. (A payout_failed claim
+    // may still carry the failed OutboundPayment id, but it IS retryable, so
+    // we don't short-circuit on the id alone.)
+    if (expense.status === "paid") {
       return {
-        status: expense.status as ExpenseStatus,
+        status: "paid" as ExpenseStatus,
         stripeOutboundPaymentId: expense.outboundPaymentId,
         onboardingUrl: null,
       };
@@ -1027,15 +1056,33 @@ export function payoutExpense(db: Kysely<DB>, deps: PayoutDeps) {
       };
     }
 
-    // Pay. Idempotency key = expense id so a retry returns the same payment.
+    // Pay. For a first attempt the idempotency key is the expense id (a
+    // double-submit returns the same payment). A retry after a webhook-failed
+    // payout uses a fresh key so Stripe creates a NEW payment rather than
+    // echoing the old failed one.
+    const idempotencyKey =
+      expense.status === "payout_failed"
+        ? `${expenseId}:retry:${crypto.randomUUID()}`
+        : expenseId;
     try {
       const op = await client.createOutboundPayment({
         recipientId,
         payoutMethodId,
         amountPence: expense.amountPence,
         description: `Percy Main expense reimbursement ${expenseId}`,
-        idempotencyKey: expenseId,
+        idempotencyKey,
       });
+
+      // A synchronously-terminal failure status must not be recorded as paid;
+      // treat it like a thrown error. processing/posted/pending are optimistic
+      // "on its way" and the webhook confirms or corrects them.
+      const terminalFailure = ["failed", "returned", "canceled"].includes(
+        op.status.toLowerCase(),
+      );
+      if (terminalFailure) {
+        throw new Error(`Stripe returned status "${op.status}"`);
+      }
+
       const now = new Date().toISOString();
       await db.transaction().execute(async (trx) => {
         await trx

--- a/apps/api/src/features/expense/service.ts
+++ b/apps/api/src/features/expense/service.ts
@@ -1,5 +1,9 @@
 import type { DB } from "@percy-main/db";
-import { ExpenseDecision, ExpenseSubmitted, type Email } from "@percy-main/email";
+import {
+  ExpenseDecision,
+  ExpenseSubmitted,
+  type Email,
+} from "@percy-main/email";
 import {
   EXPENSE_STATUSES,
   expenseNeedsTwoApprovers,
@@ -112,7 +116,9 @@ async function setExpenseTags(
   if (categoryIds.length > 0) {
     await exec
       .insertInto("expense_category_link")
-      .values(categoryIds.map((id) => ({ expense_id: expenseId, category_id: id })))
+      .values(
+        categoryIds.map((id) => ({ expense_id: expenseId, category_id: id })),
+      )
       .execute();
   }
 }
@@ -121,7 +127,7 @@ async function setExpenseTags(
 async function loadRowExtras(db: Kysely<DB>, expenseIds: string[]) {
   if (expenseIds.length === 0) {
     return {
-      tagsByExpense: new Map<string, { id: string; name: string }[]>(),
+      tagsByExpense: new Map<string, Array<{ id: string; name: string }>>(),
       approvalCountByExpense: new Map<string, number>(),
       decidedAtByExpense: new Map<string, string>(),
     };
@@ -134,7 +140,7 @@ async function loadRowExtras(db: Kysely<DB>, expenseIds: string[]) {
     .select(["l.expense_id as expenseId", "c.id as id", "c.name as name"])
     .orderBy("c.name", "asc")
     .execute();
-  const tagsByExpense = new Map<string, { id: string; name: string }[]>();
+  const tagsByExpense = new Map<string, Array<{ id: string; name: string }>>();
   for (const t of tagRows) {
     const list = tagsByExpense.get(t.expenseId) ?? [];
     list.push({ id: t.id, name: t.name });
@@ -538,7 +544,7 @@ function readEventNote(metadata: unknown): string | null {
     metadata &&
     typeof metadata === "object" &&
     "note" in metadata &&
-    typeof (metadata as { note: unknown }).note === "string"
+    typeof metadata.note === "string"
   ) {
     return (metadata as { note: string }).note;
   }
@@ -623,7 +629,10 @@ export function decideExpense(db: Kysely<DB>, deps: NotifyDeps) {
             metadata: data.note ? { note: data.note } : null,
           })
           .execute();
-        return { status: "denied" as ExpenseStatus, secondApprovalNeeded: false };
+        return {
+          status: "denied" as ExpenseStatus,
+          secondApprovalNeeded: false,
+        };
       }
 
       // Approve: finalise tags (approver may edit the set), then require at
@@ -792,21 +801,25 @@ export function getExpenseSummary(db: Kysely<DB>) {
       .select((eb) => [
         "status",
         eb.fn.countAll<string>().as("count"),
-        eb.fn.coalesce(eb.fn.sum("amount_pence"), sql<string>`0`).as("sumPence"),
+        eb.fn
+          .coalesce(eb.fn.sum("amount_pence"), sql<string>`0`)
+          .as("sumPence"),
       ])
       .groupBy("status")
       .execute();
 
     const emptyBucket = () => ({ count: 0, totalPence: 0 });
-    const byStatus: Record<ExpenseStatus, { count: number; totalPence: number }> =
-      {
-        pending: emptyBucket(),
-        awaiting_second_approval: emptyBucket(),
-        approved: emptyBucket(),
-        denied: emptyBucket(),
-        paid: emptyBucket(),
-        payout_failed: emptyBucket(),
-      };
+    const byStatus: Record<
+      ExpenseStatus,
+      { count: number; totalPence: number }
+    > = {
+      pending: emptyBucket(),
+      awaiting_second_approval: emptyBucket(),
+      approved: emptyBucket(),
+      denied: emptyBucket(),
+      paid: emptyBucket(),
+      payout_failed: emptyBucket(),
+    };
     let totalCount = 0;
     let totalPence = 0;
     for (const r of statusRows) {

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -12961,7 +12961,22 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            received: boolean;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
                 };
             };
         };

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -12896,6 +12896,81 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/expenses/{expenseId}/payout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    expenseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                            stripeOutboundPaymentId: string | null;
+                            onboardingUrl: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/stripe/payouts-webhook": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/user-groups": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -12378,6 +12378,524 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/expenses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    page?: number;
+                    pageSize?: number;
+                    status?: ("pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed") | "all";
+                    tagId?: string;
+                    search?: string;
+                    dateFrom?: string;
+                    dateTo?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                claimantUserId: string;
+                                claimantName: string;
+                                description: string;
+                                amountPence: number;
+                                currency: string;
+                                /** @enum {string} */
+                                status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                                createdAt: string;
+                                updatedAt: string;
+                                decidedAt: string | null;
+                                paidAt: string | null;
+                                approvalCount: number;
+                                needsTwoApprovers: boolean;
+                                hasReceipt: boolean;
+                                tags: {
+                                    id: string;
+                                    name: string;
+                                }[];
+                            }[];
+                            total: number;
+                            page: number;
+                            pageSize: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        description: string;
+                        amountPence: number;
+                        receiptImage?: string | null;
+                        /** @default [] */
+                        tagNames?: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expenses/mine": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                claimantUserId: string;
+                                claimantName: string;
+                                description: string;
+                                amountPence: number;
+                                currency: string;
+                                /** @enum {string} */
+                                status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                                createdAt: string;
+                                updatedAt: string;
+                                decidedAt: string | null;
+                                paidAt: string | null;
+                                approvalCount: number;
+                                needsTwoApprovers: boolean;
+                                hasReceipt: boolean;
+                                tags: {
+                                    id: string;
+                                    name: string;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expense-categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            categories: {
+                                id: string;
+                                name: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            name: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expense-categories/{categoryId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    categoryId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        archived?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/api/expenses/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    dateFrom?: string;
+                    dateTo?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            byStatus: {
+                                pending: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                awaiting_second_approval: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                approved: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                denied: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                paid: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                payout_failed: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                            };
+                            byTag: {
+                                tagId: string;
+                                tagName: string;
+                                count: number;
+                                totalPence: number;
+                            }[];
+                            totals: {
+                                count: number;
+                                totalPence: number;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expenses/{expenseId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    expenseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            expense: {
+                                id: string;
+                                claimantUserId: string;
+                                claimantName: string;
+                                claimantEmail: string | null;
+                                description: string;
+                                amountPence: number;
+                                currency: string;
+                                /** @enum {string} */
+                                status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                                receiptImageUrl: string | null;
+                                payoutFailureReason: string | null;
+                                stripeOutboundPaymentId: string | null;
+                                needsTwoApprovers: boolean;
+                                createdAt: string;
+                                updatedAt: string;
+                                paidAt: string | null;
+                            };
+                            tags: {
+                                id: string;
+                                name: string;
+                            }[];
+                            approvals: {
+                                id: string;
+                                approverUserId: string;
+                                approverName: string | null;
+                                /** @enum {string} */
+                                decision: "approved" | "denied";
+                                note: string | null;
+                                createdAt: string;
+                            }[];
+                            events: {
+                                id: string;
+                                type: string;
+                                fromStatus: string | null;
+                                toStatus: string | null;
+                                note: string | null;
+                                actorUserId: string | null;
+                                actorName: string | null;
+                                createdAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expenses/{expenseId}/decision": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    expenseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        decision: "approve" | "deny";
+                        note?: string | null;
+                        tagNames?: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expenses/{expenseId}/mark-paid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    expenseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        note?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/user-groups": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -22591,7 +22591,9 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "query",
             "name": "tagId",
@@ -22984,7 +22986,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "categoryId",
@@ -23215,7 +23218,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "expenseId",
@@ -23476,7 +23480,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "expenseId",
@@ -23537,7 +23542,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "expenseId",
@@ -23573,7 +23579,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "expenseId",
@@ -23625,7 +23632,42 @@
       "post": {
         "responses": {
           "200": {
-            "description": "Default Response"
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "received": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "received"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -23567,6 +23567,69 @@
         }
       }
     },
+    "/api/expenses/{expenseId}/payout": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "expenseId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "awaiting_second_approval",
+                        "approved",
+                        "denied",
+                        "paid",
+                        "payout_failed"
+                      ]
+                    },
+                    "stripeOutboundPaymentId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "onboardingUrl": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "stripeOutboundPaymentId",
+                    "onboardingUrl"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/stripe/payouts-webhook": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/api/admin/user-groups": {
       "get": {
         "responses": {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -22473,6 +22473,1100 @@
         }
       }
     },
+    "/api/expenses": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "amountPence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991
+                  },
+                  "receiptImage": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "tagNames": {
+                    "default": [],
+                    "maxItems": 10,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 60
+                    }
+                  }
+                },
+                "required": [
+                  "description",
+                  "amountPence"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": "all",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "awaiting_second_approval",
+                    "approved",
+                    "denied",
+                    "paid",
+                    "payout_failed"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "all"
+                  ]
+                }
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "tagId",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateFrom",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateTo",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "claimantUserId": {
+                            "type": "string"
+                          },
+                          "claimantName": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "amountPence": {
+                            "type": "number"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "pending",
+                              "awaiting_second_approval",
+                              "approved",
+                              "denied",
+                              "paid",
+                              "payout_failed"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "decidedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "paidAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "approvalCount": {
+                            "type": "number"
+                          },
+                          "needsTwoApprovers": {
+                            "type": "boolean"
+                          },
+                          "hasReceipt": {
+                            "type": "boolean"
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "name"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "claimantUserId",
+                          "claimantName",
+                          "description",
+                          "amountPence",
+                          "currency",
+                          "status",
+                          "createdAt",
+                          "updatedAt",
+                          "decidedAt",
+                          "paidAt",
+                          "approvalCount",
+                          "needsTwoApprovers",
+                          "hasReceipt",
+                          "tags"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "page": {
+                      "type": "number"
+                    },
+                    "pageSize": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "total",
+                    "page",
+                    "pageSize"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/mine": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "claimantUserId": {
+                            "type": "string"
+                          },
+                          "claimantName": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "amountPence": {
+                            "type": "number"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "pending",
+                              "awaiting_second_approval",
+                              "approved",
+                              "denied",
+                              "paid",
+                              "payout_failed"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "decidedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "paidAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "approvalCount": {
+                            "type": "number"
+                          },
+                          "needsTwoApprovers": {
+                            "type": "boolean"
+                          },
+                          "hasReceipt": {
+                            "type": "boolean"
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "name"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "claimantUserId",
+                          "claimantName",
+                          "description",
+                          "amountPence",
+                          "currency",
+                          "status",
+                          "createdAt",
+                          "updatedAt",
+                          "decidedAt",
+                          "paidAt",
+                          "approvalCount",
+                          "needsTwoApprovers",
+                          "hasReceipt",
+                          "tags"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expense-categories": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "categories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "categories"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 60
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expense-categories/{categoryId}": {
+      "patch": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 60
+                  },
+                  "archived": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "categoryId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/summary": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateFrom",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateTo",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "byStatus": {
+                      "type": "object",
+                      "properties": {
+                        "pending": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "awaiting_second_approval": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "approved": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "denied": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "paid": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "payout_failed": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "pending",
+                        "awaiting_second_approval",
+                        "approved",
+                        "denied",
+                        "paid",
+                        "payout_failed"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "byTag": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "tagId": {
+                            "type": "string"
+                          },
+                          "tagName": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          },
+                          "totalPence": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "tagId",
+                          "tagName",
+                          "count",
+                          "totalPence"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "totals": {
+                      "type": "object",
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        },
+                        "totalPence": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count",
+                        "totalPence"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "byStatus",
+                    "byTag",
+                    "totals"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/{expenseId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "expenseId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "expense": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "claimantUserId": {
+                          "type": "string"
+                        },
+                        "claimantName": {
+                          "type": "string"
+                        },
+                        "claimantEmail": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "amountPence": {
+                          "type": "number"
+                        },
+                        "currency": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "pending",
+                            "awaiting_second_approval",
+                            "approved",
+                            "denied",
+                            "paid",
+                            "payout_failed"
+                          ]
+                        },
+                        "receiptImageUrl": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "payoutFailureReason": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "stripeOutboundPaymentId": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "needsTwoApprovers": {
+                          "type": "boolean"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        },
+                        "paidAt": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "claimantUserId",
+                        "claimantName",
+                        "claimantEmail",
+                        "description",
+                        "amountPence",
+                        "currency",
+                        "status",
+                        "receiptImageUrl",
+                        "payoutFailureReason",
+                        "stripeOutboundPaymentId",
+                        "needsTwoApprovers",
+                        "createdAt",
+                        "updatedAt",
+                        "paidAt"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "approvals": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "approverUserId": {
+                            "type": "string"
+                          },
+                          "approverName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "decision": {
+                            "type": "string",
+                            "enum": [
+                              "approved",
+                              "denied"
+                            ]
+                          },
+                          "note": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "approverUserId",
+                          "approverName",
+                          "decision",
+                          "note",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "fromStatus": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "toStatus": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "note": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "actorUserId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "actorName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "fromStatus",
+                          "toStatus",
+                          "note",
+                          "actorUserId",
+                          "actorName",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "expense",
+                    "tags",
+                    "approvals",
+                    "events"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/{expenseId}/decision": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "decision": {
+                    "type": "string",
+                    "enum": [
+                      "approve",
+                      "deny"
+                    ]
+                  },
+                  "note": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "tagNames": {
+                    "maxItems": 10,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 60
+                    }
+                  }
+                },
+                "required": [
+                  "decision"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "expenseId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "awaiting_second_approval",
+                        "approved",
+                        "denied",
+                        "paid",
+                        "payout_failed"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/{expenseId}/mark-paid": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "note": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 500
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "expenseId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/user-groups": {
       "get": {
         "responses": {

--- a/apps/web/src/components/expense-tag-picker.tsx
+++ b/apps/web/src/components/expense-tag-picker.tsx
@@ -1,0 +1,86 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useState } from "react";
+
+/**
+ * Tag multi-select for expense claims. Works in tag NAMES (the API resolves
+ * names to the shared vocabulary, creating new ones), so both the claimant's
+ * proposal and the approver's edit use the same control. Existing tags toggle
+ * on/off; a free-text box adds a brand new tag.
+ */
+export function ExpenseTagPicker({
+  available,
+  selected,
+  onChange,
+}: {
+  available: readonly string[];
+  selected: readonly string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const selectedSet = new Set(selected.map((s) => s.toLowerCase()));
+  const toggle = (name: string) => {
+    if (selectedSet.has(name.toLowerCase())) {
+      onChange(selected.filter((s) => s.toLowerCase() !== name.toLowerCase()));
+    } else {
+      onChange([...selected, name]);
+    }
+  };
+
+  const addDraft = () => {
+    const name = draft.trim();
+    if (!name) return;
+    if (!selectedSet.has(name.toLowerCase())) onChange([...selected, name]);
+    setDraft("");
+  };
+
+  // Tags chosen that aren't part of the known vocabulary yet (newly typed).
+  const extras = selected.filter(
+    (s) => !available.some((a) => a.toLowerCase() === s.toLowerCase()),
+  );
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        {available.map((name) => (
+          <button key={name} type="button" onClick={() => toggle(name)}>
+            <Badge
+              variant={
+                selectedSet.has(name.toLowerCase()) ? "default" : "secondary"
+              }
+              className="cursor-pointer"
+            >
+              {name}
+            </Badge>
+          </button>
+        ))}
+        {extras.map((name) => (
+          <button key={name} type="button" onClick={() => toggle(name)}>
+            <Badge variant="default" className="cursor-pointer">
+              {name} (new)
+            </Badge>
+          </button>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Input
+          value={draft}
+          placeholder="Add a tag…"
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addDraft();
+            }
+          }}
+          className="w-48"
+        />
+        <Button type="button" variant="outline" size="sm" onClick={addDraft}>
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -12961,7 +12961,22 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            received: boolean;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
                 };
             };
         };

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -12896,6 +12896,81 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/expenses/{expenseId}/payout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    expenseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                            stripeOutboundPaymentId: string | null;
+                            onboardingUrl: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/stripe/payouts-webhook": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/user-groups": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -12378,6 +12378,524 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/expenses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    page?: number;
+                    pageSize?: number;
+                    status?: ("pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed") | "all";
+                    tagId?: string;
+                    search?: string;
+                    dateFrom?: string;
+                    dateTo?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                claimantUserId: string;
+                                claimantName: string;
+                                description: string;
+                                amountPence: number;
+                                currency: string;
+                                /** @enum {string} */
+                                status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                                createdAt: string;
+                                updatedAt: string;
+                                decidedAt: string | null;
+                                paidAt: string | null;
+                                approvalCount: number;
+                                needsTwoApprovers: boolean;
+                                hasReceipt: boolean;
+                                tags: {
+                                    id: string;
+                                    name: string;
+                                }[];
+                            }[];
+                            total: number;
+                            page: number;
+                            pageSize: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        description: string;
+                        amountPence: number;
+                        receiptImage?: string | null;
+                        /** @default [] */
+                        tagNames?: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expenses/mine": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                claimantUserId: string;
+                                claimantName: string;
+                                description: string;
+                                amountPence: number;
+                                currency: string;
+                                /** @enum {string} */
+                                status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                                createdAt: string;
+                                updatedAt: string;
+                                decidedAt: string | null;
+                                paidAt: string | null;
+                                approvalCount: number;
+                                needsTwoApprovers: boolean;
+                                hasReceipt: boolean;
+                                tags: {
+                                    id: string;
+                                    name: string;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expense-categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            categories: {
+                                id: string;
+                                name: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            name: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expense-categories/{categoryId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    categoryId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        name?: string;
+                        archived?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/api/expenses/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    dateFrom?: string;
+                    dateTo?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            byStatus: {
+                                pending: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                awaiting_second_approval: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                approved: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                denied: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                paid: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                                payout_failed: {
+                                    count: number;
+                                    totalPence: number;
+                                };
+                            };
+                            byTag: {
+                                tagId: string;
+                                tagName: string;
+                                count: number;
+                                totalPence: number;
+                            }[];
+                            totals: {
+                                count: number;
+                                totalPence: number;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expenses/{expenseId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    expenseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            expense: {
+                                id: string;
+                                claimantUserId: string;
+                                claimantName: string;
+                                claimantEmail: string | null;
+                                description: string;
+                                amountPence: number;
+                                currency: string;
+                                /** @enum {string} */
+                                status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                                receiptImageUrl: string | null;
+                                payoutFailureReason: string | null;
+                                stripeOutboundPaymentId: string | null;
+                                needsTwoApprovers: boolean;
+                                createdAt: string;
+                                updatedAt: string;
+                                paidAt: string | null;
+                            };
+                            tags: {
+                                id: string;
+                                name: string;
+                            }[];
+                            approvals: {
+                                id: string;
+                                approverUserId: string;
+                                approverName: string | null;
+                                /** @enum {string} */
+                                decision: "approved" | "denied";
+                                note: string | null;
+                                createdAt: string;
+                            }[];
+                            events: {
+                                id: string;
+                                type: string;
+                                fromStatus: string | null;
+                                toStatus: string | null;
+                                note: string | null;
+                                actorUserId: string | null;
+                                actorName: string | null;
+                                createdAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expenses/{expenseId}/decision": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    expenseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        decision: "approve" | "deny";
+                        note?: string | null;
+                        tagNames?: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "pending" | "awaiting_second_approval" | "approved" | "denied" | "paid" | "payout_failed";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/expenses/{expenseId}/mark-paid": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    expenseId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        note?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/user-groups": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -22591,7 +22591,9 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "query",
             "name": "tagId",
@@ -22984,7 +22986,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "categoryId",
@@ -23215,7 +23218,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "expenseId",
@@ -23476,7 +23480,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "expenseId",
@@ -23537,7 +23542,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "expenseId",
@@ -23573,7 +23579,8 @@
           {
             "schema": {
               "type": "string",
-              "minLength": 1
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
             },
             "in": "path",
             "name": "expenseId",
@@ -23625,7 +23632,42 @@
       "post": {
         "responses": {
           "200": {
-            "description": "Default Response"
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "received": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "received"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -23567,6 +23567,69 @@
         }
       }
     },
+    "/api/expenses/{expenseId}/payout": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "expenseId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "awaiting_second_approval",
+                        "approved",
+                        "denied",
+                        "paid",
+                        "payout_failed"
+                      ]
+                    },
+                    "stripeOutboundPaymentId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "onboardingUrl": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "stripeOutboundPaymentId",
+                    "onboardingUrl"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/stripe/payouts-webhook": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/api/admin/user-groups": {
       "get": {
         "responses": {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -22473,6 +22473,1100 @@
         }
       }
     },
+    "/api/expenses": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "amountPence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "maximum": 9007199254740991
+                  },
+                  "receiptImage": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "tagNames": {
+                    "default": [],
+                    "maxItems": 10,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 60
+                    }
+                  }
+                },
+                "required": [
+                  "description",
+                  "amountPence"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": "all",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "awaiting_second_approval",
+                    "approved",
+                    "denied",
+                    "paid",
+                    "payout_failed"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "all"
+                  ]
+                }
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "tagId",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateFrom",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateTo",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "claimantUserId": {
+                            "type": "string"
+                          },
+                          "claimantName": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "amountPence": {
+                            "type": "number"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "pending",
+                              "awaiting_second_approval",
+                              "approved",
+                              "denied",
+                              "paid",
+                              "payout_failed"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "decidedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "paidAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "approvalCount": {
+                            "type": "number"
+                          },
+                          "needsTwoApprovers": {
+                            "type": "boolean"
+                          },
+                          "hasReceipt": {
+                            "type": "boolean"
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "name"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "claimantUserId",
+                          "claimantName",
+                          "description",
+                          "amountPence",
+                          "currency",
+                          "status",
+                          "createdAt",
+                          "updatedAt",
+                          "decidedAt",
+                          "paidAt",
+                          "approvalCount",
+                          "needsTwoApprovers",
+                          "hasReceipt",
+                          "tags"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    },
+                    "page": {
+                      "type": "number"
+                    },
+                    "pageSize": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "total",
+                    "page",
+                    "pageSize"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/mine": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "claimantUserId": {
+                            "type": "string"
+                          },
+                          "claimantName": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "amountPence": {
+                            "type": "number"
+                          },
+                          "currency": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "pending",
+                              "awaiting_second_approval",
+                              "approved",
+                              "denied",
+                              "paid",
+                              "payout_failed"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "decidedAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "paidAt": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "approvalCount": {
+                            "type": "number"
+                          },
+                          "needsTwoApprovers": {
+                            "type": "boolean"
+                          },
+                          "hasReceipt": {
+                            "type": "boolean"
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "name"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "claimantUserId",
+                          "claimantName",
+                          "description",
+                          "amountPence",
+                          "currency",
+                          "status",
+                          "createdAt",
+                          "updatedAt",
+                          "decidedAt",
+                          "paidAt",
+                          "approvalCount",
+                          "needsTwoApprovers",
+                          "hasReceipt",
+                          "tags"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expense-categories": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "categories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "categories"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 60
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expense-categories/{categoryId}": {
+      "patch": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 60
+                  },
+                  "archived": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "categoryId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/summary": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateFrom",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateTo",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "byStatus": {
+                      "type": "object",
+                      "properties": {
+                        "pending": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "awaiting_second_approval": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "approved": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "denied": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "paid": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "payout_failed": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "number"
+                            },
+                            "totalPence": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "totalPence"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "pending",
+                        "awaiting_second_approval",
+                        "approved",
+                        "denied",
+                        "paid",
+                        "payout_failed"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "byTag": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "tagId": {
+                            "type": "string"
+                          },
+                          "tagName": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          },
+                          "totalPence": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "tagId",
+                          "tagName",
+                          "count",
+                          "totalPence"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "totals": {
+                      "type": "object",
+                      "properties": {
+                        "count": {
+                          "type": "number"
+                        },
+                        "totalPence": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "count",
+                        "totalPence"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "byStatus",
+                    "byTag",
+                    "totals"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/{expenseId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "expenseId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "expense": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "claimantUserId": {
+                          "type": "string"
+                        },
+                        "claimantName": {
+                          "type": "string"
+                        },
+                        "claimantEmail": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "amountPence": {
+                          "type": "number"
+                        },
+                        "currency": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "pending",
+                            "awaiting_second_approval",
+                            "approved",
+                            "denied",
+                            "paid",
+                            "payout_failed"
+                          ]
+                        },
+                        "receiptImageUrl": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "payoutFailureReason": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "stripeOutboundPaymentId": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "needsTwoApprovers": {
+                          "type": "boolean"
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        },
+                        "updatedAt": {
+                          "type": "string"
+                        },
+                        "paidAt": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "claimantUserId",
+                        "claimantName",
+                        "claimantEmail",
+                        "description",
+                        "amountPence",
+                        "currency",
+                        "status",
+                        "receiptImageUrl",
+                        "payoutFailureReason",
+                        "stripeOutboundPaymentId",
+                        "needsTwoApprovers",
+                        "createdAt",
+                        "updatedAt",
+                        "paidAt"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "approvals": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "approverUserId": {
+                            "type": "string"
+                          },
+                          "approverName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "decision": {
+                            "type": "string",
+                            "enum": [
+                              "approved",
+                              "denied"
+                            ]
+                          },
+                          "note": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "approverUserId",
+                          "approverName",
+                          "decision",
+                          "note",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "fromStatus": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "toStatus": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "note": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "actorUserId": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "actorName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "fromStatus",
+                          "toStatus",
+                          "note",
+                          "actorUserId",
+                          "actorName",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "expense",
+                    "tags",
+                    "approvals",
+                    "events"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/{expenseId}/decision": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "decision": {
+                    "type": "string",
+                    "enum": [
+                      "approve",
+                      "deny"
+                    ]
+                  },
+                  "note": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "tagNames": {
+                    "maxItems": 10,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 60
+                    }
+                  }
+                },
+                "required": [
+                  "decision"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "expenseId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "awaiting_second_approval",
+                        "approved",
+                        "denied",
+                        "paid",
+                        "payout_failed"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/expenses/{expenseId}/mark-paid": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "note": {
+                    "nullable": true,
+                    "type": "string",
+                    "maxLength": 500
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "expenseId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/user-groups": {
       "get": {
         "responses": {

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -22,6 +22,7 @@ import { MatchFeesTab } from "./match-fees-tab";
 import { MembersTab } from "./members-tab";
 import { PagesTab } from "./pages-tab";
 import { RecordLinkingTab } from "./record-linking-tab";
+import { ReimbursementsTab } from "./reimbursements-tab";
 import { SponsorshipsTab } from "./sponsorships-tab";
 import { TreasurerTab } from "./treasurer-tab";
 
@@ -137,6 +138,12 @@ const SECTIONS: readonly SectionDef[] = [
         label: "Expenses",
         visible: (role) => checkPermission(role, "finance", "manage"),
         render: () => <ExpenseHistoryTab />,
+      },
+      {
+        value: "reimbursements",
+        label: "Reimbursements",
+        visible: (role) => checkPermission(role, "expenses", "view"),
+        render: () => <ReimbursementsTab />,
       },
       {
         value: "match-fees",

--- a/apps/web/src/pages/admin/manage-expense-tags-dialog.tsx
+++ b/apps/web/src/pages/admin/manage-expense-tags-dialog.tsx
@@ -1,0 +1,139 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { api, callApi } from "@/lib/api-client";
+import type { paths } from "@/lib/api.gen";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+type Categories =
+  paths["/api/expense-categories"]["get"]["responses"]["200"]["content"]["application/json"];
+
+export function ManageExpenseTagsDialog({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [newName, setNewName] = useState("");
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const { data } = useQuery({
+    queryKey: ["expenses", "categories"],
+    queryFn: () => callApi(api.GET("/api/expense-categories")),
+    enabled: open,
+  });
+
+  const add = useMutation({
+    mutationFn: (name: string) =>
+      callApi(api.POST("/api/expense-categories", { body: { name } })),
+    onSuccess: async () => {
+      setNewName("");
+      setError(null);
+      await queryClient.invalidateQueries({
+        queryKey: ["expenses", "categories"],
+      });
+    },
+    onError: (e: Error) => setError(e.message),
+  });
+
+  const patch = useMutation({
+    mutationFn: (vars: {
+      id: string;
+      body: { name?: string; archived?: boolean };
+    }) =>
+      callApi(
+        api.PATCH("/api/expense-categories/{categoryId}", {
+          params: { path: { categoryId: vars.id } },
+          body: vars.body,
+        }),
+      ),
+    onSuccess: async () => {
+      setError(null);
+      await queryClient.invalidateQueries({
+        queryKey: ["expenses", "categories"],
+      });
+    },
+    onError: (e: Error) => setError(e.message),
+  });
+
+  const categories: Categories["categories"] = data?.categories ?? [];
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Manage expense tags</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <Input
+              placeholder="New tag name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <Button
+              disabled={!newName.trim() || add.isPending}
+              onClick={() => add.mutate(newName.trim())}
+            >
+              Add
+            </Button>
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <ul className="space-y-2">
+            {categories.map((c) => (
+              <li key={c.id} className="flex items-center gap-2">
+                <Input
+                  value={drafts[c.id] ?? c.name}
+                  onChange={(e) =>
+                    setDrafts((d) => ({ ...d, [c.id]: e.target.value }))
+                  }
+                  className="flex-1"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={patch.isPending}
+                  onClick={() =>
+                    patch.mutate({
+                      id: c.id,
+                      body: { name: (drafts[c.id] ?? c.name).trim() },
+                    })
+                  }
+                >
+                  Rename
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={patch.isPending}
+                  onClick={() =>
+                    patch.mutate({ id: c.id, body: { archived: true } })
+                  }
+                >
+                  Archive
+                </Button>
+              </li>
+            ))}
+            {categories.length === 0 && (
+              <li className="text-sm text-stone-400">No tags yet.</li>
+            )}
+          </ul>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/admin/reimbursement-detail-dialog.tsx
+++ b/apps/web/src/pages/admin/reimbursement-detail-dialog.tsx
@@ -1,0 +1,338 @@
+import { ExpenseTagPicker } from "@/components/expense-tag-picker";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { api, callApi } from "@/lib/api-client";
+import type { paths } from "@/lib/api.gen";
+import { EXPENSE_STATUS_LABELS, type ExpenseStatus } from "@percy-main/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { formatDate, formatPence } from "./status-pill";
+
+type DetailResponse =
+  paths["/api/expenses/{expenseId}"]["get"]["responses"]["200"]["content"]["application/json"];
+
+const STATUS_VARIANT: Record<
+  ExpenseStatus,
+  "default" | "secondary" | "success" | "warning" | "destructive"
+> = {
+  pending: "default",
+  awaiting_second_approval: "warning",
+  approved: "success",
+  denied: "destructive",
+  paid: "secondary",
+  payout_failed: "destructive",
+};
+
+export function ReimbursementDetailDialog({
+  expenseId,
+  availableTags,
+  canApprove,
+  canPay,
+  onClose,
+}: {
+  expenseId: string | null;
+  availableTags: readonly string[];
+  canApprove: boolean;
+  canPay: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog
+      open={!!expenseId}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Expense claim</DialogTitle>
+        </DialogHeader>
+        {/* key={expenseId} resets the body's local edit state per claim. */}
+        {expenseId && (
+          <DetailBody
+            key={expenseId}
+            expenseId={expenseId}
+            availableTags={availableTags}
+            canApprove={canApprove}
+            canPay={canPay}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DetailBody({
+  expenseId,
+  availableTags,
+  canApprove,
+  canPay,
+}: {
+  expenseId: string;
+  availableTags: readonly string[];
+  canApprove: boolean;
+  canPay: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [note, setNote] = useState("");
+  const [editedTags, setEditedTags] = useState<string[] | null>(null);
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["expenses", "detail", expenseId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/expenses/{expenseId}", {
+          params: { path: { expenseId } },
+        }),
+      ),
+  });
+
+  const loadedTags = data?.tags.map((t) => t.name) ?? [];
+  const selectedTags = editedTags ?? loadedTags;
+
+  const decide = useMutation({
+    mutationFn: (decision: "approve" | "deny") =>
+      callApi(
+        api.POST("/api/expenses/{expenseId}/decision", {
+          params: { path: { expenseId } },
+          body: {
+            decision,
+            note: note.trim() || null,
+            ...(decision === "approve" ? { tagNames: selectedTags } : {}),
+          },
+        }),
+      ),
+    onSuccess: async () => {
+      setNote("");
+      setError(null);
+      await queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+    onError: (e: Error) => setError(e.message),
+  });
+
+  const markPaid = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/expenses/{expenseId}/mark-paid", {
+          params: { path: { expenseId } },
+          body: { note: note.trim() || null },
+        }),
+      ),
+    onSuccess: async () => {
+      setNote("");
+      setError(null);
+      await queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+    onError: (e: Error) => setError(e.message),
+  });
+
+  if (isLoading || !data) {
+    return <p className="text-stone-500">Loading…</p>;
+  }
+
+  const expense = data.expense;
+  const decidable =
+    expense.status === "pending" ||
+    expense.status === "awaiting_second_approval";
+  const payable =
+    expense.status === "approved" || expense.status === "payout_failed";
+  const busy = decide.isPending || markPaid.isPending;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <p className="text-stone-500">Claimant</p>
+          <p>{expense.claimantName}</p>
+        </div>
+        <div>
+          <p className="text-stone-500">Amount</p>
+          <p className="font-medium">{formatPence(expense.amountPence)}</p>
+        </div>
+        <div className="col-span-2">
+          <p className="text-stone-500">Description</p>
+          <p>{expense.description}</p>
+        </div>
+        <div>
+          <p className="text-stone-500">Status</p>
+          <Badge variant={STATUS_VARIANT[expense.status]}>
+            {EXPENSE_STATUS_LABELS[expense.status]}
+          </Badge>
+        </div>
+        <div>
+          <p className="text-stone-500">Approvals needed</p>
+          <p>{expense.needsTwoApprovers ? "Two" : "One"}</p>
+        </div>
+        {expense.payoutFailureReason && (
+          <div className="col-span-2">
+            <p className="text-stone-500">Payout failure</p>
+            <p className="text-red-600">{expense.payoutFailureReason}</p>
+          </div>
+        )}
+      </div>
+
+      <TagsSection tags={data.tags} />
+
+      <div className="border-t pt-3">
+        <h4 className="mb-2 text-sm font-medium">Decisions</h4>
+        {data.approvals.length === 0 ? (
+          <p className="text-sm text-stone-400">No decisions yet</p>
+        ) : (
+          <ul className="space-y-1 text-sm">
+            {data.approvals.map((a) => (
+              <li key={a.id} className="flex justify-between">
+                <span>
+                  {a.approverName ?? "Unknown"} -{" "}
+                  {a.decision === "approved" ? "Approved" : "Denied"}
+                  {a.note ? `: ${a.note}` : ""}
+                </span>
+                <span className="text-stone-500">
+                  {formatDate(a.createdAt, true)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="border-t pt-3">
+        <h4 className="mb-2 text-sm font-medium">Audit trail</h4>
+        <ul className="space-y-1 text-sm">
+          {data.events.map((e) => (
+            <li key={e.id} className="flex justify-between">
+              <span>
+                {e.type}
+                {e.actorName ? ` by ${e.actorName}` : ""}
+                {e.note ? `: ${e.note}` : ""}
+              </span>
+              <span className="text-stone-500">
+                {formatDate(e.createdAt, true)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {expense.receiptImageUrl && (
+        <div className="border-t pt-3">
+          <h4 className="mb-2 text-sm font-medium">Receipt</h4>
+          <button
+            type="button"
+            onClick={() => setLightboxUrl(expense.receiptImageUrl)}
+            className="cursor-pointer"
+            aria-label="Open receipt full size"
+          >
+            <img
+              src={expense.receiptImageUrl}
+              alt="Receipt"
+              className="max-h-48 rounded border object-contain"
+            />
+          </button>
+        </div>
+      )}
+
+      {(canApprove && decidable) || (canPay && payable) ? (
+        <div className="space-y-3 border-t pt-3">
+          {canApprove && decidable && (
+            <div>
+              <p className="mb-1 text-sm text-stone-500">
+                Tags (set when approving)
+              </p>
+              <ExpenseTagPicker
+                available={availableTags}
+                selected={selectedTags}
+                onChange={setEditedTags}
+              />
+            </div>
+          )}
+          <Textarea
+            placeholder="Note (optional, shared with the claimant on a decision)"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <div className="flex flex-wrap gap-2">
+            {canApprove && decidable && (
+              <>
+                <Button
+                  disabled={busy}
+                  onClick={() => decide.mutate("approve")}
+                >
+                  Approve
+                </Button>
+                <Button
+                  variant="destructive"
+                  disabled={busy}
+                  onClick={() => decide.mutate("deny")}
+                >
+                  Deny
+                </Button>
+              </>
+            )}
+            {canPay && payable && (
+              <Button
+                variant="outline"
+                disabled={busy}
+                onClick={() => markPaid.mutate()}
+              >
+                Mark paid (manual)
+              </Button>
+            )}
+          </div>
+        </div>
+      ) : null}
+
+      {lightboxUrl && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Receipt full size"
+          tabIndex={-1}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setLightboxUrl(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape" || e.key === "Enter" || e.key === " ") {
+              setLightboxUrl(null);
+            }
+          }}
+        >
+          <img
+            src={lightboxUrl}
+            alt="Receipt full size"
+            className="max-h-[90vh] max-w-[90vw] object-contain"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TagsSection({ tags }: { tags: DetailResponse["tags"] }) {
+  return (
+    <div className="border-t pt-3">
+      <p className="mb-1 text-sm text-stone-500">Tags</p>
+      <div className="flex flex-wrap gap-2">
+        {tags.length === 0 ? (
+          <span className="text-sm text-stone-400">No tags</span>
+        ) : (
+          tags.map((t) => (
+            <Badge key={t.id} variant="secondary">
+              {t.name}
+            </Badge>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin/reimbursement-detail-dialog.tsx
+++ b/apps/web/src/pages/admin/reimbursement-detail-dialog.tsx
@@ -135,6 +135,22 @@ function DetailBody({
     onError: (e: Error) => setError(e.message),
   });
 
+  const payout = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/expenses/{expenseId}/payout", {
+          params: { path: { expenseId } },
+        }),
+      ),
+    onSuccess: async () => {
+      setError(null);
+      // If there's no payout method on file yet, the result carries a hosted
+      // link (read off payout.data below) for the claimant to add bank details.
+      await queryClient.invalidateQueries({ queryKey: ["expenses"] });
+    },
+    onError: (e: Error) => setError(e.message),
+  });
+
   if (isLoading || !data) {
     return <p className="text-stone-500">Loading…</p>;
   }
@@ -145,7 +161,7 @@ function DetailBody({
     expense.status === "awaiting_second_approval";
   const payable =
     expense.status === "approved" || expense.status === "payout_failed";
-  const busy = decide.isPending || markPaid.isPending;
+  const busy = decide.isPending || markPaid.isPending || payout.isPending;
 
   return (
     <div className="space-y-4">
@@ -279,15 +295,34 @@ function DetailBody({
               </>
             )}
             {canPay && payable && (
-              <Button
-                variant="outline"
-                disabled={busy}
-                onClick={() => markPaid.mutate()}
-              >
-                Mark paid (manual)
-              </Button>
+              <>
+                <Button disabled={busy} onClick={() => payout.mutate()}>
+                  Pay via Stripe
+                </Button>
+                <Button
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() => markPaid.mutate()}
+                >
+                  Mark paid (manual)
+                </Button>
+              </>
             )}
           </div>
+          {payout.data?.onboardingUrl && (
+            <p className="text-sm text-amber-700">
+              The claimant needs to add their bank details first.{" "}
+              <a
+                href={payout.data.onboardingUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                Open the secure Stripe setup link
+              </a>{" "}
+              and share it with them, then pay again.
+            </p>
+          )}
         </div>
       ) : null}
 

--- a/apps/web/src/pages/admin/reimbursements-tab.tsx
+++ b/apps/web/src/pages/admin/reimbursements-tab.tsx
@@ -1,0 +1,356 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useHasPermission } from "@/hooks/use-has-permission";
+import { api, callApi } from "@/lib/api-client";
+import type { paths } from "@/lib/api.gen";
+import {
+  EXPENSE_STATUS_LABELS,
+  EXPENSE_STATUSES,
+  type ExpenseStatus,
+} from "@percy-main/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useReducer, useState } from "react";
+import { ManageExpenseTagsDialog } from "./manage-expense-tags-dialog";
+import { ReimbursementDetailDialog } from "./reimbursement-detail-dialog";
+import { formatDate, formatPence } from "./status-pill";
+
+type ListResponse =
+  paths["/api/expenses"]["get"]["responses"]["200"]["content"]["application/json"];
+type SummaryResponse =
+  paths["/api/expenses/summary"]["get"]["responses"]["200"]["content"]["application/json"];
+
+const PAGE_SIZE = 20;
+
+const STATUS_VARIANT: Record<
+  ExpenseStatus,
+  "default" | "secondary" | "success" | "warning" | "destructive"
+> = {
+  pending: "default",
+  awaiting_second_approval: "warning",
+  approved: "success",
+  denied: "destructive",
+  paid: "secondary",
+  payout_failed: "destructive",
+};
+
+interface Filters {
+  status: ExpenseStatus | "all";
+  tagId: string;
+  search: string;
+  debouncedSearch: string;
+  page: number;
+}
+
+type FilterAction =
+  | { type: "setStatus"; value: ExpenseStatus | "all" }
+  | { type: "setTag"; value: string }
+  | { type: "setSearch"; value: string }
+  | { type: "commitSearch"; value: string }
+  | { type: "setPage"; value: number };
+
+const INITIAL_FILTERS: Filters = {
+  status: "all",
+  tagId: "all",
+  search: "",
+  debouncedSearch: "",
+  page: 1,
+};
+
+// Filter changes reset to page 1 so you never sit on an out-of-range page.
+function filtersReducer(state: Filters, action: FilterAction): Filters {
+  switch (action.type) {
+    case "setStatus":
+      return { ...state, status: action.value, page: 1 };
+    case "setTag":
+      return { ...state, tagId: action.value, page: 1 };
+    case "setSearch":
+      return { ...state, search: action.value };
+    case "commitSearch":
+      return { ...state, debouncedSearch: action.value, page: 1 };
+    case "setPage":
+      return { ...state, page: action.value };
+  }
+}
+
+export function ReimbursementsTab() {
+  const canApprove = useHasPermission("expenses", "approve").allowed;
+  const canPay = useHasPermission("expenses", "pay").allowed;
+  const canManageTags = useHasPermission("expenses", "manage_tags").allowed;
+
+  const [filters, dispatch] = useReducer(filtersReducer, INITIAL_FILTERS);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [manageOpen, setManageOpen] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(
+      () => dispatch({ type: "commitSearch", value: filters.search }),
+      300,
+    );
+    return () => clearTimeout(t);
+  }, [filters.search]);
+
+  const { data: categories } = useQuery({
+    queryKey: ["expenses", "categories"],
+    queryFn: () => callApi(api.GET("/api/expense-categories")),
+  });
+
+  const queryParams = {
+    page: filters.page,
+    pageSize: PAGE_SIZE,
+    status: filters.status,
+    tagId: filters.tagId === "all" ? undefined : filters.tagId,
+    search: filters.debouncedSearch || undefined,
+  };
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["expenses", "list", queryParams],
+    queryFn: () =>
+      callApi(api.GET("/api/expenses", { params: { query: queryParams } })),
+  });
+
+  const { data: summary } = useQuery({
+    queryKey: ["expenses", "summary"],
+    queryFn: () => callApi(api.GET("/api/expenses/summary", { params: {} })),
+  });
+
+  const totalPages = Math.ceil((data?.total ?? 0) / PAGE_SIZE);
+  const availableTags = (categories?.categories ?? []).map((c) => c.name);
+
+  return (
+    <div className="space-y-6 pt-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Reimbursements</h2>
+        {canManageTags && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setManageOpen(true)}
+          >
+            Manage tags
+          </Button>
+        )}
+      </div>
+
+      {summary && <SummaryCards summary={summary} />}
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="reimb-status" className="text-xs text-stone-500">
+            Status
+          </label>
+          <Select
+            value={filters.status}
+            onValueChange={(v) =>
+              dispatch({ type: "setStatus", value: v as ExpenseStatus | "all" })
+            }
+          >
+            <SelectTrigger id="reimb-status" className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All statuses</SelectItem>
+              {EXPENSE_STATUSES.map((s) => (
+                <SelectItem key={s} value={s}>
+                  {EXPENSE_STATUS_LABELS[s]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="reimb-tag" className="text-xs text-stone-500">
+            Tag
+          </label>
+          <Select
+            value={filters.tagId}
+            onValueChange={(v) => dispatch({ type: "setTag", value: v })}
+          >
+            <SelectTrigger id="reimb-tag" className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All tags</SelectItem>
+              {(categories?.categories ?? []).map((c) => (
+                <SelectItem key={c.id} value={c.id}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="reimb-search" className="text-xs text-stone-500">
+            Search
+          </label>
+          <Input
+            id="reimb-search"
+            placeholder="Claimant or description…"
+            value={filters.search}
+            onChange={(e) =>
+              dispatch({ type: "setSearch", value: e.target.value })
+            }
+            className="w-56"
+          />
+        </div>
+      </div>
+
+      <div className="text-sm text-stone-500">
+        {data
+          ? `${data.total} claim${data.total === 1 ? "" : "s"} found`
+          : isLoading
+            ? "Loading…"
+            : ""}
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Claimant</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead className="text-right">Amount</TableHead>
+              <TableHead>Tags</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Approvals</TableHead>
+              <TableHead>Submitted</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data?.items.map((row: ListResponse["items"][number]) => (
+              <TableRow key={row.id}>
+                <TableCell>{row.claimantName}</TableCell>
+                <TableCell className="max-w-xs truncate">
+                  {row.description}
+                </TableCell>
+                <TableCell className="text-right">
+                  {formatPence(row.amountPence)}
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1">
+                    {row.tags.map((t) => (
+                      <Badge key={t.id} variant="secondary">
+                        {t.name}
+                      </Badge>
+                    ))}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={STATUS_VARIANT[row.status]}>
+                    {EXPENSE_STATUS_LABELS[row.status]}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  {row.approvalCount}/{row.needsTwoApprovers ? 2 : 1}
+                </TableCell>
+                <TableCell>{formatDate(row.createdAt)}</TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setSelectedId(row.id)}
+                  >
+                    View
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+            {data?.items.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={8}
+                  className="py-8 text-center text-stone-500"
+                >
+                  No claims found.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-stone-500">
+            Page {filters.page} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={filters.page <= 1}
+              onClick={() =>
+                dispatch({ type: "setPage", value: filters.page - 1 })
+              }
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={filters.page >= totalPages}
+              onClick={() =>
+                dispatch({ type: "setPage", value: filters.page + 1 })
+              }
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <ReimbursementDetailDialog
+        expenseId={selectedId}
+        availableTags={availableTags}
+        canApprove={canApprove}
+        canPay={canPay}
+        onClose={() => setSelectedId(null)}
+      />
+      <ManageExpenseTagsDialog
+        open={manageOpen}
+        onClose={() => setManageOpen(false)}
+      />
+    </div>
+  );
+}
+
+function SummaryCards({ summary }: { summary: SummaryResponse }) {
+  const cards: Array<{ label: string; status: ExpenseStatus }> = [
+    { label: "Pending", status: "pending" },
+    { label: "Awaiting 2nd", status: "awaiting_second_approval" },
+    { label: "Approved", status: "approved" },
+    { label: "Paid", status: "paid" },
+  ];
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {cards.map((c) => {
+        const bucket = summary.byStatus[c.status];
+        return (
+          <div key={c.status} className="rounded-md border p-3">
+            <p className="text-xs text-stone-500">{c.label}</p>
+            <p className="text-lg font-semibold">
+              {formatPence(bucket.totalPence)}
+            </p>
+            <p className="text-xs text-stone-400">{bucket.count} claims</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/pages/members/expenses.tsx
+++ b/apps/web/src/pages/members/expenses.tsx
@@ -1,0 +1,241 @@
+import { ExpenseTagPicker } from "@/components/expense-tag-picker";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useDocumentMeta } from "@/hooks/use-document-meta.js";
+import { api, callApi } from "@/lib/api-client";
+import type { paths } from "@/lib/api.gen";
+import {
+  EXPENSE_RECEIPT_REQUIRED_ABOVE_PENCE,
+  EXPENSE_STATUS_LABELS,
+  expenseReceiptRequired,
+  type ExpenseStatus,
+} from "@percy-main/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { formatDate, formatPence } from "../admin/status-pill";
+
+type MineResponse =
+  paths["/api/expenses/mine"]["get"]["responses"]["200"]["content"]["application/json"];
+
+const STATUS_VARIANT: Record<
+  ExpenseStatus,
+  "default" | "secondary" | "success" | "warning" | "destructive"
+> = {
+  pending: "default",
+  awaiting_second_approval: "warning",
+  approved: "success",
+  denied: "destructive",
+  paid: "secondary",
+  payout_failed: "destructive",
+};
+
+interface FormState {
+  description: string;
+  amount: string;
+  tags: string[];
+  receipt: string | null;
+  receiptName: string | null;
+  error: string | null;
+}
+
+const INITIAL_FORM: FormState = {
+  description: "",
+  amount: "",
+  tags: [],
+  receipt: null,
+  receiptName: null,
+  error: null,
+};
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") resolve(result);
+      else reject(new Error("Could not read the file"));
+    };
+    reader.onerror = () => reject(new Error("Could not read the file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+export function Component() {
+  useDocumentMeta("My expenses");
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<FormState>(INITIAL_FORM);
+  const patch = (p: Partial<FormState>) => setForm((f) => ({ ...f, ...p }));
+
+  const { data: categories } = useQuery({
+    queryKey: ["expenses", "categories"],
+    queryFn: () => callApi(api.GET("/api/expense-categories")),
+  });
+
+  const { data: mine } = useQuery({
+    queryKey: ["expenses", "mine"],
+    queryFn: () => callApi(api.GET("/api/expenses/mine")),
+  });
+
+  const amountPence = Math.round(parseFloat(form.amount) * 100);
+  const amountValid = Number.isFinite(amountPence) && amountPence > 0;
+  const receiptRequired = amountValid && expenseReceiptRequired(amountPence);
+
+  const submit = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/expenses", {
+          body: {
+            description: form.description.trim(),
+            amountPence,
+            tagNames: form.tags,
+            receiptImage: form.receipt,
+          },
+        }),
+      ),
+    onSuccess: async () => {
+      setForm(INITIAL_FORM);
+      await queryClient.invalidateQueries({ queryKey: ["expenses", "mine"] });
+    },
+    onError: (e: Error) => patch({ error: e.message }),
+  });
+
+  const canSubmit =
+    form.description.trim().length > 0 &&
+    amountValid &&
+    (!receiptRequired || !!form.receipt) &&
+    !submit.isPending;
+
+  const onFile = async (file: File | undefined) => {
+    if (!file) {
+      patch({ receipt: null, receiptName: null });
+      return;
+    }
+    try {
+      patch({ receipt: await readFileAsDataUrl(file), receiptName: file.name });
+    } catch (e) {
+      patch({
+        error: e instanceof Error ? e.message : "Could not read the file",
+      });
+    }
+  };
+
+  const availableTags = (categories?.categories ?? []).map((c) => c.name);
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="mb-6">My expenses</h1>
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        <section className="space-y-4">
+          <h2 className="text-lg font-semibold">Submit a claim</h2>
+          <div className="space-y-2">
+            <Label htmlFor="exp-description">What was it for?</Label>
+            <Textarea
+              id="exp-description"
+              placeholder="e.g. Petrol to the away fixture at Tynemouth"
+              value={form.description}
+              onChange={(e) => patch({ description: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="exp-amount">Amount (£)</Label>
+            <Input
+              id="exp-amount"
+              type="number"
+              min="0"
+              step="0.01"
+              placeholder="0.00"
+              value={form.amount}
+              onChange={(e) => patch({ amount: e.target.value })}
+              className="w-40"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Tags</Label>
+            <ExpenseTagPicker
+              available={availableTags}
+              selected={form.tags}
+              onChange={(tags) => patch({ tags })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="exp-receipt">
+              Receipt{" "}
+              <span className="text-xs text-stone-500">
+                (required over{" "}
+                {formatPence(EXPENSE_RECEIPT_REQUIRED_ABOVE_PENCE)})
+              </span>
+            </Label>
+            <Input
+              id="exp-receipt"
+              type="file"
+              accept="image/jpeg,image/png,image/webp,image/heic"
+              onChange={(e) => void onFile(e.target.files?.[0])}
+            />
+            {form.receiptName && (
+              <p className="text-xs text-stone-500">
+                Attached: {form.receiptName}
+              </p>
+            )}
+            {receiptRequired && !form.receipt && (
+              <p className="text-xs text-amber-600">
+                A receipt is required for claims over{" "}
+                {formatPence(EXPENSE_RECEIPT_REQUIRED_ABOVE_PENCE)}.
+              </p>
+            )}
+          </div>
+          {form.error && <p className="text-sm text-red-600">{form.error}</p>}
+          <Button disabled={!canSubmit} onClick={() => submit.mutate()}>
+            {submit.isPending ? "Submitting…" : "Submit claim"}
+          </Button>
+          {submit.isSuccess && (
+            <p className="text-sm text-green-700">
+              Claim submitted. An approver will review it shortly.
+            </p>
+          )}
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-lg font-semibold">My claims</h2>
+          <MyClaims items={mine?.items ?? []} />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function MyClaims({ items }: { items: MineResponse["items"] }) {
+  if (items.length === 0) {
+    return <p className="text-sm text-stone-500">You have no claims yet.</p>;
+  }
+  return (
+    <ul className="space-y-3">
+      {items.map((c) => (
+        <li key={c.id} className="rounded-md border p-3">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <p className="font-medium">{c.description}</p>
+              <p className="text-sm text-stone-500">
+                {formatPence(c.amountPence)} · submitted{" "}
+                {formatDate(c.createdAt)}
+              </p>
+              <div className="mt-1 flex flex-wrap gap-1">
+                {c.tags.map((t) => (
+                  <Badge key={t.id} variant="secondary">
+                    {t.name}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+            <Badge variant={STATUS_VARIANT[c.status]}>
+              {EXPENSE_STATUS_LABELS[c.status]}
+            </Badge>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -185,6 +185,17 @@ export const router = createBrowserRouter([
                 path: "members/financial-relief",
                 lazy: () => import("./pages/members/financial-relief.js"),
               },
+              {
+                element: (
+                  <RequirePermission resource="expenses" action="view_own" />
+                ),
+                children: [
+                  {
+                    path: "members/expenses",
+                    lazy: () => import("./pages/members/expenses.js"),
+                  },
+                ],
+              },
               // Membership flows
               {
                 path: "membership/join",

--- a/docs/adrs/050-reimbursement-payouts-stripe-global-payouts.md
+++ b/docs/adrs/050-reimbursement-payouts-stripe-global-payouts.md
@@ -1,0 +1,103 @@
+# ADR 050: Reimbursement payouts via Stripe Global Payouts, with Stripe holding payee bank details
+
+## Status
+
+Accepted
+
+## Context
+
+The club needs to reimburse volunteers' out-of-pocket expenses (fuel, umpires'
+fees, kit) through an audited submit -> approve -> pay workflow (see
+`EXPENSES.md`). Step four, "pay the claimant", moves money from the club to an
+individual's personal bank account. That raised two coupled questions:
+
+1. **Which rail moves the money?** The club already uses Stripe to _take_
+   payments (donations, membership, match fees), so reaching for Stripe was
+   natural - but Stripe "Payouts" (the product) only pays the platform's _own_
+   bank account, not third parties.
+2. **Where do the payee's bank details live?** Sort code + account number are
+   personal data. The brief explicitly preferred a design where the club never
+   stores them.
+
+## Decision
+
+Pay claimants via **Stripe Global Payouts** (recipients + OutboundPayments on
+the v2 money-movement API), funded from a Stripe-managed Financial Account that
+draws on the club's existing GBP payments balance.
+
+The payee's bank details are **collected and held by Stripe**, not by us. On
+first payout we create a Global Payouts recipient and hand the claimant a
+Stripe-hosted setup link to enter their bank account directly into Stripe. We
+persist only opaque references on the `expense` row -
+`stripe_recipient_account_id`, `stripe_payout_method_id`,
+`stripe_outbound_payment_id` - never the sort code or account number.
+
+A manual "mark paid" path (treasurer pays by bank transfer, records it) is kept
+as a permanent fallback for when payouts aren't configured or a payout fails.
+
+## Problem
+
+Three constraints shaped the call:
+
+- **Recipients are arbitrary individuals, not marketplace sellers.** They have
+  no ongoing relationship with a platform; asking each to complete full
+  marketplace onboarding would be disproportionate for a community club paying
+  the odd £20 fuel claim.
+- **Data-protection exposure should be minimised.** Holding bank details
+  ourselves pulls in encryption-at-rest, a retention schedule, tightened
+  access control, and breach liability - all for data we only need at the
+  moment of payment.
+- **Funds already sit in Stripe.** Membership and donations settle to the
+  club's Stripe balance, so a Stripe-native payout avoids a separate bank
+  integration and reuses money already on hand.
+
+## Options considered
+
+1. **Stripe Global Payouts** (chosen). Pay third parties who hold no Stripe
+   account; Stripe stores their payout method. UK GBP domestic payouts cost
+   ~£0.50 each, no monthly fee.
+2. **Stripe Connect** (Accounts v2, transfers/payouts). The full marketplace
+   product. Each payee becomes a connected account with its own onboarding and
+   KYC surface - heavier than the use case warrants, and still ends with Stripe
+   holding the bank details, so no data-minimisation gain over Global Payouts.
+3. **Collect bank details ourselves, pay via any rail.** Simplest to reason
+   about, worst on data protection: we would store account numbers and own the
+   compliance burden. Rejected.
+4. **App tracks the workflow only; treasurer pays manually.** Zero payment-data
+   liability and zero new Stripe product, but no one-click payout. Kept as the
+   fallback rather than the primary rail.
+
+## Rationale
+
+- **Right-sized for the payee.** Global Payouts recipients are lightweight: a
+  name, an email, and bank details the claimant enters once into Stripe and
+  reuses on later claims.
+- **Data minimisation by construction.** Because Stripe holds the payout
+  method, the club's database contains no bank details - only token ids. This
+  is the outcome the brief asked for, achieved without bespoke encryption or a
+  retention policy on our side.
+- **Reuses existing funds + account.** Payouts draw on the balance donations
+  and membership already top up; no second banking integration.
+- **Idempotent and auditable.** A unique `stripe_outbound_payment_id` plus the
+  append-only `expense_event` log guarantee a claim is never paid twice and
+  every transition is recorded - matching the workflow's audit requirement.
+
+## Rejected alternatives
+
+- **Stripe Connect** - rejected as disproportionate: full connected-account
+  onboarding/KYC per volunteer for small reimbursements, with no
+  data-protection advantage over Global Payouts.
+- **Storing bank details ourselves** - rejected on data-minimisation grounds;
+  it would make the club the custodian of personal financial data it only
+  transiently needs.
+- **Manual-only** - not rejected, but demoted to the fallback path; the goal is
+  one-click payout once the Financial Account is provisioned.
+
+## Related
+
+- Global Payouts is on Stripe's preview v2 API; how we call it without an SDK
+  bump is [ADR 051](051-stripe-global-payouts-raw-request-isolation.md).
+- Implementation: `apps/api/src/features/expense/` (`payouts.ts`, `service.ts`).
+- The legal/retention sign-off and the treasurer's preference are tracked in
+  `EXPENSES.md` (decisions 13.1, 13.2). Licensing/legal positions remain
+  Alex's call; this ADR records the engineering decision, not a legal opinion.

--- a/docs/adrs/051-stripe-global-payouts-raw-request-isolation.md
+++ b/docs/adrs/051-stripe-global-payouts-raw-request-isolation.md
@@ -1,0 +1,102 @@
+# ADR 051: Drive preview v2 Global Payouts via rawRequest on an isolated client
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR 050](050-reimbursement-payouts-stripe-global-payouts.md) chose Stripe
+Global Payouts to reimburse volunteers. Global Payouts lives on Stripe's
+**preview v2 API** (`/v2/core/accounts`, `/v2/money_management/*`), which
+differs from the v1 (Basil) API every other Stripe integration in this repo
+uses (PaymentIntents for donations, subscriptions for membership, the existing
+`/api/stripe/webhook`).
+
+A Phase 0 spike probed the pinned `stripe@22.2.1` SDK and found:
+
+- It exposes `v2.core.accounts` (recipient creation) and
+  `v2.core.eventDestinations`/`events` (v2 webhooks), **but not** the
+  `MoneyManagement` resources (OutboundPayments, PayoutMethods,
+  FinancialAccounts) - those ship only in newer preview SDK releases.
+- It does expose `stripe.rawRequest(method, path, params, options)` with
+  per-request `apiVersion`, `stripeContext`, and `idempotencyKey` options, plus
+  `webhooks.constructEvent` (whose signature scheme also covers v2 thin events).
+
+So to actually send a payout we either bump the SDK to a preview channel, or
+call the preview endpoints through `rawRequest`.
+
+## Decision
+
+Do **not** bump the SDK. Call the preview money-movement endpoints via
+`stripe.rawRequest` on a **dedicated `Stripe` instance** constructed in
+`apps/api/src/features/expense/payouts.ts`, with the preview `apiVersion`
+(`STRIPE_PAYOUTS_API_VERSION`) passed as a per-request option on every call.
+The live v1 (Basil) payments client elsewhere is left completely untouched.
+
+`createPayoutsClient(config)` returns `null` when the Financial Account id or
+preview version is unset, and callers treat null as "payouts not configured"
+and surface a clear error. The config vars are placeholder-tolerant (not hard
+`z.string()` required) so the API still boots everywhere before the preview
+Financial Account is provisioned.
+
+## Problem
+
+- **A global SDK bump is blast-radius risk.** The pinned `stripe@22` SDK
+  default-pins the v1 Basil wire format that donations, membership, charges,
+  and sponsorship all depend on (including bespoke Basil-vs-legacy invoice
+  handling in `features/payments`). Upgrading the shared dependency to chase a
+  preview feature risks regressing flows that move real money today.
+- **Preview surfaces move.** Global Payouts is in public preview; its exact
+  request shapes and event names may change. Pinning the whole app's SDK to a
+  preview channel couples stable flows to an unstable one.
+- **Config must not brick boot.** CI auto-applies on merge to `main`. A
+  hard-required env var that isn't yet seeded in Secrets/SSM would fail config
+  parsing at boot and take the API down on deploy.
+
+## Options considered
+
+1. **rawRequest on an isolated, preview-pinned client** (chosen). One small
+   wrapper owns every preview call; the rest of the app keeps the stable SDK.
+2. **Bump `stripe` to a preview SDK channel.** Gives typed
+   `v2.moneyManagement.*` resources, but re-pins the default wire format for
+   _all_ Stripe usage and ties stable flows to a preview release.
+3. **A second `stripe` dependency at a different version.** Avoids re-pinning
+   the shared client but doubles the dependency, risks duplicate-instance
+   pitfalls, and bloats the bundle for a handful of endpoints.
+
+## Rationale
+
+- **Blast radius of one file.** Every preview-specific call is in `payouts.ts`.
+  If the preview API changes, that is the only thing to update; donations and
+  membership are unaffected.
+- **No dependency churn.** No SDK bump, so no risk to the v1 flows and no
+  lockfile surprises (per the `feedback_careful_installs` rule).
+- **Typed where it is stable, raw where it is not.** `rawRequest` returns
+  `Promise<any>` which we narrow behind a small typed `PayoutsClient`
+  interface, so callers stay type-safe without unsafe casts.
+- **Fails safe, not loud.** Null-when-unconfigured + placeholder-tolerant
+  config means a deploy before provisioning boots fine and the payout endpoint
+  returns a clear "not configured" error, rather than bricking the API. This
+  deliberately diverges from the usual "new env vars are required, not
+  optional" rule (`feedback_required_env_vars`) because the auto-apply-on-merge
+  pipeline makes a hard-required-but-unprovisioned var a boot hazard; enabling
+  payouts later means seeding the values and wiring them as SSM params (mirror
+  `VAPID_PUBLIC_KEY`).
+
+## Rejected alternatives
+
+- **SDK bump to a preview channel** - rejected: re-pins the wire format for all
+  Stripe usage and couples money-moving v1 flows to an unstable preview
+  release for no benefit beyond typed resources we can wrap ourselves.
+- **Second pinned `stripe` dependency** - rejected: duplicate dependency and
+  instance for a handful of endpoints; the isolated rawRequest client achieves
+  the same isolation with less weight.
+
+## Related
+
+- Client + event mapper: `apps/api/src/features/expense/payouts.ts`.
+- Raw-body webhook handling mirrors [ADR 007](007-webhook-raw-body.md) but on a
+  separate endpoint (`/api/stripe/payouts-webhook`) with its own signing secret.
+- Residual items to verify against the live preview account (exact version
+  string, event names, recipient `requirements`) are tracked in `EXPENSES.md`.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -6,24 +6,27 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 
 ## Index
 
-| #                                                        | Title                                                       | Date       | Status   |
-| -------------------------------------------------------- | ----------------------------------------------------------- | ---------- | -------- |
-| [001](001-api-framework.md)                              | API Framework - Fastify over Express                        | 2026-03-14 | Accepted |
-| [002](002-email-provider.md)                             | Email Provider - SES over Mailgun                           | 2026-03-14 | Accepted |
-| [003](003-baseline-migration-strategy.md)                | Baseline Migration Strategy - Single Consolidated Migration | 2026-03-14 | Accepted |
-| [004](004-auth-database-type.md)                         | better-auth Database Type - postgres                        | 2026-03-14 | Accepted |
-| [005](005-generated-types-approach.md)                   | Generated DB Types - Placeholder with PostgreSQL Types      | 2026-03-14 | Accepted |
-| [006](006-monorepo-structure.md)                         | Monorepo Structure - Following the Plan                     | 2026-03-14 | Accepted |
-| [007](007-webhook-raw-body.md)                           | Stripe Webhook Raw Body Handling                            | 2026-03-14 | Accepted |
-| [008](008-vite-proxy-for-local-dev.md)                   | Vite Dev Server Proxy for Local Development                 | 2026-03-14 | Accepted |
-| [009](009-dependency-injection.md)                       | Functional Dependency Injection                             | 2026-03-14 | Accepted |
-| [010](010-testcontainers.md)                             | Testcontainers for Integration Tests                        | 2026-03-14 | Accepted |
-| [011](011-api-type-safety.md)                            | API Type Safety Between Backend and Frontend                | 2026-03-16 | Accepted |
-| [012](012-prod-db-access.md)                             | Production DB Access via Tailscale                          | 2026-04-20 | Accepted |
-| [042](042-scout-recognition-sources.md)                  | Scout Recognition Sources - Public-Source Discovery         | 2026-05-14 | Accepted |
-| [043](043-db-role-split-principle-of-least-privilege.md) | DB Role Split - Principle of Least Privilege                | 2026-05-15 | Accepted |
-| [044](044-matchday-notification-channel-modelling.md)    | Matchday notification channel modelling                     | 2026-05-21 | Accepted |
-| [045](045-matchday-service-worker-push-integration.md)   | Matchday service worker push integration via importScripts  | 2026-05-21 | Accepted |
-| [046](046-vapid-public-key-via-api.md)                   | VAPID public key delivered via API, not bundled             | 2026-05-21 | Accepted |
-| [047](047-content-editor-blocknote.md)                   | Content Editor - BlockNote with JSON canonical format       | 2026-06-10 | Accepted |
-| [048](048-editor-image-webp-only-sync-processing.md)     | Editor images - WebP-only ladder, synchronous processing    | 2026-06-10 | Accepted |
+| #                                                         | Title                                                       | Date       | Status   |
+| --------------------------------------------------------- | ----------------------------------------------------------- | ---------- | -------- |
+| [001](001-api-framework.md)                               | API Framework - Fastify over Express                        | 2026-03-14 | Accepted |
+| [002](002-email-provider.md)                              | Email Provider - SES over Mailgun                           | 2026-03-14 | Accepted |
+| [003](003-baseline-migration-strategy.md)                 | Baseline Migration Strategy - Single Consolidated Migration | 2026-03-14 | Accepted |
+| [004](004-auth-database-type.md)                          | better-auth Database Type - postgres                        | 2026-03-14 | Accepted |
+| [005](005-generated-types-approach.md)                    | Generated DB Types - Placeholder with PostgreSQL Types      | 2026-03-14 | Accepted |
+| [006](006-monorepo-structure.md)                          | Monorepo Structure - Following the Plan                     | 2026-03-14 | Accepted |
+| [007](007-webhook-raw-body.md)                            | Stripe Webhook Raw Body Handling                            | 2026-03-14 | Accepted |
+| [008](008-vite-proxy-for-local-dev.md)                    | Vite Dev Server Proxy for Local Development                 | 2026-03-14 | Accepted |
+| [009](009-dependency-injection.md)                        | Functional Dependency Injection                             | 2026-03-14 | Accepted |
+| [010](010-testcontainers.md)                              | Testcontainers for Integration Tests                        | 2026-03-14 | Accepted |
+| [011](011-api-type-safety.md)                             | API Type Safety Between Backend and Frontend                | 2026-03-16 | Accepted |
+| [012](012-prod-db-access.md)                              | Production DB Access via Tailscale                          | 2026-04-20 | Accepted |
+| [042](042-scout-recognition-sources.md)                   | Scout Recognition Sources - Public-Source Discovery         | 2026-05-14 | Accepted |
+| [043](043-db-role-split-principle-of-least-privilege.md)  | DB Role Split - Principle of Least Privilege                | 2026-05-15 | Accepted |
+| [044](044-matchday-notification-channel-modelling.md)     | Matchday notification channel modelling                     | 2026-05-21 | Accepted |
+| [045](045-matchday-service-worker-push-integration.md)    | Matchday service worker push integration via importScripts  | 2026-05-21 | Accepted |
+| [046](046-vapid-public-key-via-api.md)                    | VAPID public key delivered via API, not bundled             | 2026-05-21 | Accepted |
+| [047](047-content-editor-blocknote.md)                    | Content Editor - BlockNote with JSON canonical format       | 2026-06-10 | Accepted |
+| [048](048-editor-image-webp-only-sync-processing.md)      | Editor images - WebP-only ladder, synchronous processing    | 2026-06-10 | Accepted |
+| [049](049-ai-content-author-assistant.md)                 | AI content-author assistant                                 | 2026-06-10 | Accepted |
+| [050](050-reimbursement-payouts-stripe-global-payouts.md) | Reimbursement payouts via Stripe Global Payouts             | 2026-06-18 | Accepted |
+| [051](051-stripe-global-payouts-raw-request-isolation.md) | Preview v2 Global Payouts via rawRequest on isolated client | 2026-06-18 | Accepted |

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -273,6 +273,57 @@ export interface EventSubscriber {
   meta: Json;
 }
 
+export interface Expense {
+  amount_pence: number;
+  claimant_name: string;
+  created_at: Generated<Timestamp>;
+  created_by: string;
+  currency: Generated<string>;
+  description: string;
+  id: Generated<string>;
+  paid_at: Timestamp | null;
+  payout_failure_reason: string | null;
+  receipt_image_url: string | null;
+  status: Generated<string>;
+  stripe_outbound_payment_id: string | null;
+  stripe_payout_method_id: string | null;
+  stripe_recipient_account_id: string | null;
+  updated_at: Generated<Timestamp>;
+}
+
+export interface ExpenseApproval {
+  approver_user_id: string;
+  created_at: Generated<Timestamp>;
+  decision: string;
+  expense_id: string;
+  id: Generated<string>;
+  note: string | null;
+}
+
+export interface ExpenseCategory {
+  archived_at: Timestamp | null;
+  created_at: Generated<Timestamp>;
+  created_by: string | null;
+  id: Generated<string>;
+  name: string;
+}
+
+export interface ExpenseCategoryLink {
+  category_id: string;
+  expense_id: string;
+}
+
+export interface ExpenseEvent {
+  actor_user_id: string | null;
+  created_at: Generated<Timestamp>;
+  expense_id: string;
+  from_status: string | null;
+  id: Generated<string>;
+  metadata: Json | null;
+  to_status: string | null;
+  type: string;
+}
+
 export interface FantasyChaosWeek {
   created_at: Generated<string>;
   description: string;
@@ -1045,6 +1096,11 @@ export interface DB {
   document: Document;
   document_assignment: DocumentAssignment;
   event_subscriber: EventSubscriber;
+  expense: Expense;
+  expense_approval: ExpenseApproval;
+  expense_category: ExpenseCategory;
+  expense_category_link: ExpenseCategoryLink;
+  expense_event: ExpenseEvent;
   fantasy_chaos_week: FantasyChaosWeek;
   fantasy_chip_usage: FantasyChipUsage;
   fantasy_player: FantasyPlayer;

--- a/packages/db/src/migrations/2026-06-18T10:00:00.000Z.ts
+++ b/packages/db/src/migrations/2026-06-18T10:00:00.000Z.ts
@@ -1,0 +1,171 @@
+import { type Kysely, sql } from "kysely";
+
+// Expenses reimbursement (EXPENSES.md). A standalone, audited expense-claim
+// workflow: a submitter raises a claim (optional receipt + proposed tags),
+// approvers approve/deny (two distinct approvers required for GBP 50+), and an
+// approved claim is paid via Stripe Global Payouts (Phase 2) or marked paid
+// manually (Phase 1 fallback).
+//
+// Tables:
+//   expense                 - the claim + lifecycle status + Stripe payout linkage
+//   expense_approval         - one decision row per approver (enforces the
+//                              two-distinct-approver rule and separation of duties)
+//   expense_category         - admin-editable tag vocabulary (grows by proposal)
+//   expense_category_link    - many-to-many: an expense carries one or more tags
+//   expense_event            - append-only audit log of every transition
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("expense")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    // The submitter. Referenced (not cascade) so a claim's audit trail
+    // survives even if the user account is later removed.
+    .addColumn("created_by", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("claimant_name", "text", (col) => col.notNull())
+    .addColumn("description", "text", (col) => col.notNull())
+    .addColumn("amount_pence", "integer", (col) => col.notNull())
+    .addColumn("currency", "text", (col) => col.notNull().defaultTo("gbp"))
+    .addColumn("status", "text", (col) =>
+      col.notNull().defaultTo("pending"),
+    )
+    .addColumn("receipt_image_url", "text")
+    // Stripe Global Payouts linkage (Phase 2). Nullable: a claim has no
+    // payout objects until it is paid.
+    .addColumn("stripe_recipient_account_id", "text")
+    .addColumn("stripe_payout_method_id", "text")
+    // Unique so a retried payout can never create a second OutboundPayment
+    // for the same claim.
+    .addColumn("stripe_outbound_payment_id", "text", (col) => col.unique())
+    .addColumn("payout_failure_reason", "text")
+    .addColumn("paid_at", "timestamptz")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addCheckConstraint("expense_amount_positive_check", sql`amount_pence > 0`)
+    .addCheckConstraint(
+      "expense_status_check",
+      sql`status IN ('pending','awaiting_second_approval','approved','denied','paid','payout_failed')`,
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("expense_status_idx")
+    .on("expense")
+    .column("status")
+    .execute();
+
+  await db.schema
+    .createIndex("expense_created_by_idx")
+    .on("expense")
+    .column("created_by")
+    .execute();
+
+  await db.schema
+    .createTable("expense_approval")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("expense_id", "uuid", (col) =>
+      col.notNull().references("expense.id").onDelete("cascade"),
+    )
+    .addColumn("approver_user_id", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("decision", "text", (col) => col.notNull())
+    .addColumn("note", "text")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addCheckConstraint(
+      "expense_approval_decision_check",
+      sql`decision IN ('approved','denied')`,
+    )
+    // One decision per approver per claim: the two approvals a GBP 50+ claim
+    // needs therefore must come from two distinct users.
+    .addUniqueConstraint("expense_approval_one_per_approver_uniq", [
+      "expense_id",
+      "approver_user_id",
+    ])
+    .execute();
+
+  await db.schema
+    .createIndex("expense_approval_expense_id_idx")
+    .on("expense_approval")
+    .column("expense_id")
+    .execute();
+
+  await db.schema
+    .createTable("expense_category")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("name", "text", (col) => col.notNull())
+    .addColumn("created_by", "text", (col) => col.references("user.id"))
+    .addColumn("archived_at", "timestamptz")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  // Case-insensitive uniqueness on the tag name so "Fuel" and "fuel" can't
+  // both exist; the service upserts proposed tags against this.
+  await sql`CREATE UNIQUE INDEX expense_category_name_lower_uniq ON expense_category (lower(name))`.execute(
+    db,
+  );
+
+  await db.schema
+    .createTable("expense_category_link")
+    .addColumn("expense_id", "uuid", (col) =>
+      col.notNull().references("expense.id").onDelete("cascade"),
+    )
+    // Restrict (default): a tag in use can't be hard-deleted; admins archive
+    // it instead, preserving historical links.
+    .addColumn("category_id", "uuid", (col) =>
+      col.notNull().references("expense_category.id"),
+    )
+    .addPrimaryKeyConstraint("expense_category_link_pkey", [
+      "expense_id",
+      "category_id",
+    ])
+    .execute();
+
+  await db.schema
+    .createTable("expense_event")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("expense_id", "uuid", (col) =>
+      col.notNull().references("expense.id").onDelete("cascade"),
+    )
+    // Null for Stripe-system events (e.g. a webhook-driven payout outcome).
+    .addColumn("actor_user_id", "text", (col) => col.references("user.id"))
+    .addColumn("type", "text", (col) => col.notNull())
+    .addColumn("from_status", "text")
+    .addColumn("to_status", "text")
+    .addColumn("metadata", "jsonb")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("expense_event_expense_id_idx")
+    .on("expense_event")
+    .column("expense_id")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("expense_event").execute();
+  await db.schema.dropTable("expense_category_link").execute();
+  await db.schema.dropTable("expense_category").execute();
+  await db.schema.dropTable("expense_approval").execute();
+  await db.schema.dropTable("expense").execute();
+}

--- a/packages/db/src/migrations/2026-06-18T10:00:00.000Z.ts
+++ b/packages/db/src/migrations/2026-06-18T10:00:00.000Z.ts
@@ -29,9 +29,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("description", "text", (col) => col.notNull())
     .addColumn("amount_pence", "integer", (col) => col.notNull())
     .addColumn("currency", "text", (col) => col.notNull().defaultTo("gbp"))
-    .addColumn("status", "text", (col) =>
-      col.notNull().defaultTo("pending"),
-    )
+    .addColumn("status", "text", (col) => col.notNull().defaultTo("pending"))
     .addColumn("receipt_image_url", "text")
     // Stripe Global Payouts linkage (Phase 2). Nullable: a claim has no
     // payout objects until it is paid.

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -3,6 +3,8 @@ export { createSend } from "./send.ts";
 export { AvailabilityRequest } from "./templates/AvailabilityRequest.tsx";
 export { ChaosWeekAnnouncement } from "./templates/ChaosWeekAnnouncement.tsx";
 export { ChargeNotification } from "./templates/ChargeNotification.tsx";
+export { ExpenseDecision } from "./templates/ExpenseDecision.tsx";
+export { ExpenseSubmitted } from "./templates/ExpenseSubmitted.tsx";
 export { FantasyReminder } from "./templates/FantasyReminder.tsx";
 export { FinancialReliefDecision } from "./templates/FinancialReliefDecision.tsx";
 export { FinancialReliefReceived } from "./templates/FinancialReliefReceived.tsx";

--- a/packages/email/src/templates/ExpenseDecision.tsx
+++ b/packages/email/src/templates/ExpenseDecision.tsx
@@ -79,17 +79,14 @@ const Component: FC<Props> = ({
   </Html>
 );
 
-export const ExpenseDecision = email<Props>(
-  "An update on your expense claim",
-  {
-    preview: {
-      imageBaseUrl: "http://localhost:5173/images",
-      recipientName: "Jane Smith",
-      outcome: "approved",
-      note: "Approved under the travel budget.",
-      amountPence: 2350,
-    },
+export const ExpenseDecision = email<Props>("An update on your expense claim", {
+  preview: {
+    imageBaseUrl: "http://localhost:5173/images",
+    recipientName: "Jane Smith",
+    outcome: "approved",
+    note: "Approved under the travel budget.",
+    amountPence: 2350,
   },
-)(Component);
+})(Component);
 
 export default Component;

--- a/packages/email/src/templates/ExpenseDecision.tsx
+++ b/packages/email/src/templates/ExpenseDecision.tsx
@@ -1,0 +1,95 @@
+// organize-imports-ignore — React must stay: tsx/esbuild uses classic JSX transform for workspace deps
+import React, { type FC } from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Text,
+} from "react-email";
+import { email } from "../email.ts";
+import * as styles from "../styles.ts";
+
+interface Props {
+  imageBaseUrl: string;
+  recipientName: string;
+  outcome: "approved" | "denied" | "paid";
+  note: string | null;
+  amountPence: number;
+}
+
+const formatGbp = (pence: number) => `£${(pence / 100).toFixed(2)}`;
+
+const Component: FC<Props> = ({
+  imageBaseUrl,
+  recipientName,
+  outcome,
+  note,
+  amountPence,
+}) => (
+  <Html>
+    <Head />
+    <Preview>An update on your expense claim</Preview>
+    <Body style={styles.main}>
+      <Container style={styles.container}>
+        <Img
+          src={`${imageBaseUrl}/club_logo.png`}
+          width="100"
+          height="100"
+          alt="Percy Main Club Logo"
+          style={styles.logo}
+        />
+        <Text style={styles.paragraph}>Hi {recipientName},</Text>
+        {outcome === "approved" ? (
+          <Text style={styles.paragraph}>
+            Your expense claim for {formatGbp(amountPence)} has been approved.
+            We will arrange your reimbursement shortly.
+          </Text>
+        ) : outcome === "paid" ? (
+          <Text style={styles.paragraph}>
+            Your expense claim for {formatGbp(amountPence)} has been paid. The
+            money is on its way to your bank account.
+          </Text>
+        ) : (
+          <Text style={styles.paragraph}>
+            Thank you for submitting your expense claim for{" "}
+            {formatGbp(amountPence)}. After review it has not been approved on
+            this occasion.
+          </Text>
+        )}
+        {note ? <Text style={styles.paragraph}>{note}</Text> : null}
+        <Text style={styles.paragraph}>
+          If you have any questions, please reply to this email or contact the
+          club directly.
+        </Text>
+        <Text style={styles.paragraph}>
+          Thanks,
+          <br />
+          Percy Main CC
+        </Text>
+        <Hr style={styles.hr} />
+        <Text style={styles.footer}>
+          Percy Main Cricket Club, St. Johns Terrace, North Shields, NE29 6HS
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export const ExpenseDecision = email<Props>(
+  "An update on your expense claim",
+  {
+    preview: {
+      imageBaseUrl: "http://localhost:5173/images",
+      recipientName: "Jane Smith",
+      outcome: "approved",
+      note: "Approved under the travel budget.",
+      amountPence: 2350,
+    },
+  },
+)(Component);
+
+export default Component;

--- a/packages/email/src/templates/ExpenseSubmitted.tsx
+++ b/packages/email/src/templates/ExpenseSubmitted.tsx
@@ -1,0 +1,94 @@
+// organize-imports-ignore — React must stay: tsx/esbuild uses classic JSX transform for workspace deps
+import React, { type FC } from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Text,
+} from "react-email";
+import { email } from "../email.ts";
+import * as styles from "../styles.ts";
+
+interface Props {
+  imageBaseUrl: string;
+  claimantName: string;
+  amountPence: number;
+  description: string;
+  secondApproval: boolean;
+  reviewUrl: string;
+}
+
+const formatGbp = (pence: number) => `£${(pence / 100).toFixed(2)}`;
+
+const Component: FC<Props> = ({
+  imageBaseUrl,
+  claimantName,
+  amountPence,
+  description,
+  secondApproval,
+  reviewUrl,
+}) => (
+  <Html>
+    <Head />
+    <Preview>An expense claim needs your review</Preview>
+    <Body style={styles.main}>
+      <Container style={styles.container}>
+        <Img
+          src={`${imageBaseUrl}/club_logo.png`}
+          width="100"
+          height="100"
+          alt="Percy Main Club Logo"
+          style={styles.logo}
+        />
+        <Text style={styles.paragraph}>Hi,</Text>
+        {secondApproval ? (
+          <Text style={styles.paragraph}>
+            An expense claim of {formatGbp(amountPence)} from {claimantName} has
+            its first approval and needs a second approver before it can be paid.
+          </Text>
+        ) : (
+          <Text style={styles.paragraph}>
+            {claimantName} has submitted an expense claim of{" "}
+            {formatGbp(amountPence)} for review.
+          </Text>
+        )}
+        {description ? (
+          <Text style={styles.paragraph}>&ldquo;{description}&rdquo;</Text>
+        ) : null}
+        <Text style={styles.paragraph}>
+          <Link href={reviewUrl}>Review it in the admin area</Link>.
+        </Text>
+        <Text style={styles.paragraph}>
+          Thanks,
+          <br />
+          Percy Main CC
+        </Text>
+        <Hr style={styles.hr} />
+        <Text style={styles.footer}>
+          Percy Main Cricket Club, St. Johns Terrace, North Shields, NE29 6HS
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export const ExpenseSubmitted = email<Props>(
+  "An expense claim needs your review",
+  {
+    preview: {
+      imageBaseUrl: "http://localhost:5173/images",
+      claimantName: "Jane Smith",
+      amountPence: 2350,
+      description: "Petrol to the away fixture at Tynemouth",
+      secondApproval: false,
+      reviewUrl: "http://localhost:5173/admin?section=finance&tab=expenses",
+    },
+  },
+)(Component);
+
+export default Component;

--- a/packages/email/src/templates/ExpenseSubmitted.tsx
+++ b/packages/email/src/templates/ExpenseSubmitted.tsx
@@ -87,7 +87,8 @@ export const ExpenseSubmitted = email<Props>(
       amountPence: 2350,
       description: "Petrol to the away fixture at Tynemouth",
       secondApproval: false,
-      reviewUrl: "http://localhost:5173/admin?section=finance&tab=expenses",
+      reviewUrl:
+        "http://localhost:5173/admin?section=finance&sub=reimbursements",
     },
   },
 )(Component);

--- a/packages/email/src/templates/ExpenseSubmitted.tsx
+++ b/packages/email/src/templates/ExpenseSubmitted.tsx
@@ -49,7 +49,8 @@ const Component: FC<Props> = ({
         {secondApproval ? (
           <Text style={styles.paragraph}>
             An expense claim of {formatGbp(amountPence)} from {claimantName} has
-            its first approval and needs a second approver before it can be paid.
+            its first approval and needs a second approver before it can be
+            paid.
           </Text>
         ) : (
           <Text style={styles.paragraph}>

--- a/packages/shared/src/auth/permissions.ts
+++ b/packages/shared/src/auth/permissions.ts
@@ -11,6 +11,11 @@ export const statements = {
   documents: ["manage"],
   marketing: ["view", "manage"],
   finance: ["view", "manage"],
+  // Expenses reimbursement (EXPENSES.md). submit + view_own are the
+  // member-facing claimant actions; view/approve are the approver actions;
+  // pay triggers a Stripe payout (distinct from approve so paying is a
+  // separate permission); manage_tags edits the category vocabulary.
+  expenses: ["submit", "view_own", "view", "approve", "pay", "manage_tags"],
   fantasy: ["manage"],
   matchday: ["view", "manage"],
   juniors: ["view", "manage"],
@@ -42,6 +47,7 @@ const ALL_PERMS = {
   documents: ["manage"],
   marketing: ["view", "manage"],
   finance: ["view", "manage"],
+  expenses: ["submit", "view_own", "view", "approve", "pay", "manage_tags"],
   fantasy: ["manage"],
   matchday: ["view", "manage"],
   juniors: ["view", "manage"],
@@ -79,9 +85,22 @@ export const roles = {
   marketing_viewer: ac.newRole({ marketing: ["view"] }),
   marketing_admin: ac.newRole({ marketing: ["view", "manage"] }),
 
-  // Finance — treasurer, charges, fee rates, sponsorships
+  // Finance — treasurer, charges, fee rates, sponsorships. finance_admin
+  // also owns the expenses dashboard: viewing all claims, paying out
+  // approved ones, and curating the tag vocabulary. Approving claims is a
+  // deliberately separate role (expense_approver) so paying and approving
+  // can be held by different people.
   finance_viewer: ac.newRole({ finance: ["view"] }),
-  finance_admin: ac.newRole({ finance: ["view", "manage"] }),
+  finance_admin: ac.newRole({
+    finance: ["view", "manage"],
+    expenses: ["view", "pay", "manage_tags"],
+  }),
+
+  // Expenses (EXPENSES.md). expense_submitter raises claims for themselves;
+  // expense_approver reviews and approves/denies them (a GBP 50+ claim needs
+  // two distinct approvers). Both can propose new tags inline.
+  expense_submitter: ac.newRole({ expenses: ["submit", "view_own"] }),
+  expense_approver: ac.newRole({ expenses: ["view", "approve"] }),
 
   // Fantasy — admin-only (play-fantasy itself is open to any authenticated
   // member, so no viewer role).
@@ -173,6 +192,8 @@ export const ASSIGNABLE_ROLES: readonly RoleName[] = [
   "marketing_viewer",
   "finance_admin",
   "finance_viewer",
+  "expense_approver",
+  "expense_submitter",
   "fantasy_admin",
   "matchday_admin",
   "matchday_viewer",
@@ -205,6 +226,8 @@ export const ROLE_LABELS: Record<RoleName, string> = {
   marketing_admin: "Marketing admin",
   finance_viewer: "Finance viewer",
   finance_admin: "Finance admin",
+  expense_approver: "Expense approver",
+  expense_submitter: "Expense submitter",
   fantasy_admin: "Fantasy admin",
   matchday_viewer: "Matchday viewer",
   matchday_admin: "Matchday admin",
@@ -259,6 +282,7 @@ export function hasAdminPanelAccess(
     checkPermission(rawRole, "marketing", "view") ||
     checkPermission(rawRole, "finance", "view") ||
     checkPermission(rawRole, "finance", "manage") ||
+    checkPermission(rawRole, "expenses", "view") ||
     checkPermission(rawRole, "matchday", "view") ||
     checkPermission(rawRole, "fantasy", "manage") ||
     checkPermission(rawRole, "incidents", "view") ||

--- a/packages/shared/src/expenses.ts
+++ b/packages/shared/src/expenses.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+/**
+ * Shared constants and types for the expenses reimbursement feature
+ * (EXPENSES.md). Kept here so the API (validation, state machine) and the web
+ * (form rules, copy) read the same thresholds and never drift.
+ */
+
+/**
+ * Claims of this amount or more require two distinct approvers before they can
+ * be paid. Below it, a single approval is enough. (EXPENSES.md decision 13.5.)
+ */
+export const EXPENSE_TWO_APPROVAL_THRESHOLD_PENCE = 5000;
+
+/**
+ * A receipt image is mandatory for claims over this amount (EXPENSES.md
+ * decision 13.9). Smaller claims may attach one but are not required to.
+ */
+export const EXPENSE_RECEIPT_REQUIRED_ABOVE_PENCE = 1000;
+
+export const EXPENSE_STATUSES = [
+  "pending",
+  "awaiting_second_approval",
+  "approved",
+  "denied",
+  "paid",
+  "payout_failed",
+] as const;
+
+export const expenseStatusSchema = z.enum(EXPENSE_STATUSES);
+export type ExpenseStatus = (typeof EXPENSE_STATUSES)[number];
+
+export const EXPENSE_STATUS_LABELS: Record<ExpenseStatus, string> = {
+  pending: "Pending approval",
+  awaiting_second_approval: "Awaiting second approval",
+  approved: "Approved",
+  denied: "Denied",
+  paid: "Paid",
+  payout_failed: "Payout failed",
+};
+
+/** True iff a claim of this amount needs two distinct approvers. */
+export function expenseNeedsTwoApprovers(amountPence: number): boolean {
+  return amountPence >= EXPENSE_TWO_APPROVAL_THRESHOLD_PENCE;
+}
+
+/** True iff a claim of this amount must carry a receipt. */
+export function expenseReceiptRequired(amountPence: number): boolean {
+  return amountPence > EXPENSE_RECEIPT_REQUIRED_ABOVE_PENCE;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,17 @@ export {
 
 export { stripeConfig, type StripeConfig } from "./stripe-config.ts";
 
+export {
+  EXPENSE_RECEIPT_REQUIRED_ABOVE_PENCE,
+  EXPENSE_STATUS_LABELS,
+  EXPENSE_STATUSES,
+  EXPENSE_TWO_APPROVAL_THRESHOLD_PENCE,
+  expenseNeedsTwoApprovers,
+  expenseReceiptRequired,
+  expenseStatusSchema,
+  type ExpenseStatus,
+} from "./expenses.ts";
+
 export { nameSimilarity, normalizeName } from "./name-similarity.ts";
 
 export { chartSpecSchema, type ChartSpec } from "./scout-chart.ts";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,8 +30,8 @@ export { stripeConfig, type StripeConfig } from "./stripe-config.ts";
 
 export {
   EXPENSE_RECEIPT_REQUIRED_ABOVE_PENCE,
-  EXPENSE_STATUS_LABELS,
   EXPENSE_STATUSES,
+  EXPENSE_STATUS_LABELS,
   EXPENSE_TWO_APPROVAL_THRESHOLD_PENCE,
   expenseNeedsTwoApprovers,
   expenseReceiptRequired,


### PR DESCRIPTION
Implements the audited expense-reimbursement workflow and Stripe payout rail from `EXPENSES.md` (plan + resolved decisions in that doc).

## What this does

A submitter raises an expense (description, amount, proposed tags, optional receipt). Approvers are emailed, approve/deny and finalise tags. Claims of GBP 50+ need two distinct approvers. Approved claims are paid via Stripe Global Payouts (or a manual "mark paid" fallback). Every transition is recorded in an append-only audit log. An admin dashboard shows pending/approved/denied/paid with aggregated totals; submitters get a "my expenses" page.

## Phases (one branch, sequential commits)

- **Phase 0 spike** - confirmed the pinned `stripe@22.2.1` SDK exposes `v2.core.accounts` + `rawRequest` + `Stripe-Context` but not the `MoneyManagement` resources, so Phase 2 calls the preview endpoints via `rawRequest` on an isolated client (no SDK bump).
- **Phase 1** - DB migration (`expense`, `expense_approval`, `expense_category` + link, `expense_event`), `expenses` permission resource + `expense_submitter`/`expense_approver` roles, the API feature, email notifications, admin + submitter UI, and full unit + integration tests.
- **Phase 2** - Stripe Global Payouts: a dedicated v2 client, recipient creation, a Stripe-hosted bank-details setup link (Stripe holds the details - we store only token ids), idempotent OutboundPayment, a v2 webhook for status, and the "Pay via Stripe" button.
- **ADRs** [050](docs/adrs/050-reimbursement-payouts-stripe-global-payouts.md) (rail choice + data minimisation) and [051](docs/adrs/051-stripe-global-payouts-raw-request-isolation.md) (preview v2 via rawRequest).

## Key controls

- Separation of duties: an approver can't decide their own claim; the two required approvals must come from two distinct people (DB-enforced).
- `pay` is a distinct permission from `approve`.
- Idempotent payouts (unique `stripe_outbound_payment_id`); receipts mandatory over GBP 10; at least one tag required to approve.

## Tested

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build:web` all green.
- 11 unit + 25 integration tests (testcontainers) covering the state machine, two-approver rule, self-approval/double-decision rejection, tag dedupe, payout idempotency/failure/503/webhook.
- Browser walkthrough locally: submit -> approve -> mark-paid full lifecycle, plus the "Pay via Stripe" 503 guard surfacing cleanly when Global Payouts is unconfigured.

## Follow-ups before payouts go live (flagged, not done here)

- The two payout config vars (`STRIPE_FINANCIAL_ACCOUNT_ID`, `STRIPE_PAYOUTS_API_VERSION`, plus `STRIPE_PAYOUTS_WEBHOOK_SECRET`) are **placeholder-tolerant, not hard-required** - a deliberate deviation from the usual "new env vars are required" convention, because CI auto-applies on merge and a required-but-unprovisioned var would brick API boot. They need wiring as SSM params (mirror `VAPID_PUBLIC_KEY`) and the real values seeded. Until then the payout endpoint returns a clear "not configured" error and the manual path is used.
- The exact preview `Stripe-Version`, OutboundPayment event names, and UK-individual `requirements` still need verifying against the live preview account.
- Matchday expenses were left untouched (decision 13.8); this is a standalone feature with its own "Reimbursements" admin tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)