### PR TITLE
fix(api): strip build-only tooling from runtime image to clear Trivy gate

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,11 +1,9 @@
 # Trivy vulnerability suppressions. One CVE per line, with `exp:YYYY-MM-DD`
 # to force a periodic re-review. Each entry must be justified in a comment.
 # See https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
-
-# CVE-2026-33671 — picomatch RegEx DoS via crafted extglob patterns.
-# picomatch@4.0.3 is bundled inside npm in the node:24-alpine base image
-# (at /usr/local/lib/node_modules/npm/**). We run the API via corepack +
-# pnpm; npm is not on the runtime path, and no untrusted input ever reaches
-# it. Our application-level picomatch is already 4.0.4 (the fixed version).
-# Re-check once node:24-alpine ships a refreshed bundled npm.
-CVE-2026-33671 exp:2026-08-15
+#
+# No active suppressions. The previous CVE-2026-33671 (picomatch) entry covered
+# a copy bundled inside the base image's npm; apps/api/Dockerfile now strips npm
+# and the pnpm store from the runtime image, so that copy no longer exists and
+# the suppression is unnecessary. Add new entries here with a justification and
+# an `exp:` date.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -41,7 +41,22 @@ COPY --from=builder /app/packages/shared/package.json packages/shared/
 COPY --from=builder /app/packages/db/package.json packages/db/
 COPY --from=builder /app/packages/email/package.json packages/email/
 
-RUN pnpm install --frozen-lockfile --prod
+# Install prod deps, then strip build-only tooling in the SAME layer so the
+# bytes never enter the image. The container runs node directly (see CMD), so
+# pnpm and npm are never on the runtime path. Removing them here:
+#   - drops the ~800MB pnpm store + corepack cache (real size win, same layer),
+#   - drops the base image's bundled npm,
+# which clears two classes of Trivy finding their vendored files trip:
+#   - undici 6.25.0 (CVE-2026-12151, HIGH) bundled inside pnpm + npm (our
+#     application undici is already on a fixed line),
+#   - example credentials in dependency READMEs cached under the pnpm store
+#     (Trivy's secret scanner skips node_modules but not the store path).
+# node_modules is hardlinked from the store, so it survives the store removal.
+RUN pnpm install --frozen-lockfile --prod && \
+    rm -rf /root/.local/share/pnpm \
+           /root/.cache/node/corepack \
+           /usr/local/lib/node_modules/npm \
+           /usr/local/bin/npm /usr/local/bin/npx
 
 # Rewrite package exports from source to compiled dist. Matches any
 # `"./src/<path>.ts"` export target and rewrites it to `"./dist/<path>.js"`,


### PR DESCRIPTION
## Problem

The `image-scan` CI gate is failing on **CVE-2026-12151** (`undici@6.25.0`, HIGH — DoS via unbounded memory), blocking every PR.

The vulnerable `undici` is **not** an application dependency (ours is already on a fixed line). It is bundled inside *build tooling* that lingers in the runtime image:

- `/root/.cache/node/corepack/.../pnpm/11.1.2/.../undici` — the corepack-cached pnpm
- `/usr/local/lib/node_modules/npm/.../undici` — npm bundled in `node:24-alpine`

The container runs `node` directly (see `CMD`), so neither pnpm nor npm is ever on the runtime path.

## Fix

Remove the pnpm store, corepack cache, and bundled npm **in the same layer** as the prod install, so the bytes never enter the image:

- Clears both undici findings at the source rather than suppressing them.
- Drops the image from **~1.77GB to ~1.0GB** (the pnpm store alone is ~800MB).
- Removes a class of false-positive secret findings — example credentials in dependency READMEs (e.g. `google-auth-library`) cached under the store path, which Trivy's secret scanner does not skip the way it skips `node_modules/`.

`node_modules` is hardlinked from the store, so it survives the store removal.

Also drops the now-obsolete `CVE-2026-33671` (picomatch) suppression from `.trivyignore` — it covered a copy bundled in the base image's npm, which no longer exists in the image.

## Verification

Built locally and scanned with **Trivy v0.70.0** (same version CI uses), same flags (`--scanners vuln,secret --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore`), on a freshly pulled `node:24-alpine` (`alpine 3.24.1`, matching CI):

- **Exit code 0, zero findings** (undici gone, no store secrets, 0 OS vulns).
- Confirmed the runtime image still resolves modules and boots to config validation (only fails on absent env vars, as expected) — store/npm removal did not break `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)