### PR TITLE
Fix prerenderer KVS calls: statically register JS SigV4A

### DIFF
--- a/apps/web/server/prerender/lambda.ts
+++ b/apps/web/server/prerender/lambda.ts
@@ -39,6 +39,15 @@ import {
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
+// Side-effect import: registers the pure-JS SigV4A implementation into
+// @smithy/signature-v4's container. The KVS data plane signs with
+// SigV4A, and the multi-region signer resolves the implementation from
+// that container at runtime - in the bundled Lambda there is no
+// node_modules for its optional lookup, so without this import every
+// KVS call fails with "Neither CRT nor JS SigV4a implementation is
+// available". The package declares sideEffects: true, so bundlers keep
+// this.
+import "@smithy/signature-v4a";
 import { QueryClient } from "@tanstack/react-query";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";


### PR DESCRIPTION
## Summary

First rollout invoke failed at the KVS write: `Neither CRT nor JS SigV4a implementation is available` (the risk flagged in #588's plan for first-deploy verification - now materialised and fixed).

**Cause**: `@aws-sdk/signature-v4-multi-region` resolves the SigV4A implementation from `@smithy/signature-v4`'s runtime container; `@smithy/signature-v4a` populates that container only as an import side effect, and nothing imported it - in the bundled Lambda there's no `node_modules` for any optional fallback lookup.

**Fix**: a side-effect `import "@smithy/signature-v4a"` in `lambda.ts` (package declares `sideEffects: true`, so bundlers keep it).

**Verified**: registration line present in the built bundle with a single shared container instance, and a SigV4A-signed `DescribeKeyValueStore` against the production store succeeds with this wiring.

The failed invoke was harmless: it died before any KVS write (store still has 0 items; one orphan snapshot object for /cricket in S3 will simply be overwritten on the next render).

After merge: run **deploy-web-manual** to push the fixed bundle, then continue the rollout (single render → curl verify → `PRERENDER_ENABLED=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)