### PR TITLE
Publish-time prerendering: content on first paint, per-page meta, real SEO

### DIFF
--- a/.github/workflows/deploy-web-manual.yml
+++ b/.github/workflows/deploy-web-manual.yml
@@ -63,7 +63,13 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build frontend
-        run: pnpm --filter web build
+        # build:ssr = the prerenderer Lambda bundle, built with the same
+        # env so markup and hashed asset references match the client
+        # build exactly (check:ssr-assets asserts it).
+        run: |
+          pnpm --filter web build
+          pnpm --filter web build:ssr
+          pnpm --filter web check:ssr-assets
         env:
           VITE_API_URL: https://api.v2.percymain.org/api
           VITE_STRIPE_PUBLIC_KEY: ${{ vars.STRIPE_PUBLIC_KEY }}
@@ -81,19 +87,36 @@ jobs:
           role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Sync to S3
+      - name: Upload to S3
+        # Two-phase deploy (mirrors deploy.yml): ADD/UPDATE only here; old
+        # hashed assets survive until every prerendered snapshot has been
+        # re-rendered against the new bundle. "Remove stale assets" below
+        # does the --delete pass.
         run: |
           aws s3 sync apps/web/dist/ s3://${{ vars.FRONTEND_BUCKET }} \
-            --delete \
             --cache-control "public, max-age=31536000, immutable" \
             --exclude "index.html" \
-            --exclude "*.json"
+            --exclude "*.json" \
+            --exclude "robots.txt"
 
           aws s3 cp apps/web/dist/index.html s3://${{ vars.FRONTEND_BUCKET }}/index.html \
             --cache-control "public, max-age=0, must-revalidate"
 
+          aws s3 cp apps/web/dist/robots.txt s3://${{ vars.FRONTEND_BUCKET }}/robots.txt \
+            --cache-control "public, max-age=0, must-revalidate"
+
           find apps/web/dist -name "*.json" -exec sh -c \
             'aws s3 cp "$1" s3://${{ vars.FRONTEND_BUCKET }}/${1#apps/web/dist/} --cache-control "public, max-age=0, must-revalidate"' _ {} \;
+
+      - name: Deploy prerenderer Lambda
+        run: |
+          cp apps/web/dist/index.html apps/web/dist-server/template.html
+          (cd apps/web/dist-server && zip -qr ../../../prerenderer.zip .)
+          aws lambda update-function-code \
+            --function-name percy-main-production-prerenderer \
+            --zip-file fileb://prerenderer.zip >/dev/null
+          aws lambda wait function-updated \
+            --function-name percy-main-production-prerenderer
 
       - name: Invalidate CloudFront cache
         id: invalidate
@@ -112,6 +135,36 @@ jobs:
           aws cloudfront wait invalidation-completed \
             --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} \
             --id "${{ steps.invalidate.outputs.invalidation_id }}"
+
+      - name: Rerender prerendered pages
+        # Synchronous: stale-asset cleanup below must not run until every
+        # snapshot references the new bundle. Gated like deploy.yml.
+        if: vars.PRERENDER_ENABLED == 'true'
+        run: |
+          aws lambda invoke \
+            --function-name percy-main-production-prerenderer \
+            --cli-binary-format raw-in-base64-out \
+            --cli-read-timeout 360 \
+            --payload '{"action":"render-all"}' \
+            /tmp/render-all.json
+          cat /tmp/render-all.json
+          if grep -q '"errorMessage"' /tmp/render-all.json; then
+            echo "::error::prerenderer render-all failed"
+            exit 1
+          fi
+
+      - name: Remove stale assets
+        # The excludes protect the prerenderer's bucket-side objects
+        # (snapshots, sitemap, state.json) from --delete.
+        run: |
+          aws s3 sync apps/web/dist/ s3://${{ vars.FRONTEND_BUCKET }} \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html" \
+            --exclude "*.json" \
+            --exclude "robots.txt" \
+            --exclude "_prerender/*" \
+            --exclude "sitemap.xml"
 
       - name: Record web deployment in New Relic
         id: nr-deploy-web

--- a/.github/workflows/deploy-web-manual.yml
+++ b/.github/workflows/deploy-web-manual.yml
@@ -62,6 +62,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Bake nav snapshot
+        # Mirrors deploy.yml: live nav as initialData; fail-soft.
+        run: node apps/web/scripts/fetch-nav-snapshot.mjs
+
       - name: Build frontend
         # build:ssr = the prerenderer Lambda bundle, built with the same
         # env so markup and hashed asset references match the client

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -719,7 +719,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build frontend
-        run: pnpm --filter web build
+        # The prerenderer bundle (build:ssr) is built alongside the client
+        # bundle with the same env so its markup, baked API URL and hashed
+        # asset references match exactly; check:ssr-assets asserts that
+        # asset-name parity before anything is uploaded.
+        run: |
+          pnpm --filter web build
+          pnpm --filter web build:ssr
+          pnpm --filter web check:ssr-assets
         env:
           VITE_API_URL: https://api.v2.percymain.org/api
           VITE_STRIPE_PUBLIC_KEY: ${{ vars.STRIPE_PUBLIC_KEY }}
@@ -742,19 +749,43 @@ jobs:
           role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Sync to S3
+      - name: Upload to S3
+        # Two-phase deploy for the sake of prerendered snapshots: this
+        # step only ADDS/UPDATES objects (no --delete). Old hashed assets
+        # stay live until the render-all below has rewritten every
+        # snapshot to reference the new ones - deleting them first would
+        # leave prerendered pages pointing at 404 scripts/styles for the
+        # whole re-render window. The final "Remove stale assets" step
+        # does the --delete pass.
         run: |
           aws s3 sync apps/web/dist/ s3://${{ vars.FRONTEND_BUCKET }} \
-            --delete \
             --cache-control "public, max-age=31536000, immutable" \
             --exclude "index.html" \
-            --exclude "*.json"
+            --exclude "*.json" \
+            --exclude "robots.txt"
 
           aws s3 cp apps/web/dist/index.html s3://${{ vars.FRONTEND_BUCKET }}/index.html \
             --cache-control "public, max-age=0, must-revalidate"
 
+          aws s3 cp apps/web/dist/robots.txt s3://${{ vars.FRONTEND_BUCKET }}/robots.txt \
+            --cache-control "public, max-age=0, must-revalidate"
+
           find apps/web/dist -name "*.json" -exec sh -c \
             'aws s3 cp "$1" s3://${{ vars.FRONTEND_BUCKET }}/${1#apps/web/dist/} --cache-control "public, max-age=0, must-revalidate"' _ {} \;
+
+      - name: Deploy prerenderer Lambda
+        # The function resource is Terraform's (infra/modules/prerender);
+        # its CODE ships with every web deploy so the renderer always
+        # matches the client bundle just synced. template.html is the
+        # exact built index.html the assembler swaps regions of.
+        run: |
+          cp apps/web/dist/index.html apps/web/dist-server/template.html
+          (cd apps/web/dist-server && zip -qr ../../../prerenderer.zip .)
+          aws lambda update-function-code \
+            --function-name percy-main-production-prerenderer \
+            --zip-file fileb://prerenderer.zip >/dev/null
+          aws lambda wait function-updated \
+            --function-name percy-main-production-prerenderer
 
       - name: Invalidate CloudFront cache
         id: invalidate
@@ -773,6 +804,46 @@ jobs:
           aws cloudfront wait invalidation-completed \
             --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} \
             --id "${{ steps.invalidate.outputs.invalidation_id }}"
+
+      - name: Rerender prerendered pages
+        # Every deploy changes hashed asset names, so every snapshot must
+        # be re-rendered against the new bundle. Synchronous on purpose:
+        # the stale-asset cleanup below must not run until every snapshot
+        # references the new assets. Gated on the PRERENDER_ENABLED repo
+        # variable for incremental rollout - while unset, the KVS must
+        # stay empty (rollback = delete all KVS keys AND unset the var).
+        if: vars.PRERENDER_ENABLED == 'true'
+        run: |
+          aws lambda invoke \
+            --function-name percy-main-production-prerenderer \
+            --cli-binary-format raw-in-base64-out \
+            --cli-read-timeout 360 \
+            --payload '{"action":"render-all"}' \
+            /tmp/render-all.json
+          cat /tmp/render-all.json
+          # A function error (e.g. API unreachable) must fail the deploy
+          # BEFORE the stale-asset cleanup runs.
+          if grep -q '"errorMessage"' /tmp/render-all.json; then
+            echo "::error::prerenderer render-all failed"
+            exit 1
+          fi
+
+      - name: Remove stale assets
+        # Second phase of the sync: now that snapshots reference the new
+        # hashed assets, drop the old generation. The excludes protect the
+        # prerenderer's bucket-side objects (snapshots, sitemap,
+        # state.json) - they exist only in the bucket, so an unexcluded
+        # --delete pass would tear them down while the CloudFront KVS
+        # still routes to them.
+        run: |
+          aws s3 sync apps/web/dist/ s3://${{ vars.FRONTEND_BUCKET }} \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html" \
+            --exclude "*.json" \
+            --exclude "robots.txt" \
+            --exclude "_prerender/*" \
+            --exclude "sitemap.xml"
 
       - name: Record web deployment in New Relic
         id: nr-deploy-web

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -718,6 +718,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Bake nav snapshot
+        # Live nav into the bundle as react-query initialData - the menu
+        # paints complete on first render for SPA-shell routes. Fail-soft:
+        # an API blip keeps the committed empty snapshot.
+        run: node apps/web/scripts/fetch-nav-snapshot.mjs
+
       - name: Build frontend
         # The prerenderer bundle (build:ssr) is built alongside the client
         # bundle with the same env so its markup, baked API URL and hashed

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "@arizeai/openinference-semantic-conventions": "^2.5.0",
     "@arizeai/openinference-vercel": "^2.7.8",
     "@aws-sdk/client-ecs": "^3.1078.0",
