### PR TITLE
feat: backfill member slugs with profile fallback + self-create

### DIFF
--- a/apps/api/src/features/content-proposal/integration.test.ts
+++ b/apps/api/src/features/content-proposal/integration.test.ts
@@ -13,6 +13,8 @@ import {
   getContent,
   getPublishedContent,
   listRevisions,
+  publishContent,
+  unpublishContent,
 } from "../content/service.ts";
 import {
   approveProfileProposal,
@@ -287,6 +289,46 @@ describe("content-proposal service (integration)", () => {
     if (!contentId) throw new Error("profile should now have a content id");
     const { revisions } = await listRevisions(ctx.db)(contentId);
     expect(revisions).toHaveLength(2);
+  });
+
+  it("does not republish a taken-down profile when an edit is approved", async () => {
+    const owner = await seedOwnerWithProfile("quinn-removed", "Quinn Removed");
+    // Take it live, then deliberately unpublish it. Unpublish flips status
+    // back to draft but RETAINS published_at as the ever-published marker.
+    await publishContent(ctx.db)({
+      contentId: owner.contentId,
+      userId: authorId,
+    });
+    await unpublishContent(ctx.db)({
+      contentId: owner.contentId,
+      userId: authorId,
+    });
+
+    const { deps } = recordingDeps();
+    const { id: proposalId } = await submitProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      userId: owner.userId,
+      userEmail: owner.email,
+      body: body("Trying to sneak back online"),
+      photo: null,
+    });
+    await approveProfileProposal(
+      ctx.db,
+      deps,
+    )({ proposalId, reviewerUserId: reviewerId });
+
+    // The edit applied, but the profile stays unpublished - a takedown sticks.
+    const after = await getContent(ctx.db)(owner.contentId);
+    expect(after.status).toBe("draft");
+    expect(after.body[0]?.content).toMatchObject([
+      { text: "Trying to sneak back online" },
+    ]);
+    // Still not served publicly: a tombstone (410), never resurrected.
+    await expect(
+      getPublishedContent(ctx.db)({ kind: "person", slug: "quinn-removed" }),
+    ).rejects.toMatchObject({ statusCode: 410 });
   });
 
   it("approves a proposal: applies bio + photo, preserves flags + title, writes a revision, emails the proposer", async () => {

--- a/apps/api/src/features/content-proposal/integration.test.ts
+++ b/apps/api/src/features/content-proposal/integration.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   createContent,
   getContent,
+  getPublishedContent,
   listRevisions,
 } from "../content/service.ts";
 import {
@@ -93,6 +94,20 @@ describe("content-proposal service (integration)", () => {
       .where("id", "=", owner.memberId)
       .execute();
     return { ...owner, contentId: id };
+  }
+
+  // A member slug-linked (the backfill default) but with NO person page yet -
+  // the "create on first edit" precondition.
+  async function seedLinkedMemberNoProfile(slug: string, name: string) {
+    const member = await seedTestUser(ctx.db, { name, withMember: true });
+    if (!member.memberId)
+      throw new Error("seedTestUser did not create a member");
+    await ctx.db
+      .updateTable("member")
+      .set({ slug })
+      .where("id", "=", member.memberId)
+      .execute();
+    return member;
   }
 
   beforeAll(async () => {
@@ -195,6 +210,83 @@ describe("content-proposal service (integration)", () => {
         photo: null,
       }),
     ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("offers a virtual profile to a linked member with no page yet", async () => {
+    const member = await seedLinkedMemberNoProfile("ned-new", "Ned New");
+    const state = await getProfileEditState(ctx.db)(member.email);
+    expect(state.profile).not.toBeNull();
+    expect(state.profile?.contentId).toBeNull();
+    expect(state.profile?.slug).toBe("ned-new");
+    expect(state.profile?.title).toBe("Ned New");
+    expect(state.profile?.body).toEqual([]);
+    expect(state.pendingProposal).toBeNull();
+  });
+
+  it("creates a draft profile on first submit and publishes it on approval", async () => {
+    const member = await seedLinkedMemberNoProfile(
+      "opal-author",
+      "Opal Author",
+    );
+
+    // Public lookup before any submit: the member-backed stub stands in (no
+    // page exists yet), so a leaderboard click does not dead-end.
+    const stub = await getPublishedContent(ctx.db)({
+      kind: "person",
+      slug: "opal-author",
+    });
+    expect(stub.id).toBe("member-stub:opal-author");
+
+    const { deps } = recordingDeps();
+    const { id: proposalId } = await submitProfileProposal(
+      ctx.db,
+      deps,
+    )({
+      userId: member.userId,
+      userEmail: member.email,
+      body: body("Opal's first bio"),
+      photo: null,
+    });
+
+    // The draft page now exists and is the owner's editable profile, but it
+    // is NOT public yet - the stub still answers the public lookup.
+    const afterSubmit = await getProfileEditState(ctx.db)(member.email);
+    expect(afterSubmit.profile?.contentId).not.toBeNull();
+    expect(afterSubmit.pendingProposal?.id).toBe(proposalId);
+    const stillStub = await getPublishedContent(ctx.db)({
+      kind: "person",
+      slug: "opal-author",
+    });
+    expect(stillStub.id).toBe("member-stub:opal-author");
+
+    // Approval publishes the page: the real profile now answers publicly.
+    await approveProfileProposal(
+      ctx.db,
+      deps,
+    )({ proposalId, reviewerUserId: reviewerId });
+
+    const published = await getPublishedContent(ctx.db)({
+      kind: "person",
+      slug: "opal-author",
+    });
+    expect(published.id).not.toBe("member-stub:opal-author");
+    expect(published.title).toBe("Opal Author");
+    expect(published.body[0]?.content).toMatchObject([
+      { text: "Opal's first bio" },
+    ]);
+    // A self-created profile starts with the safe default flags.
+    expect(published.metadata).toMatchObject({
+      isDBSChecked: false,
+      hasLeftClub: false,
+    });
+
+    // Owner can edit again; the proposal history is empty-draft + approval.
+    const settled = await getProfileEditState(ctx.db)(member.email);
+    expect(settled.pendingProposal).toBeNull();
+    const contentId = settled.profile?.contentId;
+    if (!contentId) throw new Error("profile should now have a content id");
+    const { revisions } = await listRevisions(ctx.db)(contentId);
+    expect(revisions).toHaveLength(2);
   });
 
   it("approves a proposal: applies bio + photo, preserves flags + title, writes a revision, emails the proposer", async () => {

--- a/apps/api/src/features/content-proposal/schemas.ts
+++ b/apps/api/src/features/content-proposal/schemas.ts
@@ -24,13 +24,15 @@ const profileEditFieldsSchema = z.object({
 /**
  * The logged-in member's profile-edit state. `profile` is null when the
  * caller has no slug-linked person profile (so the UI shows nothing to
- * edit). `pendingProposal` is the one open proposal awaiting review, if
- * any - while it exists the owner cannot submit another.
+ * edit). `contentId` is null for a slug-linked member whose profile page
+ * does not exist yet - a "virtual" profile they can author, created on
+ * first submit. `pendingProposal` is the one open proposal awaiting review,
+ * if any - while it exists the owner cannot submit another.
  */
 export const profileEditStateResponseSchema = z.object({
   profile: z
     .object({
-      contentId: z.string(),
+      contentId: z.string().nullable(),
       slug: z.string(),
       title: z.string(),
       body: contentBodyTransportSchema,

--- a/apps/api/src/features/content-proposal/service.ts
+++ b/apps/api/src/features/content-proposal/service.ts
@@ -231,6 +231,19 @@ export function submitProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
         // or an admin authoring the page) instead of clashing on the slug.
         let resolvedContentId = profile.contentId;
         if (resolvedContentId === null) {
+          // Serialise concurrent first submissions for the same slug (a member
+          // double-submitting): without this, two transactions both see no
+          // item and race the unique (kind, slug) insert, surfacing a 500.
+          // The lock makes the check-then-create below atomic per slug -
+          // mirrors lockPageTree in the content service.
+          await tx
+            .selectNoFrom(
+              sql`pg_advisory_xact_lock(hashtext(${`content-person-create:${profile.slug}`}))`.as(
+                "person_create_lock",
+              ),
+            )
+            .execute();
+
           const existingItem = await tx
             .selectFrom("content_item")
             .select("id")
@@ -476,6 +489,7 @@ export function approveProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
           "content_item.description",
           "content_item.metadata as current_metadata",
           "content_item.status as item_status",
+          "content_item.published_at as item_published_at",
         ])
         .executeTakeFirst();
       if (!proposal) throwHttpError(404, "Proposal not found");
@@ -522,17 +536,20 @@ export function approveProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
         ...(proposedMeta.photo ? { photo: proposedMeta.photo } : {}),
       };
 
-      // First approval of a self-created profile publishes it. Only ever
-      // promote a DRAFT: a published item stays published, and an archived
-      // (deliberately taken-down) profile must NOT be resurrected by an edit
-      // approval - safeguarding beats convenience.
-      const publishFields =
-        proposal.item_status === "draft"
-          ? {
-              status: "published",
-              published_at: sql<Date>`CURRENT_TIMESTAMP`,
-            }
-          : {};
+      // First approval of a self-created profile publishes it. Promote ONLY a
+      // never-published draft (status = draft AND published_at IS NULL): that
+      // is exactly the create-on-first-edit case. A published item stays
+      // published; an unpublished or archived profile retains its past
+      // published_at, so it is deliberately NOT resurrected by an edit
+      // approval - a takedown is safeguarding-relevant and must stick.
+      const isFirstPublish =
+        proposal.item_status === "draft" && proposal.item_published_at === null;
+      const publishFields = isFirstPublish
+        ? {
+            status: "published",
+            published_at: sql<Date>`CURRENT_TIMESTAMP`,
+          }
+        : {};
 
       await tx
         .updateTable("content_item")

--- a/apps/api/src/features/content-proposal/service.ts
+++ b/apps/api/src/features/content-proposal/service.ts
@@ -63,7 +63,10 @@ interface NotifyDeps {
 // profile - eligibility falls out of the existing link, no opt-in flag.
 
 interface EditableProfile {
-  contentId: string;
+  // null when the member is slug-linked but no person content_item exists
+  // yet - a "virtual" profile the owner can fill in. submitProfileProposal
+  // creates the draft item on first submit; approval publishes it.
+  contentId: string | null;
   slug: string;
   title: string;
   body: unknown;
@@ -79,7 +82,7 @@ async function resolveEditableProfile(
     .where("email", "=", userEmail)
     .where("deleted_at", "is", null)
     .where("slug", "is not", null)
-    .select(["slug"])
+    .select(["slug", "name"])
     .executeTakeFirst();
   if (!member?.slug) return null;
 
@@ -89,7 +92,22 @@ async function resolveEditableProfile(
     .where("slug", "=", member.slug)
     .select(["id", "slug", "title", "body", "metadata"])
     .executeTakeFirst();
-  if (!person) return null;
+
+  if (!person) {
+    // Linked, but the profile page does not exist yet. Offer a virtual,
+    // empty profile so the owner can author their first bio - it becomes a
+    // real (draft) person item on submit, published on approval. Needs a
+    // display title, which is the member's name; without one there is
+    // nothing to seed a profile from, so treat it as not editable.
+    if (!member.name) return null;
+    return {
+      contentId: null,
+      slug: member.slug,
+      title: member.name,
+      body: [],
+      photo: null,
+    };
+  }
 
   // A stored profile failing its schema is a server-side data problem; fall
   // back to "no photo" rather than blocking the owner from editing their bio.
@@ -153,12 +171,16 @@ export function getProfileEditState(db: Kysely<DB>) {
       return { profile: null, pendingProposal: null };
     }
 
-    const pending = await db
-      .selectFrom("content_proposal")
-      .where("content_id", "=", profile.contentId)
-      .where("status", "=", "pending")
-      .select(["id", "proposed_body", "proposed_metadata", "created_at"])
-      .executeTakeFirst();
+    // A virtual (not-yet-created) profile can have no proposal: a proposal
+    // references a content_item, which only exists once the owner submits.
+    const pending = profile.contentId
+      ? await db
+          .selectFrom("content_proposal")
+          .where("content_id", "=", profile.contentId)
+          .where("status", "=", "pending")
+          .select(["id", "proposed_body", "proposed_metadata", "created_at"])
+          .executeTakeFirst()
+      : undefined;
 
     return {
       profile: {
@@ -199,36 +221,90 @@ export function submitProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
     const body = parseBody(params.body);
     const proposedMetadata = params.photo ? { photo: params.photo } : {};
 
-    const proposalId = await db.transaction().execute(async (tx) => {
-      // One open proposal per profile: block a second while one is pending.
-      // The partial unique index is the backstop against a race; this is the
-      // friendly 409.
-      const existing = await tx
-        .selectFrom("content_proposal")
-        .select("id")
-        .where("content_id", "=", profile.contentId)
-        .where("status", "=", "pending")
-        .executeTakeFirst();
-      if (existing) {
-        throwHttpError(
-          409,
-          "You already have an edit awaiting review - it must be approved or rejected before you can submit another",
-        );
-      }
+    const { proposalId, contentId } = await db
+      .transaction()
+      .execute(async (tx) => {
+        // Resolve (or lazily create) the person item this proposal targets.
+        // A virtual profile (no page yet) gets a draft person item now so the
+        // proposal can reference it; approval publishes it. Re-check inside
+        // the txn and reuse any item that appeared meanwhile (a racing submit
+        // or an admin authoring the page) instead of clashing on the slug.
+        let resolvedContentId = profile.contentId;
+        if (resolvedContentId === null) {
+          const existingItem = await tx
+            .selectFrom("content_item")
+            .select("id")
+            .where("kind", "=", "person")
+            .where("slug", "=", profile.slug)
+            .executeTakeFirst();
+          if (existingItem) {
+            resolvedContentId = existingItem.id;
+          } else {
+            const emptyBody: unknown[] = [];
+            const seedMetadata = { isDBSChecked: false, hasLeftClub: false };
+            const created = await tx
+              .insertInto("content_item")
+              .values({
+                kind: "person",
+                slug: profile.slug,
+                parent_id: null,
+                path: null,
+                title: profile.title,
+                description: null,
+                body: JSON.stringify(emptyBody),
+                metadata: JSON.stringify(seedMetadata),
+                status: "draft",
+                created_by: params.userId,
+                updated_by: params.userId,
+              })
+              .returning("id")
+              .executeTakeFirstOrThrow();
+            resolvedContentId = created.id;
+            // Seed history like any content create, so the profile's revision
+            // log starts from its empty draft.
+            await writeRevision(
+              tx,
+              {
+                id: resolvedContentId,
+                title: profile.title,
+                description: null,
+                body: emptyBody,
+                metadata: seedMetadata,
+              },
+              params.userId,
+            );
+          }
+        }
 
-      const row = await tx
-        .insertInto("content_proposal")
-        .values({
-          content_id: profile.contentId,
-          proposed_body: JSON.stringify(body),
-          proposed_metadata: JSON.stringify(proposedMetadata),
-          proposed_by: params.userId,
-          status: "pending",
-        })
-        .returning("id")
-        .executeTakeFirstOrThrow();
-      return row.id;
-    });
+        // One open proposal per profile: block a second while one is pending.
+        // The partial unique index is the backstop against a race; this is the
+        // friendly 409.
+        const existing = await tx
+          .selectFrom("content_proposal")
+          .select("id")
+          .where("content_id", "=", resolvedContentId)
+          .where("status", "=", "pending")
+          .executeTakeFirst();
+        if (existing) {
+          throwHttpError(
+            409,
+            "You already have an edit awaiting review - it must be approved or rejected before you can submit another",
+          );
+        }
+
+        const row = await tx
+          .insertInto("content_proposal")
+          .values({
+            content_id: resolvedContentId,
+            proposed_body: JSON.stringify(body),
+            proposed_metadata: JSON.stringify(proposedMetadata),
+            proposed_by: params.userId,
+            status: "pending",
+          })
+          .returning("id")
+          .executeTakeFirstOrThrow();
+        return { proposalId: row.id, contentId: resolvedContentId };
+      });
 
     // Notify every content publisher (excluding the proposer) so any of them
     // can review. Best-effort: a mail failure must not roll back the
@@ -255,7 +331,7 @@ export function submitProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
       );
     } catch (err) {
       deps.log.error(
-        { err, contentId: profile.contentId },
+        { err, contentId },
         "profile_proposal_reviewer_notification_failed",
       );
     }
@@ -399,6 +475,7 @@ export function approveProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
           "content_item.title",
           "content_item.description",
           "content_item.metadata as current_metadata",
+          "content_item.status as item_status",
         ])
         .executeTakeFirst();
       if (!proposal) throwHttpError(404, "Proposal not found");
@@ -445,6 +522,18 @@ export function approveProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
         ...(proposedMeta.photo ? { photo: proposedMeta.photo } : {}),
       };
 
+      // First approval of a self-created profile publishes it. Only ever
+      // promote a DRAFT: a published item stays published, and an archived
+      // (deliberately taken-down) profile must NOT be resurrected by an edit
+      // approval - safeguarding beats convenience.
+      const publishFields =
+        proposal.item_status === "draft"
+          ? {
+              status: "published",
+              published_at: sql<Date>`CURRENT_TIMESTAMP`,
+            }
+          : {};
+
       await tx
         .updateTable("content_item")
         .set({
@@ -452,6 +541,7 @@ export function approveProfileProposal(db: Kysely<DB>, deps: NotifyDeps) {
           metadata: JSON.stringify(newMetadata),
           updated_by: params.reviewerUserId,
           updated_at: sql`CURRENT_TIMESTAMP`,
+          ...publishFields,
         })
         .where("id", "=", proposal.content_id)
         .execute();

--- a/apps/api/src/features/content/member-stub.integration.test.ts
+++ b/apps/api/src/features/content/member-stub.integration.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  seedTestUser,
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+import {
+  archiveContent,
+  createContent,
+  getPublishedContent,
+  publishContent,
+} from "./service.ts";
+
+const body = (text: string) => [
+  {
+    id: crypto.randomUUID(),
+    type: "paragraph",
+    props: {},
+    content: [{ type: "text", text, styles: {} }],
+    children: [],
+  },
+];
+
+// Member-backed fallback profile (#...). Slugs are backfilled across all
+// members, so a member can own a profile slug before anyone has authored
+// the profile page. getPublishedContent serves a minimal stub for such a
+// slug (so a leaderboard link never dead-ends), but ONLY when no real
+// page/tombstone applies and the member is live.
+describe("getPublishedContent member-backed person fallback (integration)", () => {
+  let ctx: TestContext;
+  let userId: string;
+
+  async function linkMember(
+    slug: string,
+    name: string,
+    opts: { deleted?: boolean } = {},
+  ) {
+    const member = await seedTestUser(ctx.db, { withMember: true, name });
+    if (!member.memberId) throw new Error("seedTestUser made no member");
+    await ctx.db
+      .updateTable("member")
+      .set({
+        slug,
+        ...(opts.deleted ? { deleted_at: new Date().toISOString() } : {}),
+      })
+      .where("id", "=", member.memberId)
+      .execute();
+    return member;
+  }
+
+  beforeAll(async () => {
+    ctx = await startTestContainer();
+    ({ userId } = await seedTestUser(ctx.db, { withMember: false }));
+  }, 120_000);
+
+  afterAll(async () => {
+    await stopTestContainer(ctx);
+  });
+
+  it("serves a stub for a slug-linked member with no profile page yet", async () => {
+    await linkMember("fallback-fred", "Fallback Fred");
+
+    const result = await getPublishedContent(ctx.db)({
+      kind: "person",
+      slug: "fallback-fred",
+    });
+
+    expect(result.kind).toBe("person");
+    expect(result.slug).toBe("fallback-fred");
+    expect(result.title).toBe("Fallback Fred");
+    expect(result.body).toEqual([]);
+    expect(result.id).toBe("member-stub:fallback-fred");
+    // Stubs never claim a DBS badge (the flag is admin-set on a real page).
+    expect(result.metadata).toMatchObject({ isDBSChecked: false });
+  });
+
+  it("404s for an unknown slug with no member and no page", async () => {
+    await expect(
+      getPublishedContent(ctx.db)({ kind: "person", slug: "nobody-here" }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("does not serve a stub for a soft-deleted member", async () => {
+    await linkMember("gone-gary", "Gone Gary", { deleted: true });
+
+    await expect(
+      getPublishedContent(ctx.db)({ kind: "person", slug: "gone-gary" }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("prefers a real published page over the member stub", async () => {
+    await linkMember("real-rita", "Rita Member");
+    const { id } = await createContent(ctx.db)({
+      kind: "person",
+      slug: "real-rita",
+      title: "Rita Published",
+      description: null,
+      body: body("A proper bio"),
+      metadata: { isDBSChecked: true, hasLeftClub: false },
+      userId,
+    });
+    await publishContent(ctx.db)({ contentId: id, userId });
+
+    const result = await getPublishedContent(ctx.db)({
+      kind: "person",
+      slug: "real-rita",
+    });
+
+    expect(result.id).toBe(id);
+    expect(result.title).toBe("Rita Published");
+    expect(result.metadata).toMatchObject({ isDBSChecked: true });
+  });
+
+  it("keeps a tombstone (410) ahead of the member stub - a takedown is never resurrected", async () => {
+    await linkMember("taken-down-tom", "Tom Member");
+    const { id } = await createContent(ctx.db)({
+      kind: "person",
+      slug: "taken-down-tom",
+      title: "Tom Published",
+      description: null,
+      body: body("Was live"),
+      metadata: { isDBSChecked: false, hasLeftClub: false },
+      userId,
+    });
+    await publishContent(ctx.db)({ contentId: id, userId });
+    await archiveContent(ctx.db)({ contentId: id, userId });
+
+    await expect(
+      getPublishedContent(ctx.db)({ kind: "person", slug: "taken-down-tom" }),
+    ).rejects.toMatchObject({ statusCode: 410 });
+  });
+});

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -1237,6 +1237,39 @@ function publishedOnly(db: Kysely<DB>) {
     .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`);
 }
 
+/**
+ * A member-backed stub person profile for a backfilled slug that has no
+ * published page yet (the fallback in getPublishedContent). Same public
+ * shape as toPublic, with an empty body and default (no-DBS) metadata; the
+ * SPA's stats and sponsor panels render from the slug alone. Returns null
+ * when no live, named member owns the slug, so the caller falls through to
+ * 404. Timestamps are "now" - the stub is transient (it disappears the
+ * moment a real page is published) so it is deliberately not cache-stable.
+ */
+async function memberProfileStub(db: Kysely<DB>, slug: string) {
+  const member = await db
+    .selectFrom("member")
+    .select(["name"])
+    .where("slug", "=", slug)
+    .where("deleted_at", "is", null)
+    .where("name", "is not", null)
+    .executeTakeFirst();
+  if (!member?.name) return null;
+
+  const now = new Date().toISOString();
+  return {
+    id: `member-stub:${slug}`,
+    kind: "person" as ContentKind,
+    slug,
+    title: member.name,
+    description: null,
+    body: [] as z.infer<typeof contentBodySchema>,
+    metadata: { isDBSChecked: false, hasLeftClub: false },
+    publishedAt: now,
+    updatedAt: now,
+  };
+}
+
 export function getPublishedContent(db: Kysely<DB>) {
   return async (params: { kind: ContentKind; slug: string }) => {
     let query = publishedOnly(db)
@@ -1271,6 +1304,17 @@ export function getPublishedContent(db: Kysely<DB>) {
           .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`)
           .executeTakeFirst();
         if (tombstone) throwHttpError(410, "This profile has been removed");
+
+        // Member-backed fallback. Slugs are backfilled across all members
+        // (the link that drives leaderboard/records profile links), so a
+        // member can have a slug before anyone has authored their profile
+        // page. Rather than dead-end a leaderboard click on "not found",
+        // serve a minimal stub - the name plus the stats/sponsor panels,
+        // which key off the slug alone. This runs only AFTER the tombstone
+        // check, so an unpublished/archived takedown still wins (410) and is
+        // never resurrected; a soft-deleted member gets nothing (404).
+        const stub = await memberProfileStub(db, params.slug);
+        if (stub) return stub;
       }
       throwHttpError(404, "Content not found");
     }

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -14369,7 +14369,7 @@ export interface paths {
                     content: {
                         "application/json": {
                             profile: {
-                                contentId: string;
+                                contentId: string | null;
                                 slug: string;
                                 title: string;
                                 body: {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -25862,6 +25862,7 @@
                       "type": "object",
                       "properties": {
                         "contentId": {
+                          "nullable": true,
                           "type": "string"
                         },
                         "slug": {

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -14369,7 +14369,7 @@ export interface paths {
                     content: {
                         "application/json": {
                             profile: {
-                                contentId: string;
+                                contentId: string | null;
                                 slug: string;
                                 title: string;
                                 body: {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -25862,6 +25862,7 @@
                       "type": "object",
                       "properties": {
                         "contentId": {
+                          "nullable": true,
                           "type": "string"
                         },
                         "slug": {

--- a/apps/web/src/pages/members/profile-edit.tsx
+++ b/apps/web/src/pages/members/profile-edit.tsx
@@ -72,7 +72,9 @@ export function Component() {
       {data.pendingProposal ? (
         <PendingNotice proposal={data.pendingProposal} />
       ) : (
-        <EditForm key={data.profile.contentId} profile={data.profile} />
+        // Keyed on slug, not contentId: a not-yet-created profile has no
+        // contentId, and the slug is stable for the profile's lifetime.
+        <EditForm key={data.profile.slug} profile={data.profile} />
       )}
     </Shell>
   );

--- a/docs/adrs/051-member-slug-backfill-and-profile-fallback.md
+++ b/docs/adrs/051-member-slug-backfill-and-profile-fallback.md
@@ -1,0 +1,113 @@
+# Decision 051: Member Slug Backfill, Member-Backed Profile Fallback, and Self-Create on First Edit
+
+**Date:** 2026-06-24
+**Status:** Accepted
+
+## Decision
+
+Three coupled changes make a profile slug the default for every member, so
+self-editing (ADR 050) and public profile links are available to all members
+rather than only the handful an admin had hand-linked:
+
+1. **Backfill `member.slug` for every member** (a one-off data migration). The
+   slug is derived from the member's name, with numeric suffixes resolving
+   collisions. The "used" set is seeded with both existing member slugs and all
+   existing person `content_item` slugs, so a backfilled slug never collides
+   with - and so never accidentally links to - an unrelated person's page.
+2. **Serve a member-backed stub profile** when `GET /content/person/:slug`
+   finds no published page but a live member owns the slug. The stub is the
+   member's name plus the slug-keyed stats/sponsor panels - no bio. It runs
+   only after the tombstone check, so a taken-down profile is never resurrected.
+3. **Let self-edit create the profile page.** A slug-linked member with no
+   `content_item` yet gets a "virtual" editable profile. Their first submitted
+   proposal creates the person item as a **draft**; approval **publishes** it.
+   This extends ADR 050's edit-only flow to also cover first creation.
+
+## Problem
+
+ADR 050 made a member's profile self-editable, but only when their `member` row
+was slug-linked to an existing published person `content_item`. In practice
+almost no members were linked (links were set one at a time in the Record
+Linking tab), and most members have no profile page at all. Two goals follow:
+
+- **Every member should be able to maintain a profile**, which requires the
+  slug link (the self-edit precondition) to exist for everyone.
+- **Leaderboard/records/scorecard rows should link to profiles.** Those links
+  are emitted whenever `member.slug` is non-null, so backfilling slugs turns
+  every player's name into a profile link.
+
+The risk a broad backfill introduces: a slug link is necessary but **not
+sufficient**. The public profile page (`/person/:slug`) renders only when a
+**published** person `content_item` exists at that slug; otherwise the API 404s
+and the SPA shows a "Person Not Found" dead-end. So backfilling slugs would,
+before any page is authored, turn every leaderboard click into a dead-end, and
+self-edit still would not work (it required the page to pre-exist).
+
+## Options considered
+
+### Member-backed fallback + self-create (chosen)
+
+Backfill slugs, serve a stub from the member row when no page exists, and let
+the first self-edit create the page.
+
+- **No dead-ends.** A leaderboard click always lands on a real page: either the
+  published profile, or a stub with the player's name and stats (the stats panel
+  already resolves off `member.slug` + `play_cricket_id`, so the stub is the
+  useful "stats, bio coming soon" state).
+- **The link genuinely unlocks editing.** A member with a backfilled slug but no
+  page can author their first bio; it lands as a draft and goes live through the
+  same ADR 050 approval gate - content is still admin-reviewed before publishing.
+- **Safeguarding is preserved.** The tombstone (410) check precedes the stub, so
+  a deliberately unpublished/archived profile is never re-exposed as a stub.
+  Approval only ever promotes a `draft` to `published`; it never republishes an
+  `archived` item. Soft-deleted members get no stub (404).
+
+### Gate leaderboard links on page existence (rejected)
+
+Only emit `/person/:slug` links when a published page exists.
+
+Rejected as the primary fix: it removes the 404 but leaves players with no
+landing page (their name stays plain text until someone authors a page), and it
+does nothing for the "let everyone self-edit" goal. It is a strictly smaller
+outcome than the stub, which already turns the link into a useful page.
+
+### Auto-create a published page for every member (rejected)
+
+Backfill slugs and also mint a published, empty person page per member.
+
+Rejected: it manufactures hundreds of empty public pages (and an unreviewed
+public surface) where the stub is a zero-storage, always-current stand-in that
+disappears the moment a real page is published.
+
+## Rationale and scope notes
+
+- **Scope: all members.** Per the product owner, junior members who hold their
+  own account are 13+, and all profile content is admin-approved before going
+  live, so no age carve-out is applied. Dependents (juniors held under a parent
+  member) have no `slug` column and are structurally untouched; the leaderboards
+  only join `member`, so dependents are never linked either.
+- **Stub exposure is bounded.** The `/people` directory lists published person
+  items, not member stubs, so a stub is reachable only via a leaderboard link
+  (cricket players) or by guessing the URL - it does not broadly publish every
+  member's name in a listing. Names of players already appear on leaderboards.
+- **Collision strategy avoids mis-linking over reuse.** A member who genuinely
+  owns an existing person page but was never linked gets a fresh suffixed slug
+  rather than being auto-attached to that page; an admin can re-link them in the
+  Record Linking tab. Never wrong-linking (which would let one member edit
+  another's profile) is the safer default.
+- **Short 404 window is acceptable.** The migration (which makes slugs, and thus
+  leaderboard links, appear) and the deploy carrying the fallback land together
+  on `main`; any gap between them is brief and tolerable.
+- **The stub is intentionally not cache-stable** (its timestamps are "now"): it
+  is transient and vanishes once a real page is published, so a fresh ETag per
+  request is fine.
+
+## Rejected alternatives
+
+- **Gate leaderboard links on page existence** - rejected as primary: removes
+  the 404 but provides no landing page and does not enable self-editing.
+- **Auto-mint a published page per member** - rejected: creates hundreds of
+  empty public pages where a zero-storage stub suffices.
+- **Reuse an existing page's slug when names match during backfill** - rejected:
+  name matching is unreliable and a wrong match cross-links two people; suffixing
+  to a distinct slug and leaving re-linking to an admin is safer.

--- a/docs/adrs/051-member-slug-backfill-and-profile-fallback.md
+++ b/docs/adrs/051-member-slug-backfill-and-profile-fallback.md
@@ -59,8 +59,11 @@ the first self-edit create the page.
   same ADR 050 approval gate - content is still admin-reviewed before publishing.
 - **Safeguarding is preserved.** The tombstone (410) check precedes the stub, so
   a deliberately unpublished/archived profile is never re-exposed as a stub.
-  Approval only ever promotes a `draft` to `published`; it never republishes an
-  `archived` item. Soft-deleted members get no stub (404).
+  Approval promotes only a **never-published** draft (status `draft` **and** no
+  past `published_at`) - exactly the create-on-first-edit case. An unpublished
+  or archived profile retains its `published_at`, so an approved edit updates
+  its body but never republishes it; a takedown sticks. Soft-deleted members
+  get no stub (404).
 
 ### Gate leaderboard links on page existence (rejected)
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -6,26 +6,27 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 
 ## Index
 
-| #                                                        | Title                                                       | Date       | Status   |
-| -------------------------------------------------------- | ----------------------------------------------------------- | ---------- | -------- |
-| [001](001-api-framework.md)                              | API Framework - Fastify over Express                        | 2026-03-14 | Accepted |
-| [002](002-email-provider.md)                             | Email Provider - SES over Mailgun                           | 2026-03-14 | Accepted |
-| [003](003-baseline-migration-strategy.md)                | Baseline Migration Strategy - Single Consolidated Migration | 2026-03-14 | Accepted |
-| [004](004-auth-database-type.md)                         | better-auth Database Type - postgres                        | 2026-03-14 | Accepted |
-| [005](005-generated-types-approach.md)                   | Generated DB Types - Placeholder with PostgreSQL Types      | 2026-03-14 | Accepted |
-| [006](006-monorepo-structure.md)                         | Monorepo Structure - Following the Plan                     | 2026-03-14 | Accepted |
-| [007](007-webhook-raw-body.md)                           | Stripe Webhook Raw Body Handling                            | 2026-03-14 | Accepted |
-| [008](008-vite-proxy-for-local-dev.md)                   | Vite Dev Server Proxy for Local Development                 | 2026-03-14 | Accepted |
-| [009](009-dependency-injection.md)                       | Functional Dependency Injection                             | 2026-03-14 | Accepted |
-| [010](010-testcontainers.md)                             | Testcontainers for Integration Tests                        | 2026-03-14 | Accepted |
-| [011](011-api-type-safety.md)                            | API Type Safety Between Backend and Frontend                | 2026-03-16 | Accepted |
-| [012](012-prod-db-access.md)                             | Production DB Access via Tailscale                          | 2026-04-20 | Accepted |
-| [042](042-scout-recognition-sources.md)                  | Scout Recognition Sources - Public-Source Discovery         | 2026-05-14 | Accepted |
-| [043](043-db-role-split-principle-of-least-privilege.md) | DB Role Split - Principle of Least Privilege                | 2026-05-15 | Accepted |
-| [044](044-matchday-notification-channel-modelling.md)    | Matchday notification channel modelling                     | 2026-05-21 | Accepted |
-| [045](045-matchday-service-worker-push-integration.md)   | Matchday service worker push integration via importScripts  | 2026-05-21 | Accepted |
-| [046](046-vapid-public-key-via-api.md)                   | VAPID public key delivered via API, not bundled             | 2026-05-21 | Accepted |
-| [047](047-content-editor-blocknote.md)                   | Content Editor - BlockNote with JSON canonical format       | 2026-06-10 | Accepted |
-| [048](048-editor-image-webp-only-sync-processing.md)     | Editor images - WebP-only ladder, synchronous processing    | 2026-06-10 | Accepted |
-| [049](049-ai-content-author-assistant.md)                | AI content-author assistant reuses Scout's tools            | 2026-06-14 | Accepted |
-| [050](050-profile-self-edit-proposal-tier.md)            | Profile self-editing via a proposal/approval tier           | 2026-06-23 | Accepted |
+| #                                                        | Title                                                             | Date       | Status   |
+| -------------------------------------------------------- | ----------------------------------------------------------------- | ---------- | -------- |
+| [001](001-api-framework.md)                              | API Framework - Fastify over Express                              | 2026-03-14 | Accepted |
+| [002](002-email-provider.md)                             | Email Provider - SES over Mailgun                                 | 2026-03-14 | Accepted |
+| [003](003-baseline-migration-strategy.md)                | Baseline Migration Strategy - Single Consolidated Migration       | 2026-03-14 | Accepted |
+| [004](004-auth-database-type.md)                         | better-auth Database Type - postgres                              | 2026-03-14 | Accepted |
+| [005](005-generated-types-approach.md)                   | Generated DB Types - Placeholder with PostgreSQL Types            | 2026-03-14 | Accepted |
+| [006](006-monorepo-structure.md)                         | Monorepo Structure - Following the Plan                           | 2026-03-14 | Accepted |
+| [007](007-webhook-raw-body.md)                           | Stripe Webhook Raw Body Handling                                  | 2026-03-14 | Accepted |
+| [008](008-vite-proxy-for-local-dev.md)                   | Vite Dev Server Proxy for Local Development                       | 2026-03-14 | Accepted |
+| [009](009-dependency-injection.md)                       | Functional Dependency Injection                                   | 2026-03-14 | Accepted |
+| [010](010-testcontainers.md)                             | Testcontainers for Integration Tests                              | 2026-03-14 | Accepted |
+| [011](011-api-type-safety.md)                            | API Type Safety Between Backend and Frontend                      | 2026-03-16 | Accepted |
+| [012](012-prod-db-access.md)                             | Production DB Access via Tailscale                                | 2026-04-20 | Accepted |
+| [042](042-scout-recognition-sources.md)                  | Scout Recognition Sources - Public-Source Discovery               | 2026-05-14 | Accepted |
+| [043](043-db-role-split-principle-of-least-privilege.md) | DB Role Split - Principle of Least Privilege                      | 2026-05-15 | Accepted |
+| [044](044-matchday-notification-channel-modelling.md)    | Matchday notification channel modelling                           | 2026-05-21 | Accepted |
+| [045](045-matchday-service-worker-push-integration.md)   | Matchday service worker push integration via importScripts        | 2026-05-21 | Accepted |
+| [046](046-vapid-public-key-via-api.md)                   | VAPID public key delivered via API, not bundled                   | 2026-05-21 | Accepted |
+| [047](047-content-editor-blocknote.md)                   | Content Editor - BlockNote with JSON canonical format             | 2026-06-10 | Accepted |
+| [048](048-editor-image-webp-only-sync-processing.md)     | Editor images - WebP-only ladder, synchronous processing          | 2026-06-10 | Accepted |
+| [049](049-ai-content-author-assistant.md)                | AI content-author assistant reuses Scout's tools                  | 2026-06-14 | Accepted |
+| [050](050-profile-self-edit-proposal-tier.md)            | Profile self-editing via a proposal/approval tier                 | 2026-06-23 | Accepted |
+| [051](051-member-slug-backfill-and-profile-fallback.md)  | Member slug backfill, member-backed profile fallback, self-create | 2026-06-24 | Accepted |

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,7 +15,8 @@
     "db:setup-scout": "tsx ./scripts/setup-scout-readonly.ts",
     "db:setup-app-roles": "tsx ./scripts/setup-app-roles.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "test": "vitest run"
   },
   "dependencies": {
     "@percy-main/shared": "workspace:*",
@@ -31,6 +32,7 @@
     "dotenv": "^17.4.2",
     "kysely-codegen": "^0.20.0",
     "tsx": "^4.22.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/db/src/migrations/2026-06-24T09:00:00.000Z.ts
+++ b/packages/db/src/migrations/2026-06-24T09:00:00.000Z.ts
@@ -27,18 +27,26 @@ import { type Kysely, sql } from "kysely";
 // getPublishedContent, so a leaderboard click never dead-ends in the short
 // window before a page exists.
 
+// The public content slug schema caps slugs at 200 chars; stay well under it
+// so a collision suffix (-2, -3, ...) still fits. member.slug feeds that
+// validated route and is inserted verbatim into content_item.slug on first
+// self-edit, so an over-long base would yield an unreachable profile.
+const SLUG_BASE_MAX = 180;
+
 // Exported for unit testing - the collision logic is the only non-trivial
 // part of this backfill, so it is covered directly.
 export function slugify(name: string): string {
   // NFKD splits an accented letter into a base char + a combining mark; drop
-  // the combining marks (U+0300-U+036F) so "José Núñez" -> "jose-nunez"
-  // rather than leaving a stray hyphen where each mark was. Everything else
-  // non-alphanumeric then collapses to a single hyphen.
+  // the combining marks so "José Núñez" -> "jose-nunez" rather than leaving a
+  // stray hyphen where each mark was. Everything else non-alphanumeric then
+  // collapses to a single hyphen. Truncate before the final trim so a cut
+  // landing on a hyphen does not leave a trailing one.
   return name
     .normalize("NFKD")
     .replace(/\p{M}/gu, "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
+    .slice(0, SLUG_BASE_MAX)
     .replace(/^-+|-+$/g, "");
 }
 

--- a/packages/db/src/migrations/2026-06-24T09:00:00.000Z.ts
+++ b/packages/db/src/migrations/2026-06-24T09:00:00.000Z.ts
@@ -1,0 +1,86 @@
+import { type Kysely, sql } from "kysely";
+
+// Backfill member.slug across every member, so a member is "linked" by
+// default - the slug is the prerequisite for self-editing a profile and the
+// source of leaderboard/records/scorecard profile links. Until now slugs
+// were set one at a time by an admin in the Record Linking tab, so most
+// members had none. This gives every member that lacks one a slug derived
+// from their name.
+//
+// Slug source: slugify(member.name). Collisions are resolved with a numeric
+// suffix (-2, -3, ...). The "used" set is seeded with BOTH existing member
+// slugs (the partial-unique index would otherwise reject a clash) AND every
+// existing person content_item slug. We deliberately never reuse an existing
+// person page's slug for an unrelated member: member.slug == a person
+// content_item.slug is exactly how the two are linked, so an accidental
+// match would land that member on - or let them edit - someone else's
+// profile. A member who genuinely owns an existing page but was never linked
+// therefore gets a distinct slug here; an admin can re-link them in the
+// Record Linking tab. Never mis-linking is the safer default.
+//
+// Dependents (juniors held under a parent member) have no slug column and
+// are untouched. Soft-deleted members (deleted_at) and members with no
+// usable name are skipped.
+//
+// Public 404s: a freshly backfilled slug whose profile page has not been
+// authored yet falls back to a member-backed stub profile (name + stats) in
+// getPublishedContent, so a leaderboard click never dead-ends in the short
+// window before a page exists.
+
+// Exported for unit testing - the collision logic is the only non-trivial
+// part of this backfill, so it is covered directly.
+export function slugify(name: string): string {
+  // NFKD splits an accented letter into a base char + a combining mark; drop
+  // the combining marks (U+0300-U+036F) so "José Núñez" -> "jose-nunez"
+  // rather than leaving a stray hyphen where each mark was. Everything else
+  // non-alphanumeric then collapses to a single hyphen.
+  return name
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * The first slug of the form base, base-2, base-3, ... not already in `used`.
+ * Does NOT mutate `used` - the caller records the result so later names in the
+ * same run cannot reuse it.
+ */
+export function nextFreeSlug(base: string, used: ReadonlySet<string>): string {
+  if (!used.has(base)) return base;
+  let n = 2;
+  while (used.has(`${base}-${n}`)) n += 1;
+  return `${base}-${n}`;
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const used = new Set<string>();
+
+  const taken = await sql<{ slug: string }>`
+    SELECT slug FROM member WHERE slug IS NOT NULL
+    UNION
+    SELECT slug FROM content_item WHERE kind = 'person'
+  `.execute(db);
+  for (const row of taken.rows) used.add(row.slug);
+
+  const members = await sql<{ id: string; name: string | null }>`
+    SELECT id, name
+    FROM member
+    WHERE slug IS NULL AND deleted_at IS NULL
+    ORDER BY name ASC, id ASC
+  `.execute(db);
+
+  for (const member of members.rows) {
+    if (!member.name) continue;
+    const base = slugify(member.name);
+    if (!base) continue;
+
+    const slug = nextFreeSlug(base, used);
+    used.add(slug);
+
+    await sql`UPDATE member SET slug = ${slug} WHERE id = ${member.id}`.execute(
+      db,
+    );
+  }
+}

--- a/packages/db/src/slug-backfill.test.ts
+++ b/packages/db/src/slug-backfill.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+// Helpers from the member.slug backfill migration. The migration itself is
+// immutable and self-contained, so its only non-trivial logic - turning a
+// name into a unique slug - is exported and tested here. Unique slugs matter
+// for safety: member.slug doubles as the profile link, so a duplicate would
+// point two members at one profile.
+import {
+  nextFreeSlug,
+  slugify,
+} from "./migrations/2026-06-24T09:00:00.000Z.ts";
+
+describe("slugify", () => {
+  it("lowercases and hyphenates names", () => {
+    expect(slugify("Alex Young")).toBe("alex-young");
+  });
+
+  it("strips accents via NFKD decomposition", () => {
+    expect(slugify("José Núñez")).toBe("jose-nunez");
+  });
+
+  it("collapses punctuation and trims leading/trailing hyphens", () => {
+    expect(slugify("  O'Brien-Smith (Jr.) ")).toBe("o-brien-smith-jr");
+  });
+
+  it("returns an empty string for a name with no slug characters", () => {
+    expect(slugify("!!!")).toBe("");
+  });
+});
+
+describe("nextFreeSlug", () => {
+  it("returns the base when it is free", () => {
+    expect(nextFreeSlug("alex-young", new Set())).toBe("alex-young");
+  });
+
+  it("suffixes -2 on the first collision", () => {
+    expect(nextFreeSlug("john-smith", new Set(["john-smith"]))).toBe(
+      "john-smith-2",
+    );
+  });
+
+  it("skips taken suffixes to the next free number", () => {
+    const used = new Set(["john-smith", "john-smith-2", "john-smith-3"]);
+    expect(nextFreeSlug("john-smith", used)).toBe("john-smith-4");
+  });
+
+  it("treats an existing person-page slug as taken (never reuses it)", () => {
+    // A person content_item slug is seeded into `used`, so a same-named member
+    // gets a distinct slug rather than being linked to that page.
+    expect(nextFreeSlug("jane-doe", new Set(["jane-doe"]))).toBe("jane-doe-2");
+  });
+
+  it("does not mutate the provided set", () => {
+    const used = new Set(["john-smith"]);
+    nextFreeSlug("john-smith", used);
+    expect(used.has("john-smith-2")).toBe(false);
+  });
+});

--- a/packages/db/src/slug-backfill.test.ts
+++ b/packages/db/src/slug-backfill.test.ts
@@ -25,6 +25,20 @@ describe("slugify", () => {
   it("returns an empty string for a name with no slug characters", () => {
     expect(slugify("!!!")).toBe("");
   });
+
+  it("caps the slug length so it stays under the content slug limit", () => {
+    const slug = slugify("a".repeat(250));
+    expect(slug.length).toBeLessThanOrEqual(180);
+    expect(slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+  });
+
+  it("does not leave a trailing hyphen when the cut lands on one", () => {
+    // 179 'a's, then a separator, then more: the slice at 180 lands on the
+    // hyphen, which the final trim removes.
+    const slug = slugify(`${"a".repeat(179)} bbbb`);
+    expect(slug.endsWith("-")).toBe(false);
+    expect(slug).toBe("a".repeat(179));
+  });
 });
 
 describe("nextFreeSlug", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/email:
     dependencies:
@@ -10220,9 +10223,9 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/infra@0.2.14(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/sso@1.5.6(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.19(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.2(zod@4.4.3)))(better-auth@1.6.19(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(zod@4.4.3)':
@@ -10237,21 +10240,21 @@ snapshots:
       libphonenumber-js: 1.13.5
       zod: 4.4.3
 
-  '@better-auth/kysely-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+  '@better-auth/kysely-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.2
 
-  '@better-auth/memory-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/passkey@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.2(zod@4.4.3))(nanostores@1.3.0)':
@@ -10266,9 +10269,9 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/sso@1.5.6(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.19(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.2(zod@4.4.3))':
@@ -10284,9 +10287,9 @@ snapshots:
       tldts: 6.1.86
       zod: 4.4.3
 
-  '@better-auth/telemetry@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -14213,12 +14216,12 @@ snapshots:
   better-auth@1.6.19(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
     dependencies:
       '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0


### PR DESCRIPTION
## What

Makes a profile slug the default for every member, so self-editing (ADR 050) and public profile links work for **all** members rather than only the handful an admin had hand-linked. Three coupled changes, recorded in [ADR 051](docs/adrs/051-member-slug-backfill-and-profile-fallback.md):

1. **Migration: backfill `member.slug`** for every non-deleted member that lacks one, derived from their name. Collisions resolve with a numeric suffix (`john-smith-2`); the used-set is seeded with existing member slugs **and** person `content_item` slugs, so a backfilled slug never accidentally links a member to another person's page. Dependents (no `slug` column) are untouched.
2. **Member-backed fallback profile.** `GET /content/person/:slug` returns a minimal stub (the member's name + the slug-keyed stats/sponsor panels) when no published page exists yet but a live member owns the slug, so a leaderboard click never dead-ends on "Person Not Found". Runs **after** the tombstone check, so a deliberate takedown (410) is never resurrected; soft-deleted members get 404.
3. **Self-create on first edit.** A slug-linked member with no profile page gets a virtual editable profile; their first submitted proposal creates the person item as a **draft**, and approval **publishes** it. Approval only ever promotes a `draft` (never resurrects an `archived` item).

## Why

A slug link is the precondition for self-editing, but it was set one member at a time in the Record Linking tab, so almost nobody was linked. Backfilling slugs unblocks everyone, but a slug alone 404s on the public profile page until someone authors it - hence the fallback (no dead-ends) and self-create (the link genuinely unlocks editing).

## Decisions / scope

- **All members** per the product owner: junior account-holders are 13+, and all profile content is admin-approved before going live. Dependents are structurally excluded (no slug column; leaderboards only join `member`).
- **Short 404 window** between the migration (which makes leaderboard links appear) and the deploy carrying the fallback is acceptable - they land together on `main`.
- Collision strategy prefers a **distinct suffixed slug over reusing** an existing page's slug, so a member is never wrong-linked to another person's profile.

## Tests

- `content/member-stub.integration.test.ts` - fallback matrix (stub, soft-deleted 404, real page wins, tombstone 410 precedence).
- `content-proposal/integration.test.ts` - virtual profile, create-draft-on-submit, publish-on-approve, stub stands in until published.
- `db/slug-backfill.test.ts` - collision-safe slug generation (accents, suffixing, no-mutation, person-slug reservation).

All gates green locally: typecheck, lint, format, unit + the affected integration suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)