### PR TITLE
feat(scout): compute an always-present outcome for Play Cricket results

### DIFF
--- a/apps/api/src/features/scout/tools/play-cricket-outcome.test.ts
+++ b/apps/api/src/features/scout/tools/play-cricket-outcome.test.ts
@@ -90,6 +90,24 @@ describe("buildOutcome", () => {
     });
     expect(outcome?.result_applied_to_club).toBeNull();
   });
+
+  it("preserves declared as a tri-state: true / false / null (unknown)", () => {
+    // match-detail innings carry declared as boolean|null (null for historical
+    // matches, where the flag is genuinely unknown - not "did not declare").
+    const outcome = buildOutcome({
+      ...wonRow,
+      innings: [
+        { team_batting_id: "134134", runs: "297", declared: true },
+        { team_batting_id: "200", runs: "130", declared: false },
+        { team_batting_id: "200", runs: "44", declared: null },
+      ],
+    });
+    expect(outcome?.innings.map((i) => i.declared)).toEqual([
+      true,
+      false,
+      null,
+    ]);
+  });
 });
 
 describe("enrichOutcomes", () => {
@@ -143,6 +161,25 @@ describe("enrichOutcomes", () => {
     expect(
       enriched.matches[0].match_details[0].outcome?.result_applied_to_club,
     ).toBe("Percy Main");
+  });
+
+  it("attaches outcome even when ONLY outcome sub-paths were projected", () => {
+    const raw = { result_summary: [wonRow] };
+    // `outcome` doesn't exist in the raw response, so projecting only an
+    // outcome sub-path leaves the projected row empty - enrichment must still
+    // materialise the full outcome so the "always present" contract holds.
+    const projected = project(raw, [
+      "result_summary[].outcome.result_description",
+    ]);
+    const enriched = enrichOutcomes(projected, raw) as {
+      result_summary: Array<{
+        outcome?: { result_description: string; innings: unknown[] };
+      }>;
+    };
+    expect(enriched.result_summary[0].outcome?.result_description).toBe(
+      "Percy Main won",
+    );
+    expect(enriched.result_summary[0].outcome?.innings).toHaveLength(2);
   });
 
   it("does not fabricate match rows for an aggregate-only projection", () => {

--- a/apps/api/src/features/scout/tools/play-cricket-outcome.test.ts
+++ b/apps/api/src/features/scout/tools/play-cricket-outcome.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { buildOutcome, enrichOutcomes } from "./play-cricket-outcome.ts";
+import { project } from "./projector.ts";
+
+// A result_summary row shaped like the live Play Cricket API: home/away
+// team_ids + club names, a bare `result` code, a result_applied_to team_id,
+// and innings that carry only team_batting_id (NO team_batting_name).
+const wonRow = {
+  id: 7262912,
+  match_date: "02/05/2026",
+  home_team_id: "200",
+  home_club_name: "Backworth CC",
+  away_team_id: "134134",
+  away_club_name: "Percy Main",
+  result: "W",
+  result_description: "Percy Main won",
+  result_applied_to: "134134",
+  batted_first: "134134",
+  innings: [
+    { team_batting_id: "134134", runs: "297", wickets: "9", overs: "50.0" },
+    { team_batting_id: "200", runs: "130", wickets: "10", overs: "38.2" },
+  ],
+};
+
+describe("buildOutcome", () => {
+  it("resolves team_ids to clubs and attributes each innings total", () => {
+    const outcome = buildOutcome(wonRow);
+    expect(outcome).not.toBeNull();
+    expect(outcome?.result_description).toBe("Percy Main won");
+    expect(outcome?.result_applied_to_club).toBe("Percy Main");
+    expect(outcome?.batted_first_club).toBe("Percy Main");
+    // The 297 belongs to Percy Main, the 130 to Backworth - the exact
+    // attribution the content AI got wrong when it only had the bare totals.
+    expect(outcome?.innings).toEqual([
+      {
+        batting_club: "Percy Main",
+        team_batting_name: "",
+        team_batting_id: "134134",
+        runs: "297",
+        wickets: "9",
+        overs: "50.0",
+        declared: false,
+      },
+      {
+        batting_club: "Backworth CC",
+        team_batting_name: "",
+        team_batting_id: "200",
+        runs: "130",
+        wickets: "10",
+        overs: "38.2",
+        declared: false,
+      },
+    ]);
+  });
+
+  it("keeps result_description trustworthy even when the raw code is 'L' for the winner", () => {
+    // Mirrors the integration-test softball fixture: result "L" alongside a
+    // result_applied_to pointing at the side that actually won. The raw code
+    // is unreliable; result_description is not.
+    const outcome = buildOutcome({
+      home_team_id: "134",
+      home_club_name: "Percy Main",
+      away_team_id: "999",
+      away_club_name: "Tynemouth CC",
+      result: "L",
+      result_description: "Tynemouth CC won",
+      result_applied_to: "999",
+      innings: [],
+    });
+    expect(outcome?.result).toBe("L");
+    expect(outcome?.result_description).toBe("Tynemouth CC won");
+    expect(outcome?.result_applied_to_club).toBe("Tynemouth CC");
+  });
+
+  it("returns null for an unplayed fixture (no result, no innings)", () => {
+    expect(
+      buildOutcome({
+        home_team_id: "1",
+        away_team_id: "2",
+        result: "",
+        result_description: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("leaves a club null when a team_id matches neither side", () => {
+    const outcome = buildOutcome({
+      ...wonRow,
+      result_applied_to: "999999",
+    });
+    expect(outcome?.result_applied_to_club).toBeNull();
+  });
+});
+
+describe("enrichOutcomes", () => {
+  it("attaches outcome to a projected result_summary even when no result field was projected", () => {
+    const raw = { result_summary: [wonRow] };
+    // Caller projected only the id - they still get the full outcome.
+    const projected = project(raw, ["result_summary[].id"]);
+    const enriched = enrichOutcomes(projected, raw) as {
+      result_summary: Array<{
+        id: number;
+        outcome?: { result_description: string };
+      }>;
+    };
+    expect(enriched.result_summary[0].id).toBe(7262912);
+    expect(enriched.result_summary[0].outcome?.result_description).toBe(
+      "Percy Main won",
+    );
+  });
+
+  it("attaches outcome under match_details for pc_match_detail", () => {
+    const raw = { match_details: [{ ...wonRow, result: "Won by 167 runs" }] };
+    const projected = project(raw, ["match_details[].match_date"]);
+    const enriched = enrichOutcomes(projected, raw) as {
+      match_details: Array<{
+        outcome?: { result: string; innings: unknown[] };
+      }>;
+    };
+    expect(enriched.match_details[0].outcome?.result).toBe("Won by 167 runs");
+    expect(enriched.match_details[0].outcome?.innings).toHaveLength(2);
+  });
+
+  it("attaches outcome under the nested matches[].match_details shape", () => {
+    const raw = {
+      oppositionName: "Backworth",
+      matchedCount: 1,
+      matches: [{ match_details: [wonRow] }],
+    };
+    const projected = project(raw, [
+      "matchedCount",
+      "matches[].match_details[].match_date",
+    ]);
+    const enriched = enrichOutcomes(projected, raw) as {
+      matchedCount: number;
+      matches: Array<{
+        match_details: Array<{
+          outcome?: { result_applied_to_club: string | null };
+        }>;
+      }>;
+    };
+    expect(enriched.matchedCount).toBe(1);
+    expect(
+      enriched.matches[0].match_details[0].outcome?.result_applied_to_club,
+    ).toBe("Percy Main");
+  });
+
+  it("does not fabricate match rows for an aggregate-only projection", () => {
+    const raw = {
+      matchedCount: 3,
+      matches: [{ match_details: [wonRow] }],
+    };
+    // Only a top-level scalar projected - leave the payload lean.
+    const projected = project(raw, ["matchedCount"]);
+    const enriched = enrichOutcomes(projected, raw) as Record<string, unknown>;
+    expect(enriched).toEqual({ matchedCount: 3 });
+    expect(enriched.matches).toBeUndefined();
+  });
+
+  it("passes through a null projection unchanged", () => {
+    expect(enrichOutcomes(null, { result_summary: [wonRow] })).toBeNull();
+  });
+});

--- a/apps/api/src/features/scout/tools/play-cricket-outcome.ts
+++ b/apps/api/src/features/scout/tools/play-cricket-outcome.ts
@@ -1,0 +1,180 @@
+/**
+ * Computes an always-present `outcome` object for Play Cricket match/result
+ * rows so the agent can never misread who won or which side made which total.
+ *
+ * Why this exists: Play Cricket scatters the result across three fields that
+ * are individually unreadable -
+ *   - `result`             is "W"/"L" in result_summary but free text
+ *                          ("Won by 5 wickets") in match_detail, and is
+ *                          expressed relative to `result_applied_to`, NOT the
+ *                          home side and NOT from any fixed club's view.
+ *   - `result_applied_to`  is a bare team_id with no name attached.
+ *   - innings totals carry only `team_batting_id` (result_summary often omits
+ *                          team_batting_name entirely), so a 297 vs 130 pair
+ *                          can't be attributed to a club from the totals alone.
+ * The only reliably human-readable winner signal is `result_description`
+ * ("Percy Main won"). We therefore surface it verbatim and, purely from the
+ * SAME response (no DB, no guessing), resolve every team_id -> club name and
+ * attribute every innings total to its batting club. The agent reads the
+ * plain-English description for the winner and the attributed innings for the
+ * scores; it never has to decode the raw `result` code.
+ */
+
+type Rec = Record<string, unknown>;
+
+function isRec(v: unknown): v is Rec {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// First string-or-number-ish value coerced to string, else "". Mirrors the
+// defensive `pickString` in play-cricket.ts so unexpected shapes never become
+// "[object Object]".
+function str(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "bigint") return String(v);
+  return "";
+}
+
+export interface OutcomeInnings {
+  /** Club that batted this innings, resolved from team_batting_id. null when unresolvable. */
+  batting_club: string | null;
+  /** Raw team_batting_name (often empty in result_summary - prefer batting_club). */
+  team_batting_name: string;
+  team_batting_id: string;
+  runs: string;
+  wickets: string;
+  overs: string;
+  declared: boolean;
+}
+
+export interface Outcome {
+  /** Raw Play Cricket result code/text, verbatim. Do not read alone. */
+  result: string;
+  /** Plain-English winner, e.g. "Percy Main won". The reliable signal. */
+  result_description: string;
+  /** team_id the raw `result` code is expressed relative to. */
+  result_applied_to: string;
+  /** result_applied_to resolved to a club name within this response. */
+  result_applied_to_club: string | null;
+  batted_first: string;
+  batted_first_club: string | null;
+  innings: OutcomeInnings[];
+}
+
+// A row is "played" (worth an outcome) when it carries any result signal. We
+// skip fixture-only rows (future matches, no result, no innings) so aggregate
+// or fixture-list projections aren't bloated with empty outcome objects.
+function isPlayed(m: Rec): boolean {
+  return (
+    str(m.result).trim() !== "" ||
+    str(m.result_description).trim() !== "" ||
+    (Array.isArray(m.innings) && m.innings.length > 0)
+  );
+}
+
+/**
+ * Build the outcome object for a single match-ish record (a result_summary row
+ * or a match_details entry). Returns null for unplayed/fixture rows.
+ */
+export function buildOutcome(match: unknown): Outcome | null {
+  if (!isRec(match) || !isPlayed(match)) return null;
+
+  const homeTeamId = str(match.home_team_id);
+  const awayTeamId = str(match.away_team_id);
+  const homeClub = str(match.home_club_name);
+  const awayClub = str(match.away_club_name);
+  const clubForTeam = (teamId: string): string | null => {
+    if (!teamId) return null;
+    if (teamId === homeTeamId) return homeClub || null;
+    if (teamId === awayTeamId) return awayClub || null;
+    return null;
+  };
+
+  const innings = Array.isArray(match.innings) ? match.innings : [];
+  return {
+    result: str(match.result),
+    result_description: str(match.result_description),
+    result_applied_to: str(match.result_applied_to),
+    result_applied_to_club: clubForTeam(str(match.result_applied_to)),
+    batted_first: str(match.batted_first),
+    batted_first_club: clubForTeam(str(match.batted_first)),
+    innings: innings.map((inn) => {
+      const i = isRec(inn) ? inn : {};
+      return {
+        batting_club: clubForTeam(str(i.team_batting_id)),
+        team_batting_name: str(i.team_batting_name),
+        team_batting_id: str(i.team_batting_id),
+        runs: str(i.runs),
+        wickets: str(i.wickets),
+        overs: str(i.overs),
+        declared: Boolean(i.declared),
+      };
+    }),
+  };
+}
+
+// Attach `outcome` to each row of a projected array, reading the matching raw
+// row by index. The projector maps every source element 1:1 (never filters),
+// so projected[i] aligns with raw[i]. Rows the projector didn't keep are left
+// untouched; unplayed rows get no outcome.
+function attachToArray(projectedArr: unknown, rawArr: unknown): unknown {
+  if (!Array.isArray(projectedArr) || !Array.isArray(rawArr)) {
+    return projectedArr;
+  }
+  const rawRows = rawArr as unknown[];
+  return (projectedArr as unknown[]).map((row: unknown, i: number) => {
+    if (!isRec(row)) return row;
+    const outcome = buildOutcome(rawRows[i]);
+    return outcome ? { ...row, outcome } : row;
+  });
+}
+
+/**
+ * Enrich a projected Play Cricket response with `outcome` objects, in place of
+ * a copy. Handles all three container shapes the pc_* tools return:
+ *   - { result_summary: [row] }                  (pc_site_results)
+ *   - { match_details:  [row] }                  (pc_match_detail)
+ *   - { matches: [{ match_details: [row] }] }     (pc_find_opposition_matches)
+ *
+ * Only enriches match rows the projection actually returned - if the caller
+ * projected aggregate-only fields (e.g. matchedCount) with no match rows, the
+ * payload is left lean. Whenever a match row IS present, it always carries the
+ * full outcome, so the agent can never receive a match without its result.
+ */
+export function enrichOutcomes(projected: unknown, raw: unknown): unknown {
+  if (!isRec(projected)) return projected;
+  const rawObj: Rec = isRec(raw) ? raw : {};
+  const out: Rec = { ...projected };
+
+  if ("result_summary" in out) {
+    out.result_summary = attachToArray(
+      out.result_summary,
+      rawObj.result_summary,
+    );
+  }
+  if ("match_details" in out) {
+    out.match_details = attachToArray(out.match_details, rawObj.match_details);
+  }
+  if (Array.isArray(out.matches)) {
+    const rawMatches: unknown[] = Array.isArray(rawObj.matches)
+      ? (rawObj.matches as unknown[])
+      : [];
+    out.matches = (out.matches as unknown[]).map(
+      (entry: unknown, j: number) => {
+        const rawEntry = rawMatches[j];
+        if (!isRec(entry) || !("match_details" in entry) || !isRec(rawEntry)) {
+          return entry;
+        }
+        return {
+          ...entry,
+          match_details: attachToArray(
+            entry.match_details,
+            rawEntry.match_details,
+          ),
+        };
+      },
+    );
+  }
+
+  return out;
+}

--- a/apps/api/src/features/scout/tools/play-cricket-outcome.ts
+++ b/apps/api/src/features/scout/tools/play-cricket-outcome.ts
@@ -44,13 +44,19 @@ export interface OutcomeInnings {
   runs: string;
   wickets: string;
   overs: string;
-  declared: boolean;
+  /** true/false when known; null for historical match-detail innings where the flag is unknown. */
+  declared: boolean | null;
 }
 
 export interface Outcome {
   /** Raw Play Cricket result code/text, verbatim. Do not read alone. */
   result: string;
-  /** Plain-English winner, e.g. "Percy Main won". The reliable signal. */
+  /**
+   * Plain-English result, expressed relative to result_applied_to_club, e.g.
+   * "Percy Main won" or "...Won bat second 27". Covers non-win states too
+   * (tied, drawn, abandoned, cancelled), so read it literally - it does not
+   * always name a winner. The reliable result signal.
+   */
   result_description: string;
   /** team_id the raw `result` code is expressed relative to. */
   result_applied_to: string;
@@ -107,7 +113,8 @@ export function buildOutcome(match: unknown): Outcome | null {
         runs: str(i.runs),
         wickets: str(i.wickets),
         overs: str(i.overs),
-        declared: Boolean(i.declared),
+        // null means "unknown" (historical match-detail), not "did not declare".
+        declared: i.declared === null ? null : Boolean(i.declared),
       };
     }),
   };
@@ -115,17 +122,20 @@ export function buildOutcome(match: unknown): Outcome | null {
 
 // Attach `outcome` to each row of a projected array, reading the matching raw
 // row by index. The projector maps every source element 1:1 (never filters),
-// so projected[i] aligns with raw[i]. Rows the projector didn't keep are left
-// untouched; unplayed rows get no outcome.
+// so projected[i] aligns with raw[i]. Unplayed rows get no outcome and are left
+// as projected. A played row always gets its outcome - including the case where
+// the caller projected ONLY outcome sub-paths (e.g. ["...outcome.result_description"]),
+// which leaves the projected row undefined because `outcome` doesn't exist in
+// the raw response yet; we materialise `{ outcome }` so the contract holds.
 function attachToArray(projectedArr: unknown, rawArr: unknown): unknown {
   if (!Array.isArray(projectedArr) || !Array.isArray(rawArr)) {
     return projectedArr;
   }
   const rawRows = rawArr as unknown[];
   return (projectedArr as unknown[]).map((row: unknown, i: number) => {
-    if (!isRec(row)) return row;
     const outcome = buildOutcome(rawRows[i]);
-    return outcome ? { ...row, outcome } : row;
+    if (!outcome) return row;
+    return isRec(row) ? { ...row, outcome } : { outcome };
   });
 }
 

--- a/apps/api/src/features/scout/tools/play-cricket.ts
+++ b/apps/api/src/features/scout/tools/play-cricket.ts
@@ -4,9 +4,21 @@ import { z } from "zod";
 import type { PlayCricketApiClient } from "../../play-cricket/api-client.ts";
 import type { ScoutCache } from "./cache.ts";
 import { approxJsonBytes } from "./payload-size.ts";
+import { enrichOutcomes } from "./play-cricket-outcome.ts";
 import { project } from "./projector.ts";
 
 const HOUR = 60 * 60;
+
+// Shared guidance embedded in every result-bearing tool description. Play
+// Cricket's raw result fields are individually unreadable (see
+// play-cricket-outcome.ts), so each played-match row is enriched with a
+// computed `outcome` object - the agent should read THAT, not the raw code.
+const OUTCOME_NOTE = `READING THE RESULT - every played-match row carries a computed \`outcome\` object. It is ALWAYS present (you do not need to project it) and is the only correct way to read the result:
+  outcome.result_description   — plain-English winner, e.g. "Percy Main won". THIS names who won; trust it above all else.
+  outcome.result               — raw Play Cricket code/text ("W", "L", "Won by 5 wickets"). NEVER read this on its own: it is "W"/"L" relative to outcome.result_applied_to (NOT the home side, NOT any fixed club) and its format is inconsistent across competitions.
+  outcome.result_applied_to / outcome.result_applied_to_club — the team_id the raw code refers to, plus that team's club name resolved within this response.
+  outcome.batted_first_club    — the club that batted first.
+  outcome.innings[].batting_club with .runs/.wickets/.overs — every innings total already attributed to the club that batted it. NEVER assume innings[0] is the home side; read batting_club. (result_summary often omits team_batting_name, so batting_club is the only reliable owner of a total.)`;
 
 export interface PlayCricketToolDeps {
   playCricket: PlayCricketApiClient;
@@ -130,6 +142,9 @@ Available field paths under match_details[]:
   match_details[].batted_first     — team that batted first
   match_details[].result, match_details[].result_description
   match_details[].players[].home_team[].player_name, match_details[].players[].away_team[].player_name
+
+${OUTCOME_NOTE}
+
   match_details[].innings[].team_batting_name, match_details[].innings[].innings_number
   match_details[].innings[].runs, match_details[].innings[].wickets, match_details[].innings[].overs
   match_details[].innings[].total_extras, match_details[].innings[].declared
@@ -156,7 +171,7 @@ Ask for the narrowest set that answers the question — e.g. for innings totals 
           24 * HOUR,
           () => playCricket.getMatchDetail(matchId),
         );
-        const projected = project(raw, fields);
+        const projected = enrichOutcomes(project(raw, fields), raw);
         logPayload(logger, "pc_match_detail", fields, raw, projected);
         return projected;
       },
@@ -233,12 +248,14 @@ Response shape: { result_summary: [<row>...] }. Each row contains the same ident
   result_summary[].match_date
   result_summary[].home_club_name, result_summary[].home_team_name, result_summary[].home_club_id, result_summary[].home_team_id
   result_summary[].away_club_name, result_summary[].away_team_name, result_summary[].away_club_id, result_summary[].away_team_id
-  result_summary[].result, result_summary[].result_applied_to, result_summary[].batted_first, result_summary[].toss
+  result_summary[].result, result_summary[].result_description, result_summary[].result_applied_to, result_summary[].batted_first, result_summary[].toss
   result_summary[].innings[]                    — innings totals (use [] alone to keep all fields per innings)
   result_summary[].innings[].team_batting_name, result_summary[].innings[].team_batting_id
   result_summary[].innings[].runs, result_summary[].innings[].wickets, result_summary[].innings[].overs
   result_summary[].innings[].declared
   result_summary[].batting_points, result_summary[].bowling_points, result_summary[].penalty_runs
+
+${OUTCOME_NOTE}
 
 Field names for bonus points may vary by competition; if a path looks empty, ask for result_summary[] (the whole row) on a single example match to inspect what's actually returned.`,
       inputSchema: z.object({
@@ -253,7 +270,7 @@ Field names for bonus points may vary by competition; if a path looks empty, ask
           6 * HOUR,
           () => playCricket.getResultSummaryForSite(siteId, season),
         );
-        const projected = project(raw, fields);
+        const projected = enrichOutcomes(project(raw, fields), raw);
         logPayload(logger, "pc_site_results", fields, raw, projected);
         return projected;
       },
@@ -262,7 +279,7 @@ Field names for bonus points may vary by competition; if a path looks empty, ask
     pc_find_opposition_matches: tool({
       description: `Find matches the named opposition team has played against Percy Main in a given season — filters Percy Main's match summary by name, then pulls full scorecards. NOTE: this only sees matches involving Percy Main. To scout an opposition's matches against OTHER clubs, use pc_site_matches instead (look up their site_id via home_club_id/away_club_id from any of our matches against them, then fetch their full season).
 
-Response shape: { oppositionName, season, matchedCount, fetchedCount, matches: [<full match-detail response>] }. Each entry in matches[] is a full match-detail response, so its inner shape is matches[].match_details[].* — use the same paths documented on pc_match_detail, just prefixed with matches[].
+Response shape: { oppositionName, season, matchedCount, fetchedCount, matches: [<full match-detail response>] }. Each entry in matches[] is a full match-detail response, so its inner shape is matches[].match_details[].* — use the same paths documented on pc_match_detail, just prefixed with matches[]. Each matches[].match_details[] entry carries the same always-present computed \`outcome\` object described on pc_match_detail; read outcome.result_description for the winner.
 
 Examples:
   ["matchedCount", "fetchedCount"]   — just the counts
@@ -333,7 +350,7 @@ Examples:
             };
           },
         );
-        const projected = project(raw, fields);
+        const projected = enrichOutcomes(project(raw, fields), raw);
         logPayload(
           logger,
           "pc_find_opposition_matches",

--- a/apps/api/src/features/scout/tools/play-cricket.ts
+++ b/apps/api/src/features/scout/tools/play-cricket.ts
@@ -14,9 +14,9 @@ const HOUR = 60 * 60;
 // play-cricket-outcome.ts), so each played-match row is enriched with a
 // computed `outcome` object - the agent should read THAT, not the raw code.
 const OUTCOME_NOTE = `READING THE RESULT - every played-match row carries a computed \`outcome\` object. It is ALWAYS present (you do not need to project it) and is the only correct way to read the result:
-  outcome.result_description   — plain-English winner, e.g. "Percy Main won". THIS names who won; trust it above all else.
+  outcome.result_description   — plain-English result, e.g. "Percy Main won". This is the reliable result signal, but read it LITERALLY: it is phrased relative to outcome.result_applied_to_club and also covers draws, ties, abandoned, cancelled and in-progress matches, so do NOT assume it always names a winner. Pair it with outcome.result_applied_to_club to know which side it describes.
   outcome.result               — raw Play Cricket code/text ("W", "L", "Won by 5 wickets"). NEVER read this on its own: it is "W"/"L" relative to outcome.result_applied_to (NOT the home side, NOT any fixed club) and its format is inconsistent across competitions.
-  outcome.result_applied_to / outcome.result_applied_to_club — the team_id the raw code refers to, plus that team's club name resolved within this response.
+  outcome.result_applied_to / outcome.result_applied_to_club — the team_id the raw code/description refers to, plus that team's club name resolved within this response.
   outcome.batted_first_club    — the club that batted first.
   outcome.innings[].batting_club with .runs/.wickets/.overs — every innings total already attributed to the club that batted it. NEVER assume innings[0] is the home side; read batting_club. (result_summary often omits team_batting_name, so batting_club is the only reliable owner of a total.)`;
 


### PR DESCRIPTION
## Why

Play Cricket scatters each match result across three individually unreadable fields:

- `result` is `"W"`/`"L"` in `result_summary` but free text (`"Won by 5 wickets"`) in `match_detail`, and is expressed relative to `result_applied_to`, **not** the home side or any fixed club.
- `result_applied_to` is a bare `team_id` with no name attached.
- innings totals carry only `team_batting_id` (`result_summary` often omits `team_batting_name`), so a `297` vs `130` pair can't be attributed to a club from the totals alone.

The content AI misread winners and misattributed innings scores as a result.

## What

- **`play-cricket-outcome.ts`** derives an `outcome` object purely from the same API response (no DB, no guessing):
  - surfaces `result_description` (`"Percy Main won"`) verbatim as the only reliable winner signal,
  - resolves every `team_id` → club name within the response,
  - attributes every innings total to the club that batted it.
- **`enrichOutcomes`** attaches `outcome` to all three `pc_*` container shapes: `{ result_summary: [...] }`, `{ match_details: [...] }`, and the nested `{ matches: [{ match_details: [...] }] }`. It only enriches match rows the projection actually returned, so aggregate-only projections (e.g. just `matchedCount`) stay lean. Unplayed/fixture rows get no outcome.
- Wired into `pc_match_detail`, `pc_site_results`, and `pc_find_opposition_matches`, with a shared note in each tool description telling the agent to read `outcome` instead of decoding the raw `result` code.

## Testing

- New unit tests (`play-cricket-outcome.test.ts`, 9 cases) cover team_id→club resolution, innings attribution, the unreliable raw `"L"`-for-winner case, unplayed rows, unresolvable team_ids, and all three container shapes including the aggregate-only / null-projection paths.
- `pnpm --filter api typecheck`, `lint`, and the new test file all pass; files formatted with Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)