### PR TITLE
Fix deploy-web waiter: grant lambda:GetFunctionConfiguration to deploy role

### DIFF
--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -469,12 +469,14 @@ data "aws_iam_policy_document" "deploy_s3_cloudfront" {
 
   # deploy-web pushes the prerenderer Lambda's code (built from the same
   # web bundle it deploys to S3) and kicks a render-all after upload.
+  # GetFunctionConfiguration backs `aws lambda wait function-updated`.
   statement {
     sid    = "PrerendererCodeDeploy"
     effect = "Allow"
     actions = [
       "lambda:UpdateFunctionCode",
       "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
       "lambda:InvokeFunction",
     ]
     resources = [


### PR DESCRIPTION
## Summary

Yesterday's deploy failed at `aws lambda wait function-updated` with AccessDenied on `lambda:GetFunctionConfiguration` - the waiter polls that action, and the `PrerendererCodeDeploy` IAM statement only granted `UpdateFunctionCode`/`GetFunction`/`InvokeFunction`. Adds the missing action with the same name-pattern resource scope.

Note the failure was post-`update-function-code`, so the real prerenderer bundle is already on the Lambda; the skipped follow-up steps were benign (index.html is `must-revalidate` so CloudFront revalidates without the invalidation; stale-asset cleanup is idempotent next run). After merge (shared Terraform applies on main), run **deploy-web-manual** once to complete a full clean web deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)