### PR TITLE
Profile self-editing via a proposal/approval tier (#575)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -47,6 +47,7 @@ import { chargeRoutes } from "./features/charges/routes.ts";
 import { contactRoutes } from "./features/contact/routes.ts";
 import { contentAuthorRoutes } from "./features/content-author/routes.ts";
 import { contentImageRoutes } from "./features/content-images/routes.ts";
+import { contentProposalRoutes } from "./features/content-proposal/routes.ts";
 import { contentRoutes } from "./features/content/routes.ts";
 import { cricketLeaderboardRoutes } from "./features/cricket-leaderboard/routes.ts";
 import { documentRoutes } from "./features/documents/routes.ts";
@@ -319,6 +320,7 @@ export async function buildApp({ db, dialect, config }: AppDeps) {
   await app.register(contentRoutes, { prefix: "/api" });
   await app.register(contentImageRoutes, { prefix: "/api" });
   await app.register(contentAuthorRoutes, { prefix: "/api" });
+  await app.register(contentProposalRoutes, { prefix: "/api" });
 
   // Marketing forwarder: periodic drain of marketing_outbox -> Google Ads.
   // No-op when GOOGLE_ADS_* env vars are absent.

--- a/apps/api/src/features/content-proposal/integration.test.ts
+++ b/apps/api/src/features/content-proposal/integration.test.ts
@@ -67,7 +67,6 @@ describe("content-proposal service (integration)", () => {
     const owner = await seedTestUser(ctx.db, {
       name,
       withMember: true,
-      role: null,
     });
     const { id } = await createContent(ctx.db)({
       kind: "person",

--- a/apps/api/src/features/content-proposal/integration.test.ts
+++ b/apps/api/src/features/content-proposal/integration.test.ts
@@ -1,0 +1,400 @@
+import type { Email } from "@percy-main/email";
+import type { PersonPhoto } from "@percy-main/shared/content";
+import Fastify from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import {
+  createContent,
+  getContent,
+  listRevisions,
+} from "../content/service.ts";
+import {
+  approveProfileProposal,
+  getProfileEditState,
+  getProposalDetail,
+  listPendingProposals,
+  rejectProfileProposal,
+  submitProfileProposal,
+} from "./service.ts";
+
+const body = (text: string) => [
+  {
+    id: crypto.randomUUID(),
+    type: "paragraph",
+    props: {},
+    content: [{ type: "text", text, styles: {} }],
+    children: [],
+  },
+];
+
+const photo = (n: string): PersonPhoto => ({
+  sources: { "image/webp": `/uploads/${n}.webp 1x` },
+  img: { src: `/uploads/${n}.png`, w: 200, h: 200 },
+});
+
+// Silent FastifyBaseLogger for the notify deps (no casts, no real I/O).
+const log = Fastify({ logger: false }).log;
+
+function recordingDeps() {
+  const sent: Array<{ to: string; subject: string }> = [];
+  const deps = {
+    baseUrl: "http://localhost:5173",
+    send: (email: Email) => {
+      sent.push({ to: email.to, subject: email.subject });
+      return Promise.resolve();
+    },
+    log,
+  };
+  return { deps, sent };
+}
+
+describe("content-proposal service (integration)", () => {
+  let ctx: TestContext;
+  let authorId: string;
+  let reviewerId: string;
+  let reviewerEmail: string;
+  let nonReviewerEmail: string;
+
+  // Create a person profile and link a fresh owner's member row to it by
+  // slug - the exact eligibility chain (user.email -> member -> slug ->
+  // person content_item) the feature relies on.
+  async function seedOwnerWithProfile(slug: string, name: string) {
+    const owner = await seedTestUser(ctx.db, {
+      name,
+      withMember: true,
+      role: null,
+    });
+    const { id } = await createContent(ctx.db)({
+      kind: "person",
+      slug,
+      title: name,
+      description: null,
+      body: body("Original bio"),
+      metadata: { isDBSChecked: true, hasLeftClub: false },
+      userId: authorId,
+    });
+    if (!owner.memberId)
+      throw new Error("seedTestUser did not create a member");
+    await ctx.db
+      .updateTable("member")
+      .set({ slug })
+      .where("id", "=", owner.memberId)
+      .execute();
+    return { ...owner, contentId: id };
+  }
+
+  beforeAll(async () => {
+    ctx = await startTestContainer();
+    ({ userId: authorId } = await seedTestUser(ctx.db, { withMember: false }));
+    // people_editor holds content_people:publish - a reviewer.
+    const reviewer = await seedTestUser(ctx.db, {
+      role: "people_editor",
+      withMember: false,
+      name: "Rev Iewer",
+    });
+    reviewerId = reviewer.userId;
+    reviewerEmail = reviewer.email;
+    // news_editor does NOT hold content_people:publish - never notified.
+    const nonReviewer = await seedTestUser(ctx.db, {
+      role: "news_editor",
+      withMember: false,
+      name: "News Person",
+    });
+    nonReviewerEmail = nonReviewer.email;
+  }, 120_000);
+
+  afterAll(async () => {
+    await stopTestContainer(ctx);
+  });
+
+  it("reports no editable profile for a member without a slug link", async () => {
+    const stranger = await seedTestUser(ctx.db, { withMember: true });
+    const state = await getProfileEditState(ctx.db)(stranger.email);
+    expect(state.profile).toBeNull();
+    expect(state.pendingProposal).toBeNull();
+  });
+
+  it("surfaces the slug-linked profile to its owner", async () => {
+    const owner = await seedOwnerWithProfile("alice-owner", "Alice Owner");
+    const state = await getProfileEditState(ctx.db)(owner.email);
+    expect(state.profile?.contentId).toBe(owner.contentId);
+    expect(state.profile?.slug).toBe("alice-owner");
+    expect(state.profile?.title).toBe("Alice Owner");
+    expect(state.pendingProposal).toBeNull();
+  });
+
+  it("submits a proposal and notifies publishers but not the proposer or non-publishers", async () => {
+    const owner = await seedOwnerWithProfile("bob-owner", "Bob Owner");
+    const { deps, sent } = recordingDeps();
+
+    const result = await submitProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("Bob's updated bio"),
+      photo: photo("bob"),
+    });
+    expect(result.status).toBe("pending");
+
+    const recipients = sent.map((s) => s.to);
+    expect(recipients).toContain(reviewerEmail);
+    expect(recipients).not.toContain(nonReviewerEmail);
+    expect(recipients).not.toContain(owner.email);
+
+    // The owner now sees their pending proposal and cannot edit live yet.
+    const state = await getProfileEditState(ctx.db)(owner.email);
+    expect(state.pendingProposal?.id).toBe(result.id);
+    expect(state.pendingProposal?.photo?.img.src).toBe("/uploads/bob.png");
+  });
+
+  it("rejects a non-eligible caller's submission with 403", async () => {
+    const stranger = await seedTestUser(ctx.db, { withMember: true });
+    const { deps } = recordingDeps();
+    await expect(
+      submitProfileProposal(
+        ctx.db,
+        deps,
+      )({
+        userId: stranger.userId,
+        userEmail: stranger.email,
+        body: body("nope"),
+        photo: null,
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("blocks a second proposal while one is pending (409)", async () => {
+    const owner = await seedOwnerWithProfile("carol-owner", "Carol Owner");
+    const { deps } = recordingDeps();
+    const submit = submitProfileProposal(ctx.db, deps);
+    await submit({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("first"),
+      photo: null,
+    });
+    await expect(
+      submit({
+        userId: owner.userId,
+        userEmail: owner.email,
+        body: body("second"),
+        photo: null,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("approves a proposal: applies bio + photo, preserves flags + title, writes a revision, emails the proposer", async () => {
+    const owner = await seedOwnerWithProfile("dave-owner", "Dave Owner");
+    const { deps: submitDeps } = recordingDeps();
+    const { id: proposalId } = await submitProfileProposal(
+      ctx.db,
+      submitDeps,
+    )({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("Dave's approved bio"),
+      photo: photo("dave"),
+    });
+
+    const { deps: approveDeps, sent } = recordingDeps();
+    const result = await approveProfileProposal(
+      ctx.db,
+      approveDeps,
+    )({
+      proposalId,
+      reviewerUserId: reviewerId,
+    });
+    expect(result.status).toBe("approved");
+
+    // The live profile now carries the new bio + photo, but title and the
+    // safeguarding flags are untouched (admin-only).
+    const profile = await getContent(ctx.db)(owner.contentId);
+    expect(profile.title).toBe("Dave Owner");
+    expect(profile.body[0]?.content).toMatchObject([
+      { text: "Dave's approved bio" },
+    ]);
+    expect(profile.metadata.isDBSChecked).toBe(true);
+    expect(profile.metadata.hasLeftClub).toBe(false);
+    expect(profile.metadata.photo).toMatchObject({
+      img: { src: "/uploads/dave.png" },
+    });
+
+    // A revision was written, attributed to the reviewer (the approver).
+    const { revisions } = await listRevisions(ctx.db)(owner.contentId);
+    expect(revisions).toHaveLength(2); // creation + approval
+    expect(revisions[0]?.savedBy).toBe(reviewerId);
+
+    // The proposer was emailed; the owner can submit again.
+    expect(sent.map((s) => s.to)).toContain(owner.email);
+    const state = await getProfileEditState(ctx.db)(owner.email);
+    expect(state.pendingProposal).toBeNull();
+  });
+
+  it("approving an already-reviewed proposal returns 409", async () => {
+    const owner = await seedOwnerWithProfile("erin-owner", "Erin Owner");
+    const { deps } = recordingDeps();
+    const { id: proposalId } = await submitProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("Erin bio"),
+      photo: null,
+    });
+    await approveProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      proposalId,
+      reviewerUserId: reviewerId,
+    });
+    await expect(
+      approveProfileProposal(
+        ctx.db,
+        deps,
+      )({
+        proposalId,
+        reviewerUserId: reviewerId,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("rejects a proposal: leaves the profile untouched, stores the note, emails the proposer", async () => {
+    const owner = await seedOwnerWithProfile("frank-owner", "Frank Owner");
+    const { deps } = recordingDeps();
+    const { id: proposalId } = await submitProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("Frank's rejected bio"),
+      photo: photo("frank"),
+    });
+
+    const { deps: rejectDeps, sent } = recordingDeps();
+    const result = await rejectProfileProposal(
+      ctx.db,
+      rejectDeps,
+    )({
+      proposalId,
+      reviewerUserId: reviewerId,
+      note: "Please keep it under 100 words",
+    });
+    expect(result.status).toBe("rejected");
+
+    // Live profile is unchanged (still the original bio, no photo).
+    const profile = await getContent(ctx.db)(owner.contentId);
+    expect(profile.body[0]?.content).toMatchObject([{ text: "Original bio" }]);
+    expect(profile.metadata.photo).toBeUndefined();
+
+    // Note persisted, proposer emailed, owner free to submit again.
+    const row = await ctx.db
+      .selectFrom("content_proposal")
+      .select(["status", "decision_note"])
+      .where("id", "=", proposalId)
+      .executeTakeFirstOrThrow();
+    expect(row.status).toBe("rejected");
+    expect(row.decision_note).toBe("Please keep it under 100 words");
+    expect(sent.map((s) => s.to)).toContain(owner.email);
+
+    const state = await getProfileEditState(ctx.db)(owner.email);
+    expect(state.pendingProposal).toBeNull();
+  });
+
+  it("returns proposed-vs-current detail for the reviewer, and lists pending oldest-first", async () => {
+    const owner = await seedOwnerWithProfile("grace-owner", "Grace Owner");
+    const { deps } = recordingDeps();
+    const { id: proposalId } = await submitProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("Grace proposed bio"),
+      photo: photo("grace"),
+    });
+
+    const detail = await getProposalDetail(ctx.db)(proposalId);
+    expect(detail.status).toBe("pending");
+    expect(detail.title).toBe("Grace Owner");
+    expect(detail.proposed.body[0]?.content).toMatchObject([
+      { text: "Grace proposed bio" },
+    ]);
+    expect(detail.proposed.photo?.img.src).toBe("/uploads/grace.png");
+    expect(detail.current.body[0]?.content).toMatchObject([
+      { text: "Original bio" },
+    ]);
+    expect(detail.current.photo).toBeNull();
+
+    const { items } = await listPendingProposals(ctx.db)();
+    const ids = items.map((i) => i.id);
+    expect(ids).toContain(proposalId);
+  });
+
+  it("does not notify a reviewer about their own proposal", async () => {
+    // A people_editor who also owns a profile submits an edit; they must not
+    // be asked to review themselves.
+    const reviewerOwner = await seedTestUser(ctx.db, {
+      role: "people_editor",
+      withMember: true,
+      name: "Helen Editor",
+    });
+    await createContent(ctx.db)({
+      kind: "person",
+      slug: "helen-editor",
+      title: "Helen Editor",
+      description: null,
+      body: body("Original bio"),
+      metadata: { isDBSChecked: false, hasLeftClub: false },
+      userId: authorId,
+    });
+    if (!reviewerOwner.memberId) throw new Error("expected a member");
+    await ctx.db
+      .updateTable("member")
+      .set({ slug: "helen-editor" })
+      .where("id", "=", reviewerOwner.memberId)
+      .execute();
+
+    const { deps, sent } = recordingDeps();
+    await submitProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      userId: reviewerOwner.userId,
+      userEmail: reviewerOwner.email,
+      body: body("Helen's new bio"),
+      photo: null,
+    });
+    expect(sent.map((s) => s.to)).not.toContain(reviewerOwner.email);
+  });
+
+  it("submit still succeeds when reviewer notification fails (best-effort)", async () => {
+    const owner = await seedOwnerWithProfile("ian-owner", "Ian Owner");
+    const failingDeps = {
+      baseUrl: "http://localhost:5173",
+      send: () => Promise.reject(new Error("SES is down")),
+      log,
+    };
+    const result = await submitProfileProposal(
+      ctx.db,
+      failingDeps,
+    )({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("Ian bio"),
+      photo: null,
+    });
+    expect(result.status).toBe("pending");
+    const state = await getProfileEditState(ctx.db)(owner.email);
+    expect(state.pendingProposal?.id).toBe(result.id);
+  });
+});

--- a/apps/api/src/features/content-proposal/integration.test.ts
+++ b/apps/api/src/features/content-proposal/integration.test.ts
@@ -63,7 +63,11 @@ describe("content-proposal service (integration)", () => {
   // Create a person profile and link a fresh owner's member row to it by
   // slug - the exact eligibility chain (user.email -> member -> slug ->
   // person content_item) the feature relies on.
-  async function seedOwnerWithProfile(slug: string, name: string) {
+  async function seedOwnerWithProfile(
+    slug: string,
+    name: string,
+    opts: { photo?: PersonPhoto } = {},
+  ) {
     const owner = await seedTestUser(ctx.db, {
       name,
       withMember: true,
@@ -74,7 +78,11 @@ describe("content-proposal service (integration)", () => {
       title: name,
       description: null,
       body: body("Original bio"),
-      metadata: { isDBSChecked: true, hasLeftClub: false },
+      metadata: {
+        isDBSChecked: true,
+        hasLeftClub: false,
+        ...(opts.photo ? { photo: opts.photo } : {}),
+      },
       userId: authorId,
     });
     if (!owner.memberId)
@@ -234,6 +242,70 @@ describe("content-proposal service (integration)", () => {
     expect(sent.map((s) => s.to)).toContain(owner.email);
     const state = await getProfileEditState(ctx.db)(owner.email);
     expect(state.pendingProposal).toBeNull();
+  });
+
+  it("approving a photo-removal proposal removes the live photo, keeping flags", async () => {
+    const owner = await seedOwnerWithProfile("jo-photo", "Jo Photo", {
+      photo: photo("jo-orig"),
+    });
+    // Sanity: the profile starts with a photo.
+    const before = await getContent(ctx.db)(owner.contentId);
+    expect(before.metadata.photo).toMatchObject({
+      img: { src: "/uploads/jo-orig.png" },
+    });
+
+    const { deps } = recordingDeps();
+    const { id: proposalId } = await submitProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("Bio with the photo removed"),
+      photo: null,
+    });
+    await approveProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      proposalId,
+      reviewerUserId: reviewerId,
+    });
+
+    const after = await getContent(ctx.db)(owner.contentId);
+    expect(after.metadata.photo).toBeUndefined();
+    expect(after.metadata.isDBSChecked).toBe(true);
+  });
+
+  it("approving a bio-only edit keeps the existing photo (resent unchanged)", async () => {
+    const owner = await seedOwnerWithProfile("kim-photo", "Kim Photo", {
+      photo: photo("kim-orig"),
+    });
+    const { deps } = recordingDeps();
+    const { id: proposalId } = await submitProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("Updated bio"),
+      // The UI seeds the photo field from the current photo, so an unchanged
+      // photo round-trips as the same value.
+      photo: photo("kim-orig"),
+    });
+    await approveProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      proposalId,
+      reviewerUserId: reviewerId,
+    });
+
+    const after = await getContent(ctx.db)(owner.contentId);
+    expect(after.metadata.photo).toMatchObject({
+      img: { src: "/uploads/kim-orig.png" },
+    });
+    expect(after.body[0]?.content).toMatchObject([{ text: "Updated bio" }]);
   });
 
   it("approving an already-reviewed proposal returns 409", async () => {

--- a/apps/api/src/features/content-proposal/routes.ts
+++ b/apps/api/src/features/content-proposal/routes.ts
@@ -1,0 +1,152 @@
+import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import {
+  getAuthSession,
+  requireAuth,
+  requirePermission,
+} from "../auth/middleware.ts";
+import {
+  listProposalsResponseSchema,
+  profileEditStateResponseSchema,
+  proposalDetailResponseSchema,
+  proposalIdParamSchema,
+  proposalIdResponseSchema,
+  rejectProposalSchema,
+  submitProposalResponseSchema,
+  submitProposalSchema,
+} from "./schemas.ts";
+import {
+  approveProfileProposal,
+  getProfileEditState,
+  getProposalDetail,
+  listPendingProposals,
+  rejectProfileProposal,
+  submitProfileProposal,
+} from "./service.ts";
+
+// eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
+export const contentProposalRoutes: FastifyPluginAsyncZod = async (app) => {
+  const notifyDeps = {
+    baseUrl: app.config.BASE_URL,
+    send: app.send,
+    log: app.log,
+  };
+
+  const editState = getProfileEditState(app.db);
+  const submit = submitProfileProposal(app.db, notifyDeps);
+  const listPending = listPendingProposals(app.db);
+  const detail = getProposalDetail(app.db);
+  const approve = approveProfileProposal(app.db, notifyDeps);
+  const reject = rejectProfileProposal(app.db, notifyDeps);
+
+  // The reviewer pool is everyone who can publish people. Approving applies
+  // the edit to the live profile, so it is gated on the same publish action
+  // the manage/publish split reserved for this review tier.
+  const reviewProposals = requirePermission("content_people", "publish");
+
+  // ── Owner: self-service ──
+  //
+  // Any authenticated member can ask for their edit state; eligibility (a
+  // slug-linked person profile) is resolved in the service, which returns
+  // profile: null for a member with nothing to edit.
+
+  app.get(
+    "/profile/edit",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        response: { 200: profileEditStateResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await editState(user.email);
+    },
+  );
+
+  app.post(
+    "/profile/edit/proposals",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        body: submitProposalSchema,
+        response: { 200: submitProposalResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await submit({
+        userId: user.id,
+        userEmail: user.email,
+        body: request.body.body,
+        photo: request.body.photo,
+      });
+    },
+  );
+
+  // ── Reviewer: approval queue ──
+
+  app.get(
+    "/admin/profile-proposals",
+    {
+      preHandler: [reviewProposals],
+      schema: {
+        response: { 200: listProposalsResponseSchema },
+      },
+    },
+    async () => {
+      return await listPending();
+    },
+  );
+
+  app.get(
+    "/admin/profile-proposals/:proposalId",
+    {
+      preHandler: [reviewProposals],
+      schema: {
+        params: proposalIdParamSchema,
+        response: { 200: proposalDetailResponseSchema },
+      },
+    },
+    async (request) => {
+      return await detail(request.params.proposalId);
+    },
+  );
+
+  app.post(
+    "/admin/profile-proposals/:proposalId/approve",
+    {
+      preHandler: [reviewProposals],
+      schema: {
+        params: proposalIdParamSchema,
+        response: { 200: proposalIdResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await approve({
+        proposalId: request.params.proposalId,
+        reviewerUserId: user.id,
+      });
+    },
+  );
+
+  app.post(
+    "/admin/profile-proposals/:proposalId/reject",
+    {
+      preHandler: [reviewProposals],
+      schema: {
+        params: proposalIdParamSchema,
+        body: rejectProposalSchema,
+        response: { 200: proposalIdResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      return await reject({
+        proposalId: request.params.proposalId,
+        reviewerUserId: user.id,
+        note: request.body?.note,
+      });
+    },
+  );
+};

--- a/apps/api/src/features/content-proposal/routes.ts
+++ b/apps/api/src/features/content-proposal/routes.ts
@@ -5,6 +5,13 @@ import {
   requirePermission,
 } from "../auth/middleware.ts";
 import {
+  confirmUploadSchema,
+  contentImageResponseSchema,
+  uploadUrlResponseSchema,
+  uploadUrlSchema,
+} from "../content-images/schemas.ts";
+import { confirmUpload, createUploadUrl } from "../content-images/service.ts";
+import {
   listProposalsResponseSchema,
   profileEditStateResponseSchema,
   proposalDetailResponseSchema,
@@ -16,6 +23,7 @@ import {
 } from "./schemas.ts";
 import {
   approveProfileProposal,
+  assertCanEditProfile,
   getProfileEditState,
   getProposalDetail,
   listPendingProposals,
@@ -37,6 +45,12 @@ export const contentProposalRoutes: FastifyPluginAsyncZod = async (app) => {
   const detail = getProposalDetail(app.db);
   const approve = approveProfileProposal(app.db, notifyDeps);
   const reject = rejectProfileProposal(app.db, notifyDeps);
+  const canEdit = assertCanEditProfile(app.db);
+  // Profile owners hold no content role, so they can't use the admin
+  // content-images endpoints. These self-service routes reuse the same
+  // upload/process service, gated instead on owning an editable profile.
+  const photoUploadUrl = createUploadUrl(app.contentImages, app.config);
+  const photoConfirm = confirmUpload(app.db, app.contentImages, app.config);
 
   // The reviewer pool is everyone who can publish people. Approving applies
   // the edit to the live profile, so it is gated on the same publish action
@@ -79,6 +93,46 @@ export const contentProposalRoutes: FastifyPluginAsyncZod = async (app) => {
         userEmail: user.email,
         body: request.body.body,
         photo: request.body.photo,
+      });
+    },
+  );
+
+  // Self-service profile photo upload (presign + confirm), reusing the
+  // content-images pipeline. Gated on owning an editable profile rather than
+  // a content-manage role.
+  app.post(
+    "/profile/edit/photo-upload-url",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        body: uploadUrlSchema,
+        response: { 200: uploadUrlResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      await canEdit(user.email);
+      return await photoUploadUrl({ contentType: request.body.contentType });
+    },
+  );
+
+  app.post(
+    "/profile/edit/photo",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        body: confirmUploadSchema,
+        response: { 200: contentImageResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      await canEdit(user.email);
+      return await photoConfirm({
+        imageId: request.body.imageId,
+        pendingKey: request.body.pendingKey,
+        alt: request.body.alt,
+        userId: user.id,
       });
     },
   );

--- a/apps/api/src/features/content-proposal/schemas.test.ts
+++ b/apps/api/src/features/content-proposal/schemas.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { rejectProposalSchema, submitProposalSchema } from "./schemas.ts";
+
+const paragraph = (text: string) => ({
+  id: crypto.randomUUID(),
+  type: "paragraph",
+  props: {},
+  content: [{ type: "text", text, styles: {} }],
+  children: [],
+});
+
+const validPhoto = {
+  sources: { "image/webp": "/uploads/me.webp 1x" },
+  img: { src: "/uploads/me.png", w: 200, h: 200 },
+};
+
+describe("submitProposalSchema (self-editable field subset)", () => {
+  it("accepts a body with a site-relative photo", () => {
+    const result = submitProposalSchema.safeParse({
+      body: [paragraph("My new bio")],
+      photo: validPhoto,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a body with the photo removed (null)", () => {
+    const result = submitProposalSchema.safeParse({
+      body: [paragraph("Just text")],
+      photo: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("requires the body", () => {
+    const result = submitProposalSchema.safeParse({ photo: null });
+    expect(result.success).toBe(false);
+  });
+
+  it("requires the photo key (null or a photo, never omitted)", () => {
+    const result = submitProposalSchema.safeParse({
+      body: [paragraph("hi")],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a photo whose image is not https or site-relative", () => {
+    const result = submitProposalSchema.safeParse({
+      body: [paragraph("hi")],
+      photo: {
+        sources: { "image/webp": "http://evil.example/me.webp 1x" },
+        img: { src: "http://evil.example/me.png", w: 200, h: 200 },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("strips admin-only fields a client tries to smuggle in (title, flags, slug)", () => {
+    // The owner can only ever change bio + photo. Zod drops unknown keys, so
+    // even a hand-crafted request carrying title/slug/safeguarding flags
+    // reaches the service as just { body, photo }.
+    const result = submitProposalSchema.safeParse({
+      body: [paragraph("hi")],
+      photo: null,
+      title: "Hacked Name",
+      slug: "somewhere-else",
+      isDBSChecked: true,
+      hasLeftClub: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(Object.keys(result.data).sort()).toEqual(["body", "photo"]);
+    }
+  });
+});
+
+describe("rejectProposalSchema", () => {
+  it("allows no body (a bare reject with no note)", () => {
+    expect(rejectProposalSchema.safeParse(undefined).success).toBe(true);
+    expect(rejectProposalSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("allows a decision note", () => {
+    expect(
+      rejectProposalSchema.safeParse({ note: "Please shorten the bio" })
+        .success,
+    ).toBe(true);
+  });
+
+  it("rejects an over-long note", () => {
+    expect(
+      rejectProposalSchema.safeParse({ note: "x".repeat(2001) }).success,
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/features/content-proposal/schemas.ts
+++ b/apps/api/src/features/content-proposal/schemas.ts
@@ -1,0 +1,112 @@
+import {
+  contentProposalStatusSchema,
+  personPhotoSchema,
+} from "@percy-main/shared/content";
+import { z } from "zod";
+import { contentBodyTransportSchema } from "../content/schemas.ts";
+
+// ── Self-editable profile slice ─────────────────────────────────────────
+//
+// Only the bio (body) and photo are self-editable; title/slug and the
+// safeguarding flags stay admin-only, so a proposal carries exactly these
+// two fields. The body uses the depth-1 transport schema (the recursive
+// shared schema can't be expressed for openapi-typescript); the service
+// re-validates the full tree, exactly as the content feature does. photo
+// null means "remove my photo".
+
+const profileEditFieldsSchema = z.object({
+  body: contentBodyTransportSchema,
+  photo: personPhotoSchema.nullable(),
+});
+
+// ── Owner: read edit state + submit ─────────────────────────────────────
+
+/**
+ * The logged-in member's profile-edit state. `profile` is null when the
+ * caller has no slug-linked person profile (so the UI shows nothing to
+ * edit). `pendingProposal` is the one open proposal awaiting review, if
+ * any - while it exists the owner cannot submit another.
+ */
+export const profileEditStateResponseSchema = z.object({
+  profile: z
+    .object({
+      contentId: z.string(),
+      slug: z.string(),
+      title: z.string(),
+      body: contentBodyTransportSchema,
+      photo: personPhotoSchema.nullable(),
+    })
+    .nullable(),
+  pendingProposal: z
+    .object({
+      id: z.string(),
+      body: contentBodyTransportSchema,
+      photo: personPhotoSchema.nullable(),
+      createdAt: z.string(),
+    })
+    .nullable(),
+});
+
+export const submitProposalSchema = profileEditFieldsSchema;
+
+export const submitProposalResponseSchema = z.object({
+  id: z.string(),
+  status: contentProposalStatusSchema,
+});
+
+// ── Reviewer: queue + decisions ─────────────────────────────────────────
+
+export const proposalIdParamSchema = z.object({
+  proposalId: z.uuid(),
+});
+
+/** One row in the reviewer's pending-proposals queue. */
+export const listProposalsResponseSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.string(),
+      contentId: z.string(),
+      slug: z.string(),
+      title: z.string(),
+      proposedBy: z.string(),
+      proposedByName: z.string().nullable(),
+      createdAt: z.string(),
+    }),
+  ),
+});
+
+/**
+ * A single proposal in full for the review screen: the proposed bio/photo
+ * alongside the live ones, so the reviewer can compare before deciding.
+ */
+export const proposalDetailResponseSchema = z.object({
+  id: z.string(),
+  contentId: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  status: contentProposalStatusSchema,
+  proposedBy: z.string(),
+  proposedByName: z.string().nullable(),
+  createdAt: z.string(),
+  proposed: z.object({
+    body: contentBodyTransportSchema,
+    photo: personPhotoSchema.nullable(),
+  }),
+  current: z.object({
+    body: contentBodyTransportSchema,
+    photo: personPhotoSchema.nullable(),
+  }),
+});
+
+export const rejectProposalSchema = z
+  .object({
+    /** Why it was rejected - carried back to the proposer in the email. */
+    note: z.string().min(1).max(2000).optional(),
+  })
+  // Optional so a bare reject (no note) needs no request body.
+  .optional();
+
+export const proposalIdResponseSchema = z.object({
+  id: z.string(),
+  status: contentProposalStatusSchema,
+});

--- a/apps/api/src/features/content-proposal/service.ts
+++ b/apps/api/src/features/content-proposal/service.ts
@@ -1,0 +1,587 @@
+import type { DB } from "@percy-main/db";
+import {
+  ProfileEditDecision,
+  ProfileEditProposalSubmitted,
+  type Email,
+} from "@percy-main/email";
+import { checkPermission } from "@percy-main/shared/auth/permissions";
+import {
+  contentBodySchema,
+  personMetadataSchema,
+  personPhotoSchema,
+  type PersonPhoto,
+} from "@percy-main/shared/content";
+import type { FastifyBaseLogger } from "fastify";
+import { sql, type Kysely } from "kysely";
+import { createElement } from "react";
+import { render } from "react-email";
+import { z } from "zod";
+import { writeRevision } from "../content/service.ts";
+
+function throwHttpError(statusCode: number, message: string): never {
+  throw Object.assign(new Error(message), { statusCode });
+}
+
+/** Validate an incoming body is a structurally sound BlockNote block array. */
+function parseBody(body: unknown) {
+  const result = contentBodySchema.safeParse(body);
+  if (!result.success) {
+    throwHttpError(400, "Body is not a valid block document");
+  }
+  return result.data;
+}
+
+/**
+ * Parse a stored body for a read response. A stored body failing the schema
+ * is a server-side data problem (500), not a bad request - the same stance
+ * as the content feature's getContent/getRevision.
+ */
+function parseStoredBody(body: unknown) {
+  const result = contentBodySchema.safeParse(body);
+  if (!result.success) {
+    throwHttpError(500, "Stored body does not match the block schema");
+  }
+  return result.data;
+}
+
+/** The photo-only metadata subset a proposal stores ({} or { photo }). */
+const proposedMetadataSchema = z.object({
+  photo: personPhotoSchema.optional(),
+});
+
+interface NotifyDeps {
+  baseUrl: string;
+  send: (email: Email) => Promise<void>;
+  log: FastifyBaseLogger;
+}
+
+// ── Eligibility resolver ────────────────────────────────────────────────
+//
+// user.email -> member (paired by email at sign-up) -> member.slug ->
+// person content_item. A caller whose member has no slug (the admin hasn't
+// linked them in the Record Linking tab) simply has no self-editable
+// profile - eligibility falls out of the existing link, no opt-in flag.
+
+interface EditableProfile {
+  contentId: string;
+  slug: string;
+  title: string;
+  body: unknown;
+  photo: PersonPhoto | null;
+}
+
+async function resolveEditableProfile(
+  db: Kysely<DB>,
+  userEmail: string,
+): Promise<EditableProfile | null> {
+  const member = await db
+    .selectFrom("member")
+    .where("email", "=", userEmail)
+    .where("deleted_at", "is", null)
+    .where("slug", "is not", null)
+    .select(["slug"])
+    .executeTakeFirst();
+  if (!member?.slug) return null;
+
+  const person = await db
+    .selectFrom("content_item")
+    .where("kind", "=", "person")
+    .where("slug", "=", member.slug)
+    .select(["id", "slug", "title", "body", "metadata"])
+    .executeTakeFirst();
+  if (!person) return null;
+
+  // A stored profile failing its schema is a server-side data problem; fall
+  // back to "no photo" rather than blocking the owner from editing their bio.
+  const meta = personMetadataSchema.safeParse(person.metadata);
+  return {
+    contentId: person.id,
+    slug: person.slug,
+    title: person.title,
+    body: person.body,
+    photo: meta.success ? (meta.data.photo ?? null) : null,
+  };
+}
+
+// ── Reviewer set ────────────────────────────────────────────────────────
+//
+// "All content editors who can publish people" - the approver pool. The
+// role column is a comma-separated list SQL can't resolve to grants, so we
+// narrow to non-banned users with a role string and confirm each with
+// checkPermission (the listOfficials pattern). The proposer is excluded so
+// an editor editing their own profile isn't asked to review it.
+
+async function listProfileReviewers(
+  db: Kysely<DB>,
+  excludeUserId: string,
+): Promise<Array<{ id: string; email: string; name: string }>> {
+  const rows = await db
+    .selectFrom("user")
+    .where("id", "!=", excludeUserId)
+    .where("role", "is not", null)
+    .where("role", "!=", "")
+    .where((eb) => eb.or([eb("banned", "is", null), eb("banned", "=", false)]))
+    .select(["id", "name", "email", "role"])
+    .orderBy("name", "asc")
+    .execute();
+  return rows
+    .filter((r) => checkPermission(r.role, "content_people", "publish"))
+    .map((r) => ({ id: r.id, email: r.email, name: r.name }));
+}
+
+// ── Owner: read edit state ──────────────────────────────────────────────
+
+export function getProfileEditState(db: Kysely<DB>) {
+  return async (userEmail: string) => {
+    const profile = await resolveEditableProfile(db, userEmail);
+    if (!profile) {
+      return { profile: null, pendingProposal: null };
+    }
+
+    const pending = await db
+      .selectFrom("content_proposal")
+      .where("content_id", "=", profile.contentId)
+      .where("status", "=", "pending")
+      .select(["id", "proposed_body", "proposed_metadata", "created_at"])
+      .executeTakeFirst();
+
+    return {
+      profile: {
+        contentId: profile.contentId,
+        slug: profile.slug,
+        title: profile.title,
+        body: parseStoredBody(profile.body),
+        photo: profile.photo,
+      },
+      pendingProposal: pending
+        ? {
+            id: pending.id,
+            body: parseStoredBody(pending.proposed_body),
+            photo:
+              proposedMetadataSchema.safeParse(pending.proposed_metadata).data
+                ?.photo ?? null,
+            createdAt: pending.created_at.toISOString(),
+          }
+        : null,
+    };
+  };
+}
+
+// ── Owner: submit a proposal ────────────────────────────────────────────
+
+export function submitProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
+  return async (params: {
+    userId: string;
+    userEmail: string;
+    body: unknown;
+    photo: PersonPhoto | null;
+  }) => {
+    const profile = await resolveEditableProfile(db, params.userEmail);
+    if (!profile) {
+      throwHttpError(403, "You do not have a profile you can edit");
+    }
+
+    const body = parseBody(params.body);
+    const proposedMetadata = params.photo ? { photo: params.photo } : {};
+
+    const proposalId = await db.transaction().execute(async (tx) => {
+      // One open proposal per profile: block a second while one is pending.
+      // The partial unique index is the backstop against a race; this is the
+      // friendly 409.
+      const existing = await tx
+        .selectFrom("content_proposal")
+        .select("id")
+        .where("content_id", "=", profile.contentId)
+        .where("status", "=", "pending")
+        .executeTakeFirst();
+      if (existing) {
+        throwHttpError(
+          409,
+          "You already have an edit awaiting review - it must be approved or rejected before you can submit another",
+        );
+      }
+
+      const row = await tx
+        .insertInto("content_proposal")
+        .values({
+          content_id: profile.contentId,
+          proposed_body: JSON.stringify(body),
+          proposed_metadata: JSON.stringify(proposedMetadata),
+          proposed_by: params.userId,
+          status: "pending",
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+      return row.id;
+    });
+
+    // Notify every content publisher (excluding the proposer) so any of them
+    // can review. Best-effort: a mail failure must not roll back the
+    // proposal, mirroring the matchday/financial-relief notifiers.
+    try {
+      const reviewers = await listProfileReviewers(db, params.userId);
+      const reviewUrl = `${deps.baseUrl}/admin`;
+      await Promise.all(
+        reviewers.map(async (reviewer) => {
+          const html = await render(
+            createElement(ProfileEditProposalSubmitted.component, {
+              imageBaseUrl: `${deps.baseUrl}/images`,
+              recipientName: reviewer.name,
+              profileName: profile.title,
+              reviewUrl,
+            }),
+          );
+          await deps.send({
+            to: reviewer.email,
+            subject: ProfileEditProposalSubmitted.subject,
+            html,
+          });
+        }),
+      );
+    } catch (err) {
+      deps.log.error(
+        { err, contentId: profile.contentId },
+        "profile_proposal_reviewer_notification_failed",
+      );
+    }
+
+    return { id: proposalId, status: "pending" as const };
+  };
+}
+
+// ── Reviewer: queue ─────────────────────────────────────────────────────
+
+export function listPendingProposals(db: Kysely<DB>) {
+  return async () => {
+    const rows = await db
+      .selectFrom("content_proposal")
+      .innerJoin(
+        "content_item",
+        "content_item.id",
+        "content_proposal.content_id",
+      )
+      .leftJoin(
+        "user as proposer",
+        "proposer.id",
+        "content_proposal.proposed_by",
+      )
+      .where("content_proposal.status", "=", "pending")
+      .select([
+        "content_proposal.id",
+        "content_proposal.content_id",
+        "content_item.slug",
+        "content_item.title",
+        "content_proposal.proposed_by",
+        "proposer.name as proposed_by_name",
+        "content_proposal.created_at",
+      ])
+      .orderBy("content_proposal.created_at", "asc")
+      .execute();
+
+    return {
+      items: rows.map((r) => ({
+        id: r.id,
+        contentId: r.content_id,
+        slug: r.slug,
+        title: r.title,
+        proposedBy: r.proposed_by,
+        proposedByName: r.proposed_by_name,
+        createdAt: r.created_at.toISOString(),
+      })),
+    };
+  };
+}
+
+export function getProposalDetail(db: Kysely<DB>) {
+  return async (proposalId: string) => {
+    const row = await db
+      .selectFrom("content_proposal")
+      .innerJoin(
+        "content_item",
+        "content_item.id",
+        "content_proposal.content_id",
+      )
+      .leftJoin(
+        "user as proposer",
+        "proposer.id",
+        "content_proposal.proposed_by",
+      )
+      .where("content_proposal.id", "=", proposalId)
+      .select([
+        "content_proposal.id",
+        "content_proposal.content_id",
+        "content_proposal.status",
+        "content_proposal.proposed_by",
+        "proposer.name as proposed_by_name",
+        "content_proposal.proposed_body",
+        "content_proposal.proposed_metadata",
+        "content_proposal.created_at",
+        "content_item.slug",
+        "content_item.title",
+        "content_item.body as current_body",
+        "content_item.metadata as current_metadata",
+      ])
+      .executeTakeFirst();
+    if (!row) throwHttpError(404, "Proposal not found");
+
+    const proposedBody = contentBodySchema.safeParse(row.proposed_body);
+    const currentBody = contentBodySchema.safeParse(row.current_body);
+    if (!proposedBody.success || !currentBody.success) {
+      throwHttpError(500, "Stored body does not match the block schema");
+    }
+    const currentMeta = personMetadataSchema.safeParse(row.current_metadata);
+
+    return {
+      id: row.id,
+      contentId: row.content_id,
+      slug: row.slug,
+      title: row.title,
+      status: row.status as "pending" | "approved" | "rejected",
+      proposedBy: row.proposed_by,
+      proposedByName: row.proposed_by_name,
+      createdAt: row.created_at.toISOString(),
+      proposed: {
+        body: proposedBody.data,
+        photo:
+          proposedMetadataSchema.safeParse(row.proposed_metadata).data?.photo ??
+          null,
+      },
+      current: {
+        body: currentBody.data,
+        photo: currentMeta.success ? (currentMeta.data.photo ?? null) : null,
+      },
+    };
+  };
+}
+
+// ── Reviewer: approve ───────────────────────────────────────────────────
+
+export function approveProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
+  return async (params: { proposalId: string; reviewerUserId: string }) => {
+    const decision = await db.transaction().execute(async (tx) => {
+      const proposal = await tx
+        .selectFrom("content_proposal")
+        .innerJoin(
+          "content_item",
+          "content_item.id",
+          "content_proposal.content_id",
+        )
+        .leftJoin(
+          "user as proposer",
+          "proposer.id",
+          "content_proposal.proposed_by",
+        )
+        .where("content_proposal.id", "=", params.proposalId)
+        .select([
+          "content_proposal.status",
+          "content_proposal.content_id",
+          "content_proposal.proposed_body",
+          "content_proposal.proposed_metadata",
+          "proposer.email as proposer_email",
+          "proposer.name as proposer_name",
+          "content_item.kind",
+          "content_item.slug",
+          "content_item.title",
+          "content_item.description",
+          "content_item.metadata as current_metadata",
+        ])
+        .executeTakeFirst();
+      if (!proposal) throwHttpError(404, "Proposal not found");
+      if (proposal.status !== "pending") {
+        throwHttpError(409, "This proposal has already been reviewed");
+      }
+      if (proposal.kind !== "person") {
+        throwHttpError(409, "Only person profiles can be self-edited");
+      }
+
+      const body = parseBody(proposal.proposed_body);
+      const proposedMeta = proposedMetadataSchema.parse(
+        proposal.proposed_metadata,
+      );
+      const currentMeta = personMetadataSchema.parse(proposal.current_metadata);
+
+      // Merge the photo onto the live metadata; the safeguarding flags
+      // (isDBSChecked / hasLeftClub) are never self-editable, so they pass
+      // through untouched. An absent proposed photo removes it.
+      const newMetadata = {
+        isDBSChecked: currentMeta.isDBSChecked,
+        hasLeftClub: currentMeta.hasLeftClub,
+        ...(proposedMeta.photo ? { photo: proposedMeta.photo } : {}),
+      };
+
+      await tx
+        .updateTable("content_item")
+        .set({
+          body: JSON.stringify(body),
+          metadata: JSON.stringify(newMetadata),
+          updated_by: params.reviewerUserId,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", proposal.content_id)
+        .execute();
+
+      // An approved proposal is just another save: snapshot it like any
+      // content edit so the profile's history is complete.
+      await writeRevision(
+        tx,
+        {
+          id: proposal.content_id,
+          title: proposal.title,
+          description: proposal.description,
+          body,
+          metadata: newMetadata,
+        },
+        params.reviewerUserId,
+      );
+
+      // Guarded status flip: only the transaction that flips pending->approved
+      // wins, so a concurrent approve/reject of the same proposal gets the 409.
+      const marked = await tx
+        .updateTable("content_proposal")
+        .set({
+          status: "approved",
+          reviewed_by: params.reviewerUserId,
+          reviewed_at: sql`CURRENT_TIMESTAMP`,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", params.proposalId)
+        .where("status", "=", "pending")
+        .returning("id")
+        .executeTakeFirst();
+      if (!marked)
+        throwHttpError(409, "This proposal has already been reviewed");
+
+      return {
+        proposerEmail: proposal.proposer_email,
+        proposerName: proposal.proposer_name,
+        profileName: proposal.title,
+        slug: proposal.slug,
+      };
+    });
+
+    await notifyProposerOfDecision(deps, {
+      to: decision.proposerEmail,
+      recipientName: decision.proposerName,
+      profileName: decision.profileName,
+      outcome: "approved",
+      decisionNote: null,
+      slug: decision.slug,
+    });
+
+    return { id: params.proposalId, status: "approved" as const };
+  };
+}
+
+// ── Reviewer: reject ────────────────────────────────────────────────────
+
+export function rejectProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
+  return async (params: {
+    proposalId: string;
+    reviewerUserId: string;
+    note?: string;
+  }) => {
+    const decision = await db.transaction().execute(async (tx) => {
+      const proposal = await tx
+        .selectFrom("content_proposal")
+        .innerJoin(
+          "content_item",
+          "content_item.id",
+          "content_proposal.content_id",
+        )
+        .leftJoin(
+          "user as proposer",
+          "proposer.id",
+          "content_proposal.proposed_by",
+        )
+        .where("content_proposal.id", "=", params.proposalId)
+        .select([
+          "content_proposal.status",
+          "proposer.email as proposer_email",
+          "proposer.name as proposer_name",
+          "content_item.slug",
+          "content_item.title",
+        ])
+        .executeTakeFirst();
+      if (!proposal) throwHttpError(404, "Proposal not found");
+      if (proposal.status !== "pending") {
+        throwHttpError(409, "This proposal has already been reviewed");
+      }
+
+      const marked = await tx
+        .updateTable("content_proposal")
+        .set({
+          status: "rejected",
+          reviewed_by: params.reviewerUserId,
+          reviewed_at: sql`CURRENT_TIMESTAMP`,
+          decision_note: params.note ?? null,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", params.proposalId)
+        .where("status", "=", "pending")
+        .returning("id")
+        .executeTakeFirst();
+      if (!marked)
+        throwHttpError(409, "This proposal has already been reviewed");
+
+      return {
+        proposerEmail: proposal.proposer_email,
+        proposerName: proposal.proposer_name,
+        profileName: proposal.title,
+        slug: proposal.slug,
+      };
+    });
+
+    await notifyProposerOfDecision(deps, {
+      to: decision.proposerEmail,
+      recipientName: decision.proposerName,
+      profileName: decision.profileName,
+      outcome: "rejected",
+      decisionNote: params.note ?? null,
+      slug: decision.slug,
+    });
+
+    return { id: params.proposalId, status: "rejected" as const };
+  };
+}
+
+/**
+ * Email the proposer their decision (approve or reject). Best-effort: a
+ * mail failure must not undo the committed review. A proposer always has a
+ * user row (they were authenticated to submit), but email may be missing on
+ * a malformed account, so guard.
+ */
+async function notifyProposerOfDecision(
+  deps: NotifyDeps,
+  params: {
+    to: string | null;
+    recipientName: string | null;
+    profileName: string;
+    outcome: "approved" | "rejected";
+    decisionNote: string | null;
+    slug: string;
+  },
+): Promise<void> {
+  if (!params.to) return;
+  try {
+    const html = await render(
+      createElement(ProfileEditDecision.component, {
+        imageBaseUrl: `${deps.baseUrl}/images`,
+        recipientName: params.recipientName ?? "there",
+        profileName: params.profileName,
+        outcome: params.outcome,
+        decisionNote: params.decisionNote,
+        profileUrl: `${deps.baseUrl}/person/${params.slug}`,
+      }),
+    );
+    await deps.send({
+      to: params.to,
+      subject: ProfileEditDecision.subject,
+      html,
+    });
+  } catch (err) {
+    deps.log.error(
+      { err, outcome: params.outcome },
+      "profile_proposal_decision_notification_failed",
+    );
+  }
+}

--- a/apps/api/src/features/content-proposal/service.ts
+++ b/apps/api/src/features/content-proposal/service.ts
@@ -129,6 +129,21 @@ async function listProfileReviewers(
     .map((r) => ({ id: r.id, email: r.email, name: r.name }));
 }
 
+/**
+ * Throw 403 unless the caller has a self-editable profile. Used to gate the
+ * self-service photo upload (which reuses the content-images service) on the
+ * same eligibility as the proposal routes - a member uploading a profile
+ * photo must own a slug-linked profile.
+ */
+export function assertCanEditProfile(db: Kysely<DB>) {
+  return async (userEmail: string) => {
+    const profile = await resolveEditableProfile(db, userEmail);
+    if (!profile) {
+      throwHttpError(403, "You do not have a profile you can edit");
+    }
+  };
+}
+
 // ── Owner: read edit state ──────────────────────────────────────────────
 
 export function getProfileEditState(db: Kysely<DB>) {

--- a/apps/api/src/features/content-proposal/service.ts
+++ b/apps/api/src/features/content-proposal/service.ts
@@ -409,15 +409,36 @@ export function approveProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
         throwHttpError(409, "Only person profiles can be self-edited");
       }
 
+      // Claim the proposal FIRST: the guarded pending->approved flip is what
+      // serialises concurrent reviews. Doing it before touching content_item
+      // means a losing concurrent approve fails here (0 rows) and rolls back
+      // without ever re-writing the profile or inserting a stray revision.
+      const marked = await tx
+        .updateTable("content_proposal")
+        .set({
+          status: "approved",
+          reviewed_by: params.reviewerUserId,
+          reviewed_at: sql`CURRENT_TIMESTAMP`,
+          updated_at: sql`CURRENT_TIMESTAMP`,
+        })
+        .where("id", "=", params.proposalId)
+        .where("status", "=", "pending")
+        .returning("id")
+        .executeTakeFirst();
+      if (!marked)
+        throwHttpError(409, "This proposal has already been reviewed");
+
       const body = parseBody(proposal.proposed_body);
       const proposedMeta = proposedMetadataSchema.parse(
         proposal.proposed_metadata,
       );
       const currentMeta = personMetadataSchema.parse(proposal.current_metadata);
 
-      // Merge the photo onto the live metadata; the safeguarding flags
-      // (isDBSChecked / hasLeftClub) are never self-editable, so they pass
-      // through untouched. An absent proposed photo removes it.
+      // Rebuild the metadata from scratch: carry the safeguarding flags
+      // (isDBSChecked / hasLeftClub) through untouched - they are never
+      // self-editable - and take the photo solely from the proposal. The
+      // proposal always reflects the owner's intended end state, so an
+      // absent proposed photo means "no photo" and removes the live one.
       const newMetadata = {
         isDBSChecked: currentMeta.isDBSChecked,
         hasLeftClub: currentMeta.hasLeftClub,
@@ -448,23 +469,6 @@ export function approveProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
         },
         params.reviewerUserId,
       );
-
-      // Guarded status flip: only the transaction that flips pending->approved
-      // wins, so a concurrent approve/reject of the same proposal gets the 409.
-      const marked = await tx
-        .updateTable("content_proposal")
-        .set({
-          status: "approved",
-          reviewed_by: params.reviewerUserId,
-          reviewed_at: sql`CURRENT_TIMESTAMP`,
-          updated_at: sql`CURRENT_TIMESTAMP`,
-        })
-        .where("id", "=", params.proposalId)
-        .where("status", "=", "pending")
-        .returning("id")
-        .executeTakeFirst();
-      if (!marked)
-        throwHttpError(409, "This proposal has already been reviewed");
 
       return {
         proposerEmail: proposal.proposer_email,

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -164,8 +164,12 @@ function selectSummary(db: Kysely<DB>) {
     .select([...summaryColumns, "updater.name as updated_by_name"]);
 }
 
-/** Snapshot the item's editorial fields into content_revision. */
-async function writeRevision(
+/**
+ * Snapshot the item's editorial fields into content_revision. Exported so
+ * the profile self-edit approval path (#575) writes history through the
+ * same helper - an approved proposal is just another save.
+ */
+export async function writeRevision(
   tx: Transaction<DB>,
   item: {
     id: string;

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -14491,6 +14491,116 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/profile/edit/photo-upload-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        contentType: "image/jpeg" | "image/png" | "image/webp" | "image/heic";
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            imageId: string;
+                            uploadUrl: string;
+                            pendingKey: string;
+                            maxBytes: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/profile/edit/photo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        imageId: string;
+                        pendingKey: string;
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                        alt?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            picture: {
+                                sources: {
+                                    [key: string]: string;
+                                };
+                                img: {
+                                    src: string;
+                                    w: number;
+                                    h: number;
+                                };
+                            };
+                            alt: string | null;
+                            width: number;
+                            height: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/profile-proposals": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -14345,6 +14345,374 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/profile/edit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            profile: {
+                                contentId: string;
+                                slug: string;
+                                title: string;
+                                body: {
+                                    id: string;
+                                    type: string;
+                                    props: {
+                                        [key: string]: string | number | boolean;
+                                    };
+                                    content?: unknown;
+                                    children: unknown[];
+                                }[];
+                                photo: {
+                                    sources: {
+                                        [key: string]: string;
+                                    };
+                                    img: {
+                                        src: string;
+                                        w: number;
+                                        h: number;
+                                    };
+                                } | null;
+                            } | null;
+                            pendingProposal: {
+                                id: string;
+                                body: {
+                                    id: string;
+                                    type: string;
+                                    props: {
+                                        [key: string]: string | number | boolean;
+                                    };
+                                    content?: unknown;
+                                    children: unknown[];
+                                }[];
+                                photo: {
+                                    sources: {
+                                        [key: string]: string;
+                                    };
+                                    img: {
+                                        src: string;
+                                        w: number;
+                                        h: number;
+                                    };
+                                } | null;
+                                createdAt: string;
+                            } | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/profile/edit/proposals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        body: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        photo: {
+                            sources: {
+                                [key: string]: string;
+                            };
+                            img: {
+                                src: string;
+                                w: number;
+                                h: number;
+                            };
+                        } | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            status: "pending" | "approved" | "rejected";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/profile-proposals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                contentId: string;
+                                slug: string;
+                                title: string;
+                                proposedBy: string;
+                                proposedByName: string | null;
+                                createdAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/profile-proposals/{proposalId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    proposalId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            contentId: string;
+                            slug: string;
+                            title: string;
+                            /** @enum {string} */
+                            status: "pending" | "approved" | "rejected";
+                            proposedBy: string;
+                            proposedByName: string | null;
+                            createdAt: string;
+                            proposed: {
+                                body: {
+                                    id: string;
+                                    type: string;
+                                    props: {
+                                        [key: string]: string | number | boolean;
+                                    };
+                                    content?: unknown;
+                                    children: unknown[];
+                                }[];
+                                photo: {
+                                    sources: {
+                                        [key: string]: string;
+                                    };
+                                    img: {
+                                        src: string;
+                                        w: number;
+                                        h: number;
+                                    };
+                                } | null;
+                            };
+                            current: {
+                                body: {
+                                    id: string;
+                                    type: string;
+                                    props: {
+                                        [key: string]: string | number | boolean;
+                                    };
+                                    content?: unknown;
+                                    children: unknown[];
+                                }[];
+                                photo: {
+                                    sources: {
+                                        [key: string]: string;
+                                    };
+                                    img: {
+                                        src: string;
+                                        w: number;
+                                        h: number;
+                                    };
+                                } | null;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/profile-proposals/{proposalId}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    proposalId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            status: "pending" | "approved" | "rejected";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/profile-proposals/{proposalId}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    proposalId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        note?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            status: "pending" | "approved" | "rejected";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -25846,6 +25846,827 @@
           }
         }
       }
+    },
+    "/api/profile/edit": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "profile": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "contentId": {
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "props": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {},
+                              "children": {
+                                "type": "array",
+                                "items": {}
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "props",
+                              "children"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "photo": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "img": {
+                              "type": "object",
+                              "properties": {
+                                "src": {
+                                  "type": "string",
+                                  "pattern": "^(?:https:|\\/(?!\\/))"
+                                },
+                                "w": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                },
+                                "h": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "src",
+                                "w",
+                                "h"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "sources",
+                            "img"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "contentId",
+                        "slug",
+                        "title",
+                        "body",
+                        "photo"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "pendingProposal": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "props": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {},
+                              "children": {
+                                "type": "array",
+                                "items": {}
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "props",
+                              "children"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "photo": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "img": {
+                              "type": "object",
+                              "properties": {
+                                "src": {
+                                  "type": "string",
+                                  "pattern": "^(?:https:|\\/(?!\\/))"
+                                },
+                                "w": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                },
+                                "h": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "src",
+                                "w",
+                                "h"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "sources",
+                            "img"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "body",
+                        "photo",
+                        "createdAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "profile",
+                    "pendingProposal"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/profile/edit/proposals": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "photo": {
+                    "nullable": true,
+                    "type": "object",
+                    "properties": {
+                      "sources": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "img": {
+                        "type": "object",
+                        "properties": {
+                          "src": {
+                            "type": "string",
+                            "pattern": "^(?:https:|\\/(?!\\/))"
+                          },
+                          "w": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991
+                          },
+                          "h": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "src",
+                          "w",
+                          "h"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "sources",
+                      "img"
+                    ]
+                  }
+                },
+                "required": [
+                  "body",
+                  "photo"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "approved",
+                        "rejected"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/profile-proposals": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "contentId": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "proposedBy": {
+                            "type": "string"
+                          },
+                          "proposedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "contentId",
+                          "slug",
+                          "title",
+                          "proposedBy",
+                          "proposedByName",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/profile-proposals/{proposalId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "proposalId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "contentId": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "approved",
+                        "rejected"
+                      ]
+                    },
+                    "proposedBy": {
+                      "type": "string"
+                    },
+                    "proposedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "proposed": {
+                      "type": "object",
+                      "properties": {
+                        "body": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "props": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {},
+                              "children": {
+                                "type": "array",
+                                "items": {}
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "props",
+                              "children"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "photo": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "img": {
+                              "type": "object",
+                              "properties": {
+                                "src": {
+                                  "type": "string",
+                                  "pattern": "^(?:https:|\\/(?!\\/))"
+                                },
+                                "w": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                },
+                                "h": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "src",
+                                "w",
+                                "h"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "sources",
+                            "img"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "body",
+                        "photo"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "current": {
+                      "type": "object",
+                      "properties": {
+                        "body": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "props": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {},
+                              "children": {
+                                "type": "array",
+                                "items": {}
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "props",
+                              "children"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "photo": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "img": {
+                              "type": "object",
+                              "properties": {
+                                "src": {
+                                  "type": "string",
+                                  "pattern": "^(?:https:|\\/(?!\\/))"
+                                },
+                                "w": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                },
+                                "h": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "src",
+                                "w",
+                                "h"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "sources",
+                            "img"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "body",
+                        "photo"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "contentId",
+                    "slug",
+                    "title",
+                    "status",
+                    "proposedBy",
+                    "proposedByName",
+                    "createdAt",
+                    "proposed",
+                    "current"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/profile-proposals/{proposalId}/approve": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "proposalId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "approved",
+                        "rejected"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/profile-proposals/{proposalId}/reject": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "note": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "proposalId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "approved",
+                        "rejected"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -26226,6 +26226,198 @@
         }
       }
     },
+    "/api/profile/edit/photo-upload-url": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contentType": {
+                    "type": "string",
+                    "enum": [
+                      "image/jpeg",
+                      "image/png",
+                      "image/webp",
+                      "image/heic"
+                    ]
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "contentType",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "imageId": {
+                      "type": "string"
+                    },
+                    "uploadUrl": {
+                      "type": "string"
+                    },
+                    "pendingKey": {
+                      "type": "string"
+                    },
+                    "maxBytes": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "imageId",
+                    "uploadUrl",
+                    "pendingKey",
+                    "maxBytes"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/profile/edit/photo": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "imageId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "pendingKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  },
+                  "alt": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "imageId",
+                  "pendingKey",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "picture": {
+                      "type": "object",
+                      "properties": {
+                        "sources": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "img": {
+                          "type": "object",
+                          "properties": {
+                            "src": {
+                              "type": "string"
+                            },
+                            "w": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "h": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "src",
+                            "w",
+                            "h"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "sources",
+                        "img"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "alt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "width": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "height": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "picture",
+                    "alt",
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/profile-proposals": {
       "get": {
         "responses": {

--- a/apps/web/src/components/profile/bio-editor.tsx
+++ b/apps/web/src/components/profile/bio-editor.tsx
@@ -1,0 +1,103 @@
+import {
+  BlockNoteSchema,
+  defaultBlockSpecs,
+  filterSuggestionItems,
+} from "@blocknote/core";
+import "@blocknote/core/fonts/inter.css";
+import {
+  getDefaultReactSlashMenuItems,
+  SuggestionMenuController,
+  useCreateBlockNote,
+} from "@blocknote/react";
+import { BlockNoteView } from "@blocknote/shadcn";
+import "@blocknote/shadcn/style.css";
+import {
+  contentBodySchema,
+  type ContentBody,
+} from "@percy-main/shared/content";
+
+// A deliberately narrow editor for member-facing bios. It keeps only the
+// default TEXT blocks: the media blocks (image/video/audio/file) are dropped
+// because they bypass the consent + EXIF-strip pipeline, and NONE of the
+// club widget blocks (person grids, league tables, game previews...) are
+// included - a member should not be inserting those into their own bio. The
+// big admin editor keeps its full schema untouched; this is a separate,
+// smaller one.
+const {
+  image: _image,
+  video: _video,
+  audio: _audio,
+  file: _file,
+  ...textBlockSpecs
+} = defaultBlockSpecs;
+
+export const bioSchema = BlockNoteSchema.create({ blockSpecs: textBlockSpecs });
+export type BioPartialBlock = typeof bioSchema.PartialBlock;
+
+const EDITABLE_BLOCK_TYPES = new Set(Object.keys(textBlockSpecs));
+
+/**
+ * True iff every block (recursively) is one this narrowed editor understands.
+ * A bio that already contains an advanced block (a club widget, an inline
+ * image) would lose that block if round-tripped through this editor, so the
+ * surface falls back to read-only for those rather than silently dropping
+ * content.
+ */
+export function bioIsEditable(body: unknown): boolean {
+  if (!Array.isArray(body)) return false;
+  const ok = (blocks: unknown[]): boolean =>
+    blocks.every((b) => {
+      if (typeof b !== "object" || b === null) return false;
+      const block = b as { type?: unknown; children?: unknown };
+      if (
+        typeof block.type !== "string" ||
+        !EDITABLE_BLOCK_TYPES.has(block.type)
+      ) {
+        return false;
+      }
+      if (Array.isArray(block.children) && block.children.length > 0) {
+        return ok(block.children);
+      }
+      return true;
+    });
+  return ok(body);
+}
+
+interface BioEditorProps {
+  initialContent: BioPartialBlock[] | undefined;
+  onChange: (body: ContentBody) => void;
+}
+
+export function BioEditor({ initialContent, onChange }: BioEditorProps) {
+  const editor = useCreateBlockNote({ schema: bioSchema, initialContent });
+
+  return (
+    <div className="bg-background rounded-md border">
+      <BlockNoteView
+        editor={editor}
+        slashMenu={false}
+        onChange={() => {
+          // Same serialise-then-validate path the admin editor uses, against
+          // the full recursive shared schema.
+          onChange(
+            contentBodySchema.parse(
+              JSON.parse(JSON.stringify(editor.document)),
+            ),
+          );
+        }}
+      >
+        <SuggestionMenuController
+          triggerCharacter="/"
+          getItems={(query) =>
+            Promise.resolve(
+              filterSuggestionItems(
+                getDefaultReactSlashMenuItems(editor),
+                query,
+              ),
+            )
+          }
+        />
+      </BlockNoteView>
+    </div>
+  );
+}

--- a/apps/web/src/components/profile/bio-editor.tsx
+++ b/apps/web/src/components/profile/bio-editor.tsx
@@ -72,9 +72,15 @@ export function BioEditor({ initialContent, onChange }: BioEditorProps) {
   const editor = useCreateBlockNote({ schema: bioSchema, initialContent });
 
   return (
-    <div className="bg-background rounded-md border">
+    // fc-theme on the canvas wrapper scopes the SAME First-Class content
+    // rules that style published profiles onto the editor, so the canvas IS
+    // the preview - matching the admin content editor (content-editor.tsx
+    // EditorPane). Without this the canvas falls back to BlockNote's default
+    // (generic serif headings) instead of the poster styling.
+    <div className="fc-theme bg-body rounded-lg border border-stone-200 py-4">
       <BlockNoteView
         editor={editor}
+        theme="light"
         slashMenu={false}
         onChange={() => {
           // Same serialise-then-validate path the admin editor uses, against

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -14491,6 +14491,116 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/profile/edit/photo-upload-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        contentType: "image/jpeg" | "image/png" | "image/webp" | "image/heic";
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            imageId: string;
+                            uploadUrl: string;
+                            pendingKey: string;
+                            maxBytes: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/profile/edit/photo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        imageId: string;
+                        pendingKey: string;
+                        /** @enum {boolean} */
+                        consentConfirmed: true;
+                        alt?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            picture: {
+                                sources: {
+                                    [key: string]: string;
+                                };
+                                img: {
+                                    src: string;
+                                    w: number;
+                                    h: number;
+                                };
+                            };
+                            alt: string | null;
+                            width: number;
+                            height: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/profile-proposals": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -14345,6 +14345,374 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/profile/edit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            profile: {
+                                contentId: string;
+                                slug: string;
+                                title: string;
+                                body: {
+                                    id: string;
+                                    type: string;
+                                    props: {
+                                        [key: string]: string | number | boolean;
+                                    };
+                                    content?: unknown;
+                                    children: unknown[];
+                                }[];
+                                photo: {
+                                    sources: {
+                                        [key: string]: string;
+                                    };
+                                    img: {
+                                        src: string;
+                                        w: number;
+                                        h: number;
+                                    };
+                                } | null;
+                            } | null;
+                            pendingProposal: {
+                                id: string;
+                                body: {
+                                    id: string;
+                                    type: string;
+                                    props: {
+                                        [key: string]: string | number | boolean;
+                                    };
+                                    content?: unknown;
+                                    children: unknown[];
+                                }[];
+                                photo: {
+                                    sources: {
+                                        [key: string]: string;
+                                    };
+                                    img: {
+                                        src: string;
+                                        w: number;
+                                        h: number;
+                                    };
+                                } | null;
+                                createdAt: string;
+                            } | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/profile/edit/proposals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        body: {
+                            id: string;
+                            type: string;
+                            props: {
+                                [key: string]: string | number | boolean;
+                            };
+                            content?: unknown;
+                            children: unknown[];
+                        }[];
+                        photo: {
+                            sources: {
+                                [key: string]: string;
+                            };
+                            img: {
+                                src: string;
+                                w: number;
+                                h: number;
+                            };
+                        } | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            status: "pending" | "approved" | "rejected";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/profile-proposals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                contentId: string;
+                                slug: string;
+                                title: string;
+                                proposedBy: string;
+                                proposedByName: string | null;
+                                createdAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/profile-proposals/{proposalId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    proposalId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            contentId: string;
+                            slug: string;
+                            title: string;
+                            /** @enum {string} */
+                            status: "pending" | "approved" | "rejected";
+                            proposedBy: string;
+                            proposedByName: string | null;
+                            createdAt: string;
+                            proposed: {
+                                body: {
+                                    id: string;
+                                    type: string;
+                                    props: {
+                                        [key: string]: string | number | boolean;
+                                    };
+                                    content?: unknown;
+                                    children: unknown[];
+                                }[];
+                                photo: {
+                                    sources: {
+                                        [key: string]: string;
+                                    };
+                                    img: {
+                                        src: string;
+                                        w: number;
+                                        h: number;
+                                    };
+                                } | null;
+                            };
+                            current: {
+                                body: {
+                                    id: string;
+                                    type: string;
+                                    props: {
+                                        [key: string]: string | number | boolean;
+                                    };
+                                    content?: unknown;
+                                    children: unknown[];
+                                }[];
+                                photo: {
+                                    sources: {
+                                        [key: string]: string;
+                                    };
+                                    img: {
+                                        src: string;
+                                        w: number;
+                                        h: number;
+                                    };
+                                } | null;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/profile-proposals/{proposalId}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    proposalId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            status: "pending" | "approved" | "rejected";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/profile-proposals/{proposalId}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    proposalId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        note?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            status: "pending" | "approved" | "rejected";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -25846,6 +25846,827 @@
           }
         }
       }
+    },
+    "/api/profile/edit": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "profile": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "contentId": {
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "props": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {},
+                              "children": {
+                                "type": "array",
+                                "items": {}
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "props",
+                              "children"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "photo": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "img": {
+                              "type": "object",
+                              "properties": {
+                                "src": {
+                                  "type": "string",
+                                  "pattern": "^(?:https:|\\/(?!\\/))"
+                                },
+                                "w": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                },
+                                "h": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "src",
+                                "w",
+                                "h"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "sources",
+                            "img"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "contentId",
+                        "slug",
+                        "title",
+                        "body",
+                        "photo"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "pendingProposal": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "props": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {},
+                              "children": {
+                                "type": "array",
+                                "items": {}
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "props",
+                              "children"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "photo": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "img": {
+                              "type": "object",
+                              "properties": {
+                                "src": {
+                                  "type": "string",
+                                  "pattern": "^(?:https:|\\/(?!\\/))"
+                                },
+                                "w": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                },
+                                "h": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "src",
+                                "w",
+                                "h"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "sources",
+                            "img"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "createdAt": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "body",
+                        "photo",
+                        "createdAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "profile",
+                    "pendingProposal"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/profile/edit/proposals": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "props": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {},
+                        "children": {
+                          "type": "array",
+                          "items": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "props",
+                        "children"
+                      ]
+                    }
+                  },
+                  "photo": {
+                    "nullable": true,
+                    "type": "object",
+                    "properties": {
+                      "sources": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "img": {
+                        "type": "object",
+                        "properties": {
+                          "src": {
+                            "type": "string",
+                            "pattern": "^(?:https:|\\/(?!\\/))"
+                          },
+                          "w": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991
+                          },
+                          "h": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": true,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "src",
+                          "w",
+                          "h"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "sources",
+                      "img"
+                    ]
+                  }
+                },
+                "required": [
+                  "body",
+                  "photo"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "approved",
+                        "rejected"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/profile-proposals": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "contentId": {
+                            "type": "string"
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "proposedBy": {
+                            "type": "string"
+                          },
+                          "proposedByName": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "contentId",
+                          "slug",
+                          "title",
+                          "proposedBy",
+                          "proposedByName",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/profile-proposals/{proposalId}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "proposalId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "contentId": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "approved",
+                        "rejected"
+                      ]
+                    },
+                    "proposedBy": {
+                      "type": "string"
+                    },
+                    "proposedByName": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "proposed": {
+                      "type": "object",
+                      "properties": {
+                        "body": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "props": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {},
+                              "children": {
+                                "type": "array",
+                                "items": {}
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "props",
+                              "children"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "photo": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "img": {
+                              "type": "object",
+                              "properties": {
+                                "src": {
+                                  "type": "string",
+                                  "pattern": "^(?:https:|\\/(?!\\/))"
+                                },
+                                "w": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                },
+                                "h": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "src",
+                                "w",
+                                "h"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "sources",
+                            "img"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "body",
+                        "photo"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "current": {
+                      "type": "object",
+                      "properties": {
+                        "body": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "props": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              "content": {},
+                              "children": {
+                                "type": "array",
+                                "items": {}
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "props",
+                              "children"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "photo": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "img": {
+                              "type": "object",
+                              "properties": {
+                                "src": {
+                                  "type": "string",
+                                  "pattern": "^(?:https:|\\/(?!\\/))"
+                                },
+                                "w": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                },
+                                "h": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "exclusiveMinimum": true,
+                                  "maximum": 9007199254740991
+                                }
+                              },
+                              "required": [
+                                "src",
+                                "w",
+                                "h"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "sources",
+                            "img"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "body",
+                        "photo"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "contentId",
+                    "slug",
+                    "title",
+                    "status",
+                    "proposedBy",
+                    "proposedByName",
+                    "createdAt",
+                    "proposed",
+                    "current"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/profile-proposals/{proposalId}/approve": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "proposalId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "approved",
+                        "rejected"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/profile-proposals/{proposalId}/reject": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "note": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+            },
+            "in": "path",
+            "name": "proposalId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "approved",
+                        "rejected"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -26226,6 +26226,198 @@
         }
       }
     },
+    "/api/profile/edit/photo-upload-url": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contentType": {
+                    "type": "string",
+                    "enum": [
+                      "image/jpeg",
+                      "image/png",
+                      "image/webp",
+                      "image/heic"
+                    ]
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "required": [
+                  "contentType",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "imageId": {
+                      "type": "string"
+                    },
+                    "uploadUrl": {
+                      "type": "string"
+                    },
+                    "pendingKey": {
+                      "type": "string"
+                    },
+                    "maxBytes": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "imageId",
+                    "uploadUrl",
+                    "pendingKey",
+                    "maxBytes"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/profile/edit/photo": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "imageId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "pendingKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "consentConfirmed": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  },
+                  "alt": {
+                    "nullable": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  }
+                },
+                "required": [
+                  "imageId",
+                  "pendingKey",
+                  "consentConfirmed"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "picture": {
+                      "type": "object",
+                      "properties": {
+                        "sources": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "img": {
+                          "type": "object",
+                          "properties": {
+                            "src": {
+                              "type": "string"
+                            },
+                            "w": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "h": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "src",
+                            "w",
+                            "h"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "sources",
+                        "img"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "alt": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "width": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "height": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "picture",
+                    "alt",
+                    "width",
+                    "height"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/profile-proposals": {
       "get": {
         "responses": {

--- a/apps/web/src/lib/profile-photo.ts
+++ b/apps/web/src/lib/profile-photo.ts
@@ -1,0 +1,68 @@
+import { api, callApi } from "@/lib/api-client.js";
+import type { paths } from "@/lib/api.gen.js";
+
+const UPLOADABLE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+] as const;
+
+type UploadableType = (typeof UPLOADABLE_TYPES)[number];
+
+function isUploadableType(type: string): type is UploadableType {
+  return (UPLOADABLE_TYPES as readonly string[]).includes(type);
+}
+
+// Derived from the generated OpenAPI types per house rule.
+export type UploadedProfilePhoto =
+  paths["/api/profile/edit/photo"]["post"]["responses"][200]["content"]["application/json"];
+
+/**
+ * Self-service profile photo upload: presign -> browser PUT of the original
+ * -> confirm (the API decodes, strips EXIF, builds the responsive ladder).
+ * Mirrors {@link uploadContentImage} but hits the profile-owner endpoints,
+ * which are gated on owning an editable profile rather than a content role.
+ */
+export async function uploadProfilePhoto(
+  file: File,
+): Promise<UploadedProfilePhoto> {
+  const contentType = file.type;
+  if (!isUploadableType(contentType)) {
+    throw new Error("Use a JPEG, PNG or WebP image");
+  }
+
+  const presigned = await callApi(
+    api.POST("/api/profile/edit/photo-upload-url", {
+      body: { contentType, consentConfirmed: true },
+    }),
+  );
+
+  if (file.size > presigned.maxBytes) {
+    throw new Error(
+      `Image is too large - maximum size is ${String(Math.floor(presigned.maxBytes / (1024 * 1024)))}MB`,
+    );
+  }
+
+  // Browser-direct PUT to S3: the one place a raw fetch is correct, the
+  // target is the presigned S3 URL rather than our API.
+  const putRes = await fetch(presigned.uploadUrl, {
+    method: "PUT",
+    body: file,
+    headers: { "content-type": file.type },
+  });
+  if (!putRes.ok) {
+    throw new Error("Upload failed - please try again");
+  }
+
+  return await callApi(
+    api.POST("/api/profile/edit/photo", {
+      body: {
+        imageId: presigned.imageId,
+        pendingKey: presigned.pendingKey,
+        consentConfirmed: true,
+        alt: null,
+      },
+    }),
+  );
+}

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -21,6 +21,7 @@ import { MarketingOutboxTab } from "./marketing-outbox-tab";
 import { MatchFeesTab } from "./match-fees-tab";
 import { MembersTab } from "./members-tab";
 import { PagesTab } from "./pages-tab";
+import { ProfileRequestsTab } from "./profile-requests-tab";
 import { RecordLinkingTab } from "./record-linking-tab";
 import { SponsorshipsTab } from "./sponsorships-tab";
 import { TreasurerTab } from "./treasurer-tab";
@@ -206,6 +207,15 @@ const SECTIONS: readonly SectionDef[] = [
         label: "Profiles",
         visible: (role) => checkPermission(role, "content_people", "view"),
         render: () => <ContentTab kind="person" />,
+      },
+      // Member-submitted profile edits awaiting review. Gated on publish
+      // (the approver action) so only editors who can apply the change see
+      // the queue.
+      {
+        value: "profile-requests",
+        label: "Profile Requests",
+        visible: (role) => checkPermission(role, "content_people", "publish"),
+        render: () => <ProfileRequestsTab />,
       },
     ],
   },

--- a/apps/web/src/pages/admin/profile-requests-tab.tsx
+++ b/apps/web/src/pages/admin/profile-requests-tab.tsx
@@ -1,0 +1,310 @@
+import { ContentBody } from "@/components/content-body.js";
+import { OptimisedImage } from "@/components/optimised-image.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
+import { Label } from "@/components/ui/label.js";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table.js";
+import { Textarea } from "@/components/ui/textarea.js";
+import { api, callApi } from "@/lib/api-client.js";
+import type { paths } from "@/lib/api.gen.js";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useSearchParams } from "react-router";
+
+type ProposalDetail =
+  paths["/api/admin/profile-proposals/{proposalId}"]["get"]["responses"][200]["content"]["application/json"];
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const listQueryKey = ["admin", "profile-proposals"] as const;
+
+export function ProfileRequestsTab() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestParam = searchParams.get("request");
+  const selectedId =
+    requestParam && UUID_RE.test(requestParam) ? requestParam : null;
+
+  const select = (id: string | null) => {
+    const params = new URLSearchParams(searchParams);
+    if (id === null) params.delete("request");
+    else params.set("request", id);
+    setSearchParams(params, { replace: false });
+  };
+
+  const {
+    data: listData,
+    isPending: listPending,
+    isError: listError,
+  } = useQuery({
+    queryKey: listQueryKey,
+    queryFn: () => callApi(api.GET("/api/admin/profile-proposals")),
+  });
+
+  if (selectedId) {
+    return <ReviewPanel proposalId={selectedId} onBack={() => select(null)} />;
+  }
+
+  if (listPending) return <p>Loading...</p>;
+  if (listError) {
+    return <p className="text-destructive">Couldn&apos;t load proposals.</p>;
+  }
+
+  const { items } = listData;
+
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-stone-600">
+        No profile edits are waiting for review.
+      </p>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Profile</TableHead>
+          <TableHead>Submitted by</TableHead>
+          <TableHead>Submitted</TableHead>
+          <TableHead className="text-right">Action</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {items.map((item) => (
+          <TableRow key={item.id}>
+            <TableCell className="font-medium">{item.title}</TableCell>
+            <TableCell>{item.proposedByName ?? "Unknown"}</TableCell>
+            <TableCell>
+              {new Date(item.createdAt).toLocaleDateString("en-GB")}
+            </TableCell>
+            <TableCell className="text-right">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => select(item.id)}
+              >
+                Review
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function ReviewPanel({
+  proposalId,
+  onBack,
+}: {
+  proposalId: string;
+  onBack: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [note, setNote] = useState("");
+
+  const {
+    data: detail,
+    isPending: detailPending,
+    isError: detailError,
+  } = useQuery({
+    queryKey: ["admin", "profile-proposals", proposalId],
+    queryFn: () =>
+      callApi(
+        api.GET("/api/admin/profile-proposals/{proposalId}", {
+          params: { path: { proposalId } },
+        }),
+      ),
+  });
+
+  const approve = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/admin/profile-proposals/{proposalId}/approve", {
+          params: { path: { proposalId } },
+        }),
+      ),
+    onSuccess: () => {
+      // The queue and (because approve applies the edit) the live public
+      // profile both change.
+      void queryClient.invalidateQueries({ queryKey: listQueryKey });
+      void queryClient.invalidateQueries({ queryKey: ["content"] });
+      onBack();
+    },
+  });
+
+  const reject = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/admin/profile-proposals/{proposalId}/reject", {
+          params: { path: { proposalId } },
+          body: { note: note.trim() === "" ? undefined : note.trim() },
+        }),
+      ),
+    onSuccess: () => {
+      setRejectOpen(false);
+      void queryClient.invalidateQueries({ queryKey: listQueryKey });
+      onBack();
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          &larr; Back to queue
+        </Button>
+      </div>
+
+      {detailPending ? (
+        <p>Loading...</p>
+      ) : detailError ? (
+        <p className="text-destructive">Couldn&apos;t load this proposal.</p>
+      ) : (
+        <Review detail={detail} />
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button
+          onClick={() => approve.mutate()}
+          disabled={
+            approve.isPending || detailPending || detail?.status !== "pending"
+          }
+        >
+          {approve.isPending ? "Approving..." : "Approve"}
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => setRejectOpen(true)}
+          disabled={detail?.status !== "pending"}
+        >
+          Reject
+        </Button>
+      </div>
+
+      {approve.isError ? (
+        <p className="text-destructive text-sm">
+          {approve.error instanceof Error
+            ? approve.error.message
+            : "Couldn't approve this proposal."}
+        </p>
+      ) : null}
+
+      <Dialog open={rejectOpen} onOpenChange={setRejectOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reject this edit</DialogTitle>
+            <DialogDescription>
+              The member is emailed when you reject. Add an optional note
+              explaining why so they can put it right.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="reject-note">Note (optional)</Label>
+            <Textarea
+              id="reject-note"
+              value={note}
+              maxLength={2000}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="e.g. Please keep the bio under 100 words."
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRejectOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => reject.mutate()}
+              disabled={reject.isPending}
+            >
+              {reject.isPending ? "Rejecting..." : "Reject edit"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function Review({ detail }: { detail: ProposalDetail }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h3 className="text-lg font-semibold">{detail.title}</h3>
+        <p className="text-sm text-stone-600">
+          Proposed by {detail.proposedByName ?? "Unknown"} on{" "}
+          {new Date(detail.createdAt).toLocaleDateString("en-GB")}
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <ProfileColumn
+          heading="Current (live)"
+          body={detail.current.body}
+          photo={detail.current.photo}
+          name={detail.title}
+        />
+        <ProfileColumn
+          heading="Proposed"
+          body={detail.proposed.body}
+          photo={detail.proposed.photo}
+          name={detail.title}
+          highlight
+        />
+      </div>
+    </div>
+  );
+}
+
+function ProfileColumn({
+  heading,
+  body,
+  photo,
+  name,
+  highlight,
+}: {
+  heading: string;
+  body: ProposalDetail["current"]["body"];
+  photo: ProposalDetail["current"]["photo"];
+  name: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-md border p-4 ${highlight ? "border-stone-800" : ""}`}
+    >
+      <p className="mb-3 text-sm font-medium tracking-wide text-stone-500 uppercase">
+        {heading}
+      </p>
+      {photo ? (
+        <OptimisedImage
+          picture={photo}
+          alt={name}
+          className="mb-4 h-32 w-32 rounded-full object-cover"
+          width={128}
+          height={128}
+        />
+      ) : (
+        <p className="mb-4 text-sm text-stone-500">No photo</p>
+      )}
+      <ContentBody body={body} />
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin/profile-requests-tab.tsx
+++ b/apps/web/src/pages/admin/profile-requests-tab.tsx
@@ -287,8 +287,10 @@ function ProfileColumn({
   highlight?: boolean;
 }) {
   return (
+    // fc-theme so the bio renders in the same poster styling the live profile
+    // uses - the reviewer compares like-for-like with the published look.
     <div
-      className={`rounded-md border p-4 ${highlight ? "border-stone-800" : ""}`}
+      className={`fc-theme bg-body rounded-md border p-4 ${highlight ? "border-stone-800" : ""}`}
     >
       <p className="mb-3 text-sm font-medium tracking-wide text-stone-500 uppercase">
         {heading}

--- a/apps/web/src/pages/members/members-dashboard.tsx
+++ b/apps/web/src/pages/members/members-dashboard.tsx
@@ -60,6 +60,14 @@ export function Component() {
   const hasAdminAccess = useHasAdminPanelAccess();
   const hasJuniorAccess = useHasPermission("juniors", "view").allowed;
 
+  // Only members whose account is slug-linked to a player profile have
+  // something to edit; the link is hidden otherwise.
+  const { data: profileEditState } = useQuery({
+    queryKey: ["profile", "edit"],
+    queryFn: () => callApi(api.GET("/api/profile/edit")),
+  });
+  const hasEditableProfile = profileEditState?.profile != null;
+
   if (!session) return null;
 
   const { user } = session;
@@ -105,6 +113,14 @@ export function Component() {
             >
               Fantasy Cricket
             </Link>
+            {hasEditableProfile && (
+              <Link
+                className="rounded border border-stone-800 px-3 py-1.5 text-sm text-stone-900 hover:bg-stone-200"
+                to="/members/profile"
+              >
+                Edit my profile
+              </Link>
+            )}
             <ScoutLink />
             <Link
               className="rounded border border-stone-800 px-3 py-1.5 text-sm text-stone-900 hover:bg-stone-200"

--- a/apps/web/src/pages/members/profile-edit.tsx
+++ b/apps/web/src/pages/members/profile-edit.tsx
@@ -124,7 +124,7 @@ function PendingNotice({
         ) : null}
         <div>
           <p className="mb-2 text-sm font-medium">Proposed bio</p>
-          <div className="rounded-md border p-4">
+          <div className="fc-theme bg-body rounded-md border p-4">
             <ContentBody body={proposal.body} />
           </div>
         </div>
@@ -142,6 +142,12 @@ function EditForm({ profile }: { profile: NonNullable<EditState["profile"]> }) {
   // component is keyed on the profile so it remounts if the profile changes.
   const [body, setBody] = useState<SubmitBody>(() => profile.body);
   const [photo, setPhoto] = useState<ProfilePhoto>(() => profile.photo);
+  // Photo consent gates SUBMIT (not the upload button). It is only relevant
+  // when the submission includes a photo.
+  const [consent, setConsent] = useState(false);
+  const [consentError, setConsentError] = useState(false);
+
+  const needsConsent = photo != null;
 
   const submit = useMutation({
     mutationFn: () =>
@@ -153,6 +159,25 @@ function EditForm({ profile }: { profile: NonNullable<EditState["profile"]> }) {
     },
   });
 
+  const onSubmit = () => {
+    if (needsConsent && !consent) {
+      setConsentError(true);
+      return;
+    }
+    setConsentError(false);
+    submit.mutate();
+  };
+
+  // Changing the photo or ticking consent clears a previous consent error.
+  const onPhotoChange = (next: ProfilePhoto) => {
+    setPhoto(next);
+    setConsentError(false);
+  };
+  const onConsentChange = (next: boolean) => {
+    setConsent(next);
+    if (next) setConsentError(false);
+  };
+
   return (
     <div className="flex flex-col gap-6">
       <Card>
@@ -160,7 +185,14 @@ function EditForm({ profile }: { profile: NonNullable<EditState["profile"]> }) {
           <CardTitle>Photo</CardTitle>
         </CardHeader>
         <CardContent>
-          <PhotoField photo={photo} name={profile.title} onChange={setPhoto} />
+          <PhotoField
+            photo={photo}
+            name={profile.title}
+            onChange={onPhotoChange}
+            consent={consent}
+            onConsentChange={onConsentChange}
+            consentError={consentError}
+          />
         </CardContent>
       </Card>
 
@@ -184,13 +216,20 @@ function EditForm({ profile }: { profile: NonNullable<EditState["profile"]> }) {
                 Your bio contains advanced content that can only be edited by a
                 content editor. You can still update your photo here.
               </p>
-              <div className="rounded-md border p-4">
+              <div className="fc-theme bg-body rounded-md border p-4">
                 <ContentBody body={profile.body} />
               </div>
             </div>
           )}
         </CardContent>
       </Card>
+
+      {consentError ? (
+        <p className="text-destructive text-sm">
+          Please tick the box confirming you have permission to use your photo
+          before submitting.
+        </p>
+      ) : null}
 
       {submit.isError ? (
         <p className="text-destructive text-sm">
@@ -202,7 +241,7 @@ function EditForm({ profile }: { profile: NonNullable<EditState["profile"]> }) {
 
       <div className="flex items-center gap-3">
         <Button
-          onClick={() => submit.mutate()}
+          onClick={onSubmit}
           disabled={submit.isPending || submit.isSuccess}
         >
           {submit.isPending ? "Submitting..." : "Submit for review"}
@@ -219,13 +258,18 @@ function PhotoField({
   photo,
   name,
   onChange,
+  consent,
+  onConsentChange,
+  consentError,
 }: {
   photo: ProfilePhoto;
   name: string;
   onChange: (photo: ProfilePhoto) => void;
+  consent: boolean;
+  onConsentChange: (consent: boolean) => void;
+  consentError: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [consent, setConsent] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
 
@@ -266,7 +310,7 @@ function PhotoField({
           <Button
             type="button"
             variant="outline"
-            disabled={!consent || uploading}
+            disabled={uploading}
             onClick={() => inputRef.current?.click()}
           >
             {uploading ? "Uploading..." : photo ? "Replace photo" : "Add photo"}
@@ -284,20 +328,29 @@ function PhotoField({
         </div>
       </div>
 
-      <div className="flex items-start gap-2">
-        <Checkbox
-          id="profile-photo-consent"
-          checked={consent}
-          onCheckedChange={(v) => setConsent(v === true)}
-        />
-        <Label
-          htmlFor="profile-photo-consent"
-          className="text-sm font-normal text-stone-600"
-        >
-          I confirm I have permission to use this photo and consent to it being
-          shown on the club website.
-        </Label>
-      </div>
+      {/* Consent only applies when a photo is part of the submission. It no
+          longer gates the upload button - it gates Submit (handled by the
+          parent), with a clear error there if it's missing. */}
+      {photo ? (
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="profile-photo-consent"
+            checked={consent}
+            onCheckedChange={(v) => onConsentChange(v === true)}
+          />
+          <Label
+            htmlFor="profile-photo-consent"
+            className={
+              consentError
+                ? "text-destructive text-sm font-normal"
+                : "text-sm font-normal text-stone-600"
+            }
+          >
+            I confirm I have permission to use this photo and consent to it
+            being shown on the club website.
+          </Label>
+        </div>
+      ) : null}
       <Label className="sr-only" htmlFor="profile-photo-input">
         Profile photo
       </Label>

--- a/apps/web/src/pages/members/profile-edit.tsx
+++ b/apps/web/src/pages/members/profile-edit.tsx
@@ -1,0 +1,317 @@
+import { ContentBody } from "@/components/content-body.js";
+import { OptimisedImage } from "@/components/optimised-image.js";
+import { PageLoading } from "@/components/page-loading.js";
+import {
+  BioEditor,
+  bioIsEditable,
+  type BioPartialBlock,
+} from "@/components/profile/bio-editor.js";
+import { Button } from "@/components/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.js";
+import { Checkbox } from "@/components/ui/checkbox.js";
+import { Label } from "@/components/ui/label.js";
+import { useDocumentMeta } from "@/hooks/use-document-meta.js";
+import { api, callApi } from "@/lib/api-client.js";
+import type { paths } from "@/lib/api.gen.js";
+import { uploadProfilePhoto } from "@/lib/profile-photo.js";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import { Link } from "react-router";
+
+type EditState =
+  paths["/api/profile/edit"]["get"]["responses"][200]["content"]["application/json"];
+type SubmitBody =
+  paths["/api/profile/edit/proposals"]["post"]["requestBody"]["content"]["application/json"]["body"];
+type ProfilePhoto = NonNullable<EditState["profile"]>["photo"];
+
+const profileEditQueryKey = ["profile", "edit"] as const;
+
+export function Component() {
+  useDocumentMeta("Edit my profile");
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: profileEditQueryKey,
+    queryFn: () => callApi(api.GET("/api/profile/edit")),
+  });
+
+  if (isPending) return <PageLoading />;
+
+  if (isError) {
+    return (
+      <Shell>
+        <p className="text-destructive">
+          We couldn&apos;t load your profile. Please try again later.
+        </p>
+      </Shell>
+    );
+  }
+
+  if (!data.profile) {
+    return (
+      <Shell>
+        <Card>
+          <CardContent className="py-6">
+            <p>
+              Your account isn&apos;t linked to a player profile, so
+              there&apos;s nothing to edit here. If you think you should have a
+              profile, please <Link to="/members">contact a club admin</Link>.
+            </p>
+          </CardContent>
+        </Card>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      {data.pendingProposal ? (
+        <PendingNotice proposal={data.pendingProposal} />
+      ) : (
+        <EditForm key={data.profile.contentId} profile={data.profile} />
+      )}
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8">
+      <div className="mb-6 flex flex-col gap-1">
+        <h1>Edit my profile</h1>
+        <p className="text-sm text-stone-600">
+          Update your bio and photo. Changes are reviewed by a content editor
+          before they go live on your public profile.
+        </p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function PendingNotice({
+  proposal,
+}: {
+  proposal: NonNullable<EditState["pendingProposal"]>;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Your edit is awaiting review</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <p className="text-sm text-stone-600">
+          You submitted this on{" "}
+          {new Date(proposal.createdAt).toLocaleDateString("en-GB")}. A content
+          editor will approve or reject it, and you&apos;ll get an email either
+          way. You can submit another change once this one has been reviewed.
+        </p>
+        {proposal.photo ? (
+          <div>
+            <p className="mb-2 text-sm font-medium">Proposed photo</p>
+            <OptimisedImage
+              picture={proposal.photo}
+              alt="Proposed profile photo"
+              className="h-32 w-32 rounded-full object-cover"
+              width={128}
+              height={128}
+            />
+          </div>
+        ) : null}
+        <div>
+          <p className="mb-2 text-sm font-medium">Proposed bio</p>
+          <div className="rounded-md border p-4">
+            <ContentBody body={proposal.body} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function EditForm({ profile }: { profile: NonNullable<EditState["profile"]> }) {
+  const queryClient = useQueryClient();
+  const editable = bioIsEditable(profile.body);
+  // The latest bio to submit: the edited document when the bio is editable,
+  // otherwise the unchanged original (a photo-only change still re-submits
+  // the existing bio, which approval simply re-applies). Seeded once - the
+  // component is keyed on the profile so it remounts if the profile changes.
+  const [body, setBody] = useState<SubmitBody>(() => profile.body);
+  const [photo, setPhoto] = useState<ProfilePhoto>(() => profile.photo);
+
+  const submit = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/profile/edit/proposals", { body: { body, photo } }),
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: profileEditQueryKey });
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Photo</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PhotoField photo={photo} name={profile.title} onChange={setPhoto} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Bio</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {editable ? (
+            <BioEditor
+              initialContent={
+                profile.body.length > 0
+                  ? (profile.body as BioPartialBlock[])
+                  : undefined
+              }
+              onChange={setBody}
+            />
+          ) : (
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-stone-600">
+                Your bio contains advanced content that can only be edited by a
+                content editor. You can still update your photo here.
+              </p>
+              <div className="rounded-md border p-4">
+                <ContentBody body={profile.body} />
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {submit.isError ? (
+        <p className="text-destructive text-sm">
+          {submit.error instanceof Error
+            ? submit.error.message
+            : "Something went wrong submitting your change."}
+        </p>
+      ) : null}
+
+      <div className="flex items-center gap-3">
+        <Button
+          onClick={() => submit.mutate()}
+          disabled={submit.isPending || submit.isSuccess}
+        >
+          {submit.isPending ? "Submitting..." : "Submit for review"}
+        </Button>
+        <Link to="/members" className="text-sm text-stone-600">
+          Cancel
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function PhotoField({
+  photo,
+  name,
+  onChange,
+}: {
+  photo: ProfilePhoto;
+  name: string;
+  onChange: (photo: ProfilePhoto) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [consent, setConsent] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const onPick = async (file: File | undefined) => {
+    if (!file) return;
+    setUploadError(null);
+    setUploading(true);
+    try {
+      const uploaded = await uploadProfilePhoto(file);
+      onChange(uploaded.picture);
+    } catch (err) {
+      setUploadError(
+        err instanceof Error ? err.message : "Upload failed - please try again",
+      );
+    } finally {
+      setUploading(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-4">
+        {photo ? (
+          <OptimisedImage
+            picture={photo}
+            alt={name}
+            className="h-32 w-32 rounded-full object-cover"
+            width={128}
+            height={128}
+          />
+        ) : (
+          <div className="flex h-32 w-32 items-center justify-center rounded-full bg-stone-100 text-sm text-stone-500">
+            No photo
+          </div>
+        )}
+        <div className="flex flex-col gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!consent || uploading}
+            onClick={() => inputRef.current?.click()}
+          >
+            {uploading ? "Uploading..." : photo ? "Replace photo" : "Add photo"}
+          </Button>
+          {photo ? (
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={uploading}
+              onClick={() => onChange(null)}
+            >
+              Remove photo
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex items-start gap-2">
+        <Checkbox
+          id="profile-photo-consent"
+          checked={consent}
+          onCheckedChange={(v) => setConsent(v === true)}
+        />
+        <Label
+          htmlFor="profile-photo-consent"
+          className="text-sm font-normal text-stone-600"
+        >
+          I confirm I have permission to use this photo and consent to it being
+          shown on the club website.
+        </Label>
+      </div>
+      <Label className="sr-only" htmlFor="profile-photo-input">
+        Profile photo
+      </Label>
+      <input
+        id="profile-photo-input"
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/heic"
+        className="hidden"
+        onChange={(e) => void onPick(e.target.files?.[0])}
+      />
+      {uploadError ? (
+        <p className="text-destructive text-sm">{uploadError}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -170,6 +170,10 @@ export const router = createBrowserRouter([
                 lazy: () => import("./pages/members/members-dashboard.js"),
               },
               {
+                path: "members/profile",
+                lazy: () => import("./pages/members/profile-edit.js"),
+              },
+              {
                 path: "members/fantasy",
                 lazy: () => import("./pages/members/members-fantasy.js"),
               },

--- a/docs/adrs/050-profile-self-edit-proposal-tier.md
+++ b/docs/adrs/050-profile-self-edit-proposal-tier.md
@@ -1,0 +1,114 @@
+# Decision 050: Profile Self-Editing via a Proposal/Approval Tier
+
+**Date:** 2026-06-23
+**Status:** Accepted
+
+## Decision
+
+Members may edit their own person profile, but their edits do **not** publish
+directly. A slug-linked member submits a **proposal** (a `content_proposal`
+row) carrying only the self-editable slice of their profile - the bio (body)
+and the photo. The proposal is invisible to the public and to the live profile
+until a `content_people:publish` editor **approves** it, at which point it
+wholesale-replaces the live profile's body/metadata and writes a
+`content_revision` exactly like any other save. Editors may instead **reject**
+it with an optional note. This is the first use of the review tier the content
+permission model deliberately reserved (#479) by keeping `manage` and `publish`
+distinct on the content resources.
+
+Eligibility is derived, not granted: a member is eligible iff their `member`
+row is slug-linked to a person `content_item` (`member.slug = content_item.slug`
+where `kind = 'person'`). That link already exists and is set by an admin in
+the Record Linking tab. No new link table, opt-in flag, or role is introduced.
+
+## Problem
+
+Issue #575 wants members to keep their own profiles current without giving them
+access to the admin content editor. Two properties are non-negotiable:
+
+1. **A profile is safeguarding-adjacent.** `isDBSChecked` and `hasLeftClub` are
+   public flags parents rely on, and the display name (title) and slug feed the
+   public roster and URLs. A member must never be able to change those, only
+   their bio and photo.
+2. **Edits must be reviewed before going live.** The existing publish path is
+   direct (single body, no staged drafts), so letting members write to it would
+   put unreviewed text on a public profile instantly.
+
+## Options considered
+
+### Proposal table + approval tier (chosen)
+
+A dedicated `content_proposal` table stores the proposed body + a photo-only
+metadata subset, with a `pending/approved/rejected` status and reviewer
+columns (mirroring the `matchday_expense` approval precedent). A partial unique
+index enforces one pending proposal per profile. Approval merges only the photo
+onto the live metadata, leaving the safeguarding flags untouched, and snapshots
+a revision through the shared `writeRevision` helper.
+
+- **The field subset is enforced structurally, not by trust.** The submit
+  schema accepts only `{ body, photo }`; title/slug/flags cannot be expressed,
+  so even a hand-crafted request cannot touch them. Approval re-derives the new
+  metadata from the live row's flags, never from the proposal.
+- **Review is a first-class state, not a flag bolted onto the live row.** The
+  live profile is never in a half-edited state; a pending proposal sits beside
+  it and either replaces it atomically or is discarded.
+- **Reuses everything.** Eligibility falls out of the existing member↔slug
+  link; approval reuses the content service's revision snapshotting; the
+  reviewer pool is resolved with the same `checkPermission`-over-elevated-users
+  pattern as the Scout share list.
+
+### Direct write to the live profile, gated by a new self-edit permission (rejected)
+
+Give eligible members a narrow write to their own `content_item` body/photo.
+
+Rejected: it violates property 2 (edits go live unreviewed), and a per-row
+ownership check on the live table is easy to get subtly wrong in a way that
+exposes the safeguarding flags or another member's row. The whole point of
+#575's brief was that changes "must be approved by a content editor before
+going live."
+
+### A new link table mapping users to editable profiles (rejected)
+
+The original triage assumed the user↔profile link did not exist.
+
+Rejected: it already does (`user` → `member` by email → `member.slug` → person
+`content_item`). A second mapping would be a redundant source of truth that
+could drift from the Record Linking tab.
+
+## Rationale
+
+The permission model already carved out `manage` vs `publish` on
+`content_people` precisely so a review tier could be added "without a data
+migration" to the permissions. #575 is that tier, so the approver gate is the
+existing `content_people:publish` action - no new role. The proposal table is
+the only new storage, and it is additive.
+
+Concurrency and safety choices, explicitly:
+
+- **One open proposal per profile.** A partial unique index
+  (`status = 'pending'`) is the backstop; the service raises a friendly 409
+  before hitting it. Approved/rejected rows are historical and excluded, so a
+  member can submit again once their last proposal is resolved.
+- **Approve/reject flip the status with a guarded `WHERE status = 'pending'`
+  UPDATE inside the transaction**, so two editors racing the same proposal
+  resolve to one winner and a 409 for the loser - the same pattern as the
+  content publish path.
+- **Notifications are best-effort.** On submit, every `content_people:publish`
+  editor except the proposer is emailed; on decision, the proposer is emailed
+  (rejections carry the note). A mail failure is logged and never rolls back
+  the committed proposal/decision, matching the matchday and financial-relief
+  notifiers.
+- **Photo removal is expressible** (`photo: null`) because the owner controls
+  their own photo; the safeguarding flags are simply never part of the
+  proposal payload.
+
+## Rejected alternatives
+
+- **Direct gated write to the live profile** - rejected: unreviewed edits go
+  live, contradicting the issue's core requirement.
+- **A user→profile link table** - rejected: duplicates the existing
+  member-slug link and invites drift.
+- **A generic content-approval workflow across all kinds** - deferred: only
+  person self-editing needs review today. The `content_proposal` table is
+  scoped to that; generalising it (other kinds, multi-field proposals) can
+  build on the same shape if a need appears, without retrofitting it now.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -27,3 +27,5 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 | [046](046-vapid-public-key-via-api.md)                   | VAPID public key delivered via API, not bundled             | 2026-05-21 | Accepted |
 | [047](047-content-editor-blocknote.md)                   | Content Editor - BlockNote with JSON canonical format       | 2026-06-10 | Accepted |
 | [048](048-editor-image-webp-only-sync-processing.md)     | Editor images - WebP-only ladder, synchronous processing    | 2026-06-10 | Accepted |
+| [049](049-ai-content-author-assistant.md)                | AI content-author assistant reuses Scout's tools            | 2026-06-14 | Accepted |
+| [050](050-profile-self-edit-proposal-tier.md)            | Profile self-editing via a proposal/approval tier           | 2026-06-23 | Accepted |

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -206,6 +206,20 @@ export interface ContentItem {
   updated_by: string;
 }
 
+export interface ContentProposal {
+  content_id: string;
+  created_at: Generated<Timestamp>;
+  decision_note: string | null;
+  id: Generated<string>;
+  proposed_body: Json;
+  proposed_by: string;
+  proposed_metadata: Generated<Json>;
+  reviewed_at: Timestamp | null;
+  reviewed_by: string | null;
+  status: Generated<string>;
+  updated_at: Generated<Timestamp>;
+}
+
 export interface ContentRevision {
   body: Json;
   content_id: string;
@@ -1040,6 +1054,7 @@ export interface DB {
   contact_submission: ContactSubmission;
   content_image: ContentImage;
   content_item: ContentItem;
+  content_proposal: ContentProposal;
   content_revision: ContentRevision;
   dependent: Dependent;
   document: Document;

--- a/packages/db/src/migrations/2026-06-23T10:15:00.000Z.ts
+++ b/packages/db/src/migrations/2026-06-23T10:15:00.000Z.ts
@@ -1,0 +1,81 @@
+import { type Kysely, sql } from "kysely";
+
+// Profile self-editing review tier (#575).
+//
+// A club member whose `member` row is slug-linked to their person
+// `content_item` may propose edits to their own profile (bio body + photo
+// only). The edit is NOT applied directly: it lands here as a
+// content_proposal awaiting review. A content_people:publish editor then
+// approves (wholesale-replacing the person item's body/metadata and writing
+// a content_revision) or rejects (with an optional decision_note). This is
+// the "review tier" the content permission model deliberately reserved by
+// keeping manage and publish distinct (packages/shared auth/permissions.ts).
+//
+// Only the bio (body) and photo are self-editable; title/slug and the
+// safeguarding flags (isDBSChecked / hasLeftClub) stay admin-only, so the
+// proposal stores just the proposed body and a photo-only metadata subset.
+// proposed_metadata is `{}` or `{ "photo": ... }`; approval merges the photo
+// onto the live metadata, leaving the safeguarding flags untouched.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("content_proposal")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    // The person content_item this proposal edits. No ON DELETE CASCADE:
+    // content_item is never hard-deleted (archive instead), matching the
+    // content_revision foreign key.
+    .addColumn("content_id", "uuid", (col) =>
+      col.notNull().references("content_item.id"),
+    )
+    .addColumn("proposed_body", "jsonb", (col) => col.notNull())
+    // Photo-only metadata subset ({} or { photo }); approval merges it onto
+    // the live person metadata so the safeguarding flags are never touched.
+    .addColumn("proposed_metadata", "jsonb", (col) =>
+      col.notNull().defaultTo(sql`'{}'::jsonb`),
+    )
+    .addColumn("proposed_by", "text", (col) =>
+      col.notNull().references("user.id"),
+    )
+    .addColumn("status", "text", (col) => col.notNull().defaultTo("pending"))
+    // Reviewer columns mirror the matchday_expense approval precedent: null
+    // until a content_people:publish editor decides.
+    .addColumn("reviewed_by", "text", (col) => col.references("user.id"))
+    .addColumn("reviewed_at", "timestamptz")
+    // Carried back to the proposer on rejection (the "why").
+    .addColumn("decision_note", "text")
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addCheckConstraint(
+      "content_proposal_status_check",
+      sql`status IN ('pending','approved','rejected')`,
+    )
+    .execute();
+
+  // One open proposal per profile at a time: block a second submission while
+  // one is still pending. Approved/rejected rows are historical and excluded
+  // by the partial predicate, so a member can submit again once reviewed.
+  await db.schema
+    .createIndex("content_proposal_one_pending_per_content")
+    .on("content_proposal")
+    .column("content_id")
+    .unique()
+    .where(sql.ref("status"), "=", sql.lit("pending"))
+    .execute();
+
+  // The review queue lists pending proposals oldest-first.
+  await db.schema
+    .createIndex("content_proposal_status_created_at_idx")
+    .on("content_proposal")
+    .columns(["status", "created_at"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("content_proposal").execute();
+}

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -11,6 +11,8 @@ export { MembershipUpdated } from "./templates/MembershipUpdated.tsx";
 export { PaymentReminder } from "./templates/PaymentReminder.tsx";
 export { PlayerSponsorshipConfirmation } from "./templates/PlayerSponsorshipConfirmation.tsx";
 export { PlayerWithdrawal } from "./templates/PlayerWithdrawal.tsx";
+export { ProfileEditDecision } from "./templates/ProfileEditDecision.tsx";
+export { ProfileEditProposalSubmitted } from "./templates/ProfileEditProposalSubmitted.tsx";
 export { ResetPassword } from "./templates/ResetPassword.tsx";
 export { SponsorshipConfirmation } from "./templates/SponsorshipConfirmation.tsx";
 export { VerifyEmail } from "./templates/VerifyEmail.tsx";

--- a/packages/email/src/templates/ProfileEditDecision.tsx
+++ b/packages/email/src/templates/ProfileEditDecision.tsx
@@ -1,0 +1,105 @@
+// organize-imports-ignore — React must stay: tsx/esbuild uses classic JSX transform for workspace deps
+import React, { type FC } from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Text,
+} from "react-email";
+import { email } from "../email.ts";
+import * as styles from "../styles.ts";
+
+interface Props {
+  imageBaseUrl: string;
+  recipientName: string;
+  profileName: string;
+  outcome: "approved" | "rejected";
+  decisionNote: string | null;
+  profileUrl: string;
+}
+
+const Component: FC<Props> = ({
+  imageBaseUrl,
+  recipientName,
+  profileName,
+  outcome,
+  decisionNote,
+  profileUrl,
+}) => (
+  <Html>
+    <Head />
+    <Preview>An update on your profile edit</Preview>
+    <Body style={styles.main}>
+      <Container style={styles.container}>
+        <Img
+          src={`${imageBaseUrl}/club_logo.png`}
+          width="100"
+          height="100"
+          alt="Percy Main Club Logo"
+          style={styles.logo}
+        />
+        <Text style={styles.paragraph}>Hi {recipientName},</Text>
+        {outcome === "approved" ? (
+          <>
+            <Text style={styles.paragraph}>
+              Good news: the edit you proposed to your profile has been approved
+              and is now live.
+            </Text>
+            <Section style={styles.btnContainer}>
+              <Button style={styles.button} href={profileUrl}>
+                View your profile
+              </Button>
+            </Section>
+          </>
+        ) : (
+          <Text style={styles.paragraph}>
+            Thank you for proposing an edit to your profile. After review, a
+            content editor was not able to publish this change.
+          </Text>
+        )}
+        {decisionNote ? (
+          <Text style={styles.paragraph}>
+            <strong>Note from the reviewer:</strong> {decisionNote}
+          </Text>
+        ) : null}
+        {outcome === "rejected" ? (
+          <Text style={styles.paragraph}>
+            You can make further changes and submit your profile {profileName}{" "}
+            for review again at any time.
+          </Text>
+        ) : null}
+        <Text style={styles.paragraph}>
+          Best,
+          <br />
+          Percy Main CC
+        </Text>
+        <Hr style={styles.hr} />
+        <Text style={styles.footer}>
+          Percy Main Cricket Club, St. Johns Terrace, North Shields, NE29 6HS
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export const ProfileEditDecision = email<Props>(
+  "An update on your profile edit",
+  {
+    preview: {
+      imageBaseUrl: "http://localhost:5173/images",
+      recipientName: "John Doe",
+      profileName: "John Doe",
+      outcome: "approved",
+      decisionNote: null,
+      profileUrl: "http://localhost:5173/person/john-doe",
+    },
+  },
+)(Component);
+
+export default Component;

--- a/packages/email/src/templates/ProfileEditProposalSubmitted.tsx
+++ b/packages/email/src/templates/ProfileEditProposalSubmitted.tsx
@@ -1,0 +1,83 @@
+// organize-imports-ignore — React must stay: tsx/esbuild uses classic JSX transform for workspace deps
+import React, { type FC } from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Text,
+} from "react-email";
+import { email } from "../email.ts";
+import * as styles from "../styles.ts";
+
+interface Props {
+  imageBaseUrl: string;
+  recipientName: string;
+  profileName: string;
+  reviewUrl: string;
+}
+
+const Component: FC<Props> = ({
+  imageBaseUrl,
+  recipientName,
+  profileName,
+  reviewUrl,
+}) => (
+  <Html>
+    <Head />
+    <Preview>A profile edit is waiting for your review</Preview>
+    <Body style={styles.main}>
+      <Container style={styles.container}>
+        <Img
+          src={`${imageBaseUrl}/club_logo.png`}
+          width="100"
+          height="100"
+          alt="Percy Main Club Logo"
+          style={styles.logo}
+        />
+        <Text style={styles.paragraph}>Hi {recipientName},</Text>
+        <Text style={styles.paragraph}>
+          {profileName} has proposed an edit to their own profile. It will not
+          go live until a content editor approves it.
+        </Text>
+        <Text style={styles.paragraph}>
+          Open the admin panel and go to Content, then Profile Requests, to
+          review and approve or reject the change.
+        </Text>
+        <Section style={styles.btnContainer}>
+          <Button style={styles.button} href={reviewUrl}>
+            Review profile edits
+          </Button>
+        </Section>
+        <Text style={styles.paragraph}>
+          Best,
+          <br />
+          Percy Main CC
+        </Text>
+        <Hr style={styles.hr} />
+        <Text style={styles.footer}>
+          Percy Main Cricket Club, St. Johns Terrace, North Shields, NE29 6HS
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export const ProfileEditProposalSubmitted = email<Props>(
+  "A profile edit is waiting for your review",
+  {
+    preview: {
+      imageBaseUrl: "http://localhost:5173/images",
+      recipientName: "Jane Smith",
+      profileName: "John Doe",
+      reviewUrl: "http://localhost:5173/admin",
+    },
+  },
+)(Component);
+
+export default Component;

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -287,6 +287,38 @@ export const CONTENT_METADATA_SCHEMAS: Partial<
   person: personMetadataSchema,
 };
 
+// ── Profile self-edit proposals (#575) ──────────────────────────────────
+//
+// The review tier the permissions model reserved (manage vs publish on
+// content_people). A slug-linked member proposes edits to ONLY the
+// self-editable subset of their own person profile - the bio (body) and
+// the photo; title/slug and the safeguarding flags (isDBSChecked /
+// hasLeftClub) stay admin-only. The proposal awaits a content_people
+// publisher's approval before it replaces the live profile content.
+
+export const CONTENT_PROPOSAL_STATUSES = [
+  "pending",
+  "approved",
+  "rejected",
+] as const;
+
+export const contentProposalStatusSchema = z.enum(CONTENT_PROPOSAL_STATUSES);
+export type ContentProposalStatus = z.infer<typeof contentProposalStatusSchema>;
+
+/**
+ * The self-editable slice of a person profile a proposal carries: the bio
+ * body and the photo (null = remove it). The owner cannot touch their
+ * name (title), slug, or the safeguarding flags, so those are absent here
+ * by construction. The body is the full recursive BlockNote schema; the
+ * API's transport layer validates depth-1 and the service re-validates the
+ * whole tree on submit/approve, mirroring the content feature.
+ */
+export const selfEditableProfileSchema = z.object({
+  body: contentBodySchema,
+  photo: personPhotoSchema.nullable(),
+});
+export type SelfEditableProfile = z.infer<typeof selfEditableProfileSchema>;
+
 // ── Recurrence expansion ────────────────────────────────────────────────
 export {
   EVENT_TIME_ZONE,

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -305,20 +305,6 @@ export const CONTENT_PROPOSAL_STATUSES = [
 export const contentProposalStatusSchema = z.enum(CONTENT_PROPOSAL_STATUSES);
 export type ContentProposalStatus = z.infer<typeof contentProposalStatusSchema>;
 
-/**
- * The self-editable slice of a person profile a proposal carries: the bio
- * body and the photo (null = remove it). The owner cannot touch their
- * name (title), slug, or the safeguarding flags, so those are absent here
- * by construction. The body is the full recursive BlockNote schema; the
- * API's transport layer validates depth-1 and the service re-validates the
- * whole tree on submit/approve, mirroring the content feature.
- */
-export const selfEditableProfileSchema = z.object({
-  body: contentBodySchema,
-  photo: personPhotoSchema.nullable(),
-});
-export type SelfEditableProfile = z.infer<typeof selfEditableProfileSchema>;
-
 // ── Recurrence expansion ────────────────────────────────────────────────
 export {
   EVENT_TIME_ZONE,


### PR DESCRIPTION
Closes #575

## What

Lets a member whose account is slug-linked to their player profile propose edits to **their own bio + photo**. Edits don't publish directly: they become a `content_proposal` that a `content_people:publish` editor must approve before it goes live. This is the review tier the content permission model deliberately reserved by keeping `manage` and `publish` distinct (ADR 050).

## How it works

- **Eligibility is derived, not granted:** `user.email` → `member` → `member.slug` → person `content_item`. A member with no slug link simply has nothing to edit; no opt-in flag, no new link table.
- **Self-editable scope is bio (body) + photo only.** `title`/`slug` and the safeguarding flags (`isDBSChecked` / `hasLeftClub`) stay admin-only. The submit schema can't even express them, and approval rebuilds metadata from the live row's flags + the proposed photo.
- **One open proposal per profile** (partial unique index + friendly 409).
- **On approve:** the live profile body/metadata is wholesale-replaced, a `content_revision` is written (an approved edit is just another save), and the proposal is marked approved. The guarded `WHERE status='pending'` flip happens *first*, so a losing concurrent approve never touches the profile.
- **Email:** every publisher (except the proposer) is notified on submit; the proposer is emailed on approve and reject (rejection carries the note). Best-effort, never rolls back the decision.

## Surfaces

**Owner** — `/members/profile` (linked from the Members Area when eligible):
- Bio editor uses a deliberately narrow BlockNote schema (default text blocks only — no club widgets, no admin-gated image insertion). Falls back to read-only when a bio already contains advanced blocks, so nothing is silently dropped.
- Self-service photo upload via new owner-gated endpoints that reuse the content-images pipeline (owners hold no content role).
- Clear "awaiting review" state while a proposal is pending.

**Reviewer** — new admin **Content → Profile Requests** tab (gated on `content_people:publish`): pending queue, current-vs-proposed bio + photo side by side, approve / reject-with-note, URL-persisted selection.

## Packages touched

- `packages/db` — `content_proposal` migration (status enum CHECK + reviewer columns; partial unique index for one-pending) + regenerated types
- `packages/shared` — content proposal status enum
- `apps/api` — new `content-proposal` feature (eligibility, submit, review queue, approve/reject, self-service photo routes); `writeRevision` exported from the content service
- `packages/email` — two React Email templates
- `apps/web` — owner self-edit page, narrow bio editor, self-service photo client, reviewer approval-queue tab
- `docs/adrs/050` — the decision record

## Tests

- Unit (schema): self-editable field subset, admin fields stripped, reject-note bounds
- Integration (testcontainers, 13 tests): eligibility chain, submit/approve/reject lifecycle, one-pending guard, **safeguarding-flag preservation**, **photo removal vs. preservation on approve**, reviewer recipient set (publishers only, excludes proposer + non-publishers), already-reviewed 409, best-effort notification

Full monorepo typecheck, lint, unit suite (613), integration suite (500), web build, and format check all pass.

## Notes / follow-ups

- The owner bio editor reuses the public renderer's block vocabulary by construction (default text blocks), so it round-trips simple bios losslessly and degrades to read-only for the rare bio containing advanced blocks. A future enhancement could let owners edit those too by extracting a shared narrowed schema.
- HEIC is accepted at the input but rejected at processing (same known behaviour as the admin image path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)