+    "@aws-sdk/client-lambda": "^3.1078.0",
     "@aws-sdk/client-rekognition": "^3.1078.0",
     "@aws-sdk/client-s3": "^3.1078.0",
     "@aws-sdk/s3-request-presigner": "^3.1078.0",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -311,6 +311,12 @@ const configSchema = z.object({
     .enum(["true", "false"])
     .default("false")
     .transform((v) => v === "true"),
+
+  // Prerenderer Lambda (publish-time static HTML snapshots). Optional
+  // AWS integration like SYNC_ECS_*: the function only exists in
+  // deployed environments; unset makes the publish-path trigger a
+  // logged no-op (dev / test / preview).
+  PRERENDER_LAMBDA_ARN: z.string().optional(),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/apps/api/src/features/content-proposal/routes.ts
+++ b/apps/api/src/features/content-proposal/routes.ts
@@ -1,4 +1,5 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { createPrerenderTrigger } from "../../lib/prerender-trigger.ts";
 import {
   getAuthSession,
   requireAuth,
@@ -46,6 +47,7 @@ export const contentProposalRoutes: FastifyPluginAsyncZod = async (app) => {
   const approve = approveProfileProposal(app.db, notifyDeps);
   const reject = rejectProfileProposal(app.db, notifyDeps);
   const canEdit = assertCanEditProfile(app.db);
+  const prerenderTrigger = createPrerenderTrigger(app.config, app.log);
   // Profile owners hold no content role, so they can't use the admin
   // content-images endpoints. These self-service routes reuse the same
   // upload/process service, gated instead on owning an editable profile.
@@ -177,10 +179,14 @@ export const contentProposalRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request) => {
       const { user } = getAuthSession(request);
-      return await approve({
+      const result = await approve({
         proposalId: request.params.proposalId,
         reviewerUserId: user.id,
       });
+      // Approval rewrites the live person profile (fire-and-forget; the
+      // prerenderer re-renders the changed page).
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -26,6 +26,7 @@ import {
   pageByPathQuerySchema,
   pageTreeResponseSchema,
   playCricketIdParamSchema,
+  prerenderManifestResponseSchema,
   publicContentParamsSchema,
   publicContentResponseSchema,
   publishContentSchema,
@@ -45,6 +46,7 @@ import {
   getRevision,
   listContent,
   listPageTree,
+  listPrerenderManifest,
   listPublishedEvents,
   listPublishedNews,
   listPublishedPeople,
@@ -97,6 +99,7 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const publicEvents = listPublishedEvents(app.db);
   const publicPeople = listPublishedPeople(app.db);
   const publicNav = getPublishedNav(app.db);
+  const prerenderManifest = listPrerenderManifest(app.db);
   const publicPageByPath = getPublishedPageByPath(app.db);
 
   // ── Admin ──
@@ -427,6 +430,21 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async () => {
       return await publicNav();
+    },
+  );
+
+  // Consumed by the prerenderer Lambda (apps/web/server/prerender) on
+  // every sync. Public like the other list routes: it reveals nothing the
+  // nav/news/people lists don't already.
+  app.get(
+    "/content/prerender-manifest",
+    {
+      schema: {
+        response: { 200: prerenderManifestResponseSchema },
+      },
+    },
+    async () => {
+      return await prerenderManifest();
     },
   );
 };

--- a/apps/api/src/features/content/routes.ts
+++ b/apps/api/src/features/content/routes.ts
@@ -9,6 +9,7 @@ import {
 import type { FastifyRequest } from "fastify";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { createPrerenderTrigger } from "../../lib/prerender-trigger.ts";
 import { getAuthSession, requireAuth } from "../auth/middleware.ts";
 import {
   contentDetailResponseSchema,
@@ -100,6 +101,10 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
   const publicPeople = listPublishedPeople(app.db);
   const publicNav = getPublishedNav(app.db);
   const prerenderManifest = listPrerenderManifest(app.db);
+  // Fire-and-forget on every mutation that changes the public site; the
+  // Lambda's manifest diff works out what to re-render (no-op when a
+  // publish is scheduled for the future - the item isn't live yet).
+  const prerenderTrigger = createPrerenderTrigger(app.config, app.log);
   const publicPageByPath = getPublishedPageByPath(app.db);
 
   // ── Admin ──
@@ -189,11 +194,14 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
         assertContentPermission(request, kind, "publish");
       }
       const { user } = getAuthSession(request);
-      return await update({
+      const result = await update({
         ...request.body,
         contentId: request.params.contentId,
         userId: user.id,
       });
+      // Draft edits don't change the public site.
+      if (status === "published") prerenderTrigger.reconcile();
+      return result;
     },
   );
 
@@ -211,11 +219,13 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       const { kind } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "publish");
       const { user } = getAuthSession(request);
-      return await publish({
+      const result = await publish({
         contentId: request.params.contentId,
         publishedAt: request.body?.publishedAt,
         userId: user.id,
       });
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 
@@ -232,10 +242,12 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       const { kind } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "publish");
       const { user } = getAuthSession(request);
-      return await unpublish({
+      const result = await unpublish({
         contentId: request.params.contentId,
         userId: user.id,
       });
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 
@@ -252,10 +264,12 @@ export const contentRoutes: FastifyPluginAsyncZod = async (app) => {
       const { kind } = await metaOf(request.params.contentId);
       assertContentPermission(request, kind, "manage");
       const { user } = getAuthSession(request);
-      return await archive({
+      const result = await archive({
         contentId: request.params.contentId,
         userId: user.id,
       });
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 

--- a/apps/api/src/features/content/schemas.ts
+++ b/apps/api/src/features/content/schemas.ts
@@ -301,3 +301,21 @@ export const pageByPathQuerySchema = z.object({
 export const goneResponseSchema = z.object({
   error: z.string(),
 });
+
+/**
+ * One row per live public content URL, for the prerenderer Lambda: it
+ * diffs `updatedAt`/`publishedAt` against its state file to decide what
+ * to re-render, and builds sitemap.xml from the URL list. Game reports
+ * are excluded (they keep the CloudFront OG redirect).
+ */
+export const prerenderManifestResponseSchema = z.object({
+  items: z.array(
+    z.object({
+      url: z.string(),
+      kind: z.enum(["page", "news", "event", "person"]),
+      slug: z.string(),
+      updatedAt: z.string(),
+      publishedAt: z.string(),
+    }),
+  ),
+});

--- a/apps/api/src/features/content/service.ts
+++ b/apps/api/src/features/content/service.ts
@@ -7,6 +7,7 @@ import {
   newsMetadataSchema,
   pageMetadataSchema,
   personMetadataSchema,
+  publicContentUrl,
   RESERVED_ROOT_SLUGS,
   type ContentKind,
   type ContentStatus,
@@ -1599,6 +1600,47 @@ export function listPublishedPeople(db: Kysely<DB>) {
     return {
       items: rows.map((row) => toPublicListItem(personMetadataSchema, row)),
       removed: removedRows.map((row) => row.slug),
+    };
+  };
+}
+
+/**
+ * Everything the prerenderer needs to sync: one row per LIVE public
+ * content URL (game reports excluded - they keep the CloudFront OG
+ * redirect). The Lambda diffs this against its state file to decide what
+ * to (re)render, and builds sitemap.xml from it, so the timestamps must
+ * change whenever the rendered output would.
+ */
+export function listPrerenderManifest(db: Kysely<DB>) {
+  return async () => {
+    const rows = await publishedOnly(db)
+      .select(["kind", "slug", "path", "updated_at", "published_at"])
+      .where("kind", "in", ["page", "news", "event", "person"])
+      .orderBy("kind", "asc")
+      .orderBy("slug", "asc")
+      .execute();
+
+    return {
+      items: rows.flatMap((row) => {
+        // Non-null by check constraint when status='published'; skip
+        // rather than 500 so one bad row cannot take down the whole sync.
+        if (!row.published_at) return [];
+        const url = publicContentUrl(
+          row.kind as ContentKind,
+          row.slug,
+          row.path,
+        );
+        if (url === null) return [];
+        return [
+          {
+            url,
+            kind: row.kind as "page" | "news" | "event" | "person",
+            slug: row.slug,
+            updatedAt: row.updated_at.toISOString(),
+            publishedAt: row.published_at.toISOString(),
+          },
+        ];
+      }),
     };
   };
 }

--- a/apps/api/src/lib/prerender-trigger.test.ts
+++ b/apps/api/src/lib/prerender-trigger.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted; the factory runs before the import below.
+const sendLambda = vi.fn();
+
+vi.mock("@aws-sdk/client-lambda", () => {
+  class InvokeCommand {
+    constructor(public input: unknown) {}
+  }
+  class LambdaClient {
+    send = sendLambda;
+  }
+  return { InvokeCommand, LambdaClient };
+});
+
+import type { FastifyBaseLogger } from "fastify";
+import type { Config } from "../config.ts";
+import { createPrerenderTrigger } from "./prerender-trigger.ts";
+
+function makeLog() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  } as unknown as FastifyBaseLogger & {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeConfig(arn: string | undefined): Config {
+  return { PRERENDER_LAMBDA_ARN: arn, AWS_REGION: "eu-west-2" } as Config;
+}
+
+/** Let the fire-and-forget promise chain settle. */
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+beforeEach(() => {
+  sendLambda.mockReset();
+});
+
+describe("createPrerenderTrigger", () => {
+  it("is a logged no-op when PRERENDER_LAMBDA_ARN is unset", async () => {
+    const log = makeLog();
+    const trigger = createPrerenderTrigger(makeConfig(undefined), log);
+    trigger.reconcile();
+    await flush();
+    expect(sendLambda).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalled();
+  });
+
+  it("fires an async Event invoke with the reconcile action", async () => {
+    sendLambda.mockResolvedValue({});
+    const log = makeLog();
+    const trigger = createPrerenderTrigger(
+      makeConfig("arn:aws:lambda:eu-west-2:123:function:prerenderer"),
+      log,
+    );
+    trigger.reconcile();
+    await flush();
+
+    expect(sendLambda).toHaveBeenCalledTimes(1);
+    const command = sendLambda.mock.calls[0][0] as {
+      input: { FunctionName: string; InvocationType: string; Payload: Buffer };
+    };
+    expect(command.input.FunctionName).toBe(
+      "arn:aws:lambda:eu-west-2:123:function:prerenderer",
+    );
+    expect(command.input.InvocationType).toBe("Event");
+    expect(JSON.parse(command.input.Payload.toString())).toEqual({
+      action: "reconcile",
+    });
+    expect(log.info).toHaveBeenCalled();
+  });
+
+  it("never throws when the invoke fails - publish must not break on render trouble", async () => {
+    sendLambda.mockRejectedValue(new Error("lambda down"));
+    const log = makeLog();
+    const trigger = createPrerenderTrigger(
+      makeConfig("arn:aws:lambda:eu-west-2:123:function:prerenderer"),
+      log,
+    );
+    expect(() => {
+      trigger.reconcile();
+    }).not.toThrow();
+    await flush();
+    expect(log.error).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/prerender-trigger.test.ts
+++ b/apps/api/src/lib/prerender-trigger.test.ts
@@ -50,6 +50,15 @@ describe("createPrerenderTrigger", () => {
     expect(log.debug).toHaveBeenCalled();
   });
 
+  it("is a logged no-op without any config (minimal test apps)", async () => {
+    const log = makeLog();
+    const trigger = createPrerenderTrigger(undefined, log);
+    trigger.reconcile();
+    await flush();
+    expect(sendLambda).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalled();
+  });
+
   it("fires an async Event invoke with the reconcile action", async () => {
     sendLambda.mockResolvedValue({});
     const log = makeLog();

--- a/apps/api/src/lib/prerender-trigger.ts
+++ b/apps/api/src/lib/prerender-trigger.ts
@@ -1,0 +1,53 @@
+import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+import type { FastifyBaseLogger } from "fastify";
+import type { Config } from "../config.ts";
+
+/**
+ * Publish-path hook for the prerenderer Lambda
+ * (apps/web/server/prerender): any mutation that changes what the public
+ * site serves fires one async `reconcile` - the Lambda diffs the live
+ * manifest against its state file and re-renders exactly what changed,
+ * so callers never compute URLs or distinguish publish from unpublish.
+ *
+ * Fire-and-forget BY DESIGN: publishing must never fail (or slow down)
+ * because rendering is broken. A lost trigger self-heals via the
+ * 15-minute reconcile schedule; failures land on the alarms topic
+ * through the Lambda's async-invoke on_failure destination.
+ */
+export interface PrerenderTrigger {
+  reconcile(): void;
+}
+
+export function createPrerenderTrigger(
+  config: Config,
+  log: FastifyBaseLogger,
+): PrerenderTrigger {
+  const functionArn = config.PRERENDER_LAMBDA_ARN;
+  if (functionArn === undefined) {
+    return {
+      reconcile() {
+        log.debug("prerender trigger unconfigured; skipping reconcile");
+      },
+    };
+  }
+
+  const lambda = new LambdaClient({ region: config.AWS_REGION });
+  return {
+    reconcile() {
+      lambda
+        .send(
+          new InvokeCommand({
+            FunctionName: functionArn,
+            InvocationType: "Event",
+            Payload: Buffer.from(JSON.stringify({ action: "reconcile" })),
+          }),
+        )
+        .then(() => {
+          log.info("prerender reconcile triggered");
+        })
+        .catch((error: unknown) => {
+          log.error({ err: error }, "prerender reconcile invoke failed");
+        });
+    },
+  };
+}

--- a/apps/api/src/lib/prerender-trigger.ts
+++ b/apps/api/src/lib/prerender-trigger.ts
@@ -19,11 +19,13 @@ export interface PrerenderTrigger {
 }
 
 export function createPrerenderTrigger(
-  config: Config,
+  // Optional because minimal integration-test apps register the content
+  // routes without decorating app.config; no config = unconfigured.
+  config: Config | undefined,
   log: FastifyBaseLogger,
 ): PrerenderTrigger {
-  const functionArn = config.PRERENDER_LAMBDA_ARN;
-  if (functionArn === undefined) {
+  const functionArn = config?.PRERENDER_LAMBDA_ARN;
+  if (config === undefined || functionArn === undefined) {
     return {
       reconcile() {
         log.debug("prerender trigger unconfigured; skipping reconcile");

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -14235,6 +14235,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/content/prerender-manifest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                url: string;
+                                /** @enum {string} */
+                                kind: "page" | "news" | "event" | "person";
+                                slug: string;
+                                updatedAt: string;
+                                publishedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/content-images/upload-url": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -25655,6 +25655,65 @@
         }
       }
     },
+    "/api/content/prerender-manifest": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "page",
+                              "news",
+                              "event",
+                              "person"
+                            ]
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "url",
+                          "kind",
+                          "slug",
+                          "updatedAt",
+                          "publishedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/content-images/upload-url": {
       "post": {
         "requestBody": {

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,1 @@
+dist-server/

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=5"
     />
+    <!-- pm-meta:start -->
     <title>Percy Main Community Sports Club</title>
     <meta
       name="description"
@@ -32,6 +33,7 @@
       name="twitter:image"
       content="https://www.percymain.org/images/og-default.png"
     />
+    <!-- pm-meta:end -->
     <link
       rel="icon"
       type="image/png"
@@ -90,6 +92,7 @@
     <!-- pm-gtag:end -->
   </head>
   <body>
+    <!-- pm-theme:start -->
     <script>
       (function () {
         var t = localStorage.getItem("percy-theme");
@@ -99,6 +102,7 @@
         if (d) document.documentElement.classList.add("dark");
       })();
     </script>
+    <!-- pm-theme:end -->
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,8 +5,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:ssr": "vite build --ssr server/prerender/lambda.ts --outDir dist/prerender",
+    "check:ssr-assets": "node scripts/check-ssr-asset-parity.mjs",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.server.json --noEmit",
     "lint": "eslint src/",
     "test": "vitest run",
     "test:watch": "vitest"
@@ -63,6 +65,7 @@
     "@rolldown/plugin-babel": "^0.2.3",
     "@tailwindcss/vite": "^4.3.2",
     "@types/google.maps": "^3.65.2",
+    "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-react": "^6.0.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "build:ssr": "vite build --ssr server/prerender/lambda.ts --outDir dist/prerender",
+    "build:ssr": "vite build --ssr server/prerender/lambda.ts --outDir dist-server",
     "check:ssr-assets": "node scripts/check-ssr-asset-parity.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.server.json --noEmit",
@@ -62,7 +62,12 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@aws-sdk/client-cloudfront": "^3.1078.0",
+    "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1078.0",
+    "@aws-sdk/client-s3": "^3.1078.0",
+    "@aws-sdk/signature-v4-multi-region": "^3.996.38",
     "@rolldown/plugin-babel": "^0.2.3",
+    "@smithy/signature-v4a": "^3.4.1",
     "@tailwindcss/vite": "^4.3.2",
     "@types/google.maps": "^3.65.2",
     "@types/node": "^25.9.3",

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,10 @@
+User-agent: *
+Disallow: /admin
+Disallow: /members
+Disallow: /membership
+Disallow: /auth
+Disallow: /scout
+Disallow: /junior-manager
+Disallow: /_prerender/
+
+Sitemap: https://www.percymain.org/sitemap.xml

--- a/apps/web/scripts/check-ssr-asset-parity.mjs
+++ b/apps/web/scripts/check-ssr-asset-parity.mjs
@@ -1,0 +1,54 @@
+// Guards the prerenderer's asset-hash parity: the SSR bundle
+// (dist/prerender) references content-hashed /assets/ URLs, but only the
+// CLIENT build emits those files. Both builds hash the same content with
+// the same config so the names should always agree - this asserts they
+// actually do, catching config drift or a bundler upgrade changing the
+// hash scheme before a deploy ships prerendered pages full of 404 images.
+//
+// Run after BOTH `pnpm --filter web build` and `pnpm --filter web build:ssr`.
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const distDir = resolve(import.meta.dirname, "../dist");
+const ssrDir = join(distDir, "prerender");
+
+if (!existsSync(ssrDir)) {
+  console.error(`check-ssr-asset-parity: ${ssrDir} not found - run build:ssr first`);
+  process.exit(1);
+}
+
+const ssrFiles = readdirSync(ssrDir, { recursive: true })
+  .map(String)
+  .filter((f) => f.endsWith(".js") || f.endsWith(".mjs") || f.endsWith(".cjs"));
+
+if (ssrFiles.length === 0) {
+  console.error(`check-ssr-asset-parity: no JS bundle found in ${ssrDir}`);
+  process.exit(1);
+}
+
+const missing = new Set();
+let referenced = 0;
+
+for (const file of ssrFiles) {
+  const code = readFileSync(join(ssrDir, file), "utf8");
+  for (const match of code.matchAll(/["'](\/assets\/[^"'\s?#]+)["']/g)) {
+    const assetPath = match[1];
+    referenced += 1;
+    if (!existsSync(join(distDir, assetPath))) {
+      missing.add(assetPath);
+    }
+  }
+}
+
+if (missing.size > 0) {
+  console.error(
+    `check-ssr-asset-parity: ${String(missing.size)} asset reference(s) in the SSR bundle do not exist in the client build:`,
+  );
+  for (const assetPath of missing) console.error(`  ${assetPath}`);
+  process.exit(1);
+}
+
+console.log(
+  `check-ssr-asset-parity: OK (${String(referenced)} asset references all present in client build)`,
+);

--- a/apps/web/scripts/check-ssr-asset-parity.mjs
+++ b/apps/web/scripts/check-ssr-asset-parity.mjs
@@ -11,7 +11,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const distDir = resolve(import.meta.dirname, "../dist");
-const ssrDir = join(distDir, "prerender");
+const ssrDir = resolve(import.meta.dirname, "../dist-server");
 
 if (!existsSync(ssrDir)) {
   console.error(`check-ssr-asset-parity: ${ssrDir} not found - run build:ssr first`);

--- a/apps/web/scripts/check-ssr-asset-parity.mjs
+++ b/apps/web/scripts/check-ssr-asset-parity.mjs
@@ -14,7 +14,9 @@ const distDir = resolve(import.meta.dirname, "../dist");
 const ssrDir = resolve(import.meta.dirname, "../dist-server");
 
 if (!existsSync(ssrDir)) {
-  console.error(`check-ssr-asset-parity: ${ssrDir} not found - run build:ssr first`);
+  console.error(
+    `check-ssr-asset-parity: ${ssrDir} not found - run build:ssr first`,
+  );
   process.exit(1);
 }
 

--- a/apps/web/scripts/fetch-nav-snapshot.mjs
+++ b/apps/web/scripts/fetch-nav-snapshot.mjs
@@ -1,0 +1,42 @@
+// Deploy-time prebuild step: bake the CURRENT live nav into the bundle
+// as react-query initialData (src/generated/nav-snapshot.json), so the
+// header's content-section links paint on first render on SPA-shell
+// routes (/fantasy, /calendar, ...) instead of popping in when
+// GET /api/content/nav resolves. initialDataUpdatedAt: 0 marks it
+// immediately stale, so the client still refetches in the background -
+// staleness is bounded by one page load, not one deploy.
+//
+// Fail-soft BY DESIGN: local/offline builds and API outages keep the
+// committed empty snapshot (today's behaviour) rather than failing the
+// build.
+
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const NAV_URL =
+  process.env.NAV_SNAPSHOT_URL ?? "https://api.v2.percymain.org/api/content/nav";
+const OUT_PATH = resolve(
+  import.meta.dirname,
+  "../src/generated/nav-snapshot.json",
+);
+
+try {
+  const response = await fetch(NAV_URL, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${String(response.status)}`);
+  }
+  const nav = await response.json();
+  if (!Array.isArray(nav?.items) || !Array.isArray(nav?.removed)) {
+    throw new Error("Response is not a nav payload");
+  }
+  writeFileSync(OUT_PATH, `${JSON.stringify(nav, null, 2)}\n`);
+  console.log(
+    `fetch-nav-snapshot: baked ${String(nav.items.length)} nav item(s) from ${NAV_URL}`,
+  );
+} catch (error) {
+  console.warn(
+    `fetch-nav-snapshot: keeping committed snapshot (${error instanceof Error ? error.message : String(error)})`,
+  );
+}

--- a/apps/web/scripts/fetch-nav-snapshot.mjs
+++ b/apps/web/scripts/fetch-nav-snapshot.mjs
@@ -14,7 +14,8 @@ import { writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const NAV_URL =
-  process.env.NAV_SNAPSHOT_URL ?? "https://api.v2.percymain.org/api/content/nav";
+  process.env.NAV_SNAPSHOT_URL ??
+  "https://api.v2.percymain.org/api/content/nav";
 const OUT_PATH = resolve(
   import.meta.dirname,
   "../src/generated/nav-snapshot.json",

--- a/apps/web/scripts/prerender-preview.mjs
+++ b/apps/web/scripts/prerender-preview.mjs
@@ -1,0 +1,37 @@
+// Local preview of a prerendered document, end-to-end minus AWS: fetches
+// live data from the API baked into the SSR bundle, renders through the
+// real entry-server + head builder + assembler, and writes the HTML to
+// stdout or a file.
+//
+// Usage:
+//   pnpm --filter web build && VITE_API_URL=https://api.v2.percymain.org/api pnpm --filter web build:ssr
+//   node scripts/prerender-preview.mjs /club [out.html]
+
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const url = process.argv[2];
+if (!url) {
+  console.error(
+    "usage: node scripts/prerender-preview.mjs <url-path> [out-file]",
+  );
+  process.exit(1);
+}
+
+process.env.TEMPLATE_PATH ??= resolve(
+  import.meta.dirname,
+  "../dist/index.html",
+);
+
+const { renderDocument } = await import(
+  resolve(import.meta.dirname, "../dist-server/lambda.mjs")
+);
+
+const html = await renderDocument(url);
+const outFile = process.argv[3];
+if (outFile) {
+  writeFileSync(outFile, html);
+  console.error(`wrote ${String(html.length)} bytes to ${outFile}`);
+} else {
+  process.stdout.write(html);
+}

--- a/apps/web/server/prerender/lambda.ts
+++ b/apps/web/server/prerender/lambda.ts
@@ -1,0 +1,427 @@
+import { render } from "@/entry-server.js";
+import { api, callApi } from "@/lib/api-client.js";
+import {
+  eventQueryOptions,
+  isPageGone,
+  navQueryOptions,
+  newsArticleQueryOptions,
+  pageByPathQueryOptions,
+  peopleListQueryOptions,
+  personQueryOptions,
+} from "@/lib/content-queries.js";
+import { assembleDocument } from "@/prerender/assemble-document.js";
+import { buildHead } from "@/prerender/build-head.js";
+import {
+  snapshotInvalidationPath,
+  snapshotKvsKey,
+  snapshotS3Key,
+} from "@/prerender/paths.js";
+import {
+  navHash,
+  nextState,
+  planReconcile,
+  type ManifestItem,
+  type PrerenderState,
+} from "@/prerender/reconcile.js";
+import { buildSitemap } from "@/prerender/sitemap.js";
+import {
+  CloudFrontClient,
+  CreateInvalidationCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  CloudFrontKeyValueStoreClient,
+  DescribeKeyValueStoreCommand,
+  UpdateKeysCommand,
+} from "@aws-sdk/client-cloudfront-keyvaluestore";
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { QueryClient } from "@tanstack/react-query";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The prerenderer: renders live content to static HTML in the frontend
+// bucket and keeps the CloudFront KeyValueStore + sitemap in step. Built
+// from apps/web's SSR bundle by deploy-web (so its markup, asset hashes
+// and template index.html are always the deployed SPA's), invoked by the
+// API on publish-path mutations, by deploy-web after every web deploy,
+// and by an EventBridge schedule as the drift/scheduled-publish backstop.
+//
+// One code path (sync) covers all of it: fetch the manifest, diff against
+// the state file, render what changed, tear down what vanished. The API
+// origin is baked into the bundle at build time via VITE_API_URL, exactly
+// like the SPA.
+
+export type PrerenderEvent =
+  | { action: "reconcile" }
+  | { action: "render-all" }
+  | { action: "render"; url: string };
+
+interface SyncSummary {
+  mode: string;
+  rendered: string[];
+  unrendered: string[];
+  failed: string[];
+}
+
+const STATE_KEY = "_prerender/state.json";
+// CDN may cache for a day (invalidated on change); browsers must
+// revalidate so a publish is visible on the next load.
+const SNAPSHOT_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=86400, must-revalidate";
+
+interface Env {
+  frontendBucket: string;
+  kvsArn: string;
+  distributionId: string;
+  siteOrigin: string;
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var ${name}`);
+  return value;
+}
+
+let envCache: Env | undefined;
+function getEnv(): Env {
+  envCache ??= {
+    frontendBucket: requiredEnv("FRONTEND_BUCKET"),
+    kvsArn: requiredEnv("KVS_ARN"),
+    distributionId: requiredEnv("CLOUDFRONT_DISTRIBUTION_ID"),
+    siteOrigin: process.env.SITE_ORIGIN ?? "https://www.percymain.org",
+  };
+  return envCache;
+}
+
+// Region comes from the Lambda's AWS_REGION; CloudFront + KVS are global
+// services pinned to us-east-1.
+const s3 = new S3Client({});
+const cloudfront = new CloudFrontClient({ region: "us-east-1" });
+const kvs = new CloudFrontKeyValueStoreClient({ region: "us-east-1" });
+
+let templateCache: string | undefined;
+function loadTemplate(): string {
+  // deploy-web zips the client build's dist/index.html alongside the
+  // bundle as template.html.
+  templateCache ??= readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "template.html"),
+    "utf8",
+  );
+  return templateCache;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Data fetching ────────────────────────────────────────────────────────
+
+async function fetchShared() {
+  const [nav, people] = await Promise.all([
+    callApi(api.GET("/api/content/nav")),
+    callApi(api.GET("/api/content/people")),
+  ]);
+  return { nav, people };
+}
+
+type SharedData = Awaited<ReturnType<typeof fetchShared>>;
+
+async function fetchManifest(): Promise<ManifestItem[]> {
+  const manifest = await callApi(api.GET("/api/content/prerender-manifest"));
+  return manifest.items;
+}
+
+interface DetailData {
+  title: string;
+  description: string | null;
+  body: unknown;
+  metadata: Record<string, unknown>;
+  publishedAt: string;
+  updatedAt: string;
+}
+
+/**
+ * The page/article/profile/event backing `item`, through the same query
+ * options the SPA reads - so the dehydrated cache entry lands under
+ * exactly the key the component hydrates from. Null when the item
+ * vanished (404) or was taken down (410) between manifest and fetch; the
+ * next reconcile tears it down.
+ */
+async function fetchDetail(
+  queryClient: QueryClient,
+  item: ManifestItem,
+): Promise<DetailData | null> {
+  switch (item.kind) {
+    case "page": {
+      const data = await queryClient.fetchQuery(
+        pageByPathQueryOptions(item.url),
+      );
+      return data === null || isPageGone(data) ? null : data;
+    }
+    case "news": {
+      const data = await queryClient.fetchQuery(
+        newsArticleQueryOptions(item.slug),
+      );
+      return data ?? null;
+    }
+    case "event": {
+      const data = await queryClient.fetchQuery(eventQueryOptions(item.slug));
+      return data ?? null;
+    }
+    case "person": {
+      const data = await queryClient.fetchQuery(personQueryOptions(item.slug));
+      return data === null || isPageGone(data) ? null : data;
+    }
+  }
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────
+
+async function renderSnapshot(
+  item: ManifestItem,
+  shared: SharedData,
+  template: string,
+): Promise<string | null> {
+  // Fresh client per document: no state bleed between pages, and its
+  // dehydrated form is exactly this page's data (nav + people + detail).
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: 1 } },
+  });
+  queryClient.setQueryData(navQueryOptions().queryKey, shared.nav);
+  queryClient.setQueryData(peopleListQueryOptions().queryKey, shared.people);
+
+  const detail = await fetchDetail(queryClient, item);
+  if (detail === null) return null;
+
+  const { appHtml, dehydratedState } = await render(item.url, queryClient);
+  const headHtml = buildHead(
+    {
+      kind: item.kind,
+      url: item.url,
+      title: detail.title,
+      description: detail.description,
+      metadata: detail.metadata,
+      body: detail.body,
+      publishedAt: detail.publishedAt,
+      updatedAt: detail.updatedAt,
+    },
+    getEnv().siteOrigin,
+  );
+  return assembleDocument({ template, headHtml, appHtml, dehydratedState });
+}
+
+// ── S3 ───────────────────────────────────────────────────────────────────
+
+async function putObject(
+  key: string,
+  body: string,
+  contentType: string,
+): Promise<void> {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: getEnv().frontendBucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+      CacheControl: SNAPSHOT_CACHE_CONTROL,
+    }),
+  );
+}
+
+async function readState(): Promise<PrerenderState | null> {
+  try {
+    const response = await s3.send(
+      new GetObjectCommand({ Bucket: getEnv().frontendBucket, Key: STATE_KEY }),
+    );
+    const raw: unknown = JSON.parse(
+      (await response.Body?.transformToString()) ?? "",
+    );
+    if (
+      typeof raw === "object" &&
+      raw !== null &&
+      (raw as PrerenderState).v === 1
+    ) {
+      return raw as PrerenderState;
+    }
+    return null;
+  } catch (error) {
+    if ((error as { name?: string }).name === "NoSuchKey") return null;
+    throw error;
+  }
+}
+
+// ── KVS ──────────────────────────────────────────────────────────────────
+
+/**
+ * Batched, ETag-guarded key sync. Chunked because UpdateKeys caps the
+ * batch size; the ETag is refetched per chunk (each update rotates it)
+ * and conflicts retry - concurrent syncs are already rare (the Lambda
+ * runs with reserved concurrency 1), this covers out-of-band edits.
+ */
+async function kvsUpdate(puts: string[], deletes: string[]): Promise<void> {
+  const CHUNK = 25;
+  const ops = [
+    ...puts.map((key) => ({ put: true, key })),
+    ...deletes.map((key) => ({ put: false, key })),
+  ];
+  for (let i = 0; i < ops.length; i += CHUNK) {
+    const chunk = ops.slice(i, i + CHUNK);
+    for (let attempt = 1; ; attempt++) {
+      const { ETag } = await kvs.send(
+        new DescribeKeyValueStoreCommand({ KvsARN: getEnv().kvsArn }),
+      );
+      try {
+        await kvs.send(
+          new UpdateKeysCommand({
+            KvsARN: getEnv().kvsArn,
+            IfMatch: ETag,
+            Puts: chunk
+              .filter((op) => op.put)
+              .map((op) => ({ Key: op.key, Value: "1" })),
+            Deletes: chunk
+              .filter((op) => !op.put)
+              .map((op) => ({ Key: op.key })),
+          }),
+        );
+        break;
+      } catch (error) {
+        const name = (error as { name?: string }).name;
+        if (attempt < 3 && (name === "ConflictException" || name === "PreconditionFailedException")) {
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+}
+
+// ── CloudFront invalidation ─────────────────────────────────────────────
+
+async function invalidate(paths: string[]): Promise<void> {
+  if (paths.length === 0) return;
+  await cloudfront.send(
+    new CreateInvalidationCommand({
+      DistributionId: getEnv().distributionId,
+      InvalidationBatch: {
+        CallerReference: `prerender-${Date.now().toString()}-${Math.random().toString(36).slice(2)}`,
+        Paths: { Quantity: paths.length, Items: paths },
+      },
+    }),
+  );
+}
+
+// ── Sync ─────────────────────────────────────────────────────────────────
+
+async function sync(force: boolean): Promise<SyncSummary> {
+  const template = loadTemplate();
+  const [manifest, shared, state] = await Promise.all([
+    fetchManifest(),
+    fetchShared(),
+    readState(),
+  ]);
+  const currentNavHash = navHash(shared.nav.items);
+  const plan = planReconcile({ manifest, state, currentNavHash, force });
+  console.log(
+    `prerender sync: mode=${plan.mode} render=${plan.toRender.length.toString()} unrender=${plan.toUnrender.length.toString()}`,
+  );
+
+  const rendered: string[] = [];
+  const failed = new Set<string>();
+  for (const item of plan.toRender) {
+    try {
+      const html = await renderSnapshot(item, shared, template);
+      if (html === null) {
+        // Vanished between manifest and fetch; the next sync unrenders it.
+        failed.add(item.url);
+        continue;
+      }
+      await putObject(snapshotS3Key(item.url), html, "text/html; charset=utf-8");
+      rendered.push(item.url);
+    } catch (error) {
+      console.error(`prerender render failed: ${item.url}`, error);
+      failed.add(item.url);
+    }
+  }
+
+  // Route new/changed snapshots and stop routing vanished ones. Failures
+  // keep their previous state: a stale snapshot stays up (the SPA
+  // refetches over it) rather than flapping to CSR.
+  await kvsUpdate(
+    rendered.map(snapshotKvsKey),
+    plan.toUnrender.map(snapshotKvsKey),
+  );
+
+  await putObject(
+    "sitemap.xml",
+    buildSitemap(manifest, getEnv().siteOrigin),
+    "application/xml",
+  );
+  await putObject(
+    STATE_KEY,
+    JSON.stringify(nextState(manifest, currentNavHash, failed)),
+    "application/json",
+  );
+
+  const invalidationPaths =
+    plan.mode === "diff"
+      ? [
+          ...rendered.map(snapshotInvalidationPath),
+          ...plan.toUnrender.map(snapshotInvalidationPath),
+          "/sitemap.xml",
+        ]
+      : ["/_prerender/*", "/sitemap.xml"];
+  await invalidate(invalidationPaths);
+
+  if (plan.toUnrender.length > 0) {
+    // KVS deletes propagate in seconds; waiting before removing the
+    // objects keeps the window where the function still routes to a
+    // deleted object (S3 AccessDenied) effectively closed.
+    await sleep(5000);
+    for (const url of plan.toUnrender) {
+      await s3.send(
+        new DeleteObjectCommand({
+          Bucket: getEnv().frontendBucket,
+          Key: snapshotS3Key(url),
+        }),
+      );
+    }
+  }
+
+  const summary: SyncSummary = {
+    mode: plan.mode,
+    rendered,
+    unrendered: plan.toUnrender,
+    failed: [...failed],
+  };
+  console.log(`prerender sync done: ${JSON.stringify(summary)}`);
+  return summary;
+}
+
+/** Render one URL, bypassing state/sitemap - the rollout/debug tool. */
+async function renderOne(url: string): Promise<SyncSummary> {
+  const [manifest, shared] = await Promise.all([fetchManifest(), fetchShared()]);
+  const item = manifest.find((candidate) => candidate.url === url);
+  if (!item) throw new Error(`URL not in the prerender manifest: ${url}`);
+  const html = await renderSnapshot(item, shared, loadTemplate());
+  if (html === null) throw new Error(`Content vanished while rendering ${url}`);
+  await putObject(snapshotS3Key(url), html, "text/html; charset=utf-8");
+  await kvsUpdate([snapshotKvsKey(url)], []);
+  await invalidate([snapshotInvalidationPath(url)]);
+  return { mode: "single", rendered: [url], unrendered: [], failed: [] };
+}
+
+export async function handler(event: PrerenderEvent): Promise<SyncSummary> {
+  switch (event.action) {
+    case "reconcile":
+      return await sync(false);
+    case "render-all":
+      return await sync(true);
+    case "render":
+      return await renderOne(event.url);
+  }
+}

--- a/apps/web/server/prerender/lambda.ts
+++ b/apps/web/server/prerender/lambda.ts
@@ -78,7 +78,6 @@ interface Env {
   frontendBucket: string;
   kvsArn: string;
   distributionId: string;
-  siteOrigin: string;
 }
 
 function requiredEnv(name: string): string {
@@ -93,9 +92,14 @@ function getEnv(): Env {
     frontendBucket: requiredEnv("FRONTEND_BUCKET"),
     kvsArn: requiredEnv("KVS_ARN"),
     distributionId: requiredEnv("CLOUDFRONT_DISTRIBUTION_ID"),
-    siteOrigin: process.env.SITE_ORIGIN ?? "https://www.percymain.org",
   };
   return envCache;
+}
+
+// Resolved independently of the AWS env so renderDocument works without
+// any AWS configuration (local preview via scripts/prerender-preview.mjs).
+function siteOrigin(): string {
+  return process.env.SITE_ORIGIN ?? "https://www.percymain.org";
 }
 
 // Region comes from the Lambda's AWS_REGION; CloudFront + KVS are global
@@ -107,9 +111,10 @@ const kvs = new CloudFrontKeyValueStoreClient({ region: "us-east-1" });
 let templateCache: string | undefined;
 function loadTemplate(): string {
   // deploy-web zips the client build's dist/index.html alongside the
-  // bundle as template.html.
+  // bundle as template.html. TEMPLATE_PATH is the local-preview override.
   templateCache ??= readFileSync(
-    join(dirname(fileURLToPath(import.meta.url)), "template.html"),
+    process.env.TEMPLATE_PATH ??
+      join(dirname(fileURLToPath(import.meta.url)), "template.html"),
     "utf8",
   );
   return templateCache;
@@ -210,9 +215,26 @@ async function renderSnapshot(
       publishedAt: detail.publishedAt,
       updatedAt: detail.updatedAt,
     },
-    getEnv().siteOrigin,
+    siteOrigin(),
   );
   return assembleDocument({ template, headHtml, appHtml, dehydratedState });
+}
+
+/**
+ * Render one URL to its full document WITHOUT touching AWS - the local
+ * preview / smoke path (scripts/prerender-preview.mjs) and the seam the
+ * deploy pipeline's render-all is built on.
+ */
+export async function renderDocument(url: string): Promise<string> {
+  const [manifest, shared] = await Promise.all([
+    fetchManifest(),
+    fetchShared(),
+  ]);
+  const item = manifest.find((candidate) => candidate.url === url);
+  if (!item) throw new Error(`URL not in the prerender manifest: ${url}`);
+  const html = await renderSnapshot(item, shared, loadTemplate());
+  if (html === null) throw new Error(`Content vanished while rendering ${url}`);
+  return html;
 }
 
 // ── S3 ───────────────────────────────────────────────────────────────────
@@ -291,7 +313,11 @@ async function kvsUpdate(puts: string[], deletes: string[]): Promise<void> {
         break;
       } catch (error) {
         const name = (error as { name?: string }).name;
-        if (attempt < 3 && (name === "ConflictException" || name === "PreconditionFailedException")) {
+        if (
+          attempt < 3 &&
+          (name === "ConflictException" ||
+            name === "PreconditionFailedException")
+        ) {
           continue;
         }
         throw error;
@@ -340,7 +366,11 @@ async function sync(force: boolean): Promise<SyncSummary> {
         failed.add(item.url);
         continue;
       }
-      await putObject(snapshotS3Key(item.url), html, "text/html; charset=utf-8");
+      await putObject(
+        snapshotS3Key(item.url),
+        html,
+        "text/html; charset=utf-8",
+      );
       rendered.push(item.url);
     } catch (error) {
       console.error(`prerender render failed: ${item.url}`, error);
@@ -358,7 +388,7 @@ async function sync(force: boolean): Promise<SyncSummary> {
 
   await putObject(
     "sitemap.xml",
-    buildSitemap(manifest, getEnv().siteOrigin),
+    buildSitemap(manifest, siteOrigin()),
     "application/xml",
   );
   await putObject(
@@ -404,11 +434,7 @@ async function sync(force: boolean): Promise<SyncSummary> {
 
 /** Render one URL, bypassing state/sitemap - the rollout/debug tool. */
 async function renderOne(url: string): Promise<SyncSummary> {
-  const [manifest, shared] = await Promise.all([fetchManifest(), fetchShared()]);
-  const item = manifest.find((candidate) => candidate.url === url);
-  if (!item) throw new Error(`URL not in the prerender manifest: ${url}`);
-  const html = await renderSnapshot(item, shared, loadTemplate());
-  if (html === null) throw new Error(`Content vanished while rendering ${url}`);
+  const html = await renderDocument(url);
   await putObject(snapshotS3Key(url), html, "text/html; charset=utf-8");
   await kvsUpdate([snapshotKvsKey(url)], []);
   await invalidate([snapshotInvalidationPath(url)]);

--- a/apps/web/src/components/consent-banner.tsx
+++ b/apps/web/src/components/consent-banner.tsx
@@ -7,7 +7,13 @@ import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 
 export function ConsentBanner() {
-  const [open, setOpen] = useState<boolean>(() => needsConsent());
+  // Closed under the prerenderer: readCookie returns null in Node, so
+  // needsConsent() would report true and bake the banner into every
+  // cached document. The client render re-evaluates the real cookie on
+  // take-over.
+  const [open, setOpen] = useState<boolean>(
+    () => typeof window !== "undefined" && needsConsent(),
+  );
   const reopenedRef = useRef(false);
 
   useEffect(() => {

--- a/apps/web/src/entry-server.test.tsx
+++ b/apps/web/src/entry-server.test.tsx
@@ -14,7 +14,12 @@ import { render } from "./entry-server.js";
 const NAV_DATA = {
   items: [
     { path: "/club", title: "The Club", menuOrder: 1, isMainMenu: true },
-    { path: "/club/history", title: "History", menuOrder: 1, isMainMenu: false },
+    {
+      path: "/club/history",
+      title: "History",
+      menuOrder: 1,
+      isMainMenu: false,
+    },
   ],
   removed: [],
 };

--- a/apps/web/src/entry-server.test.tsx
+++ b/apps/web/src/entry-server.test.tsx
@@ -1,0 +1,107 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+// mdx-components transitively imports the vite-imagetools image map,
+// which doesn't exist outside a Vite build - stub the lookups, the
+// renderer only needs their shapes (same stance as content-body.test).
+vi.mock("@/lib/image-map.js", () => ({
+  getImageUrl: () => undefined,
+  getPicture: () => undefined,
+}));
+
+import { render } from "./entry-server.js";
+
+const NAV_DATA = {
+  items: [
+    { path: "/club", title: "The Club", menuOrder: 1, isMainMenu: true },
+    { path: "/club/history", title: "History", menuOrder: 1, isMainMenu: false },
+  ],
+  removed: [],
+};
+
+function paragraph(text: string) {
+  return {
+    id: `b-${text.length.toString()}`,
+    type: "paragraph",
+    props: {},
+    content: [{ type: "text", text, styles: {} }],
+    children: [],
+  };
+}
+
+function seededClient(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.setQueryData(["content", "nav"], NAV_DATA);
+  return queryClient;
+}
+
+describe("entry-server render", () => {
+  it("renders a CMS page with real content, chrome and no loading state", async () => {
+    const queryClient = seededClient();
+    queryClient.setQueryData(["content", "page", "/club/history"], {
+      id: "11111111-1111-1111-1111-111111111111",
+      kind: "page",
+      slug: "history",
+      title: "Club History",
+      description: "How it all started.",
+      body: [paragraph("Founded on the banks of the Tyne.")],
+      metadata: { menuOrder: 1, isMainMenu: false, hideTitle: false },
+      publishedAt: "2026-06-01T10:00:00.000Z",
+      updatedAt: "2026-06-02T10:00:00.000Z",
+    });
+
+    const { appHtml, dehydratedState } = await render(
+      "/club/history",
+      queryClient,
+    );
+
+    // The page body and title are in the markup - crawlers see content.
+    expect(appHtml).toContain("Founded on the banks of the Tyne.");
+    expect(appHtml).toContain("Club History");
+    // Site chrome rendered with the seeded nav: the header main-menu item
+    // and the section sidebar both link to /club.
+    expect(appHtml).toContain("The Club");
+    expect(appHtml).toContain('href="/club"');
+    // Nothing on the page is a spinner (PageLoading's animate-spin).
+    expect(appHtml).not.toContain("animate-spin");
+    // The dehydrated state carries both seeded queries for the take-over.
+    const hashes = dehydratedState.queries.map((q) => q.queryHash);
+    expect(hashes).toHaveLength(2);
+    expect(hashes.join()).toContain("nav");
+  });
+
+  it("renders a news article", async () => {
+    const queryClient = seededClient();
+    queryClient.setQueryData(["content", "news", "season-opener"], {
+      id: "22222222-2222-2222-2222-222222222222",
+      kind: "news",
+      slug: "season-opener",
+      title: "Season Opener",
+      description: "First game of the season.",
+      body: [paragraph("A cracking start to the season.")],
+      metadata: { tags: ["cricket"] },
+      publishedAt: "2026-04-01T10:00:00.000Z",
+      updatedAt: "2026-04-01T10:00:00.000Z",
+    });
+
+    const { appHtml } = await render(
+      "/news/article/season-opener",
+      queryClient,
+    );
+
+    expect(appHtml).toContain("Season Opener");
+    expect(appHtml).toContain("A cracking start to the season.");
+    expect(appHtml).not.toContain("animate-spin");
+  });
+
+  it("renders the not-found view for an unseeded confirmed miss", async () => {
+    const queryClient = seededClient();
+    queryClient.setQueryData(["content", "page", "/nope"], null);
+
+    const { appHtml } = await render("/nope", queryClient);
+
+    expect(appHtml).toContain("Page Not Found");
+  });
+});

--- a/apps/web/src/entry-server.tsx
+++ b/apps/web/src/entry-server.tsx
@@ -42,9 +42,7 @@ export async function render(
   url: string,
   queryClient: QueryClient,
 ): Promise<RenderResult> {
-  const context = await handler.query(
-    new Request(new URL(url, RENDER_ORIGIN)),
-  );
+  const context = await handler.query(new Request(new URL(url, RENDER_ORIGIN)));
 
   // Without loaders/actions the handler never short-circuits to a
   // redirect/error Response; if one ever appears, fail the render loudly

--- a/apps/web/src/entry-server.tsx
+++ b/apps/web/src/entry-server.tsx
@@ -1,0 +1,73 @@
+import {
+  dehydrate,
+  QueryClientProvider,
+  type DehydratedState,
+  type QueryClient,
+} from "@tanstack/react-query";
+import { renderToString } from "react-dom/server";
+import {
+  createStaticHandler,
+  createStaticRouter,
+  StaticRouterProvider,
+} from "react-router";
+import { ThemeProvider } from "./hooks/use-theme.js";
+import { routes } from "./routes.js";
+
+// Prerenderer entry (Node, not the browser): renders the real app -
+// RootLayout, SiteHeader, ContentBody et al - to markup for the
+// publish-time snapshot pipeline. Deliberately does NOT import main.tsx:
+// its module side effects (New Relic browser agent, consent/attribution
+// capture, app.css) are browser-only.
+//
+// The URL origin only anchors relative parsing - rendered links are
+// relative, so any host works.
+const RENDER_ORIGIN = "https://www.percymain.org";
+
+// Module-level: the handler resolves each route's lazy module once and
+// caches it on the route table, so a warm Lambda renders subsequent
+// documents without re-importing modules.
+const handler = createStaticHandler(routes);
+
+export interface RenderResult {
+  appHtml: string;
+  dehydratedState: DehydratedState;
+}
+
+/**
+ * Render `url` (path + optional search) with `queryClient` already
+ * seeded (the caller fetchQuery's nav/detail data first - anything not
+ * seeded renders its pending state, exactly as the SPA would).
+ */
+export async function render(
+  url: string,
+  queryClient: QueryClient,
+): Promise<RenderResult> {
+  const context = await handler.query(
+    new Request(new URL(url, RENDER_ORIGIN)),
+  );
+
+  // Without loaders/actions the handler never short-circuits to a
+  // redirect/error Response; if one ever appears, fail the render loudly
+  // rather than snapshotting an empty document.
+  if (context instanceof Response) {
+    throw new Error(
+      `Static handler returned a Response (${String(context.status)}) for ${url}`,
+    );
+  }
+
+  const router = createStaticRouter(handler.dataRoutes, context);
+
+  const appHtml = renderToString(
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <StaticRouterProvider
+          router={router}
+          context={context}
+          hydrate={false}
+        />
+      </QueryClientProvider>
+    </ThemeProvider>,
+  );
+
+  return { appHtml, dehydratedState: dehydrate(queryClient) };
+}

--- a/apps/web/src/generated/nav-snapshot.json
+++ b/apps/web/src/generated/nav-snapshot.json
@@ -1,0 +1,209 @@
+{
+  "items": [
+    {
+      "path": "/boxing",
+      "title": "Boxing",
+      "menuOrder": 5,
+      "isMainMenu": true
+    },
+    {
+      "path": "/charity",
+      "title": "Charity",
+      "menuOrder": 1,
+      "isMainMenu": true
+    },
+    {
+      "path": "/charity/agm-2025",
+      "title": "AGM 2025",
+      "menuOrder": 3,
+      "isMainMenu": false
+    },
+    {
+      "path": "/charity/agm-2026",
+      "title": "AGM 2026",
+      "menuOrder": 1,
+      "isMainMenu": false
+    },
+    {
+      "path": "/charity/redevelopment",
+      "title": "Redevelopment Plans",
+      "menuOrder": 0,
+      "isMainMenu": false
+    },
+    {
+      "path": "/charity/refugee-week-2025",
+      "title": "Refugee Week 2025",
+      "menuOrder": 2,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket",
+      "title": "Cricket",
+      "menuOrder": 2,
+      "isMainMenu": true
+    },
+    {
+      "path": "/cricket/become-a-sponsor",
+      "title": "Become A Sponsor",
+      "menuOrder": 8,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/committee",
+      "title": "Committee",
+      "menuOrder": 4,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/ground",
+      "title": "Ground",
+      "menuOrder": 4,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/ground/grounds-team",
+      "title": "Grounds Team",
+      "menuOrder": 1,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/juniors",
+      "title": "Juniors",
+      "menuOrder": 3,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/juniors/coaches",
+      "title": "Junior Coaches",
+      "menuOrder": 3,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/juniors/junior-code-of-conduct",
+      "title": "Junior Code of Conduct",
+      "menuOrder": 1,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/juniors/parents-code-of-conduct",
+      "title": "Parents Code of Conduct",
+      "menuOrder": 2,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/juniors/welcome-2026",
+      "title": "Welcome to Junior Cricket 2026",
+      "menuOrder": 0,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/kit-shop",
+      "title": "Kit Shop",
+      "menuOrder": 7,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/records",
+      "title": "Records",
+      "menuOrder": 5,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/records/club-records",
+      "title": "Club Records",
+      "menuOrder": 2,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/records/leaderboards",
+      "title": "Leaderboards",
+      "menuOrder": 1,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/safeguarding",
+      "title": "Safeguarding",
+      "menuOrder": 6,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/senior",
+      "title": "Senior Teams",
+      "menuOrder": 1,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/senior/1st-xi",
+      "title": "1st XI",
+      "menuOrder": 1,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/senior/2nd-xi",
+      "title": "2nd XI",
+      "menuOrder": 2,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/senior/midweek-xi",
+      "title": "Midweek XI",
+      "menuOrder": 3,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/social",
+      "title": "Social Media",
+      "menuOrder": 9,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/women",
+      "title": "Women's Cricket",
+      "menuOrder": 2,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/women/girls-dynamos",
+      "title": "Girls Dynamos",
+      "menuOrder": 1,
+      "isMainMenu": false
+    },
+    {
+      "path": "/cricket/women/players",
+      "title": "Players",
+      "menuOrder": 99,
+      "isMainMenu": false
+    },
+    {
+      "path": "/football",
+      "title": "Football",
+      "menuOrder": 4,
+      "isMainMenu": true
+    },
+    {
+      "path": "/legal",
+      "title": "Legal",
+      "menuOrder": 99,
+      "isMainMenu": false
+    },
+    {
+      "path": "/legal/privacy",
+      "title": "Privacy Policy",
+      "menuOrder": 99,
+      "isMainMenu": false
+    },
+    {
+      "path": "/people",
+      "title": "People",
+      "menuOrder": 7,
+      "isMainMenu": true
+    },
+    {
+      "path": "/running",
+      "title": "Running",
+      "menuOrder": 3,
+      "isMainMenu": true
+    }
+  ],
+  "removed": []
+}

--- a/apps/web/src/hooks/use-theme.tsx
+++ b/apps/web/src/hooks/use-theme.tsx
@@ -15,6 +15,9 @@ const ThemeContext = createContext<ThemeContextValue | null>(null);
 const STORAGE_KEY = "percy-theme";
 
 function getSystemTheme(): ResolvedTheme {
+  // Under the prerenderer (Node) there is no media query to consult;
+  // "light" matches the fc-theme documents the prerenderer emits.
+  if (typeof window === "undefined") return "light";
   return window.matchMedia("(prefers-color-scheme: dark)").matches
     ? "dark"
     : "light";
@@ -30,6 +33,7 @@ function applyTheme(resolved: ResolvedTheme) {
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>(() => {
+    if (typeof window === "undefined") return "system";
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === "light" || stored === "dark" || stored === "system") {
       return stored;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -14235,6 +14235,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/content/prerender-manifest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                url: string;
+                                /** @enum {string} */
+                                kind: "page" | "news" | "event" | "person";
+                                slug: string;
+                                updatedAt: string;
+                                publishedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/content-images/upload-url": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -25655,6 +25655,65 @@
         }
       }
     },
+    "/api/content/prerender-manifest": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "page",
+                              "news",
+                              "event",
+                              "person"
+                            ]
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "url",
+                          "kind",
+                          "slug",
+                          "updatedAt",
+                          "publishedAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/content-images/upload-url": {
       "post": {
         "requestBody": {

--- a/apps/web/src/lib/content-queries.ts
+++ b/apps/web/src/lib/content-queries.ts
@@ -9,6 +9,7 @@ import {
   type PersonMetadata,
 } from "@percy-main/shared/content";
 import { queryOptions } from "@tanstack/react-query";
+import navSnapshot from "../generated/nav-snapshot.json";
 import { api, callApi } from "./api-client.js";
 
 // Shared query definitions for public DB-backed content (#489). List pages
@@ -164,6 +165,13 @@ export function navQueryOptions() {
     queryFn: () => callApi(api.GET("/api/content/nav")),
     staleTime: STALE_TIME,
     gcTime: NAV_GC_TIME,
+    // Deploy-time snapshot (scripts/fetch-nav-snapshot.mjs) so the menu
+    // paints complete on first render; updatedAt 0 = immediately stale,
+    // so a background refetch corrects any post-deploy drift. On
+    // prerendered documents the hydrated cache entry wins (hydrate()
+    // runs before mount and initialData never overwrites cache).
+    initialData: navSnapshot,
+    initialDataUpdatedAt: 0,
   });
 }
 

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,0 +1,50 @@
+import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
+
+/**
+ * Forward any react-query (or react-query-mutation) error to NR
+ * Browser. Without this, react-query failures bubble to component-
+ * local `error` state and never reach NR — a server 5xx on a query
+ * shows as a toast (or nothing) and is invisible to observability.
+ */
+function noticeQueryError(
+  err: unknown,
+  attrs: Record<string, string | number | boolean>,
+) {
+  const error = err instanceof Error ? err : new Error(String(err));
+  if (typeof window !== "undefined" && window.newrelic) {
+    window.newrelic.noticeError(error, attrs);
+  } else {
+    console.error("react-query (NR not loaded):", error.message, attrs);
+  }
+}
+
+/**
+ * The app QueryClient, as a factory so main.tsx can create it before
+ * first render and seed it from a prerendered document's dehydrated
+ * state (prerender/take-over.ts) — the cache must be populated before
+ * React mounts or the first commit wipes the prerendered DOM with
+ * spinners.
+ */
+export function createAppQueryClient(): QueryClient {
+  return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (err, query) =>
+        noticeQueryError(err, {
+          kind: "query",
+          queryKey: query.queryKey
+            .flatMap((part) => (typeof part === "string" ? [part] : []))
+            .join(":"),
+        }),
+    }),
+    mutationCache: new MutationCache({
+      onError: (err, _vars, _ctx, mutation) =>
+        noticeQueryError(err, {
+          kind: "mutation",
+          mutationKey:
+            mutation.options.mutationKey
+              ?.flatMap((part) => (typeof part === "string" ? [part] : []))
+              .join(":") ?? "unknown",
+        }),
+    }),
+  });
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -12,14 +12,12 @@ import "./app.css";
 import { maybeCaptureAttribution } from "./lib/marketing/attribution.js";
 import { applyStoredConsentToGtag } from "./lib/marketing/consent.js";
 import "./lib/newrelic.js";
+import { createAppQueryClient } from "./lib/query-client.js";
 import {
   preloadMatchedRoutes,
   readPrerenderPayload,
 } from "./prerender/take-over.js";
-import {
-  AppProviders,
-  createAppQueryClient,
-} from "./providers/app-providers.js";
+import { AppProviders } from "./providers/app-providers.js";
 import { routes } from "./routes.js";
 
 // Mirror any stored consent record to gtag inside the 500ms wait_for_update

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,26 +4,54 @@ import "@fontsource-variable/source-sans-3";
 // theme (riso / screenprint poster look). Self-hosted to keep the no-external-
 // fonts policy; stands in for Haettenschweiler / Impact, which have no web font.
 import "@fontsource/anton";
+import { hydrate } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { RouterProvider } from "react-router";
+import { createBrowserRouter, RouterProvider } from "react-router";
 import "./app.css";
 import { maybeCaptureAttribution } from "./lib/marketing/attribution.js";
 import { applyStoredConsentToGtag } from "./lib/marketing/consent.js";
 import "./lib/newrelic.js";
-import { AppProviders } from "./providers/app-providers.js";
-import { router } from "./router.js";
+import {
+  preloadMatchedRoutes,
+  readPrerenderPayload,
+} from "./prerender/take-over.js";
+import {
+  AppProviders,
+  createAppQueryClient,
+} from "./providers/app-providers.js";
+import { routes } from "./routes.js";
 
 // Mirror any stored consent record to gtag inside the 500ms wait_for_update
 // window, then capture attribution on first campaign-linked hit.
 applyStoredConsentToGtag();
 maybeCaptureAttribution();
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- root element always exists in index.html
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <AppProviders>
-      <RouterProvider router={router} />
-    </AppProviders>
-  </StrictMode>,
-);
+/**
+ * Boot, prerender-aware (take-over.ts): seed the query cache from the
+ * document's embedded state and resolve the matched route's lazy module
+ * BEFORE the first render, so on a prerendered document React's first
+ * commit reproduces the DOM already on screen instead of wiping it with
+ * a loading state. On a plain CSR document both steps are cheap no-ops
+ * (empty cache seed; the router would await the same lazy import before
+ * its first commit anyway).
+ */
+async function boot() {
+  const queryClient = createAppQueryClient();
+  const payload = readPrerenderPayload();
+  if (payload) hydrate(queryClient, payload.dehydratedState);
+
+  await preloadMatchedRoutes(routes, window.location.pathname);
+  const router = createBrowserRouter(routes);
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- root element always exists in index.html
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <AppProviders queryClient={queryClient}>
+        <RouterProvider router={router} />
+      </AppProviders>
+    </StrictMode>,
+  );
+}
+
+void boot();

--- a/apps/web/src/prerender/assemble-document.test.ts
+++ b/apps/web/src/prerender/assemble-document.test.ts
@@ -55,7 +55,9 @@ describe("assembleDocument", () => {
 
   it("injects the state payload before the rendered root", () => {
     const stateIndex = doc.indexOf("window.__PM_PRERENDER__");
-    const rootIndex = doc.indexOf('<div id="root"><div>rendered content</div></div>');
+    const rootIndex = doc.indexOf(
+      '<div id="root"><div>rendered content</div></div>',
+    );
     expect(stateIndex).toBeGreaterThan(-1);
     expect(rootIndex).toBeGreaterThan(stateIndex);
     expect(doc).toContain('"v":1');

--- a/apps/web/src/prerender/assemble-document.test.ts
+++ b/apps/web/src/prerender/assemble-document.test.ts
@@ -1,0 +1,102 @@
+import type { DehydratedState } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { assembleDocument } from "./assemble-document.js";
+
+const TEMPLATE = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- pm-meta:start -->
+    <title>Percy Main Community Sports Club</title>
+    <meta name="description" content="generic" />
+    <!-- pm-meta:end -->
+    <link rel="manifest" href="/images/favicon/site.webmanifest" />
+    <script type="module" crossorigin src="/assets/index-abc123.js"></script>
+  </head>
+  <body>
+    <!-- pm-theme:start -->
+    <script>
+      (function () {
+        var t = localStorage.getItem("percy-theme");
+      })();
+    </script>
+    <!-- pm-theme:end -->
+    <div id="root"></div>
+  </body>
+</html>
+`;
+
+const STATE = { queries: [], mutations: [] } as unknown as DehydratedState;
+
+describe("assembleDocument", () => {
+  const doc = assembleDocument({
+    template: TEMPLATE,
+    headHtml: "<title>Club History | Percy Main</title>",
+    appHtml: "<div>rendered content</div>",
+    dehydratedState: STATE,
+  });
+
+  it("swaps the pm-meta block for the page head", () => {
+    expect(doc).toContain("<title>Club History | Percy Main</title>");
+    expect(doc).not.toContain('content="generic"');
+    expect(doc).not.toContain("pm-meta:start");
+  });
+
+  it("keeps the built asset tags untouched", () => {
+    expect(doc).toContain('src="/assets/index-abc123.js"');
+    expect(doc).toContain('href="/images/favicon/site.webmanifest"');
+  });
+
+  it("bakes the fc-theme class and drops the dark-mode script", () => {
+    expect(doc).toContain('<html lang="en" class="fc-theme">');
+    expect(doc).not.toContain("percy-theme");
+    expect(doc).not.toContain("pm-theme:start");
+  });
+
+  it("injects the state payload before the rendered root", () => {
+    const stateIndex = doc.indexOf("window.__PM_PRERENDER__");
+    const rootIndex = doc.indexOf('<div id="root"><div>rendered content</div></div>');
+    expect(stateIndex).toBeGreaterThan(-1);
+    expect(rootIndex).toBeGreaterThan(stateIndex);
+    expect(doc).toContain('"v":1');
+  });
+
+  it("escapes < in the embedded state so markup cannot break out", () => {
+    const doc2 = assembleDocument({
+      template: TEMPLATE,
+      headHtml: "<title>t</title>",
+      appHtml: "<div />",
+      dehydratedState: {
+        queries: [
+          {
+            queryKey: ["x"],
+            queryHash: '["x"]',
+            state: { data: "</script><script>alert(1)" },
+          },
+        ],
+        mutations: [],
+      } as unknown as DehydratedState,
+    });
+    expect(doc2).not.toContain("</script><script>alert(1)");
+    expect(doc2).toContain("\\u003c/script");
+  });
+
+  it("throws when a marker is missing rather than emitting a broken document", () => {
+    expect(() =>
+      assembleDocument({
+        template: TEMPLATE.replace("<!-- pm-meta:start -->", ""),
+        headHtml: "<title>t</title>",
+        appHtml: "<div />",
+        dehydratedState: STATE,
+      }),
+    ).toThrow(/pm-meta/);
+    expect(() =>
+      assembleDocument({
+        template: TEMPLATE.replace('<div id="root"></div>', "<div></div>"),
+        headHtml: "<title>t</title>",
+        appHtml: "<div />",
+        dehydratedState: STATE,
+      }),
+    ).toThrow(/root div/);
+  });
+});

--- a/apps/web/src/prerender/assemble-document.ts
+++ b/apps/web/src/prerender/assemble-document.ts
@@ -24,10 +24,7 @@ const ROOT_DIV = '<div id="root"></div>';
 
 /** `</script>`-safe serialization for the inline state payload. */
 function serializePayload(dehydratedState: DehydratedState): string {
-  return JSON.stringify({ v: 1, dehydratedState }).replaceAll(
-    "<",
-    "\\u003c",
-  );
+  return JSON.stringify({ v: 1, dehydratedState }).replaceAll("<", "\\u003c");
 }
 
 export function assembleDocument(input: AssembleInput): string {
@@ -40,7 +37,9 @@ export function assembleDocument(input: AssembleInput): string {
     ["root div", ROOT_DIV],
   ] as const) {
     if (
-      typeof needle === "string" ? !template.includes(needle) : !needle.test(template)
+      typeof needle === "string"
+        ? !template.includes(needle)
+        : !needle.test(template)
     ) {
       throw new Error(`Prerender template is missing the ${name}`);
     }

--- a/apps/web/src/prerender/assemble-document.ts
+++ b/apps/web/src/prerender/assemble-document.ts
@@ -1,0 +1,64 @@
+import type { DehydratedState } from "@tanstack/react-query";
+
+// Assembles a prerendered HTML document from the CLIENT build's
+// dist/index.html. Using the built file as the template - not a copy -
+// means the hashed script/stylesheet tags, modulepreloads and gtag
+// stripping are always exactly what the deployed SPA uses; the assembler
+// only swaps the marked regions.
+
+export interface AssembleInput {
+  /** The built dist/index.html (after Vite's transforms). */
+  template: string;
+  /** Replacement for the pm-meta block (build-head.ts). */
+  headHtml: string;
+  /** renderToString output for the page (entry-server.tsx). */
+  appHtml: string;
+  /** react-query state to embed for the client take-over. */
+  dehydratedState: DehydratedState;
+}
+
+const META_BLOCK = /<!-- pm-meta:start -->[\s\S]*?<!-- pm-meta:end -->/;
+const THEME_BLOCK = /<!-- pm-theme:start -->[\s\S]*?<!-- pm-theme:end -->/;
+const HTML_OPEN = '<html lang="en">';
+const ROOT_DIV = '<div id="root"></div>';
+
+/** `</script>`-safe serialization for the inline state payload. */
+function serializePayload(dehydratedState: DehydratedState): string {
+  return JSON.stringify({ v: 1, dehydratedState }).replaceAll(
+    "<",
+    "\\u003c",
+  );
+}
+
+export function assembleDocument(input: AssembleInput): string {
+  const { template, headHtml, appHtml, dehydratedState } = input;
+
+  for (const [name, needle] of [
+    ["pm-meta markers", META_BLOCK],
+    ["pm-theme markers", THEME_BLOCK],
+    ["html open tag", HTML_OPEN],
+    ["root div", ROOT_DIV],
+  ] as const) {
+    if (
+      typeof needle === "string" ? !template.includes(needle) : !needle.test(template)
+    ) {
+      throw new Error(`Prerender template is missing the ${name}`);
+    }
+  }
+
+  return (
+    template
+      .replace(META_BLOCK, headHtml)
+      // Every prerendered URL is an fc-theme route (fc-theme.ts): bake the
+      // class the ContentThemeClass effect would apply and drop the
+      // pre-paint dark-mode script - fc-theme has no dark variant, so a
+      // stored dark preference must not flash html.dark.fc-theme over
+      // real first-paint content.
+      .replace(THEME_BLOCK, "")
+      .replace(HTML_OPEN, '<html lang="en" class="fc-theme">')
+      .replace(
+        ROOT_DIV,
+        `<script>window.__PM_PRERENDER__ = ${serializePayload(dehydratedState)};</script>\n    <div id="root">${appHtml}</div>`,
+      )
+  );
+}

--- a/apps/web/src/prerender/build-head.test.ts
+++ b/apps/web/src/prerender/build-head.test.ts
@@ -26,7 +26,9 @@ describe("buildHead", () => {
     expect(head).toContain(
       `<link rel="canonical" href="${ORIGIN}/club/history" />`,
     );
-    expect(head).toContain('<meta property="og:title" content="Club History" />');
+    expect(head).toContain(
+      '<meta property="og:title" content="Club History" />',
+    );
     expect(head).toContain(
       `<meta property="og:url" content="${ORIGIN}/club/history" />`,
     );
@@ -132,7 +134,10 @@ describe("buildHead", () => {
           {
             id: "1",
             type: "contentImage",
-            props: { src: "/uploads/content/abc/original.webp", picture: "{oops" },
+            props: {
+              src: "/uploads/content/abc/original.webp",
+              picture: "{oops",
+            },
             children: [],
           },
         ],

--- a/apps/web/src/prerender/build-head.test.ts
+++ b/apps/web/src/prerender/build-head.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import { buildHead, type HeadInput } from "./build-head.js";
+
+const ORIGIN = "https://www.percymain.org";
+
+function input(overrides: Partial<HeadInput> = {}): HeadInput {
+  return {
+    kind: "page",
+    url: "/club/history",
+    title: "Club History",
+    description: "How it all started.",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("buildHead", () => {
+  it("emits title, description, canonical and OG basics", () => {
+    const head = buildHead(input());
+    expect(head).toContain(
+      "<title>Club History | Percy Main Community Sports Club</title>",
+    );
+    expect(head).toContain(
+      '<meta name="description" content="How it all started." />',
+    );
+    expect(head).toContain(
+      `<link rel="canonical" href="${ORIGIN}/club/history" />`,
+    );
+    expect(head).toContain('<meta property="og:title" content="Club History" />');
+    expect(head).toContain(
+      `<meta property="og:url" content="${ORIGIN}/club/history" />`,
+    );
+    expect(head).toContain('<meta property="og:type" content="website" />');
+    expect(head).toContain(
+      `<meta property="og:image" content="${ORIGIN}/images/og-default.png" />`,
+    );
+    expect(head).toContain('<meta name="twitter:card" content="summary" />');
+  });
+
+  it("falls back to the site description when the item has none", () => {
+    const head = buildHead(input({ description: null }));
+    expect(head).toContain('content="Percy Main Community Sports Club');
+  });
+
+  it("escapes HTML in titles and descriptions", () => {
+    const head = buildHead(
+      input({ title: 'A "great" <club>', description: "Fish & chips" }),
+    );
+    expect(head).toContain("A &quot;great&quot; &lt;club&gt;");
+    expect(head).toContain("Fish &amp; chips");
+    expect(head).not.toContain("<club>");
+  });
+
+  it("passes page metadata.ldjson through as JSON-LD", () => {
+    const head = buildHead(
+      input({
+        metadata: {
+          ldjson: { "@type": "SportsClub", name: "Percy Main" },
+        },
+      }),
+    );
+    expect(head).toContain('<script type="application/ld+json">');
+    expect(head).toContain('"@type":"SportsClub"');
+  });
+
+  it("emits no JSON-LD for a page without ldjson", () => {
+    expect(buildHead(input())).not.toContain("application/ld+json");
+  });
+
+  it("escapes </script> content inside JSON-LD", () => {
+    const head = buildHead(
+      input({ metadata: { ldjson: { name: "</script><script>alert(1)" } } }),
+    );
+    expect(head).not.toContain("</script><script>alert(1)");
+    expect(head).toContain("\\u003c/script");
+  });
+
+  describe("news", () => {
+    const news = input({
+      kind: "news",
+      url: "/news/article/season-opener",
+      title: "Season Opener",
+      publishedAt: "2026-04-01T10:00:00.000Z",
+      updatedAt: "2026-04-02T09:00:00.000Z",
+    });
+
+    it("emits article OG type, timestamps and NewsArticle JSON-LD", () => {
+      const head = buildHead(news);
+      expect(head).toContain('<meta property="og:type" content="article" />');
+      expect(head).toContain(
+        '<meta property="article:published_time" content="2026-04-01T10:00:00.000Z" />',
+      );
+      expect(head).toContain(
+        '<meta property="article:modified_time" content="2026-04-02T09:00:00.000Z" />',
+      );
+      expect(head).toContain('"@type":"NewsArticle"');
+      expect(head).toContain('"headline":"Season Opener"');
+      expect(head).toContain('"datePublished":"2026-04-01T10:00:00.000Z"');
+    });
+
+    it("uses the first contentImage block as the lead OG image", () => {
+      const head = buildHead({
+        ...news,
+        body: [
+          { id: "1", type: "paragraph", props: {}, children: [] },
+          {
+            id: "2",
+            type: "contentImage",
+            props: {
+              src: "/uploads/content/abc/original.webp",
+              picture: JSON.stringify({
+                sources: {},
+                img: { src: "/uploads/content/abc/1280.webp", w: 1280, h: 720 },
+              }),
+            },
+            children: [],
+          },
+        ],
+      });
+      expect(head).toContain(
+        `<meta property="og:image" content="${ORIGIN}/uploads/content/abc/1280.webp" />`,
+      );
+      expect(head).toContain(
+        '<meta name="twitter:card" content="summary_large_image" />',
+      );
+    });
+
+    it("falls back to plain src when the picture descriptor is malformed", () => {
+      const head = buildHead({
+        ...news,
+        body: [
+          {
+            id: "1",
+            type: "contentImage",
+            props: { src: "/uploads/content/abc/original.webp", picture: "{oops" },
+            children: [],
+          },
+        ],
+      });
+      expect(head).toContain(
+        `content="${ORIGIN}/uploads/content/abc/original.webp"`,
+      );
+    });
+  });
+
+  describe("event", () => {
+    it("emits Event JSON-LD with schedule and venue", () => {
+      const head = buildHead(
+        input({
+          kind: "event",
+          url: "/calendar/event/quiz-night",
+          title: "Quiz Night",
+          metadata: {
+            when: "2026-08-01T19:00:00+01:00",
+            finish: "2026-08-01T22:00:00+01:00",
+            location: {
+              name: "The Clubhouse",
+              street: "St John's Terrace",
+              city: "North Shields",
+              postcode: "NE29 6HS",
+            },
+          },
+        }),
+      );
+      expect(head).toContain('"@type":"Event"');
+      expect(head).toContain('"startDate":"2026-08-01T19:00:00+01:00"');
+      expect(head).toContain('"endDate":"2026-08-01T22:00:00+01:00"');
+      expect(head).toContain('"addressLocality":"North Shields"');
+    });
+
+    it("emits no JSON-LD when event metadata does not parse", () => {
+      const head = buildHead(
+        input({ kind: "event", url: "/calendar/event/x", metadata: {} }),
+      );
+      expect(head).not.toContain("application/ld+json");
+    });
+  });
+
+  describe("person", () => {
+    it("uses the profile photo for OG image and Person JSON-LD", () => {
+      const head = buildHead(
+        input({
+          kind: "person",
+          url: "/person/jane-smith",
+          title: "Jane Smith",
+          metadata: {
+            isDBSChecked: true,
+            hasLeftClub: false,
+            photo: {
+              sources: {},
+              img: { src: "/uploads/content/p/1280.webp", w: 1280, h: 1280 },
+            },
+          },
+        }),
+      );
+      expect(head).toContain('<meta property="og:type" content="profile" />');
+      expect(head).toContain(
+        `<meta property="og:image" content="${ORIGIN}/uploads/content/p/1280.webp" />`,
+      );
+      expect(head).toContain('"@type":"Person"');
+      expect(head).toContain('"name":"Jane Smith"');
+    });
+
+    it("falls back to the default OG image without a photo", () => {
+      const head = buildHead(
+        input({
+          kind: "person",
+          url: "/person/jane-smith",
+          title: "Jane Smith",
+          metadata: { isDBSChecked: false, hasLeftClub: false },
+        }),
+      );
+      expect(head).toContain(
+        `<meta property="og:image" content="${ORIGIN}/images/og-default.png" />`,
+      );
+    });
+  });
+});

--- a/apps/web/src/prerender/build-head.ts
+++ b/apps/web/src/prerender/build-head.ts
@@ -209,7 +209,11 @@ export function buildHead(
   }
 
   lines.push(
-    meta("name", "twitter:card", isDefaultImage ? "summary" : "summary_large_image"),
+    meta(
+      "name",
+      "twitter:card",
+      isDefaultImage ? "summary" : "summary_large_image",
+    ),
     meta("name", "twitter:title", input.title),
     meta("name", "twitter:description", description),
     meta("name", "twitter:image", image),

--- a/apps/web/src/prerender/build-head.ts
+++ b/apps/web/src/prerender/build-head.ts
@@ -1,0 +1,226 @@
+import {
+  eventMetadataSchema,
+  pageMetadataSchema,
+  personMetadataSchema,
+} from "@percy-main/shared/content";
+
+// Per-page <head> block for prerendered documents: title, description,
+// canonical, OG/Twitter cards and JSON-LD. Pure string assembly - no DOM,
+// no fetching - so it unit-tests exhaustively. The output replaces the
+// generic block between the pm-meta markers in index.html
+// (assemble-document.ts).
+
+const SITE_NAME = "Percy Main Community Sports Club";
+const DEFAULT_DESCRIPTION =
+  "Percy Main Community Sports Club — football, cricket, and community sports in North Shields. Find fixtures, results, news, and membership info.";
+const DEFAULT_OG_IMAGE_PATH = "/images/og-default.png";
+
+/** Public content kinds the prerenderer snapshots (game reports excluded). */
+export type PrerenderKind = "page" | "news" | "event" | "person";
+
+export interface HeadInput {
+  kind: PrerenderKind;
+  /** Public URL path, e.g. `/club/history` or `/news/article/foo`. */
+  url: string;
+  title: string;
+  description: string | null;
+  metadata: Record<string, unknown>;
+  /** BlockNote document; scanned for a lead image on news articles. */
+  body?: unknown;
+  publishedAt?: string;
+  updatedAt?: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+/** `</script>`-safe JSON for inline ld+json. */
+function ldJsonSerialize(value: unknown): string {
+  return JSON.stringify(value).replaceAll("<", "\\u003c");
+}
+
+function meta(attr: "property" | "name", key: string, value: string): string {
+  return `<meta ${attr}="${key}" content="${escapeHtml(value)}" />`;
+}
+
+function absolutize(src: string, origin: string): string {
+  return src.startsWith("/") ? `${origin}${src}` : src;
+}
+
+/**
+ * Lead image for a news article: the first contentImage block's picture
+ * fallback (or plain src). Walks top-level blocks only - a lead image
+ * nested inside another block isn't a lead image.
+ */
+function findLeadImage(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const blocks = Array.isArray(body)
+    ? body
+    : (body as { blocks?: unknown }).blocks;
+  if (!Array.isArray(blocks)) return undefined;
+  for (const block of blocks) {
+    if (
+      typeof block !== "object" ||
+      block === null ||
+      (block as { type?: unknown }).type !== "contentImage"
+    ) {
+      continue;
+    }
+    const props = (block as { props?: Record<string, unknown> }).props ?? {};
+    if (typeof props.picture === "string" && props.picture) {
+      try {
+        const picture = JSON.parse(props.picture) as {
+          img?: { src?: unknown };
+        };
+        if (typeof picture.img?.src === "string") return picture.img.src;
+      } catch {
+        // fall through to plain src
+      }
+    }
+    if (typeof props.src === "string" && props.src) return props.src;
+  }
+  return undefined;
+}
+
+function resolveOgImage(input: HeadInput, origin: string): string {
+  if (input.kind === "person") {
+    const parsed = personMetadataSchema.safeParse(input.metadata);
+    if (parsed.success && parsed.data.photo) {
+      return absolutize(parsed.data.photo.img.src, origin);
+    }
+  }
+  if (input.kind === "news") {
+    const lead = findLeadImage(input.body);
+    if (lead) return absolutize(lead, origin);
+  }
+  return `${origin}${DEFAULT_OG_IMAGE_PATH}`;
+}
+
+function buildLdJson(input: HeadInput, origin: string): unknown {
+  const pageUrl = `${origin}${input.url}`;
+  switch (input.kind) {
+    case "page": {
+      const parsed = pageMetadataSchema.safeParse(input.metadata);
+      // metadata.ldjson is author-supplied structured data, stored since
+      // the MDX pipeline but never rendered until now (#241 in
+      // content-page.tsx documents the old parity stance).
+      if (parsed.success && parsed.data.ldjson) return parsed.data.ldjson;
+      return undefined;
+    }
+    case "news": {
+      const image = resolveOgImage(input, origin);
+      return {
+        "@context": "https://schema.org",
+        "@type": "NewsArticle",
+        headline: input.title,
+        ...(input.description ? { description: input.description } : {}),
+        ...(input.publishedAt ? { datePublished: input.publishedAt } : {}),
+        ...(input.updatedAt ? { dateModified: input.updatedAt } : {}),
+        image: [image],
+        mainEntityOfPage: pageUrl,
+        publisher: { "@type": "Organization", name: SITE_NAME },
+      };
+    }
+    case "event": {
+      const parsed = eventMetadataSchema.safeParse(input.metadata);
+      if (!parsed.success) return undefined;
+      const { when, finish, location } = parsed.data;
+      return {
+        "@context": "https://schema.org",
+        "@type": "Event",
+        name: input.title,
+        ...(input.description ? { description: input.description } : {}),
+        startDate: when,
+        ...(finish ? { endDate: finish } : {}),
+        ...(location
+          ? {
+              location: {
+                "@type": "Place",
+                name: location.name,
+                address: {
+                  "@type": "PostalAddress",
+                  streetAddress: location.street,
+                  addressLocality: location.city,
+                  postalCode: location.postcode,
+                },
+              },
+            }
+          : {}),
+        url: pageUrl,
+      };
+    }
+    case "person": {
+      return {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        name: input.title,
+        ...(input.description ? { description: input.description } : {}),
+        image: resolveOgImage(input, origin),
+        url: pageUrl,
+      };
+    }
+  }
+}
+
+function ogType(kind: PrerenderKind): string {
+  if (kind === "news") return "article";
+  if (kind === "person") return "profile";
+  return "website";
+}
+
+/**
+ * The full replacement for index.html's pm-meta block. `origin` is the
+ * canonical public origin (no trailing slash).
+ */
+export function buildHead(
+  input: HeadInput,
+  origin = "https://www.percymain.org",
+): string {
+  const title = `${input.title} | ${SITE_NAME}`;
+  const description = input.description ?? DEFAULT_DESCRIPTION;
+  const pageUrl = `${origin}${input.url}`;
+  const image = resolveOgImage(input, origin);
+  const isDefaultImage = image === `${origin}${DEFAULT_OG_IMAGE_PATH}`;
+
+  const lines: string[] = [
+    `<title>${escapeHtml(title)}</title>`,
+    meta("name", "description", description),
+    `<link rel="canonical" href="${escapeHtml(pageUrl)}" />`,
+    meta("property", "og:title", input.title),
+    meta("property", "og:description", description),
+    meta("property", "og:url", pageUrl),
+    meta("property", "og:image", image),
+    meta("property", "og:type", ogType(input.kind)),
+    meta("property", "og:site_name", SITE_NAME),
+  ];
+
+  if (input.kind === "news") {
+    if (input.publishedAt) {
+      lines.push(meta("property", "article:published_time", input.publishedAt));
+    }
+    if (input.updatedAt) {
+      lines.push(meta("property", "article:modified_time", input.updatedAt));
+    }
+  }
+
+  lines.push(
+    meta("name", "twitter:card", isDefaultImage ? "summary" : "summary_large_image"),
+    meta("name", "twitter:title", input.title),
+    meta("name", "twitter:description", description),
+    meta("name", "twitter:image", image),
+  );
+
+  const ldJson = buildLdJson(input, origin);
+  if (ldJson !== undefined) {
+    lines.push(
+      `<script type="application/ld+json">${ldJsonSerialize(ldJson)}</script>`,
+    );
+  }
+
+  return lines.join("\n    ");
+}

--- a/apps/web/src/prerender/paths.test.ts
+++ b/apps/web/src/prerender/paths.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSnapshotUrl,
+  snapshotInvalidationPath,
+  snapshotKvsKey,
+  snapshotS3Key,
+} from "./paths.js";
+
+// These fixtures are pinned on the CloudFront side too
+// (infra/modules/cdn/spa-rewrite.test.js) - the function derives the S3
+// object from the KVS key by the same convention.
+
+describe("prerender path mapping", () => {
+  it("maps URLs to _prerender S3 keys", () => {
+    expect(snapshotS3Key("/club")).toBe("_prerender/club.html");
+    expect(snapshotS3Key("/club/history/honours")).toBe(
+      "_prerender/club/history/honours.html",
+    );
+    expect(snapshotS3Key("/news/article/season-opener")).toBe(
+      "_prerender/news/article/season-opener.html",
+    );
+  });
+
+  it("uses the exact URL path as the KVS key", () => {
+    expect(snapshotKvsKey("/person/jane-smith")).toBe("/person/jane-smith");
+  });
+
+  it("derives the invalidation path from the S3 key", () => {
+    expect(snapshotInvalidationPath("/club")).toBe("/_prerender/club.html");
+  });
+
+  it("rejects URLs that can never be snapshots", () => {
+    expect(isSnapshotUrl("/")).toBe(false);
+    expect(isSnapshotUrl("")).toBe(false);
+    expect(isSnapshotUrl("/club/")).toBe(false);
+    expect(isSnapshotUrl("/club?x=1")).toBe(false);
+    expect(isSnapshotUrl("/assets/index-abc.js")).toBe(false);
+    expect(isSnapshotUrl("/Club")).toBe(false);
+    expect(() => snapshotS3Key("/club/")).toThrow();
+  });
+});

--- a/apps/web/src/prerender/paths.ts
+++ b/apps/web/src/prerender/paths.ts
@@ -1,0 +1,37 @@
+// URL <-> storage mappings for prerendered documents. The CloudFront
+// Function (infra/modules/cdn/spa-rewrite.js) derives the S3 object from
+// the KVS key BY CONVENTION - `"/_prerender" + uri + ".html"` - so this
+// module and that function must agree byte-for-byte. Its tests pin the
+// same fixtures (infra/modules/cdn/spa-rewrite.test.js).
+
+export const PRERENDER_S3_PREFIX = "_prerender";
+
+/**
+ * A public URL path eligible for snapshotting: absolute, extensionless,
+ * no trailing slash (except never "/" itself - the home page is not CMS
+ * content), no query/hash.
+ */
+export function isSnapshotUrl(url: string): boolean {
+  return /^(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)+$/.test(url);
+}
+
+/** `/club/history` -> `_prerender/club/history.html` (S3 object key, no leading slash). */
+export function snapshotS3Key(url: string): string {
+  if (!isSnapshotUrl(url)) {
+    throw new Error(`Not a snapshot-eligible URL: ${url}`);
+  }
+  return `${PRERENDER_S3_PREFIX}${url}.html`;
+}
+
+/** The KVS key for a snapshot: the exact public URL path. */
+export function snapshotKvsKey(url: string): string {
+  if (!isSnapshotUrl(url)) {
+    throw new Error(`Not a snapshot-eligible URL: ${url}`);
+  }
+  return url;
+}
+
+/** The CloudFront invalidation path for one snapshot's cache entry. */
+export function snapshotInvalidationPath(url: string): string {
+  return `/${snapshotS3Key(url)}`;
+}

--- a/apps/web/src/prerender/reconcile.test.ts
+++ b/apps/web/src/prerender/reconcile.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  navHash,
+  nextState,
+  planReconcile,
+  type ManifestItem,
+  type PrerenderState,
+} from "./reconcile.js";
+
+function item(url: string, overrides: Partial<ManifestItem> = {}): ManifestItem {
+  return {
+    url,
+    kind: "page",
+    slug: url.split("/").pop() ?? "",
+    updatedAt: "2026-06-01T10:00:00.000Z",
+    publishedAt: "2026-06-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const NAV = [{ path: "/club", title: "The Club", menuOrder: 1, isMainMenu: true }];
+
+function state(
+  items: Record<string, { updatedAt: string; publishedAt: string }>,
+  hash = navHash(NAV),
+): PrerenderState {
+  return { v: 1, navHash: hash, items };
+}
+
+describe("navHash", () => {
+  it("is stable across item ordering", () => {
+    const a = [
+      { path: "/a", title: "A", menuOrder: 1, isMainMenu: true },
+      { path: "/b", title: "B", menuOrder: 2, isMainMenu: false },
+    ];
+    expect(navHash(a)).toBe(navHash([...a].reverse()));
+  });
+
+  it("changes when a title, order or flag changes", () => {
+    const base = [{ path: "/a", title: "A", menuOrder: 1, isMainMenu: true }];
+    expect(navHash(base)).not.toBe(
+      navHash([{ ...base[0], title: "A2" }]),
+    );
+    expect(navHash(base)).not.toBe(
+      navHash([{ ...base[0], menuOrder: 2 }]),
+    );
+    expect(navHash(base)).not.toBe(
+      navHash([{ ...base[0], isMainMenu: false }]),
+    );
+  });
+});
+
+describe("planReconcile", () => {
+  it("renders everything on first run (no state)", () => {
+    const manifest = [item("/club"), item("/news/article/x", { kind: "news" })];
+    const plan = planReconcile({
+      manifest,
+      state: null,
+      currentNavHash: navHash(NAV),
+    });
+    expect(plan.mode).toBe("initial");
+    expect(plan.toRender).toEqual(manifest);
+    expect(plan.toUnrender).toEqual([]);
+  });
+
+  it("renders only new and changed items on a steady-state diff", () => {
+    const unchanged = item("/club");
+    const edited = item("/club/history", {
+      updatedAt: "2026-06-05T10:00:00.000Z",
+    });
+    const fresh = item("/news/article/new", { kind: "news" });
+    const plan = planReconcile({
+      manifest: [unchanged, edited, fresh],
+      state: state({
+        "/club": { updatedAt: unchanged.updatedAt, publishedAt: unchanged.publishedAt },
+        "/club/history": {
+          updatedAt: "2026-06-01T10:00:00.000Z",
+          publishedAt: edited.publishedAt,
+        },
+      }),
+      currentNavHash: navHash(NAV),
+    });
+    expect(plan.mode).toBe("diff");
+    expect(plan.toRender.map((i) => i.url)).toEqual([
+      "/club/history",
+      "/news/article/new",
+    ]);
+    expect(plan.toUnrender).toEqual([]);
+  });
+
+  it("detects a scheduled publish crossing go-live as a new item", () => {
+    // Before go-live the manifest excludes the item entirely (the API
+    // lists only live content), so at go-live it appears - a plain "new
+    // item" to the diff.
+    const scheduled = item("/news/article/matchday", { kind: "news" });
+    const plan = planReconcile({
+      manifest: [scheduled],
+      state: state({}),
+      currentNavHash: navHash(NAV),
+    });
+    expect(plan.toRender.map((i) => i.url)).toEqual(["/news/article/matchday"]);
+  });
+
+  it("tears down items that left the manifest", () => {
+    const plan = planReconcile({
+      manifest: [],
+      state: state({
+        "/person/gone": {
+          updatedAt: "2026-06-01T10:00:00.000Z",
+          publishedAt: "2026-06-01T10:00:00.000Z",
+        },
+      }),
+      currentNavHash: navHash(NAV),
+    });
+    expect(plan.mode).toBe("diff");
+    expect(plan.toRender).toEqual([]);
+    expect(plan.toUnrender).toEqual(["/person/gone"]);
+  });
+
+  it("escalates to a full re-render when the nav changes", () => {
+    const unchanged = item("/club");
+    const plan = planReconcile({
+      manifest: [unchanged],
+      state: state(
+        { "/club": { updatedAt: unchanged.updatedAt, publishedAt: unchanged.publishedAt } },
+        "stale-nav-hash",
+      ),
+      currentNavHash: navHash(NAV),
+    });
+    expect(plan.mode).toBe("nav-changed");
+    expect(plan.toRender).toEqual([unchanged]);
+  });
+
+  it("force renders everything but still tears down vanished items", () => {
+    const live = item("/club");
+    const plan = planReconcile({
+      manifest: [live],
+      state: state({
+        "/club": { updatedAt: live.updatedAt, publishedAt: live.publishedAt },
+        "/person/gone": {
+          updatedAt: "2026-06-01T10:00:00.000Z",
+          publishedAt: "2026-06-01T10:00:00.000Z",
+        },
+      }),
+      currentNavHash: navHash(NAV),
+      force: true,
+    });
+    expect(plan.mode).toBe("forced");
+    expect(plan.toRender).toEqual([live]);
+    expect(plan.toUnrender).toEqual(["/person/gone"]);
+  });
+});
+
+describe("nextState", () => {
+  it("records the manifest minus failures so retries happen next sync", () => {
+    const ok = item("/club");
+    const failed = item("/club/history");
+    const result = nextState([ok, failed], "abc", new Set(["/club/history"]));
+    expect(Object.keys(result.items)).toEqual(["/club"]);
+    expect(result.navHash).toBe("abc");
+    expect(result.v).toBe(1);
+  });
+});

--- a/apps/web/src/prerender/reconcile.test.ts
+++ b/apps/web/src/prerender/reconcile.test.ts
@@ -7,7 +7,10 @@ import {
   type PrerenderState,
 } from "./reconcile.js";
 
-function item(url: string, overrides: Partial<ManifestItem> = {}): ManifestItem {
+function item(
+  url: string,
+  overrides: Partial<ManifestItem> = {},
+): ManifestItem {
   return {
     url,
     kind: "page",
@@ -18,7 +21,9 @@ function item(url: string, overrides: Partial<ManifestItem> = {}): ManifestItem 
   };
 }
 
-const NAV = [{ path: "/club", title: "The Club", menuOrder: 1, isMainMenu: true }];
+const NAV = [
+  { path: "/club", title: "The Club", menuOrder: 1, isMainMenu: true },
+];
 
 function state(
   items: Record<string, { updatedAt: string; publishedAt: string }>,
@@ -38,12 +43,8 @@ describe("navHash", () => {
 
   it("changes when a title, order or flag changes", () => {
     const base = [{ path: "/a", title: "A", menuOrder: 1, isMainMenu: true }];
-    expect(navHash(base)).not.toBe(
-      navHash([{ ...base[0], title: "A2" }]),
-    );
-    expect(navHash(base)).not.toBe(
-      navHash([{ ...base[0], menuOrder: 2 }]),
-    );
+    expect(navHash(base)).not.toBe(navHash([{ ...base[0], title: "A2" }]));
+    expect(navHash(base)).not.toBe(navHash([{ ...base[0], menuOrder: 2 }]));
     expect(navHash(base)).not.toBe(
       navHash([{ ...base[0], isMainMenu: false }]),
     );
@@ -72,7 +73,10 @@ describe("planReconcile", () => {
     const plan = planReconcile({
       manifest: [unchanged, edited, fresh],
       state: state({
-        "/club": { updatedAt: unchanged.updatedAt, publishedAt: unchanged.publishedAt },
+        "/club": {
+          updatedAt: unchanged.updatedAt,
+          publishedAt: unchanged.publishedAt,
+        },
         "/club/history": {
           updatedAt: "2026-06-01T10:00:00.000Z",
           publishedAt: edited.publishedAt,
@@ -122,7 +126,12 @@ describe("planReconcile", () => {
     const plan = planReconcile({
       manifest: [unchanged],
       state: state(
-        { "/club": { updatedAt: unchanged.updatedAt, publishedAt: unchanged.publishedAt } },
+        {
+          "/club": {
+            updatedAt: unchanged.updatedAt,
+            publishedAt: unchanged.publishedAt,
+          },
+        },
         "stale-nav-hash",
       ),
       currentNavHash: navHash(NAV),

--- a/apps/web/src/prerender/reconcile.ts
+++ b/apps/web/src/prerender/reconcile.ts
@@ -84,7 +84,8 @@ export function planReconcile(options: {
   );
 
   if (force) return { mode: "forced", toRender: manifest, toUnrender };
-  if (state === null) return { mode: "initial", toRender: manifest, toUnrender };
+  if (state === null)
+    return { mode: "initial", toRender: manifest, toUnrender };
   if (state.navHash !== currentNavHash) {
     return { mode: "nav-changed", toRender: manifest, toUnrender };
   }

--- a/apps/web/src/prerender/reconcile.ts
+++ b/apps/web/src/prerender/reconcile.ts
@@ -1,0 +1,118 @@
+// Pure diff logic for the prerender reconcile loop: given the API's
+// manifest of live content and the state file from the last successful
+// sync, decide what to (re)render and what to tear down. The Lambda
+// (server/prerender/lambda.ts) runs this on every publish trigger and on
+// the 15-minute schedule - one code path covers publishes, unpublishes,
+// edits, scheduled go-lives, missed triggers and drift.
+
+export interface ManifestItem {
+  url: string;
+  kind: "page" | "news" | "event" | "person";
+  slug: string;
+  updatedAt: string;
+  publishedAt: string;
+}
+
+export interface NavItem {
+  path: string;
+  title: string;
+  menuOrder: number;
+  isMainMenu: boolean;
+}
+
+interface StateEntry {
+  updatedAt: string;
+  publishedAt: string;
+}
+
+/**
+ * `_prerender/state.json`: what the last sync rendered, plus the hash of
+ * the nav it embedded in every document. Rendered bundle version is NOT
+ * tracked here - deploys always force a full render-all because every
+ * document's asset references change.
+ */
+export interface PrerenderState {
+  v: 1;
+  navHash: string;
+  items: Record<string, StateEntry>;
+}
+
+export interface ReconcilePlan {
+  /** Why everything is being re-rendered, when it is. */
+  mode: "initial" | "nav-changed" | "forced" | "diff";
+  toRender: ManifestItem[];
+  /** URLs rendered previously that are no longer live. */
+  toUnrender: string[];
+}
+
+/**
+ * Stable content hash of the nav items every snapshot embeds (djb2 -
+ * cheap and deterministic; collision risk is irrelevant, a false match
+ * self-heals on the next full render). Any change to the published page
+ * set - title, path, menu placement - changes the header/sidebars baked
+ * into EVERY document, so a nav change escalates to a full re-render.
+ */
+export function navHash(items: NavItem[]): string {
+  const canonical = JSON.stringify(
+    items
+      .map(({ path, title, menuOrder, isMainMenu }) => ({
+        path,
+        title,
+        menuOrder,
+        isMainMenu,
+      }))
+      .sort((a, b) => a.path.localeCompare(b.path)),
+  );
+  let hash = 5381;
+  for (let i = 0; i < canonical.length; i++) {
+    hash = ((hash << 5) + hash + canonical.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(16);
+}
+
+export function planReconcile(options: {
+  manifest: ManifestItem[];
+  state: PrerenderState | null;
+  currentNavHash: string;
+  force?: boolean;
+}): ReconcilePlan {
+  const { manifest, state, currentNavHash, force = false } = options;
+
+  const liveUrls = new Set(manifest.map((item) => item.url));
+  const toUnrender = Object.keys(state?.items ?? {}).filter(
+    (url) => !liveUrls.has(url),
+  );
+
+  if (force) return { mode: "forced", toRender: manifest, toUnrender };
+  if (state === null) return { mode: "initial", toRender: manifest, toUnrender };
+  if (state.navHash !== currentNavHash) {
+    return { mode: "nav-changed", toRender: manifest, toUnrender };
+  }
+
+  const toRender = manifest.filter((item) => {
+    const previous = state.items[item.url];
+    return (
+      previous?.updatedAt !== item.updatedAt ||
+      previous.publishedAt !== item.publishedAt
+    );
+  });
+  return { mode: "diff", toRender, toUnrender };
+}
+
+/** The state file a completed sync should persist. */
+export function nextState(
+  manifest: ManifestItem[],
+  currentNavHash: string,
+  /** URLs that failed to render this sync - left out so the next reconcile retries them. */
+  failedUrls: ReadonlySet<string> = new Set(),
+): PrerenderState {
+  const items: Record<string, StateEntry> = {};
+  for (const item of manifest) {
+    if (failedUrls.has(item.url)) continue;
+    items[item.url] = {
+      updatedAt: item.updatedAt,
+      publishedAt: item.publishedAt,
+    };
+  }
+  return { v: 1, navHash: currentNavHash, items };
+}

--- a/apps/web/src/prerender/sitemap.test.ts
+++ b/apps/web/src/prerender/sitemap.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildSitemap } from "./sitemap.js";
+
+describe("buildSitemap", () => {
+  const xml = buildSitemap(
+    [
+      { url: "/club/history", updatedAt: "2026-06-02T10:30:00.000Z" },
+      { url: "/news/article/a&b", updatedAt: "2026-06-03T10:30:00.000Z" },
+    ],
+    "https://www.percymain.org",
+  );
+
+  it("emits a urlset with evergreen routes and content items", () => {
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(xml).toContain("<loc>https://www.percymain.org/</loc>");
+    expect(xml).toContain("<loc>https://www.percymain.org/news/1</loc>");
+    expect(xml).toContain(
+      "<url><loc>https://www.percymain.org/club/history</loc><lastmod>2026-06-02</lastmod></url>",
+    );
+  });
+
+  it("escapes XML-significant characters in URLs", () => {
+    expect(xml).toContain("a&amp;b");
+    expect(xml).not.toContain("a&b<");
+  });
+});

--- a/apps/web/src/prerender/sitemap.ts
+++ b/apps/web/src/prerender/sitemap.ts
@@ -1,0 +1,58 @@
+import type { ManifestItem } from "./reconcile.js";
+
+// sitemap.xml for the public site, rebuilt by every prerender sync from
+// the same manifest that drives rendering. Served straight from the
+// frontend bucket ("/sitemap.xml" has an extension, so the CloudFront
+// SPA rewrite passes it through untouched).
+
+/**
+ * Evergreen app routes that are not CMS content but should be crawled.
+ * The home page tops the list; the rest are the stable public sections
+ * and the recruitment landing pages.
+ */
+const EVERGREEN_ROUTES = [
+  "/",
+  "/news/1",
+  "/calendar",
+  "/person",
+  "/tell-me-about",
+  "/tell-me-about/mens-cricket",
+  "/tell-me-about/womens-cricket",
+  "/tell-me-about/junior-boys",
+  "/tell-me-about/junior-girls",
+] as const;
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("'", "&apos;")
+    .replaceAll('"', "&quot;");
+}
+
+export function buildSitemap(
+  items: ReadonlyArray<Pick<ManifestItem, "url" | "updatedAt">>,
+  origin = "https://www.percymain.org",
+): string {
+  const urls: string[] = [];
+
+  for (const route of EVERGREEN_ROUTES) {
+    urls.push(`  <url><loc>${escapeXml(`${origin}${route}`)}</loc></url>`);
+  }
+
+  for (const item of items) {
+    const lastmod = item.updatedAt.slice(0, 10);
+    urls.push(
+      `  <url><loc>${escapeXml(`${origin}${item.url}`)}</loc><lastmod>${escapeXml(lastmod)}</lastmod></url>`,
+    );
+  }
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls,
+    "</urlset>",
+    "",
+  ].join("\n");
+}

--- a/apps/web/src/prerender/stubs/add-to-calendar-button.tsx
+++ b/apps/web/src/prerender/stubs/add-to-calendar-button.tsx
@@ -1,0 +1,9 @@
+// SSR stand-in for add-to-calendar-button-react (aliased in
+// vite.config.ts for the prerender build only). The real package
+// registers a web component against `customElements` at import time,
+// which does not exist in Node; the button is interactive chrome with no
+// SEO value, so prerendered documents render nothing and the take-over
+// render mounts the real component.
+export function AddToCalendarButton(): null {
+  return null;
+}

--- a/apps/web/src/prerender/take-over.ts
+++ b/apps/web/src/prerender/take-over.ts
@@ -1,0 +1,50 @@
+import type { DehydratedState } from "@tanstack/react-query";
+import { matchRoutes, type RouteObject } from "react-router";
+
+/**
+ * Payload the prerenderer embeds in each cached document
+ * (assemble-document.ts). Versioned so a stale snapshot rendered by an
+ * older bundle degrades to a plain CSR boot instead of hydrating a shape
+ * the current code no longer understands.
+ */
+export interface PrerenderPayload {
+  v: 1;
+  dehydratedState: DehydratedState;
+}
+
+declare global {
+  interface Window {
+    __PM_PRERENDER__?: unknown;
+  }
+}
+
+/** The embedded prerender payload, or null on a plain CSR document. */
+export function readPrerenderPayload(): PrerenderPayload | null {
+  const raw = window.__PM_PRERENDER__;
+  if (typeof raw !== "object" || raw === null) return null;
+  const payload = raw as Partial<PrerenderPayload>;
+  if (payload.v !== 1) return null;
+  if (typeof payload.dehydratedState !== "object") return null;
+  return payload as PrerenderPayload;
+}
+
+/**
+ * Resolve the lazy modules for every route matching the current URL and
+ * graft them onto the route objects, so the first router render commits
+ * synchronously. Without this the initial commit renders the router's
+ * fallback (nothing), wiping a prerendered document's DOM and flashing
+ * blank before the module loads.
+ */
+export async function preloadMatchedRoutes(
+  routes: RouteObject[],
+  pathname: string,
+): Promise<void> {
+  const matches = matchRoutes(routes, pathname) ?? [];
+  await Promise.all(
+    matches.map(async ({ route }) => {
+      if (typeof route.lazy !== "function") return;
+      const mod = await route.lazy();
+      Object.assign(route, mod, { lazy: undefined });
+    }),
+  );
+}

--- a/apps/web/src/providers/app-providers.tsx
+++ b/apps/web/src/providers/app-providers.tsx
@@ -18,41 +18,54 @@ function noticeQueryError(
   attrs: Record<string, string | number | boolean>,
 ) {
   const error = err instanceof Error ? err : new Error(String(err));
-  if (window.newrelic) {
+  if (typeof window !== "undefined" && window.newrelic) {
     window.newrelic.noticeError(error, attrs);
   } else {
     console.error("react-query (NR not loaded):", error.message, attrs);
   }
 }
 
-export function AppProviders({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        queryCache: new QueryCache({
-          onError: (err, query) =>
-            noticeQueryError(err, {
-              kind: "query",
-              queryKey: query.queryKey
-                .flatMap((part) => (typeof part === "string" ? [part] : []))
-                .join(":"),
-            }),
+/**
+ * The app QueryClient, as a factory so main.tsx can create it before
+ * first render and seed it from a prerendered document's dehydrated
+ * state (take-over.ts) — the cache must be populated before React
+ * mounts or the first commit wipes the prerendered DOM with spinners.
+ */
+export function createAppQueryClient(): QueryClient {
+  return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (err, query) =>
+        noticeQueryError(err, {
+          kind: "query",
+          queryKey: query.queryKey
+            .flatMap((part) => (typeof part === "string" ? [part] : []))
+            .join(":"),
         }),
-        mutationCache: new MutationCache({
-          onError: (err, _vars, _ctx, mutation) =>
-            noticeQueryError(err, {
-              kind: "mutation",
-              mutationKey:
-                mutation.options.mutationKey
-                  ?.flatMap((part) => (typeof part === "string" ? [part] : []))
-                  .join(":") ?? "unknown",
-            }),
+    }),
+    mutationCache: new MutationCache({
+      onError: (err, _vars, _ctx, mutation) =>
+        noticeQueryError(err, {
+          kind: "mutation",
+          mutationKey:
+            mutation.options.mutationKey
+              ?.flatMap((part) => (typeof part === "string" ? [part] : []))
+              .join(":") ?? "unknown",
         }),
-      }),
-  );
+    }),
+  });
+}
+
+export function AppProviders({
+  children,
+  queryClient,
+}: {
+  children: ReactNode;
+  queryClient?: QueryClient;
+}) {
+  const [client] = useState(() => queryClient ?? createAppQueryClient());
   return (
     <ThemeProvider>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
     </ThemeProvider>
   );
 }

--- a/apps/web/src/providers/app-providers.tsx
+++ b/apps/web/src/providers/app-providers.tsx
@@ -1,59 +1,7 @@
 import { ThemeProvider } from "@/hooks/use-theme.js";
-import {
-  MutationCache,
-  QueryCache,
-  QueryClient,
-  QueryClientProvider,
-} from "@tanstack/react-query";
+import { createAppQueryClient } from "@/lib/query-client.js";
+import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
-
-/**
- * Forward any react-query (or react-query-mutation) error to NR
- * Browser. Without this, react-query failures bubble to component-
- * local `error` state and never reach NR — a server 5xx on a query
- * shows as a toast (or nothing) and is invisible to observability.
- */
-function noticeQueryError(
-  err: unknown,
-  attrs: Record<string, string | number | boolean>,
-) {
-  const error = err instanceof Error ? err : new Error(String(err));
-  if (typeof window !== "undefined" && window.newrelic) {
-    window.newrelic.noticeError(error, attrs);
-  } else {
-    console.error("react-query (NR not loaded):", error.message, attrs);
-  }
-}
-
-/**
- * The app QueryClient, as a factory so main.tsx can create it before
- * first render and seed it from a prerendered document's dehydrated
- * state (take-over.ts) — the cache must be populated before React
- * mounts or the first commit wipes the prerendered DOM with spinners.
- */
-export function createAppQueryClient(): QueryClient {
-  return new QueryClient({
-    queryCache: new QueryCache({
-      onError: (err, query) =>
-        noticeQueryError(err, {
-          kind: "query",
-          queryKey: query.queryKey
-            .flatMap((part) => (typeof part === "string" ? [part] : []))
-            .join(":"),
-        }),
-    }),
-    mutationCache: new MutationCache({
-      onError: (err, _vars, _ctx, mutation) =>
-        noticeQueryError(err, {
-          kind: "mutation",
-          mutationKey:
-            mutation.options.mutationKey
-              ?.flatMap((part) => (typeof part === "string" ? [part] : []))
-              .join(":") ?? "unknown",
-        }),
-    }),
-  });
-}
 
 export function AppProviders({
   children,

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from "react-router";
+import type { RouteObject } from "react-router";
 import { RequireAuth } from "./components/require-auth.js";
 import { RequireElevated } from "./components/require-elevated.js";
 import { RequirePermission } from "./components/require-permission.js";
@@ -7,7 +7,10 @@ import { RouteError } from "./components/route-error.js";
 import { AuthLayout } from "./layouts/auth-layout.js";
 import { RootLayout } from "./layouts/root-layout.js";
 
-export const router = createBrowserRouter([
+// The route table, shared by the browser router (main.tsx) and the
+// prerenderer's static handler (entry-server.tsx). Keep it free of
+// browser-only module-level work: it is imported in Node.
+export const routes: RouteObject[] = [
   {
     element: <RootLayout />,
     // Catches render exceptions in any descendant route, plus
@@ -269,4 +272,4 @@ export const router = createBrowserRouter([
       },
     ],
   },
-]);
+];

--- a/apps/web/tsconfig.server.json
+++ b/apps/web/tsconfig.server.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "noEmit": true,
+    "types": ["node", "google.maps"]
+  },
+  "include": ["server/**/*", "src/**/*"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -43,7 +43,7 @@ function gtagHtmlPlugin(mode: string): Plugin {
   };
 }
 
-export default defineConfig(({ mode }) => ({
+export default defineConfig(({ mode, isSsrBuild }) => ({
   plugins: [
     react(),
     babel({
@@ -62,24 +62,47 @@ export default defineConfig(({ mode }) => ({
     }),
     gtagHtmlPlugin(mode),
   ],
+  // The prerenderer bundle (build:ssr) ships to Lambda with no
+  // node_modules: bundle every dependency in. Asset imports still resolve
+  // to the same content-hashed /assets/ URLs as the client build - CI
+  // asserts that parity (scripts/check-ssr-asset-parity.mjs).
+  ...(isSsrBuild ? { ssr: { noExternal: true } } : {}),
   build: {
     rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (
-            /[\\/]node_modules[\\/](\.pnpm[\\/])?(@tanstack[\\/]react-query|react|react-dom|react-router|scheduler)([\\/@]|$)/.test(
-              id,
-            )
-          ) {
-            return "vendor";
+      output: isSsrBuild
+        ? {
+            // The Lambda zip ships no package.json, so Node only treats
+            // the bundle as ESM via the .mjs extension.
+            entryFileNames: "[name].mjs",
+            chunkFileNames: "chunks/[name]-[hash].mjs",
           }
-        },
-      },
+        : {
+            manualChunks(id) {
+              if (
+                /[\\/]node_modules[\\/](\.pnpm[\\/])?(@tanstack[\\/]react-query|react|react-dom|react-router|scheduler)([\\/@]|$)/.test(
+                  id,
+                )
+              ) {
+                return "vendor";
+              }
+              return undefined;
+            },
+          },
     },
   },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // The real package registers a web component at import time -
+      // browser-only; the prerender bundle renders nothing in its place.
+      ...(isSsrBuild
+        ? {
+            "add-to-calendar-button-react": path.resolve(
+              __dirname,
+              "./src/prerender/stubs/add-to-calendar-button.tsx",
+            ),
+          }
+        : {}),
     },
   },
   server: {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -68,6 +68,9 @@ export default defineConfig(({ mode, isSsrBuild }) => ({
   // asserts that parity (scripts/check-ssr-asset-parity.mjs).
   ...(isSsrBuild ? { ssr: { noExternal: true } } : {}),
   build: {
+    // The Lambda zip doesn't serve static files; don't copy public/ into
+    // the SSR outDir.
+    ...(isSsrBuild ? { copyPublicDir: false } : {}),
     rollupOptions: {
       output: isSsrBuild
         ? {

--- a/docs/adrs/052-publish-time-prerendering.md
+++ b/docs/adrs/052-publish-time-prerendering.md
@@ -1,0 +1,51 @@
+# Decision 052: Publish-Time Prerendering via Lambda + CloudFront KeyValueStore
+
+**Date:** 2026-07-03
+**Status:** Accepted
+
+## Decision
+
+Public content (CMS pages, news articles, people profiles, events) is rendered to static HTML at publish time by a "prerenderer" Lambda built from the web app's own SSR bundle, stored under `_prerender/` in the frontend S3 bucket, and served as the initial document to everyone - users and crawlers - via a CloudFront KeyValueStore lookup in the existing viewer-request function. The SPA seeds react-query from state embedded in the document, resolves the matched route's lazy module, then renders over the prerendered DOM in a single, visually identical commit. Game reports keep their existing OG-redirect mechanism.
+
+One diff-driven `reconcile` action covers the whole lifecycle: the Lambda fetches a manifest of live content from the API, diffs it against a state file, renders what changed and tears down what vanished. A change to the nav (which is baked into every document's header/sidebar) escalates to a full re-render. Triggers: async invoke from the API on publish-path mutations, a render-all from deploy-web on every web deploy (asset hashes change), and a 15-minute EventBridge sweep as the backstop for scheduled publishes, lost triggers and drift.
+
+## Problem
+
+The public site was a pure client-rendered SPA. Three consequences:
+
+1. Menus and content loaded in gradually - the nav is derived from published pages via an API call, and content pages showed a spinner while `by-path` resolved.
+2. No per-page meta tags: every URL shipped the same generic `<title>`/OG tags, so shared links (WhatsApp/Facebook - a club's main channels) always showed the site-generic card, and there was no sitemap, robots.txt or JSON-LD.
+3. Crawlers that don't execute JavaScript saw an empty shell.
+
+Publishing had to stay instant (seconds), and the club runs on volunteer time and free-tier-conscious AWS spend.
+
+## Options considered
+
+1. **Publish-time prerendering (chosen).** Render on publish into S3; route via KVS at the edge; SPA takes over client-side.
+2. **Full SSR migration** - react-router framework mode (or similar) rendered by a Node service on ECS/Lambda behind CloudFront.
+3. **Crawler-only dynamic rendering** - UA-sniff bots in the CloudFront Function (the game-report OG redirect already does this) and serve them API-generated snapshots; keep users on the SPA.
+4. **CI rebuild-on-publish (classic SSG)** - publish triggers a GitHub Actions build that prerenders the whole site and redeploys.
+
+## Rationale
+
+- Fixes all three problems for **everyone**, not just bots: real content and the full menu are in the first byte of HTML, per-page title/OG/JSON-LD are correct, and crawlers get plain static documents plus a sitemap.
+- Keeps the existing hosting model (S3 + CloudFront, no always-on page server) and publishing latency (seconds).
+- The renderer being the web app's own SSR bundle (`vite build --ssr`, `ssr.noExternal: true`) means zero dual-renderer maintenance across the 13+ custom block types, markup that matches the client render, and - because it's built and shipped by `deploy-web` alongside the client bundle - hashed asset references that always agree (a CI check asserts this).
+- The empty-KVS state is byte-identical to historical behaviour, which gives incremental rollout and an instant rollback (delete keys, unset `PRERENDER_ENABLED`).
+- Failure degrades gracefully: a dead renderer means new content serves via CSR fallback and edited content serves a stale snapshot that the SPA immediately refetches over.
+- Render-over instead of `hydrateRoot`: the app has guaranteed root-level mismatch sources (theme-derived icons, locale/timezone date formatting, session timing), and React 19 recovers from root mismatches by re-rendering the whole tree client-side anyway - so hydration would buy console noise, not correctness. Requires resolving the matched lazy route module before the first render, or React's first commit wipes the prerendered DOM.
+
+## Rejected alternatives
+
+- **Full SSR migration**: the cleanest long-term architecture (per-route `meta`/loaders eliminate this machinery), but a large app migration plus a new always-on runtime to operate and pay for. Becomes attractive if the SPA is ever rewritten wholesale or if personalised server-rendered pages are needed.
+- **Crawler-only dynamic rendering**: least effort, but users never get content on first paint (problem 1 unsolved), it needs a hand-rolled BlockNote-to-HTML renderer maintained in parallel with the React one, and Google documents dynamic rendering as a workaround. Reconsider only as a stopgap if the render-over approach had proven unworkable.
+- **CI rebuild-on-publish**: simplest machinery and atomic regeneration, but 5-10 minutes publish-to-live (a regression from seconds), CI minutes per publish, and scheduled publishes would need scheduled builds. Becomes attractive if publish frequency drops to near-zero and the Lambda pipeline proves burdensome.
+- **Per-item EventBridge one-shot schedules for scheduled publishes**: rejected in favour of the 15-minute sweep - content is live instantly via CSR fallback either way (the query layer gates visibility by `published_at`), so one-shots would add scheduler IAM and cancellation bookkeeping to shave minutes off snapshot latency nobody can see.
+- **SQS between API and Lambda**: async Lambda invoke already gives 2 retries and an on-failure destination to the alarms topic; a queue is overengineering at a few publishes a week.
+
+## Operational notes
+
+- **Rollout**: deploy with `PRERENDER_ENABLED` unset (empty KVS = no behaviour change) → invoke `{"action":"render","url":"/club"}` manually → verify `curl https://www.percymain.org/club` shows content + meta → set the repo variable.
+- **Rollback**: delete all KVS keys and unset `PRERENDER_ENABLED`; snapshots in S3 are inert.
+- **Deploy ordering is load-bearing**: `deploy-web` uploads new assets WITHOUT `--delete`, updates the Lambda code, re-renders every snapshot synchronously, and only then removes stale assets (with `_prerender/*` and `sitemap.xml` excluded). Collapsing this back to a single `--delete` sync would serve snapshots referencing deleted scripts for the re-render window - or delete every snapshot outright if the excludes are dropped.
+- **Local preview**: `apps/web/scripts/prerender-preview.mjs` renders any URL through the full pipeline minus AWS.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -30,3 +30,4 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 | [049](049-ai-content-author-assistant.md)                | AI content-author assistant reuses Scout's tools                  | 2026-06-14 | Accepted |
 | [050](050-profile-self-edit-proposal-tier.md)            | Profile self-editing via a proposal/approval tier                 | 2026-06-23 | Accepted |
 | [051](051-member-slug-backfill-and-profile-fallback.md)  | Member slug backfill, member-backed profile fallback, self-create | 2026-06-24 | Accepted |
+| [052](052-publish-time-prerendering.md)                  | Publish-time prerendering via Lambda + CloudFront KeyValueStore   | 2026-07-03 | Accepted |

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -209,10 +209,10 @@ module "ecs" {
     SCOUT_MODEL_REPORT            = "deepseek-v4-pro"
     SCOUT_ATTACHMENT_DERIVE_MODEL = "claude-haiku-4-5-20251001"
     # Content-author AI assistant ("Generate with AI" over the content editor).
-    CONTENT_AI_PROVIDER           = "deepseek"
-    CONTENT_AI_MODEL              = "deepseek-v4-pro"
-    VOYAGE_EMBED_MODEL            = "voyage-4"
-    VOYAGE_RERANK_MODEL           = "rerank-2.5"
+    CONTENT_AI_PROVIDER = "deepseek"
+    CONTENT_AI_MODEL    = "deepseek-v4-pro"
+    VOYAGE_EMBED_MODEL  = "voyage-4"
+    VOYAGE_RERANK_MODEL = "rerank-2.5"
     # Arize Phoenix LLM tracing - isolated from NR. The collector endpoint
     # is the bare Phoenix Cloud space URL; the API code appends /v1/traces.
     # Project name is per-env so prod traces don't collide with staging.
@@ -387,6 +387,21 @@ module "cdn" {
   acm_certificate_arn = local.shared.acm_cloudfront_certificate_arn
   extra_aliases       = ["www.percymain.org", "kit.percymain.org"]
   api_base_url        = "https://api.v2.percymain.org"
+}
+
+# Prerenderer: publish-time static HTML snapshots of public content
+# (pages/news/people/events) served as the initial document via the cdn
+# module's KeyValueStore-gated rewrite. Terraform owns the function; the
+# deploy-web workflow pushes its code on every web deploy.
+module "prerender" {
+  source               = "../../modules/prerender"
+  environment          = "production"
+  frontend_bucket_name = module.cdn.frontend_bucket_name
+  frontend_bucket_arn  = module.cdn.frontend_bucket_arn
+  kvs_arn              = module.cdn.prerender_kvs_arn
+  distribution_id      = module.cdn.distribution_id
+  distribution_arn     = module.cdn.distribution_arn
+  alarms_sns_topic_arn = module.monitoring.sns_topic_arn
 }
 
 # Matchday PWA distribution - separate from the main marketing site so a

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -227,6 +227,11 @@ module "ecs" {
     SYNC_ECS_SUBNETS          = join(",", module.vpc.public_subnet_ids)
     SYNC_ECS_SECURITY_GROUP   = module.vpc.ecs_security_group_id
     SYNC_ECS_ASSIGN_PUBLIC_IP = "true"
+    # Publish-path trigger for the prerenderer (fire-and-forget async
+    # invoke; the Lambda's manifest diff decides what to re-render). Safe
+    # at the resource level: the function depends on cdn + the monitoring
+    # SNS topic, neither of which depends on the ECS task definition.
+    PRERENDER_LAMBDA_ARN = module.prerender.function_arn
   }
 
   # Migration task connects as app_ddl once the role split is active.

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -466,6 +466,21 @@ data "aws_iam_policy_document" "deploy_s3_cloudfront" {
     ]
     resources = ["*"]
   }
+
+  # deploy-web pushes the prerenderer Lambda's code (built from the same
+  # web bundle it deploys to S3) and kicks a render-all after upload.
+  statement {
+    sid    = "PrerendererCodeDeploy"
+    effect = "Allow"
+    actions = [
+      "lambda:UpdateFunctionCode",
+      "lambda:GetFunction",
+      "lambda:InvokeFunction",
+    ]
+    resources = [
+      "arn:aws:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:percy-main-*-prerenderer",
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "deploy_s3_cloudfront" {

--- a/infra/modules/cdn/main.tf
+++ b/infra/modules/cdn/main.tf
@@ -293,8 +293,19 @@ resource "aws_cloudfront_origin_access_control" "s3" {
 }
 
 # -----------------------------------------------------------------------------
-# CloudFront Function — SPA Rewrite
+# CloudFront Function — SPA Rewrite + prerender routing
+#
+# The KeyValueStore holds one key per prerendered public URL (written by
+# the prerenderer Lambda, infra/modules/prerender). The function rewrites
+# a KVS hit to its /_prerender/... object and falls back to /index.html
+# on a miss - so an EMPTY store is exactly the historical pure-SPA
+# behaviour, which is also the rollback path (delete all keys).
 # -----------------------------------------------------------------------------
+
+resource "aws_cloudfront_key_value_store" "prerender" {
+  name    = "${var.environment}-percy-main-prerender"
+  comment = "Prerendered public URLs; managed by the prerenderer Lambda"
+}
 
 resource "aws_cloudfront_function" "spa_rewrite" {
   name    = "${var.environment}-percy-main-spa-rewrite"
@@ -302,6 +313,7 @@ resource "aws_cloudfront_function" "spa_rewrite" {
   code = templatefile("${path.module}/spa-rewrite.js", {
     api_base_url = var.api_base_url
   })
+  key_value_store_associations = [aws_cloudfront_key_value_store.prerender.arn]
 }
 
 # -----------------------------------------------------------------------------
@@ -485,4 +497,19 @@ output "frontend_bucket_name" {
 output "uploads_bucket_name" {
   value       = aws_s3_bucket.uploads.id
   description = "S3 bucket name for user uploads"
+}
+
+output "frontend_bucket_arn" {
+  value       = aws_s3_bucket.frontend.arn
+  description = "S3 bucket ARN for frontend assets (prerenderer IAM scoping)"
+}
+
+output "distribution_arn" {
+  value       = aws_cloudfront_distribution.main.arn
+  description = "CloudFront distribution ARN (prerenderer invalidation IAM)"
+}
+
+output "prerender_kvs_arn" {
+  value       = aws_cloudfront_key_value_store.prerender.arn
+  description = "CloudFront KeyValueStore holding prerendered URL keys"
 }

--- a/infra/modules/cdn/spa-rewrite.handler.js
+++ b/infra/modules/cdn/spa-rewrite.handler.js
@@ -1,14 +1,19 @@
 /**
- * CloudFront Function handler — SPA rewrite + OG redirect.
+ * CloudFront Function handler — SPA rewrite + OG redirect + prerender
+ * routing.
  *
  * This module exports the handler for testing. The actual CF function
  * source (spa-rewrite.js) is a Terraform template that inlines the
- * API_BASE_URL variable. Both files must stay in sync.
+ * API_BASE_URL variable and obtains the KVS handle from the cloudfront
+ * runtime. Both files must stay in sync.
  *
  * @param {string} apiBaseUrl — injected at deploy time via Terraform templatefile()
+ * @param {{ get(key: string): Promise<string> } | null} kvsHandle — the
+ *   prerender KeyValueStore (cf.kvs() in the real function; get() throws
+ *   on a missing key). null when no store is associated.
  */
-export function createHandler(apiBaseUrl) {
-  return function handler(event) {
+export function createHandler(apiBaseUrl, kvsHandle) {
+  return async function handler(event) {
     var request = event.request;
     var host = request.headers.host && request.headers.host.value;
 
@@ -38,6 +43,12 @@ export function createHandler(apiBaseUrl) {
 
     var uri = request.uri;
     var qs = request.querystring;
+
+    // Snapshot objects are reachable only via the extensionless rewrite
+    // below; direct hits would serve duplicate content at the wrong URL.
+    if (uri.startsWith("/_prerender/")) {
+      return { statusCode: 404, statusDescription: "Not Found" };
+    }
 
     // Redirect game pages to API for OG meta tags (unless returning via bypass param)
     if (apiBaseUrl) {
@@ -78,8 +89,25 @@ export function createHandler(apiBaseUrl) {
       }
     }
 
-    // If URI has no file extension, rewrite to /index.html for SPA routing
+    // Extensionless URIs are app routes: prerendered documents when the
+    // KVS says a snapshot exists (trailing slash normalised so /club/ and
+    // /club share one cache entry), the SPA shell otherwise.
     if (!uri.includes(".")) {
+      var lookupUri = uri;
+      if (lookupUri.length > 1 && lookupUri.endsWith("/")) {
+        lookupUri = lookupUri.slice(0, -1);
+      }
+      // The home page is never a snapshot (the prerenderer only writes
+      // content URLs, which always have at least one slug segment).
+      if (kvsHandle && lookupUri !== "/") {
+        try {
+          await kvsHandle.get(lookupUri);
+          request.uri = "/_prerender" + lookupUri + ".html";
+          return request;
+        } catch (err) {
+          // Key missing (or KVS error): fall through to the SPA shell.
+        }
+      }
       request.uri = "/index.html";
     }
     return request;

--- a/infra/modules/cdn/spa-rewrite.js
+++ b/infra/modules/cdn/spa-rewrite.js
@@ -2,9 +2,21 @@
 // Logic is duplicated from spa-rewrite.handler.js — keep in sync.
 // This file is a Terraform template; ${api_base_url} is interpolated at deploy time.
 
+import cf from "cloudfront";
+
 var API_BASE_URL = "${api_base_url}";
 
-function handler(event) {
+// The prerender KeyValueStore holds one key per prerendered public URL
+// (kept in step by the prerenderer Lambda). No store associated, or an
+// empty store, means pure-SPA behaviour.
+var kvsHandle = null;
+try {
+  kvsHandle = cf.kvs();
+} catch (err) {
+  kvsHandle = null;
+}
+
+async function handler(event) {
   var request = event.request;
   var host = request.headers.host && request.headers.host.value;
 
@@ -34,6 +46,12 @@ function handler(event) {
 
   var uri = request.uri;
   var qs = request.querystring;
+
+  // Snapshot objects are reachable only via the extensionless rewrite
+  // below; direct hits would serve duplicate content at the wrong URL.
+  if (uri.startsWith("/_prerender/")) {
+    return { statusCode: 404, statusDescription: "Not Found" };
+  }
 
   // Redirect game pages to API for OG meta tags (unless returning via bypass param)
   if (API_BASE_URL) {
@@ -74,8 +92,25 @@ function handler(event) {
     }
   }
 
-  // If URI has no file extension, rewrite to /index.html for SPA routing
+  // Extensionless URIs are app routes: prerendered documents when the
+  // KVS says a snapshot exists (trailing slash normalised so /club/ and
+  // /club share one cache entry), the SPA shell otherwise.
   if (!uri.includes(".")) {
+    var lookupUri = uri;
+    if (lookupUri.length > 1 && lookupUri.endsWith("/")) {
+      lookupUri = lookupUri.slice(0, -1);
+    }
+    // The home page is never a snapshot (the prerenderer only writes
+    // content URLs, which always have at least one slug segment).
+    if (kvsHandle && lookupUri !== "/") {
+      try {
+        await kvsHandle.get(lookupUri);
+        request.uri = "/_prerender" + lookupUri + ".html";
+        return request;
+      } catch (err) {
+        // Key missing (or KVS error): fall through to the SPA shell.
+      }
+    }
     request.uri = "/index.html";
   }
   return request;

--- a/infra/modules/cdn/spa-rewrite.test.js
+++ b/infra/modules/cdn/spa-rewrite.test.js
@@ -174,9 +174,7 @@ describe("spa-rewrite CloudFront function", () => {
     });
 
     it("normalises a trailing slash before the lookup", async () => {
-      const result = await kvsHandler(
-        makeEvent("/club/", "www.percymain.org"),
-      );
+      const result = await kvsHandler(makeEvent("/club/", "www.percymain.org"));
       expect(result.uri).toBe("/_prerender/club.html");
     });
 

--- a/infra/modules/cdn/spa-rewrite.test.js
+++ b/infra/modules/cdn/spa-rewrite.test.js
@@ -1,7 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { createHandler } from "./spa-rewrite.handler.js";
 
-const handler = createHandler("https://api.v2.percymain.org");
+/**
+ * Test double for the cloudfront runtime's KVS handle: get() resolves
+ * for known keys and throws for missing ones, exactly like cf.kvs().
+ */
+function fakeKvs(keys) {
+  return {
+    get(key) {
+      if (keys.includes(key)) return Promise.resolve("1");
+      return Promise.reject(new Error(`KeyNotFound: ${key}`));
+    },
+  };
+}
+
+const handler = createHandler("https://api.v2.percymain.org", null);
 
 function makeEvent(uri, host, querystring = {}) {
   return {
@@ -15,16 +28,16 @@ function makeEvent(uri, host, querystring = {}) {
 
 describe("spa-rewrite CloudFront function", () => {
   describe("domain redirects", () => {
-    it("redirects apex to www", () => {
-      const result = handler(makeEvent("/about", "percymain.org"));
+    it("redirects apex to www", async () => {
+      const result = await handler(makeEvent("/about", "percymain.org"));
       expect(result.statusCode).toBe(301);
       expect(result.headers.location.value).toBe(
         "https://www.percymain.org/about",
       );
     });
 
-    it("redirects kit subdomain to vx-3", () => {
-      const result = handler(makeEvent("/", "kit.percymain.org"));
+    it("redirects kit subdomain to vx-3", async () => {
+      const result = await handler(makeEvent("/", "kit.percymain.org"));
       expect(result.statusCode).toBe(301);
       expect(result.headers.location.value).toBe(
         "https://vx-3.com/collections/percy-main-cricket-club",
@@ -33,8 +46,8 @@ describe("spa-rewrite CloudFront function", () => {
   });
 
   describe("OG game page redirect", () => {
-    it("redirects /games/:matchId to API OG page", () => {
-      const result = handler(
+    it("redirects /games/:matchId to API OG page", async () => {
+      const result = await handler(
         makeEvent("/calendar/game/12345", "www.percymain.org"),
       );
       expect(result.statusCode).toBe(302);
@@ -43,8 +56,8 @@ describe("spa-rewrite CloudFront function", () => {
       );
     });
 
-    it("bypasses redirect when og=1 query param is set", () => {
-      const result = handler(
+    it("bypasses redirect when og=1 query param is set", async () => {
+      const result = await handler(
         makeEvent("/calendar/game/12345", "www.percymain.org", {
           og: { value: "1" },
         }),
@@ -53,8 +66,8 @@ describe("spa-rewrite CloudFront function", () => {
       expect(result.statusCode).toBeUndefined();
     });
 
-    it("forwards non-og query params to the OG page", () => {
-      const result = handler(
+    it("forwards non-og query params to the OG page", async () => {
+      const result = await handler(
         makeEvent("/calendar/game/12345", "www.percymain.org", {
           bbb: { value: "1" },
         }),
@@ -65,8 +78,8 @@ describe("spa-rewrite CloudFront function", () => {
       );
     });
 
-    it("strips the og param from forwarded query (only og=1 should round-trip via bypass)", () => {
-      const result = handler(
+    it("strips the og param from forwarded query (only og=1 should round-trip via bypass)", async () => {
+      const result = await handler(
         makeEvent("/calendar/game/12345", "www.percymain.org", {
           og: { value: "0" },
           foo: { value: "bar" },
@@ -81,8 +94,8 @@ describe("spa-rewrite CloudFront function", () => {
       );
     });
 
-    it("URL-encodes forwarded query values", () => {
-      const result = handler(
+    it("URL-encodes forwarded query values", async () => {
+      const result = await handler(
         makeEvent("/calendar/game/12345", "www.percymain.org", {
           q: { value: "hello world & friends" },
         }),
@@ -92,31 +105,46 @@ describe("spa-rewrite CloudFront function", () => {
       );
     });
 
-    it("does not redirect non-game pages", () => {
-      const result = handler(makeEvent("/about", "www.percymain.org"));
+    it("does not redirect non-game pages", async () => {
+      const result = await handler(makeEvent("/about", "www.percymain.org"));
       expect(result.uri).toBe("/index.html");
       expect(result.statusCode).toBeUndefined();
     });
 
-    it("does not redirect game paths with non-numeric IDs", () => {
-      const result = handler(
+    it("does not redirect game paths with non-numeric IDs", async () => {
+      const result = await handler(
         makeEvent("/calendar/game/abc", "www.percymain.org"),
       );
       expect(result.uri).toBe("/index.html");
       expect(result.statusCode).toBeUndefined();
     });
 
-    it("does not redirect /calendar/game/ without an ID", () => {
-      const result = handler(makeEvent("/calendar/game/", "www.percymain.org"));
+    it("does not redirect /calendar/game/ without an ID", async () => {
+      const result = await handler(
+        makeEvent("/calendar/game/", "www.percymain.org"),
+      );
       expect(result.uri).toBe("/index.html");
       expect(result.statusCode).toBeUndefined();
+    });
+
+    it("keeps the OG redirect even when a snapshot store exists", async () => {
+      // Game reports are never prerendered; their KVS keys never exist,
+      // and the OG branch runs before the KVS lookup anyway.
+      const kvsHandler = createHandler(
+        "https://api.v2.percymain.org",
+        fakeKvs(["/club"]),
+      );
+      const result = await kvsHandler(
+        makeEvent("/calendar/game/12345", "www.percymain.org"),
+      );
+      expect(result.statusCode).toBe(302);
     });
   });
 
   describe("OG redirect disabled when no API URL", () => {
-    it("skips redirect when apiBaseUrl is empty", () => {
-      const noApiHandler = createHandler("");
-      const result = noApiHandler(
+    it("skips redirect when apiBaseUrl is empty", async () => {
+      const noApiHandler = createHandler("", null);
+      const result = await noApiHandler(
         makeEvent("/calendar/game/12345", "www.percymain.org"),
       );
       expect(result.uri).toBe("/index.html");
@@ -124,16 +152,88 @@ describe("spa-rewrite CloudFront function", () => {
     });
   });
 
+  describe("prerender routing", () => {
+    // KVS keys are exact public URL paths; the S3 object is derived by
+    // convention ("/_prerender" + uri + ".html"). These fixtures are
+    // pinned on the Lambda side too (apps/web/src/prerender/paths.test.ts).
+    const kvsHandler = createHandler(
+      "https://api.v2.percymain.org",
+      fakeKvs(["/club", "/club/history", "/news/article/season-opener"]),
+    );
+
+    it("rewrites a snapshot URL to its prerendered object", async () => {
+      const result = await kvsHandler(makeEvent("/club", "www.percymain.org"));
+      expect(result.uri).toBe("/_prerender/club.html");
+    });
+
+    it("rewrites nested snapshot URLs", async () => {
+      const result = await kvsHandler(
+        makeEvent("/club/history", "www.percymain.org"),
+      );
+      expect(result.uri).toBe("/_prerender/club/history.html");
+    });
+
+    it("normalises a trailing slash before the lookup", async () => {
+      const result = await kvsHandler(
+        makeEvent("/club/", "www.percymain.org"),
+      );
+      expect(result.uri).toBe("/_prerender/club.html");
+    });
+
+    it("falls back to the SPA shell on a KVS miss", async () => {
+      const result = await kvsHandler(
+        makeEvent("/fantasy", "www.percymain.org"),
+      );
+      expect(result.uri).toBe("/index.html");
+    });
+
+    it("falls back to the SPA shell when the KVS handle throws", async () => {
+      const broken = createHandler("https://api.v2.percymain.org", {
+        get() {
+          return Promise.reject(new Error("kvs unavailable"));
+        },
+      });
+      const result = await broken(makeEvent("/club", "www.percymain.org"));
+      expect(result.uri).toBe("/index.html");
+    });
+
+    it("never routes the root URL to a snapshot, even with a lying store", async () => {
+      // The Lambda can never write a "/" key (isSnapshotUrl rejects it),
+      // and the function skips the lookup at the root outright.
+      const withRoot = createHandler("https://api.v2.percymain.org", {
+        get() {
+          return Promise.resolve("1");
+        },
+      });
+      const result = await withRoot(makeEvent("/", "www.percymain.org"));
+      expect(result.uri).toBe("/index.html");
+    });
+
+    it("returns 404 for direct hits on the snapshot prefix", async () => {
+      const result = await kvsHandler(
+        makeEvent("/_prerender/club.html", "www.percymain.org"),
+      );
+      expect(result.statusCode).toBe(404);
+    });
+
+    it("still serves static assets untouched", async () => {
+      const result = await kvsHandler(
+        makeEvent("/assets/logo.png", "www.percymain.org"),
+      );
+      expect(result.uri).toBe("/assets/logo.png");
+    });
+  });
+
   describe("SPA rewrite", () => {
-    it("rewrites paths without file extensions to /index.html", () => {
-      const result = handler(
+    it("rewrites paths without file extensions to /index.html", async () => {
+      const result = await handler(
         makeEvent("/members/profile", "www.percymain.org"),
       );
       expect(result.uri).toBe("/index.html");
     });
 
-    it("does not rewrite paths with file extensions", () => {
-      const result = handler(
+    it("does not rewrite paths with file extensions", async () => {
+      const result = await handler(
         makeEvent("/assets/logo.png", "www.percymain.org"),
       );
       expect(result.uri).toBe("/assets/logo.png");

--- a/infra/modules/ecs-service/main.tf
+++ b/infra/modules/ecs-service/main.tf
@@ -409,6 +409,26 @@ resource "aws_iam_role_policy" "task_run_sync" {
   })
 }
 
+resource "aws_iam_role_policy" "task_invoke_prerenderer" {
+  name = "${local.name_prefix}-task-invoke-prerenderer"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Publish-path trigger for the prerenderer Lambda (fire-and-forget
+        # async invoke on content mutations). Name-pattern ARN rather than
+        # the prerender module's output: referencing the output here would
+        # couple this module to one that is wired up after it.
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
+        Resource = "arn:aws:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:${local.name_prefix}-prerenderer"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy" "task_s3_document_uploads" {
   name = "${local.name_prefix}-task-s3-document-uploads"
   role = aws_iam_role.task.id

--- a/infra/modules/prerender/main.tf
+++ b/infra/modules/prerender/main.tf
@@ -1,0 +1,290 @@
+# Prerenderer Lambda
+#
+# Renders published content to static HTML in the frontend bucket and
+# keeps the CloudFront KeyValueStore + sitemap.xml in step (see
+# apps/web/server/prerender/lambda.ts). Terraform owns the function
+# resource, IAM and schedule; deploy-web owns the CODE (update-function-code
+# on every web deploy, so the renderer is always built from the exact
+# client bundle it must match) - hence ignore_changes on the package.
+#
+# Invocation paths:
+#   - API publish/unpublish/edit -> async invoke {"action":"reconcile"}
+#   - deploy-web after S3 sync   -> async invoke {"action":"render-all"}
+#   - EventBridge 15-min sweep   -> {"action":"reconcile"} (scheduled
+#     publishes crossing go-live, missed triggers, drift)
+#
+# reserved_concurrent_executions = 1 serialises syncs: concurrent runs
+# would race the KVS ETag and the state file; async invokes queue instead.
+
+# ------------------------------------------------------------------------------
+# Variables
+# ------------------------------------------------------------------------------
+
+variable "environment" {
+  type        = string
+  description = "Environment name"
+}
+
+variable "frontend_bucket_name" {
+  type        = string
+  description = "Frontend S3 bucket the snapshots are written to"
+}
+
+variable "frontend_bucket_arn" {
+  type        = string
+  description = "Frontend S3 bucket ARN (IAM scoping)"
+}
+
+variable "kvs_arn" {
+  type        = string
+  description = "CloudFront KeyValueStore ARN for prerendered URL keys"
+}
+
+variable "distribution_id" {
+  type        = string
+  description = "CloudFront distribution ID (invalidations)"
+}
+
+variable "distribution_arn" {
+  type        = string
+  description = "CloudFront distribution ARN (invalidation IAM)"
+}
+
+variable "site_origin" {
+  type        = string
+  default     = "https://www.percymain.org"
+  description = "Canonical public origin baked into meta tags and the sitemap"
+}
+
+variable "alarms_sns_topic_arn" {
+  type        = string
+  description = "SNS topic for the async-invoke failure destination and the errors alarm"
+}
+
+# ------------------------------------------------------------------------------
+# Locals
+# ------------------------------------------------------------------------------
+
+locals {
+  name_prefix   = "percy-main-${var.environment}"
+  function_name = "${local.name_prefix}-prerenderer"
+
+  tags = {
+    Environment = var.environment
+    Project     = "percy-main"
+    ManagedBy   = "terraform"
+    Module      = "prerender"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# IAM — Lambda execution role
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "prerenderer" {
+  name = local.function_name
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "prerenderer_logs" {
+  role       = aws_iam_role.prerenderer.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "prerenderer" {
+  name = "${local.function_name}-sync"
+  role = aws_iam_role.prerenderer.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "SnapshotObjects"
+        Effect = "Allow"
+        Action = ["s3:PutObject", "s3:GetObject", "s3:DeleteObject"]
+        Resource = [
+          "${var.frontend_bucket_arn}/_prerender/*",
+          "${var.frontend_bucket_arn}/sitemap.xml",
+        ]
+      },
+      {
+        Sid      = "Invalidate"
+        Effect   = "Allow"
+        Action   = ["cloudfront:CreateInvalidation"]
+        Resource = [var.distribution_arn]
+      },
+      {
+        Sid    = "KvsSync"
+        Effect = "Allow"
+        Action = [
+          "cloudfront-keyvaluestore:DescribeKeyValueStore",
+          "cloudfront-keyvaluestore:GetKey",
+          "cloudfront-keyvaluestore:ListKeys",
+          "cloudfront-keyvaluestore:PutKey",
+          "cloudfront-keyvaluestore:DeleteKey",
+          "cloudfront-keyvaluestore:UpdateKeys",
+        ]
+        Resource = [var.kvs_arn]
+      },
+      {
+        Sid      = "FailureDestination"
+        Effect   = "Allow"
+        Action   = ["sns:Publish"]
+        Resource = [var.alarms_sns_topic_arn]
+      },
+    ]
+  })
+}
+
+# ------------------------------------------------------------------------------
+# Lambda function
+# ------------------------------------------------------------------------------
+
+# Placeholder package so Terraform can create the function before the
+# first deploy-web run pushes the real bundle.
+data "archive_file" "placeholder" {
+  type        = "zip"
+  output_path = "${path.module}/placeholder.zip"
+  source {
+    content  = "export const handler = async () => { throw new Error('prerenderer code not deployed yet - run deploy-web'); };"
+    filename = "lambda.mjs"
+  }
+}
+
+resource "aws_lambda_function" "prerenderer" {
+  function_name    = local.function_name
+  role             = aws_iam_role.prerenderer.arn
+  runtime          = "nodejs22.x"
+  handler          = "lambda.handler"
+  architectures    = ["arm64"]
+  memory_size      = 1024
+  timeout          = 300
+  filename         = data.archive_file.placeholder.output_path
+  source_code_hash = data.archive_file.placeholder.output_base64sha256
+
+  reserved_concurrent_executions = 1
+
+  environment {
+    variables = {
+      FRONTEND_BUCKET            = var.frontend_bucket_name
+      KVS_ARN                    = var.kvs_arn
+      CLOUDFRONT_DISTRIBUTION_ID = var.distribution_id
+      SITE_ORIGIN                = var.site_origin
+      # date-fns "local" formatting in snapshots renders club (UK) time.
+      TZ = "Europe/London"
+    }
+  }
+
+  lifecycle {
+    # deploy-web pushes the real bundle with update-function-code.
+    ignore_changes = [filename, source_code_hash]
+  }
+
+  tags = local.tags
+}
+
+# Async-invoke policy: 2 retries, then the failed event lands on the
+# alarms topic so a broken renderer is visible (content stays served via
+# the CSR fallback / stale snapshot either way).
+resource "aws_lambda_function_event_invoke_config" "prerenderer" {
+  function_name          = aws_lambda_function.prerenderer.function_name
+  maximum_retry_attempts = 2
+
+  destination_config {
+    on_failure {
+      destination = var.alarms_sns_topic_arn
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "prerenderer_errors" {
+  alarm_name          = "${local.function_name}-errors"
+  alarm_description   = "Prerenderer Lambda failing - published content is serving stale snapshots or CSR fallback"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.prerenderer.function_name
+  }
+
+  alarm_actions = [var.alarms_sns_topic_arn]
+  ok_actions    = [var.alarms_sns_topic_arn]
+  tags          = local.tags
+}
+
+# ------------------------------------------------------------------------------
+# EventBridge Scheduler — 15-minute reconcile sweep
+#
+# The single backstop for scheduled publishes crossing their go-live
+# moment (there is no other scheduler in the system), triggers lost while
+# the Lambda was down, and any state drift. A no-op sweep is one manifest
+# fetch + one state read.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role" "scheduler" {
+  name = "${local.function_name}-scheduler"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "scheduler.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "scheduler" {
+  name = "${local.function_name}-scheduler-invoke"
+  role = aws_iam_role.scheduler.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["lambda:InvokeFunction"]
+      Resource = [aws_lambda_function.prerenderer.arn]
+    }]
+  })
+}
+
+resource "aws_scheduler_schedule" "reconcile" {
+  name                = "${local.function_name}-reconcile"
+  schedule_expression = "rate(15 minutes)"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = aws_lambda_function.prerenderer.arn
+    role_arn = aws_iam_role.scheduler.arn
+    input    = jsonencode({ action = "reconcile" })
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Outputs
+# ------------------------------------------------------------------------------
+
+output "function_name" {
+  value       = aws_lambda_function.prerenderer.function_name
+  description = "Prerenderer Lambda function name (deploy-web update-function-code target)"
+}
+
+output "function_arn" {
+  value       = aws_lambda_function.prerenderer.arn
+  description = "Prerenderer Lambda ARN (API task role invoke permission)"
+}

--- a/packages/shared/src/content/index.ts
+++ b/packages/shared/src/content/index.ts
@@ -106,13 +106,13 @@ export const contentPathSchema = z
  * segment routes, so child pages are unaffected.
  *
  * Two sources:
- *  - the SPA router's top-level literals (apps/web/src/router.tsx) -
+ *  - the SPA router's top-level literals (apps/web/src/routes.tsx) -
  *    they are matched ahead of the content catch-all, so a root page at
  *    one of these could never be reached;
  *  - infra prefixes (API mount, upload/asset serving, the content API
  *    itself).
  *
- * Keep in lockstep with router.tsx when adding top-level routes.
+ * Keep in lockstep with routes.tsx when adding top-level routes.
  */
 export const RESERVED_ROOT_SLUGS: ReadonlySet<string> = new Set([
   // SPA router top-level literals
@@ -140,6 +140,33 @@ export const RESERVED_ROOT_SLUGS: ReadonlySet<string> = new Set([
   "assets",
   "content",
 ]);
+
+/**
+ * The public URL for a published content item - the single source of
+ * truth shared by the API's prerender triggers/manifest and the
+ * prerenderer Lambda's path mapping (they must agree byte-for-byte or a
+ * publish renders one path while the CDN routes another). Returns null
+ * for game reports: they keep the CloudFront-Function OG redirect and are
+ * never prerendered.
+ */
+export function publicContentUrl(
+  kind: ContentKind,
+  slug: string,
+  path: string | null,
+): string | null {
+  switch (kind) {
+    case "page":
+      return path;
+    case "news":
+      return `/news/article/${slug}`;
+    case "event":
+      return `/calendar/event/${slug}`;
+    case "person":
+      return `/person/${slug}`;
+    case "game_report":
+      return null;
+  }
+}
 
 // ── Kind-specific metadata (replaces MDX frontmatter) ───────────────────
 //

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@aws-sdk/client-ecs':
         specifier: ^3.1078.0
         version: 3.1078.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3.1078.0
+        version: 3.1078.0
       '@aws-sdk/client-rekognition':
         specifier: ^3.1078.0
         version: 3.1078.0
@@ -865,6 +868,10 @@ packages:
 
   '@aws-sdk/client-ecs@3.1078.0':
     resolution: {integrity: sha512-xpsHD43i7DT5ChIaQNiizUSCu8pK0p0IFpml7/e0uP6olYRonX0S58/RauPKsunNr/syYDxpNcXi/Gldb0YTnQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-lambda@3.1078.0':
+    resolution: {integrity: sha512-p4AiIWWbosEQ/eZuH6aO6mBs05zzbvvswIqZOJ3ZUQvlZ3NCABuvTvZJjsDwdlSz8UzKMZB7UkvzPveIbtH0AA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-rekognition@3.1078.0':
@@ -9342,6 +9349,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-ecs@3.1078.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/credential-provider-node': 3.972.61
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-lambda@3.1078.0':
     dependencies:
       '@aws-sdk/core': 3.974.26
       '@aws-sdk/credential-provider-node': 3.972.61

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,9 +623,24 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@aws-sdk/client-cloudfront':
+        specifier: ^3.1078.0
+        version: 3.1078.0
+      '@aws-sdk/client-cloudfront-keyvaluestore':
+        specifier: ^3.1078.0
+        version: 3.1078.0
+      '@aws-sdk/client-s3':
+        specifier: ^3.1078.0
+        version: 3.1078.0
+      '@aws-sdk/signature-v4-multi-region':
+        specifier: ^3.996.38
+        version: 3.996.38
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.2(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@smithy/signature-v4a':
+        specifier: ^3.4.1
+        version: 3.4.1
       '@tailwindcss/vite':
         specifier: ^4.3.2
         version: 4.3.2(vite@8.1.2(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -838,6 +853,14 @@ packages:
 
   '@aws-sdk/checksums@3.1000.11':
     resolution: {integrity: sha512-nW5kNBJBwVxkvBqygBYksS8WUFDO8Ad8OSfsVa+f5KFRRTrHL1rnWZNsWBwc5fC9YvZbET/57+X4hym/jKfV+g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cloudfront-keyvaluestore@3.1078.0':
+    resolution: {integrity: sha512-dt6SK9H+z6+BV3aiVEluMSDUq/b3e8nY4V+aYg/mhxs4ggYnOxvp/IfFxQh+WcWdPdphlwHSX1vZtkZezdzgPg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cloudfront@3.1078.0':
+    resolution: {integrity: sha512-lSGQgCSof/ac28X0PQn0Ma3uBVacoSiEOJvhgTkynStU2pOEfFlsKexoekTvNQJxdA7E1xGh1bWNVOsPwyuM/Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-ecs@3.1078.0':
@@ -4491,6 +4514,10 @@ packages:
 
   '@smithy/signature-v4@5.6.1':
     resolution: {integrity: sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4a@3.4.1':
+    resolution: {integrity: sha512-O8C1UXdmTXoHLmVgoG89aDkeIWJggTUoRsV+NFnfr7E6kvM8GmYfa9tXwxfM+7JLMbV4bqiXn/Qg+WKyqTo0xA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.15.1':
@@ -9291,6 +9318,29 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-cloudfront-keyvaluestore@3.1078.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/credential-provider-node': 3.972.61
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudfront@3.1078.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.26
+      '@aws-sdk/credential-provider-node': 3.972.61
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-ecs@3.1078.0':
     dependencies:
       '@aws-sdk/core': 3.974.26
@@ -13255,6 +13305,13 @@ snapshots:
   '@smithy/signature-v4@5.6.1':
     dependencies:
       '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4a@3.4.1':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/signature-v4': 5.6.1
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,9 @@ importers:
       '@types/google.maps':
         specifier: ^3.65.2
         version: 3.65.2
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17


### PR DESCRIPTION
## Summary

Fixes the three CSR problems on the public site (gradual menu/content load-in, no per-page meta tags, crawlers seeing an empty shell) with publish-time prerendering, per the plan agreed with Alex and recorded in [ADR 052](docs/adrs/052-publish-time-prerendering.md).

**How it works:**

- A **prerenderer Lambda** (apps/web/server/prerender, built as the web app's own Vite SSR bundle so markup and hashed asset references always match the deployed SPA) renders published pages/news/people/events to static HTML under `_prerender/` in the frontend bucket, with per-page title/description/canonical/OG/Twitter/JSON-LD heads and embedded dehydrated react-query state.
- The existing **viewer-request CloudFront Function** consults a **KeyValueStore** of prerendered URLs: hit = serve the snapshot as the initial document (users AND bots), miss = `/index.html` exactly as today. Empty store = zero behaviour change = the rollback.
- The SPA boot (`main.tsx`) seeds the query cache from the embedded state, resolves the matched lazy route module, then renders over the prerendered DOM in one visually identical commit (render-over, not hydrateRoot - rationale in the ADR).
- One diff-driven **reconcile** covers the lifecycle: the Lambda diffs the API's new `/content/prerender-manifest` against a state file, renders what changed, tears down what vanished; a nav change (baked into every document) escalates to a full re-render. Triggered async by the API on publish/unpublish/archive/published-edit/proposal-approval, by deploy-web after each deploy (render-all), and by a 15-minute EventBridge sweep (scheduled publishes, lost triggers, drift). Publishing stays instant and never fails on render trouble.
- **SEO artifacts**: sitemap.xml rebuilt on every sync, robots.txt, JSON-LD (incl. finally rendering the stored `ldjson` page metadata).
- **Nav on SPA-shell routes**: deploy bakes the live nav into the bundle as `initialData`, so the menu paints complete on first render everywhere.

**Deploy safety (the load-bearing bits):**

- Two-phase S3 sync: upload new assets → update Lambda code → re-render all snapshots synchronously → only then `--delete` stale assets (with `_prerender/*`/`sitemap.xml` excluded). Prevents snapshots referencing deleted scripts and prevents deploys deleting snapshots the KVS still routes to.
- CI check (`check:ssr-assets`) asserts SSR-bundle asset references exist in the client build.

## Rollout (after merge + first deploy)

1. Terraform applies the new `prerender` module + KVS on the merge deploy; `PRERENDER_ENABLED` stays **unset** - no behaviour change.
2. Manually invoke `aws --profile percy-main lambda invoke --function-name percy-main-production-prerenderer --cli-binary-format raw-in-base64-out --payload '{"action":"render","url":"/club"}' /tmp/out.json`
3. `curl -s https://www.percymain.org/club | head -80` - expect real content + per-page meta in raw HTML; browser-check the page (content on first paint, no swap flash).
4. Set repo variable `PRERENDER_ENABLED=true`, re-run deploy-web (or wait for the next deploy) to render everything; submit sitemap.xml in Search Console.
5. Rollback at any point: delete all KVS keys + unset the variable.

## Verified

- 632 web unit tests (incl. entry-server renderToString through the real app), 617 API unit tests, 55 content integration tests (testcontainers), 22 CloudFront Function tests - all green; typecheck + lint clean.
- End-to-end locally: full pipeline (manifest → fetch → render → assemble) run against the dev API via `scripts/prerender-preview.mjs`; output verified for head correctness and no loading states; served through a CloudFront-mimicking local server and browser-verified: content on first paint, silent React take-over (zero console errors), working SPA navigation afterwards, plain CSR routes unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)