### PR TITLE
Fix deploy-web: deterministic .jpeg extension for imagetools outputs

### DIFF
--- a/apps/web/scripts/check-ssr-asset-parity.mjs
+++ b/apps/web/scripts/check-ssr-asset-parity.mjs
@@ -34,11 +34,20 @@ let referenced = 0;
 
 for (const file of ssrFiles) {
   const code = readFileSync(join(ssrDir, file), "utf8");
-  for (const match of code.matchAll(/["'](\/assets\/[^"'\s?#]+)["']/g)) {
-    const assetPath = match[1];
-    referenced += 1;
-    if (!existsSync(join(distDir, assetPath))) {
-      missing.add(assetPath);
+  // Two shapes: plain URL strings ("/assets/x.jpeg") and srcset strings
+  // ("/assets/a.webp 320w, /assets/b.webp 640w") - the latter is how the
+  // imagetools picture ladders land in the bundle, so skipping them
+  // would leave most image renditions unchecked.
+  for (const match of code.matchAll(/["']((?:\/assets\/)[^"']+)["']/g)) {
+    for (const candidate of match[1].split(",")) {
+      const assetPath = candidate.trim().split(/\s+/)[0];
+      if (!assetPath.startsWith("/assets/") || assetPath.includes("?")) {
+        continue;
+      }
+      referenced += 1;
+      if (!existsSync(join(distDir, assetPath))) {
+        missing.add(assetPath);
+      }
     }
   }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -53,8 +53,14 @@ export default defineConfig(({ mode, isSsrBuild }) => ({
     imagetools({
       defaultDirectives: (url) => {
         if (url.searchParams.has("optimise")) {
+          // "jpeg", not the "jpg" alias: imagetools names the output file
+          // from the directive on a cache miss but from sharp's reported
+          // format ("jpeg") on a disk-cache hit. With "jpg", a cold client
+          // build emits .jpg while the warm SSR build right after
+          // references .jpeg - prerendered pages then point at files that
+          // don't exist (caught by check-ssr-asset-parity in deploy).
           return new URLSearchParams(
-            "w=320;640;960;1280;1920&format=avif;webp;jpg&as=picture",
+            "w=320;640;960;1280;1920&format=avif;webp;jpeg&as=picture",
           );
         }
         return new URLSearchParams();


### PR DESCRIPTION
## Summary

The first post-#588 deploy failed at `check-ssr-asset-parity`: the SSR bundle referenced `club_logo-0eyYT4g0.jpeg` (and two others) while the client build had emitted `club_logo-0eyYT4g0.jpg` - same hash, different extension.

**Root cause**: with `format=jpg`, vite-imagetools names the output file from the directive spelling on a disk-cache MISS but from sharp's reported format (`jpeg`) on a cache HIT. In CI the client build always runs cold (`.jpg`) and the SSR build immediately after runs warm (`.jpeg`). Locally both builds were warm, so the check passed.

**Fix**: spell the directive `jpeg` so both cache paths agree. Verified with cold-cache builds in a `node:24-slim` container (reproduced the failure on the old config, passes on this one).

Also widens the parity check to parse srcset strings, so every picture-ladder rendition is verified (41 URLs vs 8 before).

Note the failed deploy stopped at the build step - nothing was uploaded, and the Terraform stage had already applied the (dark, KVS-empty) prerender infra as designed. Merging this re-runs the full deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)