### PR TITLE
Fix prerenderer IAM: ListBucket on the snapshot prefix for the state probe

### DIFF
--- a/infra/modules/prerender/main.tf
+++ b/infra/modules/prerender/main.tf
@@ -115,6 +115,19 @@ resource "aws_iam_role_policy" "prerenderer" {
         ]
       },
       {
+        # Without ListBucket, a GetObject on a missing key returns
+        # AccessDenied instead of NoSuchKey (S3 hides existence), so the
+        # Lambda's state-file probe cannot distinguish "first sync" from
+        # a real permission failure. Scoped to the snapshot prefix.
+        Sid      = "StateProbe"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = [var.frontend_bucket_arn]
+        Condition = {
+          StringLike = { "s3:prefix" = ["_prerender/*"] }
+        }
+      },
+      {
         Sid      = "Invalidate"
         Effect   = "Allow"
         Action   = ["cloudfront:CreateInvalidation"]


### PR DESCRIPTION
## Summary

During rollout, the first `render-all` failed reading `_prerender/state.json`: without `s3:ListBucket`, S3 returns `AccessDenied` (not `NoSuchKey`) for a GET on a missing key, so the Lambda's "no state yet = first sync" handling never fired. Adds `s3:ListBucket` scoped to the `_prerender/*` prefix.

The rollout itself was unblocked by seeding an initial state file (equivalent semantics to no-state), and all 113 pages are now rendered and serving. This change just makes a future state-file loss self-heal instead of requiring the same manual nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)