### PR TITLE
feat(prerender): fixtures and calendar months join the prerender pipeline

### DIFF
--- a/.github/workflows/deploy-web-manual.yml
+++ b/.github/workflows/deploy-web-manual.yml
@@ -148,7 +148,7 @@ jobs:
           aws lambda invoke \
             --function-name percy-main-production-prerenderer \
             --cli-binary-format raw-in-base64-out \
-            --cli-read-timeout 360 \
+            --cli-read-timeout 960 \
             --payload '{"action":"render-all"}' \
             /tmp/render-all.json
           cat /tmp/render-all.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -823,7 +823,7 @@ jobs:
           aws lambda invoke \
             --function-name percy-main-production-prerenderer \
             --cli-binary-format raw-in-base64-out \
-            --cli-read-timeout 360 \
+            --cli-read-timeout 960 \
             --payload '{"action":"render-all"}' \
             /tmp/render-all.json
           cat /tmp/render-all.json

--- a/apps/api/src/features/games/routes.ts
+++ b/apps/api/src/features/games/routes.ts
@@ -5,9 +5,15 @@ import {
   gameDetailResponseSchema,
   gamesListResponseSchema,
   gamesListSchema,
+  gamesPrerenderManifestResponseSchema,
   wagonWheelResponseSchema,
 } from "./schemas.ts";
-import { getGame, getWagonWheel, listGames } from "./service.ts";
+import {
+  getGame,
+  getWagonWheel,
+  listGames,
+  listGamesPrerenderManifest,
+} from "./service.ts";
 
 // eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
 export const gamesRoutes: FastifyPluginAsyncZod = async (app) => {
@@ -30,6 +36,7 @@ export const gamesRoutes: FastifyPluginAsyncZod = async (app) => {
   const list = listGames(app.db, api, siteId);
   const detail = getGame(app.db, api, siteId);
   const wagonWheel = getWagonWheel(app.db);
+  const prerenderManifest = listGamesPrerenderManifest(app.db, api, siteId);
 
   app.get(
     "/games",
@@ -43,6 +50,22 @@ export const gamesRoutes: FastifyPluginAsyncZod = async (app) => {
       const { season } = request.query;
       const effectiveSeason = season ?? new Date().getFullYear();
       return await list(effectiveSeason);
+    },
+  );
+
+  // Consumed by the prerenderer Lambda on every sync. Public like the
+  // content manifest: it reveals only public game URLs, dates and opaque
+  // hashes. A Play Cricket outage 500s here BY DESIGN - the Lambda must
+  // abort its sync rather than treat an empty list as "all games gone".
+  app.get(
+    "/games/prerender-manifest",
+    {
+      schema: {
+        response: { 200: gamesPrerenderManifestResponseSchema },
+      },
+    },
+    async () => {
+      return await prerenderManifest();
     },
   );
 

--- a/apps/api/src/features/games/schemas.ts
+++ b/apps/api/src/features/games/schemas.ts
@@ -122,6 +122,24 @@ export const gameDetailResponseSchema = gameListItemSchema.extend({
   availabilityRequest: availabilityRequestSummarySchema,
 });
 
+// --- Prerender manifest ---
+
+// Consumed by the prerenderer Lambda (apps/web/server/prerender), merged
+// with the content manifest. `hash` is an opaque content fingerprint -
+// the diff key for pages whose sources carry no update timestamps.
+export const gamesPrerenderManifestResponseSchema = z.object({
+  items: z.array(
+    z.object({
+      url: z.string(),
+      kind: z.enum(["game", "calendar-month"]),
+      slug: z.string(),
+      updatedAt: z.string(),
+      publishedAt: z.string(),
+      hash: z.string(),
+    }),
+  ),
+});
+
 // --- Wagon wheel ---
 
 const wagonWheelBallSchema = z.object({

--- a/apps/api/src/features/games/service.test.ts
+++ b/apps/api/src/features/games/service.test.ts
@@ -1,0 +1,322 @@
+import type { DB } from "@percy-main/db";
+import type { Kysely } from "kysely";
+import { describe, expect, it, vi } from "vitest";
+import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
+import { listGamesPrerenderManifest } from "./service.ts";
+
+// The module-level match-summary cache is keyed by season with a
+// 30-minute TTL, so every test uses its own `now` year to keep its
+// Play Cricket fixtures isolated from other tests in this run.
+
+interface RecordedQuery {
+  table: string;
+  wheres: unknown[][];
+}
+
+/**
+ * Minimal Kysely stand-in: selectFrom() returns a chain proxy that
+ * records where() calls and resolves execute() through `handler`, so
+ * each test dispatches per-table (and, for content_item, per-kind)
+ * fixture rows.
+ */
+function createMockDb(
+  handler: (query: RecordedQuery) => unknown[],
+): Kysely<DB> {
+  const selectFrom = (table: string) => {
+    const query: RecordedQuery = { table, wheres: [] };
+    const chain: unknown = new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          if (prop === "execute") {
+            return () => Promise.resolve(handler(query));
+          }
+          if (prop === "executeTakeFirst") {
+            return () => Promise.resolve(handler(query)[0]);
+          }
+          if (prop === "where") {
+            return (...args: unknown[]) => {
+              query.wheres.push(args);
+              return chain;
+            };
+          }
+          return () => chain;
+        },
+      },
+    );
+    return chain;
+  };
+  return { selectFrom } as unknown as Kysely<DB>;
+}
+
+const SITE_ID = "SITE1";
+
+function pcMatch(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 100001,
+    status: "New",
+    published: "Yes",
+    last_updated: "10/06/2030",
+    season: "2030",
+    match_date: "15/06/2030",
+    match_time: "13:00",
+    home_club_name: "Percy Main",
+    home_team_name: "1st XI",
+    home_team_id: "T1",
+    home_club_id: SITE_ID,
+    away_club_name: "Tynemouth CC",
+    away_team_name: "2nd XI",
+    away_team_id: "T9",
+    away_club_id: "C9",
+    league_name: "NTCL",
+    league_id: "L1",
+    competition_name: "Division 1",
+    competition_id: "CMP1",
+    competition_type: "League",
+    ground_name: "St Johns Terrace",
+    ...overrides,
+  };
+}
+
+interface Fixtures {
+  matchesBySeason: Record<number, unknown[]>;
+  sponsorships?: unknown[];
+  matchdays?: unknown[];
+  matchdayPlayers?: unknown[];
+  gameReports?: unknown[];
+  events?: unknown[];
+}
+
+// Full client object like play-cricket/sync.test.ts - no casts; the
+// untyped vi.fn() mocks are assignable to the method signatures.
+function createMockApi(
+  getMatchesSummary: PlayCricketApiClient["getMatchesSummary"],
+): PlayCricketApiClient {
+  return {
+    getTeams: vi.fn().mockResolvedValue({ teams: [] }),
+    getMatchesSummary,
+    getMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
+    getPlayers: vi.fn().mockResolvedValue({ players: [] }),
+    getLeagueTable: vi.fn().mockResolvedValue({}),
+    getMatchesForSite: vi.fn().mockResolvedValue({ matches: [] }),
+    getResultSummaryForSite: vi.fn().mockResolvedValue({ result_summary: [] }),
+  };
+}
+
+function createHarness(fixtures: Fixtures) {
+  const getMatchesSummary = vi.fn();
+  getMatchesSummary.mockImplementation((season: number) =>
+    Promise.resolve({ matches: fixtures.matchesBySeason[season] ?? [] }),
+  );
+  const api = createMockApi(getMatchesSummary);
+
+  const db = createMockDb((query) => {
+    switch (query.table) {
+      case "content_item": {
+        const kindWhere = query.wheres.find((args) => args[0] === "kind");
+        return kindWhere?.[2] === "event"
+          ? (fixtures.events ?? [])
+          : (fixtures.gameReports ?? []);
+      }
+      case "game_sponsorship": {
+        // listGames filters to approved+paid (it surfaces sponsorName on
+        // the list); the manifest reads ALL rows. Mirror the predicate so
+        // hash behaviour matches real SQL.
+        const rows = (fixtures.sponsorships ?? []) as Array<{
+          approved: boolean;
+          paid_at: string | null;
+        }>;
+        const filtersPaid = query.wheres.some((args) => args[0] === "paid_at");
+        return filtersPaid
+          ? rows.filter((row) => row.approved && row.paid_at !== null)
+          : rows;
+      }
+      case "matchday":
+        return fixtures.matchdays ?? [];
+      case "matchday_player":
+        return fixtures.matchdayPlayers ?? [];
+      case "match_result":
+        return [];
+      default:
+        return [];
+    }
+  });
+
+  return {
+    manifest: listGamesPrerenderManifest(db, api, SITE_ID),
+    getMatchesSummary,
+  };
+}
+
+describe("listGamesPrerenderManifest", () => {
+  it("emits a game item per current-season game and 24 month items", async () => {
+    const { manifest, getMatchesSummary } = createHarness({
+      matchesBySeason: {
+        2030: [
+          pcMatch({ id: 100001 }),
+          pcMatch({ id: 100002, match_date: "20/07/2030" }),
+        ],
+        2029: [
+          pcMatch({
+            id: 90001,
+            season: "2029",
+            match_date: "15/06/2029",
+            last_updated: "16/06/2029",
+          }),
+        ],
+      },
+    });
+
+    const { items } = await manifest(new Date("2030-06-01T12:00:00Z"));
+
+    expect(getMatchesSummary).toHaveBeenCalledWith(2029);
+    expect(getMatchesSummary).toHaveBeenCalledWith(2030);
+
+    const games = items.filter((item) => item.kind === "game");
+    const months = items.filter((item) => item.kind === "calendar-month");
+
+    // Current season only - the 2029 game keeps the OG-redirect fallback.
+    expect(games.map((game) => game.url).sort()).toEqual([
+      "/calendar/game/100001",
+      "/calendar/game/100002",
+    ]);
+    expect(games[0].slug).toBe("100001");
+
+    expect(months).toHaveLength(24);
+    expect(months.map((month) => month.url)).toContain("/calendar/2030/june");
+    expect(months.map((month) => month.url)).toContain(
+      "/calendar/2029/january",
+    );
+    expect(months.every((month) => month.slug.includes("/"))).toBe(true);
+  });
+
+  it("produces identical hashes for identical inputs", async () => {
+    const fixtures: Fixtures = {
+      matchesBySeason: { 2032: [pcMatch({ match_date: "15/06/2032" })] },
+      events: [{ slug: "quiz-night", updated_at: new Date("2032-01-01") }],
+    };
+    const { manifest } = createHarness(fixtures);
+
+    const first = await manifest(new Date("2032-06-01T12:00:00Z"));
+    const second = await manifest(new Date("2032-06-01T12:00:00Z"));
+
+    expect(second.items).toEqual(first.items);
+  });
+
+  it("a sponsorship change flips the game hash but not month hashes", async () => {
+    const sponsorships: unknown[] = [];
+    const fixtures: Fixtures = {
+      matchesBySeason: { 2034: [pcMatch({ match_date: "15/06/2034" })] },
+      sponsorships,
+    };
+    const { manifest } = createHarness(fixtures);
+
+    const before = await manifest(new Date("2034-06-01T12:00:00Z"));
+    sponsorships.push({
+      id: "s1",
+      game_id: "100001",
+      approved: true,
+      paid_at: null,
+      display_name: null,
+      sponsor_name: "Acme",
+      sponsor_logo_url: null,
+      sponsor_message: "Go team",
+      sponsor_website: null,
+      sponsor_phone: null,
+    });
+    const after = await manifest(new Date("2034-06-01T12:00:00Z"));
+
+    const gameBefore = before.items.find((item) => item.kind === "game");
+    const gameAfter = after.items.find((item) => item.kind === "game");
+    expect(gameAfter?.hash).not.toBe(gameBefore?.hash);
+
+    // The month page renders sponsorName from the games list overlay
+    // (which this mock leaves unchanged), so month hashes hold steady.
+    const monthsBefore = before.items.filter(
+      (item) => item.kind === "calendar-month",
+    );
+    const monthsAfter = after.items.filter(
+      (item) => item.kind === "calendar-month",
+    );
+    expect(monthsAfter.map((month) => month.hash)).toEqual(
+      monthsBefore.map((month) => month.hash),
+    );
+  });
+
+  it("an event change flips every month hash but no game hash", async () => {
+    const events: unknown[] = [
+      { slug: "quiz-night", updated_at: new Date("2036-01-01") },
+    ];
+    const fixtures: Fixtures = {
+      matchesBySeason: { 2036: [pcMatch({ match_date: "15/06/2036" })] },
+      events,
+    };
+    const { manifest } = createHarness(fixtures);
+
+    const before = await manifest(new Date("2036-06-01T12:00:00Z"));
+    (events[0] as { updated_at: Date }).updated_at = new Date("2036-02-01");
+    const after = await manifest(new Date("2036-06-01T12:00:00Z"));
+
+    const gameBefore = before.items.find((item) => item.kind === "game");
+    const gameAfter = after.items.find((item) => item.kind === "game");
+    expect(gameAfter?.hash).toBe(gameBefore?.hash);
+
+    const monthHashesBefore = before.items
+      .filter((item) => item.kind === "calendar-month")
+      .map((month) => month.hash);
+    const monthHashesAfter = after.items
+      .filter((item) => item.kind === "calendar-month")
+      .map((month) => month.hash);
+    monthHashesAfter.forEach((hash, index) => {
+      expect(hash).not.toBe(monthHashesBefore[index]);
+    });
+  });
+
+  it("normalizes Play Cricket DD/MM/YYYY timestamps to ISO", async () => {
+    const { manifest } = createHarness({
+      matchesBySeason: {
+        2038: [
+          pcMatch({ match_date: "15/06/2038", last_updated: "10/06/2038" }),
+        ],
+      },
+    });
+
+    const { items } = await manifest(new Date("2038-06-01T12:00:00Z"));
+    const game = items.find((item) => item.kind === "game");
+
+    expect(game?.updatedAt).toBe("2038-06-10T00:00:00.000Z");
+    expect(game?.publishedAt).toBe("2038-06-15T13:00:00");
+    // Sitemap lastmod does .slice(0, 10) on both.
+    expect(game?.updatedAt.slice(0, 10)).toBe("2038-06-10");
+  });
+
+  it("skips games with unparseable dates but still emits 24 months", async () => {
+    const { manifest } = createHarness({
+      matchesBySeason: {
+        2040: [pcMatch({ match_date: "TBC", last_updated: "01/06/2040" })],
+      },
+    });
+
+    const { items } = await manifest(new Date("2040-06-01T12:00:00Z"));
+
+    expect(items.filter((item) => item.kind === "game")).toHaveLength(0);
+    expect(items.filter((item) => item.kind === "calendar-month")).toHaveLength(
+      24,
+    );
+  });
+
+  it("propagates a Play Cricket failure instead of returning empty", async () => {
+    const getMatchesSummary = vi.fn();
+    getMatchesSummary.mockRejectedValue(new Error("PC down"));
+    const db = createMockDb(() => []);
+    const manifest = listGamesPrerenderManifest(
+      db,
+      createMockApi(getMatchesSummary),
+      SITE_ID,
+    );
+
+    await expect(manifest(new Date("2042-06-01T12:00:00Z"))).rejects.toThrow(
+      "PC down",
+    );
+  });
+});

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -1,6 +1,6 @@
 import type { DB } from "@percy-main/db";
 import type { FastifyBaseLogger } from "fastify";
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 
 // --- In-memory cache for match summaries ---
@@ -28,6 +28,10 @@ export interface MatchSummary {
   league: { id: string; name: string };
   competition: { id: string; name: string; type: string };
   groundName: string | null;
+  // Play Cricket's own change marker (DD/MM/YYYY, date precision only).
+  // Feeds the prerender manifest hash; response schemas strip it, so it
+  // never reaches API clients.
+  lastUpdated: string;
 }
 
 export type Outcome = "W" | "L" | "D" | "T" | "A" | "C" | "N";
@@ -452,6 +456,7 @@ export function getGame(
         type: detail.competition_type ?? "",
       },
       groundName: matchSummary?.groundName ?? null,
+      lastUpdated: matchSummary?.lastUpdated ?? "",
       when: parseMatchDateTime(matchDate, matchTime),
       outcome,
       scoreDescription: result ? buildScoreDescription(result.innings) : null,
@@ -681,10 +686,294 @@ async function fetchMatchSummaries(
         type: match.competition_type ?? "",
       },
       groundName: match.ground_name ?? null,
+      lastUpdated: match.last_updated,
     };
   });
 
   summaryCache.set(season, { data: matches, fetchedAt: Date.now() });
 
   return matches;
+}
+
+// --- Prerender manifest ---
+
+// Must match MONTH_NAMES in apps/web/src/pages/calendar/calendar-month.lib.ts:
+// the web router parses /calendar/:year/:month against that list, so a URL
+// built from any other spelling would prerender a not-found page.
+const CALENDAR_MONTH_NAMES = [
+  "january",
+  "february",
+  "march",
+  "april",
+  "may",
+  "june",
+  "july",
+  "august",
+  "september",
+  "october",
+  "november",
+  "december",
+] as const;
+
+export interface GamesManifestItem {
+  url: string;
+  kind: "game" | "calendar-month";
+  slug: string;
+  updatedAt: string;
+  publishedAt: string;
+  hash: string;
+}
+
+/**
+ * djb2 content fingerprint (mirrors navHash in
+ * apps/web/src/prerender/reconcile.ts). Game pages compose Play Cricket
+ * data with DB overlays that carry no usable update timestamps
+ * (match_result has none), so the prerender diff compares this hash of
+ * everything render-relevant instead. A false collision self-heals on
+ * the next forced render-all.
+ */
+function contentHash(value: unknown): string {
+  const canonical = JSON.stringify(value);
+  let hash = 5381;
+  for (let i = 0; i < canonical.length; i++) {
+    hash = ((hash << 5) + hash + canonical.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(16);
+}
+
+/** Play Cricket's DD/MM/YYYY last_updated -> ISO; null when malformed. */
+function pcDateToIso(value: string): string | null {
+  if (!/^\d{2}\/\d{2}\/\d{4}$/.test(value)) return null;
+  const [dd, mm, yyyy] = value.split("/");
+  return `${yyyy}-${mm}-${dd}T00:00:00.000Z`;
+}
+
+function groupBy<T>(rows: T[], key: (row: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const row of rows) {
+    const k = key(row);
+    const group = map.get(k);
+    if (group) group.push(row);
+    else map.set(k, [row]);
+  }
+  return map;
+}
+
+/** The game fields a calendar month page actually renders (mirrors the
+ * CalendarItem mapping in calendar-month.tsx) - a month page only
+ * re-renders when one of these, or an event, changes. */
+function monthRenderFields(game: GameListItem) {
+  return {
+    id: game.id,
+    when: game.when,
+    home: game.home,
+    teamName: game.team.name,
+    oppositionClub: game.opposition.club.name,
+    oppositionTeam: game.opposition.team.name,
+    leagueName: game.league.name,
+    competitionName: game.competition.name,
+    sponsorName: game.sponsorName,
+    outcome: game.outcome,
+    scoreDescription: game.scoreDescription,
+  };
+}
+
+async function buildGameItems(
+  db: Kysely<DB>,
+  games: GameListItem[],
+): Promise<GamesManifestItem[]> {
+  // Games without a parseable date can't get stable manifest timestamps;
+  // they stay un-snapshotted and keep the OG-redirect fallback.
+  const renderable = games.filter(
+    (game): game is GameListItem & { when: string } => game.when !== null,
+  );
+  if (renderable.length === 0) return [];
+  const ids = renderable.map((game) => game.id);
+
+  const [sponsorships, matchdays, reports] = await Promise.all([
+    // ALL rows, not just approved+paid: an approval or payment must flip
+    // the hash so the sponsor badge appears on the next render.
+    db
+      .selectFrom("game_sponsorship")
+      .where("game_id", "in", ids)
+      .select([
+        "id",
+        "game_id",
+        "approved",
+        "paid_at",
+        "display_name",
+        "sponsor_name",
+        "sponsor_logo_url",
+        "sponsor_message",
+        "sponsor_website",
+        "sponsor_phone",
+      ])
+      .orderBy("id", "asc")
+      .execute(),
+    db
+      .selectFrom("matchday")
+      .where("play_cricket_match_id", "in", ids)
+      .select([
+        "id",
+        "play_cricket_match_id",
+        "result_type",
+        "result_source",
+        "confirmed_at",
+        "cancelled_at",
+        "finished_at",
+      ])
+      .orderBy("id", "asc")
+      .execute(),
+    // Published game reports render on the game page, so their publish
+    // state must flip its hash. Same liveness predicate as the content
+    // feature's publishedOnly(); deliberate cross-feature table read
+    // rather than a feature-to-feature service import.
+    db
+      .selectFrom("content_item")
+      .where("kind", "=", "game_report")
+      .where("status", "=", "published")
+      .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`)
+      .where(sql<string>`metadata->>'playCricketId'`, "in", ids)
+      .select([
+        sql<string>`metadata->>'playCricketId'`.as("play_cricket_id"),
+        "updated_at",
+        "published_at",
+      ])
+      .execute(),
+  ]);
+
+  const matchdayIds = matchdays.map((matchday) => matchday.id);
+  const players =
+    matchdayIds.length > 0
+      ? await db
+          .selectFrom("matchday_player")
+          .where("matchday_id", "in", matchdayIds)
+          .where("status", "in", ["selected", "playing"])
+          .select(["matchday_id", "player_name", "status"])
+          .orderBy("created_at", "asc")
+          .execute()
+      : [];
+
+  const sponsorshipsByGame = groupBy(sponsorships, (row) => row.game_id);
+  const matchdaysByGame = groupBy(
+    matchdays,
+    (row) => row.play_cricket_match_id ?? "",
+  );
+  const playersByMatchday = groupBy(players, (row) => row.matchday_id);
+  const reportsByGame = new Map(
+    reports.map((row) => [row.play_cricket_id, row]),
+  );
+
+  return renderable.map((game) => {
+    const report = reportsByGame.get(game.id);
+    const hash = contentHash({
+      game,
+      sponsorships: sponsorshipsByGame.get(game.id) ?? [],
+      matchdays: (matchdaysByGame.get(game.id) ?? []).map((matchday) => ({
+        resultType: matchday.result_type,
+        resultSource: matchday.result_source,
+        confirmedAt: matchday.confirmed_at,
+        cancelledAt: matchday.cancelled_at,
+        finishedAt: matchday.finished_at,
+        players: playersByMatchday.get(matchday.id) ?? [],
+      })),
+      report: report
+        ? { updatedAt: report.updated_at, publishedAt: report.published_at }
+        : null,
+    });
+    return {
+      url: `/calendar/game/${game.id}`,
+      kind: "game" as const,
+      slug: game.id,
+      updatedAt: pcDateToIso(game.lastUpdated) ?? game.when,
+      publishedAt: game.when,
+      hash,
+    };
+  });
+}
+
+async function buildMonthItems(
+  db: Kysely<DB>,
+  seasons: Array<[year: number, games: GameListItem[]]>,
+): Promise<GamesManifestItem[]> {
+  // Every month snapshot embeds the full dehydrated events list (the
+  // month page merges games with expanded event occurrences), so any
+  // event change legitimately flips every month hash. 24 re-renders per
+  // event edit is cheap.
+  const events = await db
+    .selectFrom("content_item")
+    .where("kind", "=", "event")
+    .where("status", "=", "published")
+    .where("published_at", "<=", sql<Date>`CURRENT_TIMESTAMP`)
+    .select(["slug", "updated_at"])
+    .orderBy("slug", "asc")
+    .execute();
+  const eventStamps = events.map((event) => ({
+    slug: event.slug,
+    updatedAt: event.updated_at.toISOString(),
+  }));
+
+  const items: GamesManifestItem[] = [];
+  for (const [year, games] of seasons) {
+    for (let monthIndex = 0; monthIndex < 12; monthIndex++) {
+      const monthName = CALENDAR_MONTH_NAMES[monthIndex];
+      // Bucket by the local ISO date prefix, exactly how the month page
+      // groups items - no timezone parsing.
+      const prefix = `${year.toString()}-${(monthIndex + 1).toString().padStart(2, "0")}`;
+      const subset = games.filter(
+        (game): game is GameListItem & { when: string } =>
+          game.when?.startsWith(prefix) ?? false,
+      );
+      const monthStart = `${prefix}-01T00:00:00.000Z`;
+      const updatedAt = [
+        ...subset.map((game) => pcDateToIso(game.lastUpdated) ?? game.when),
+        ...eventStamps.map((event) => event.updatedAt),
+        monthStart,
+      ].reduce((a, b) => (a > b ? a : b));
+      items.push({
+        url: `/calendar/${year.toString()}/${monthName}`,
+        kind: "calendar-month",
+        slug: `${year.toString()}/${monthName}`,
+        updatedAt,
+        publishedAt: monthStart,
+        hash: contentHash({
+          games: subset.map(monthRenderFields),
+          events: eventStamps,
+        }),
+      });
+    }
+  }
+  return items;
+}
+
+/**
+ * Manifest of prerenderable game + calendar month URLs, merged by the
+ * prerenderer Lambda with the content manifest
+ * (GET /api/content/prerender-manifest). Game pages: current season
+ * only - older games keep the CloudFront OG-redirect fallback. Month
+ * pages: previous + current year, so last season's results stay
+ * browsable with content on first paint.
+ */
+export function listGamesPrerenderManifest(
+  db: Kysely<DB>,
+  api: PlayCricketApiClient,
+  siteId: string,
+) {
+  return async (now = new Date()): Promise<{ items: GamesManifestItem[] }> => {
+    const currentSeason = now.getFullYear();
+    const list = listGames(db, api, siteId);
+    const [previousGames, currentGames] = await Promise.all([
+      list(currentSeason - 1),
+      list(currentSeason),
+    ]);
+
+    const [gameItems, monthItems] = await Promise.all([
+      buildGameItems(db, currentGames),
+      buildMonthItems(db, [
+        [currentSeason - 1, previousGames],
+        [currentSeason, currentGames],
+      ]),
+    ]);
+    return { items: [...gameItems, ...monthItems] };
+  };
 }

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -1,4 +1,5 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { createPrerenderTrigger } from "../../lib/prerender-trigger.ts";
 import {
   getAuthSession,
   requireAuth,
@@ -82,6 +83,10 @@ import { generateTeamNewsImage } from "./team-news-image.ts";
 export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
   const officialRole = requirePermission("matchday", "view");
   const adminRole = requirePermission("matchday", "manage");
+  // Manual results and cancellations surface on prerendered game pages
+  // (outcome badge); fire a reconcile so they don't wait for the
+  // 15-minute sweep.
+  const prerenderTrigger = createPrerenderTrigger(app.config, app.log);
 
   // ── Existing routes ──
 
@@ -640,7 +645,14 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       const { user } = getAuthSession(request);
       const role = (user as { role?: string | null }).role ?? "user";
-      return await finish(user.id, role, request.params.matchId, request.body);
+      const result = await finish(
+        user.id,
+        role,
+        request.params.matchId,
+        request.body,
+      );
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 
@@ -673,7 +685,14 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
     async (request) => {
       const { user } = getAuthSession(request);
       const role = (user as { role?: string | null }).role ?? "user";
-      return await cancel(user.id, role, request.params.matchId, request.body);
+      const result = await cancel(
+        user.id,
+        role,
+        request.params.matchId,
+        request.body,
+      );
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 };

--- a/apps/api/src/features/payments/integration.test.ts
+++ b/apps/api/src/features/payments/integration.test.ts
@@ -44,6 +44,8 @@ const mockLog = {
   level: "info",
 } as any;
 
+const mockPrerenderTrigger = { reconcile: vi.fn() };
+
 // Stripe timestamp for 2026-03-14T12:00:00Z
 const EVENT_CREATED = Math.floor(
   new Date("2026-03-14T12:00:00Z").getTime() / 1000,
@@ -200,6 +202,7 @@ describe("handleCheckoutCompleted", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -257,6 +260,7 @@ describe("handleCheckoutCompleted", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -304,6 +308,7 @@ describe("handleCheckoutCompleted", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -384,6 +389,7 @@ describe("handleInvoicePayment", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -464,6 +470,7 @@ describe("handleInvoicePayment", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -539,6 +546,7 @@ describe("handleInvoicePayment", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -619,6 +627,7 @@ describe("handleInvoicePayment", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -658,6 +667,7 @@ describe("handleInvoicePayment", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -679,6 +689,7 @@ describe("handleInvoicePayment", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -750,6 +761,7 @@ describe("handleInvoicePayment", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -829,6 +841,7 @@ describe("handlePaymentIntentSucceeded", () => {
       db: ctx.db,
       stripe: {} as any,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -889,6 +902,7 @@ describe("handlePaymentIntentSucceeded", () => {
       db: ctx.db,
       stripe: {} as any,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -954,6 +968,7 @@ describe("handlePaymentIntentSucceeded", () => {
       db: ctx.db,
       stripe: {} as any,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -1005,6 +1020,7 @@ describe("handlePaymentIntentSucceeded", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -1048,6 +1064,7 @@ describe("handlePaymentIntentSucceeded", () => {
       db: ctx.db,
       stripe: {} as any,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });
@@ -1095,6 +1112,7 @@ describe("handlePaymentIntentSucceeded", () => {
       db: ctx.db,
       stripe: mockStripe,
       log: mockLog,
+      prerenderTrigger: mockPrerenderTrigger,
       baseUrl: "http://localhost:5173",
       send: vi.fn(),
     });

--- a/apps/api/src/features/payments/webhook-service.ts
+++ b/apps/api/src/features/payments/webhook-service.ts
@@ -20,6 +20,7 @@ import type { Kysely } from "kysely";
 import { createElement } from "react";
 import { render } from "react-email";
 import type Stripe from "stripe";
+import type { PrerenderTrigger } from "../../lib/prerender-trigger.ts";
 import { emitMarketingEventForMembership } from "../marketing/membership-hook.ts";
 import { invoiceLinesToDuration, stripeDate } from "./stripe-utils.ts";
 
@@ -43,6 +44,10 @@ interface WebhookDeps {
   log: FastifyBaseLogger;
   baseUrl: string;
   send: (email: Email) => Promise<void>;
+  // A paid game sponsorship changes the prerendered game page; the
+  // webhook fires a reconcile so the sponsor badge appears without
+  // waiting for the 15-minute sweep.
+  prerenderTrigger: PrerenderTrigger;
 }
 
 // ---------------------------------------------------------------------------
@@ -418,6 +423,7 @@ export function handlePaymentIntentSucceeded({
   log,
   baseUrl,
   send,
+  prerenderTrigger,
 }: WebhookDeps) {
   const imageBaseUrl = `${baseUrl}/images`;
   const charge = createPaymentCharge(db);
@@ -622,6 +628,8 @@ export function handlePaymentIntentSucceeded({
         })
         .where("id", "=", meta.sponsorshipId)
         .execute();
+
+      prerenderTrigger.reconcile();
 
       const sponsorship = await db
         .selectFrom("game_sponsorship")

--- a/apps/api/src/features/payments/webhook.ts
+++ b/apps/api/src/features/payments/webhook.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync } from "fastify";
 import type Stripe from "stripe";
+import { createPrerenderTrigger } from "../../lib/prerender-trigger.ts";
 import { withSpan } from "../../lib/tracing.ts";
 import { createStripe } from "./stripe.ts";
 import {
@@ -38,6 +39,7 @@ export const webhookRoutes: FastifyPluginAsync = async (app) => {
     log: app.log,
     baseUrl: app.config.BASE_URL,
     send: app.send,
+    prerenderTrigger: createPrerenderTrigger(app.config, app.log),
   };
 
   const onCheckoutCompleted = handleCheckoutCompleted(deps);

--- a/apps/api/src/features/sponsorship/routes.ts
+++ b/apps/api/src/features/sponsorship/routes.ts
@@ -1,5 +1,6 @@
 import { stripeConfig } from "@percy-main/shared";
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
+import { createPrerenderTrigger } from "../../lib/prerender-trigger.ts";
 import { requirePermission } from "../auth/middleware.ts";
 import { createStripe } from "../payments/stripe.ts";
 import { createApiClient } from "../play-cricket/api-client.ts";
@@ -69,6 +70,10 @@ export const sponsorshipRoutes: FastifyPluginAsyncZod = async (app) => {
   const stripe = createStripe({
     stripeSecretKey: app.config.STRIPE_SECRET_KEY,
   });
+  // Approved+paid game sponsorships render on prerendered game pages;
+  // any mutation that can change that fires a reconcile (fire-and-forget,
+  // the 15-minute sweep is the backstop).
+  const prerenderTrigger = createPrerenderTrigger(app.config, app.log);
   const prices =
     app.config.NODE_ENV === "production"
       ? stripeConfig.live.prices
@@ -319,7 +324,9 @@ export const sponsorshipRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await approveGame(request.body.sponsorshipId);
+      const result = await approveGame(request.body.sponsorshipId);
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 
@@ -333,7 +340,9 @@ export const sponsorshipRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await rejectGame(request.body.sponsorshipId);
+      const result = await rejectGame(request.body.sponsorshipId);
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 
@@ -375,7 +384,9 @@ export const sponsorshipRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await manualGame(request.body);
+      const result = await manualGame(request.body);
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 
@@ -404,7 +415,12 @@ export const sponsorshipRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await updateGame(request.params.sponsorshipId, request.body);
+      const result = await updateGame(
+        request.params.sponsorshipId,
+        request.body,
+      );
+      prerenderTrigger.reconcile();
+      return result;
     },
   );
 

--- a/apps/api/src/lib/prerender-trigger.test.ts
+++ b/apps/api/src/lib/prerender-trigger.test.ts
@@ -13,9 +13,13 @@ vi.mock("@aws-sdk/client-lambda", () => {
   return { InvokeCommand, LambdaClient };
 });
 
+import { LambdaClient } from "@aws-sdk/client-lambda";
 import type { FastifyBaseLogger } from "fastify";
 import type { Config } from "../config.ts";
-import { createPrerenderTrigger } from "./prerender-trigger.ts";
+import {
+  createPrerenderTrigger,
+  invokePrerenderReconcile,
+} from "./prerender-trigger.ts";
 
 function makeLog() {
   return {
@@ -95,5 +99,34 @@ describe("createPrerenderTrigger", () => {
     }).not.toThrow();
     await flush();
     expect(log.error).toHaveBeenCalled();
+  });
+});
+
+describe("invokePrerenderReconcile", () => {
+  it("awaits delivery of the reconcile invoke (the sync-runner exit path)", async () => {
+    sendLambda.mockResolvedValue({});
+    await invokePrerenderReconcile(
+      new LambdaClient({}),
+      "arn:aws:lambda:eu-west-2:123:function:prerenderer",
+    );
+
+    expect(sendLambda).toHaveBeenCalledTimes(1);
+    const command = sendLambda.mock.calls[0][0] as {
+      input: { FunctionName: string; InvocationType: string; Payload: Buffer };
+    };
+    expect(command.input.InvocationType).toBe("Event");
+    expect(JSON.parse(command.input.Payload.toString())).toEqual({
+      action: "reconcile",
+    });
+  });
+
+  it("rejects on invoke failure so callers can log without masking", async () => {
+    sendLambda.mockRejectedValue(new Error("lambda down"));
+    await expect(
+      invokePrerenderReconcile(
+        new LambdaClient({}),
+        "arn:aws:lambda:eu-west-2:123:function:prerenderer",
+      ),
+    ).rejects.toThrow("lambda down");
   });
 });

--- a/apps/api/src/lib/prerender-trigger.ts
+++ b/apps/api/src/lib/prerender-trigger.ts
@@ -18,6 +18,25 @@ export interface PrerenderTrigger {
   reconcile(): void;
 }
 
+/**
+ * The awaitable core: one async `reconcile` invoke. Route code wants the
+ * fire-and-forget wrapper below; short-lived workers (the Play Cricket
+ * sync runner) must await delivery before process.exit or the invoke is
+ * lost with the event loop.
+ */
+export async function invokePrerenderReconcile(
+  lambda: LambdaClient,
+  functionArn: string,
+): Promise<void> {
+  await lambda.send(
+    new InvokeCommand({
+      FunctionName: functionArn,
+      InvocationType: "Event",
+      Payload: Buffer.from(JSON.stringify({ action: "reconcile" })),
+    }),
+  );
+}
+
 export function createPrerenderTrigger(
   // Optional because minimal integration-test apps register the content
   // routes without decorating app.config; no config = unconfigured.
@@ -36,14 +55,7 @@ export function createPrerenderTrigger(
   const lambda = new LambdaClient({ region: config.AWS_REGION });
   return {
     reconcile() {
-      lambda
-        .send(
-          new InvokeCommand({
-            FunctionName: functionArn,
-            InvocationType: "Event",
-            Payload: Buffer.from(JSON.stringify({ action: "reconcile" })),
-          }),
-        )
+      invokePrerenderReconcile(lambda, functionArn)
         .then(() => {
           log.info("prerender reconcile triggered");
         })

--- a/apps/api/src/sync-runner.ts
+++ b/apps/api/src/sync-runner.ts
@@ -6,10 +6,12 @@
  * (injected by the ECS task definition).
  */
 
+import { LambdaClient } from "@aws-sdk/client-lambda";
 import { createClient } from "@percy-main/db";
 import { createApiClient } from "./features/play-cricket/api-client.ts";
 import { createRvClient } from "./features/play-cricket/rv-client.ts";
 import { runSync } from "./features/play-cricket/sync.ts";
+import { invokePrerenderReconcile } from "./lib/prerender-trigger.ts";
 import { withSpan } from "./lib/tracing.ts";
 import { createWorkerLogger } from "./lib/worker-logger.ts";
 
@@ -29,6 +31,30 @@ if (!PLAY_CRICKET_API_TOKEN)
   throw new Error("Missing required env var: PLAY_CRICKET_API_TOKEN");
 if (!PLAY_CRICKET_SITE_ID)
   throw new Error("Missing required env var: PLAY_CRICKET_SITE_ID");
+
+// Optional: when set (the ECS task inherits the API service's env), the
+// runner pings the prerenderer after writing results so game snapshots
+// refresh without waiting for the 15-minute sweep.
+const PRERENDER_LAMBDA_ARN = process.env.PRERENDER_LAMBDA_ARN;
+
+/**
+ * Awaited (a fire-and-forget invoke would die with process.exit), but
+ * never allowed to change the exit code - the sweep is the backstop.
+ * Runs after completed-with-errors syncs too: partial runs still write
+ * match_result rows that prerendered game pages render.
+ */
+async function triggerPrerenderReconcile(): Promise<void> {
+  if (!PRERENDER_LAMBDA_ARN) return;
+  try {
+    await invokePrerenderReconcile(
+      new LambdaClient({ region: process.env.AWS_REGION }),
+      PRERENDER_LAMBDA_ARN,
+    );
+    logger.info("prerender_reconcile_triggered");
+  } catch (error) {
+    logger.error({ err: error }, "prerender_reconcile_invoke_failed");
+  }
+}
 
 const { client } = createClient(DATABASE_URL);
 const api = createApiClient({
@@ -76,6 +102,7 @@ try {
         { errorCount: syncResult.errors.length, errors: syncResult.errors },
         "play_cricket_sync_completed_with_errors",
       );
+      await triggerPrerenderReconcile();
       await client.destroy();
       process.exit(1);
     }
@@ -89,6 +116,7 @@ try {
     "play_cricket_sync_complete",
   );
 
+  await triggerPrerenderReconcile();
   await client.destroy();
   process.exit(0);
 } catch (error) {

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -2454,6 +2454,51 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/games/prerender-manifest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                url: string;
+                                /** @enum {string} */
+                                kind: "game" | "calendar-month";
+                                slug: string;
+                                updatedAt: string;
+                                publishedAt: string;
+                                hash: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/games/{matchId}": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -4186,6 +4186,67 @@
         }
       }
     },
+    "/api/games/prerender-manifest": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "game",
+                              "calendar-month"
+                            ]
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "hash": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "url",
+                          "kind",
+                          "slug",
+                          "updatedAt",
+                          "publishedAt",
+                          "hash"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/games/{matchId}": {
       "get": {
         "parameters": [

--- a/apps/web/server/prerender/lambda.ts
+++ b/apps/web/server/prerender/lambda.ts
@@ -1,7 +1,8 @@
 import { render } from "@/entry-server.js";
-import { api, callApi } from "@/lib/api-client.js";
+import { API_BASE, api, callApi } from "@/lib/api-client.js";
 import {
   eventQueryOptions,
+  eventsListQueryOptions,
   isPageGone,
   navQueryOptions,
   newsArticleQueryOptions,
@@ -9,8 +10,14 @@ import {
   peopleListQueryOptions,
   personQueryOptions,
 } from "@/lib/content-queries.js";
+import {
+  gameQueryOptions,
+  gameReportQueryOptions,
+  gamesListQueryOptions,
+} from "@/lib/games-queries.js";
 import { assembleDocument } from "@/prerender/assemble-document.js";
 import { buildHead } from "@/prerender/build-head.js";
+import { gameHeadData, monthHeadData } from "@/prerender/game-meta.js";
 import {
   snapshotInvalidationPath,
   snapshotKvsKey,
@@ -146,8 +153,29 @@ async function fetchShared() {
 type SharedData = Awaited<ReturnType<typeof fetchShared>>;
 
 async function fetchManifest(): Promise<ManifestItem[]> {
-  const manifest = await callApi(api.GET("/api/content/prerender-manifest"));
-  return manifest.items;
+  const [content, games] = await Promise.all([
+    callApi(api.GET("/api/content/prerender-manifest")),
+    fetchGamesManifest(),
+  ]);
+  return [...content.items, ...games];
+}
+
+/**
+ * 404 means the games feature is off (no Play Cricket creds): zero
+ * game/month items, content-only sync. Anything else - a Play Cricket
+ * outage surfaces as a 500 here - aborts the whole sync, so a transient
+ * failure can never read as "all games vanished" and tear down every
+ * game snapshot. State and snapshots stay put; the 15-minute sweep
+ * retries.
+ */
+async function fetchGamesManifest(): Promise<ManifestItem[]> {
+  try {
+    const manifest = await callApi(api.GET("/api/games/prerender-manifest"));
+    return manifest.items;
+  } catch (error) {
+    if ((error as { status?: number }).status === 404) return [];
+    throw error;
+  }
 }
 
 interface DetailData {
@@ -157,6 +185,8 @@ interface DetailData {
   metadata: Record<string, unknown>;
   publishedAt: string;
   updatedAt: string;
+  /** Absolute og:image override (game pages use the API scorecard PNG). */
+  ogImageUrl?: string;
 }
 
 /**
@@ -191,6 +221,47 @@ async function fetchDetail(
       const data = await queryClient.fetchQuery(personQueryOptions(item.slug));
       return data === null || isPageGone(data) ? null : data;
     }
+    case "game": {
+      let game;
+      try {
+        game = await queryClient.fetchQuery(gameQueryOptions(item.slug));
+      } catch (error) {
+        // Vanished from Play Cricket between manifest and fetch.
+        if ((error as { status?: number }).status === 404) return null;
+        throw error;
+      }
+      // Seed the report the page reads (its queryFn maps 404 to null, so
+      // report-less games dehydrate a null entry rather than pending).
+      await queryClient.fetchQuery(gameReportQueryOptions(item.slug));
+      const head = gameHeadData(game);
+      return {
+        title: head.title,
+        description: head.description,
+        body: undefined,
+        metadata: head.metadata,
+        publishedAt: item.publishedAt,
+        updatedAt: item.updatedAt,
+        ogImageUrl: `${API_BASE}/og/game/${item.slug}`,
+      };
+    }
+    case "calendar-month": {
+      const [yearRaw, monthName] = item.slug.split("/");
+      const year = Number(yearRaw);
+      if (!monthName || !Number.isFinite(year)) return null;
+      await Promise.all([
+        queryClient.fetchQuery(gamesListQueryOptions(year)),
+        queryClient.fetchQuery(eventsListQueryOptions()),
+      ]);
+      const head = monthHeadData(year, monthName);
+      return {
+        title: head.title,
+        description: head.description,
+        body: undefined,
+        metadata: {},
+        publishedAt: item.publishedAt,
+        updatedAt: item.updatedAt,
+      };
+    }
   }
 }
 
@@ -223,6 +294,7 @@ async function renderSnapshot(
       body: detail.body,
       publishedAt: detail.publishedAt,
       updatedAt: detail.updatedAt,
+      ogImageUrl: detail.ogImageUrl,
     },
     siteOrigin(),
   );
@@ -367,9 +439,43 @@ async function sync(force: boolean): Promise<SyncSummary> {
 
   const rendered: string[] = [];
   const failed = new Set<string>();
+  // Not-yet-processed render targets; treated as "failed" in mid-sync
+  // state flushes so a resumed sync retries exactly the remainder.
+  const pendingUrls = new Set(plan.toRender.map((item) => item.url));
+  // With games in the manifest a render-all is ~350 documents; flushing
+  // KVS routing, state and invalidations every batch turns a Lambda
+  // timeout from "start over, never converge" into "resume from where
+  // the last flush left off on the next sweep".
+  const FLUSH_EVERY = 25;
+  let unflushed: string[] = [];
+
+  const flushProgress = async () => {
+    await kvsUpdate(unflushed.map(snapshotKvsKey), []);
+    await putObject(
+      STATE_KEY,
+      JSON.stringify(
+        nextState(
+          manifest,
+          currentNavHash,
+          new Set([...failed, ...pendingUrls]),
+        ),
+      ),
+      "application/json",
+    );
+    // Full-render modes invalidate the whole prefix (one wildcard path
+    // per flush) rather than hundreds of per-document paths.
+    await invalidate(
+      plan.mode === "diff"
+        ? unflushed.map(snapshotInvalidationPath)
+        : ["/_prerender/*"],
+    );
+    unflushed = [];
+  };
+
   for (const item of plan.toRender) {
     try {
       const html = await renderSnapshot(item, shared, template);
+      pendingUrls.delete(item.url);
       if (html === null) {
         // Vanished between manifest and fetch; the next sync unrenders it.
         failed.add(item.url);
@@ -381,17 +487,22 @@ async function sync(force: boolean): Promise<SyncSummary> {
         "text/html; charset=utf-8",
       );
       rendered.push(item.url);
+      unflushed.push(item.url);
+      if (unflushed.length >= FLUSH_EVERY) await flushProgress();
     } catch (error) {
+      pendingUrls.delete(item.url);
       console.error(`prerender render failed: ${item.url}`, error);
       failed.add(item.url);
     }
   }
 
-  // Route new/changed snapshots and stop routing vanished ones. Failures
-  // keep their previous state: a stale snapshot stays up (the SPA
-  // refetches over it) rather than flapping to CSR.
+  // Route the remaining snapshots and stop routing vanished ones.
+  // Failures keep their previous state: a stale snapshot stays up (the
+  // SPA refetches over it) rather than flapping to CSR.
+  const finalBatch = unflushed;
+  unflushed = [];
   await kvsUpdate(
-    rendered.map(snapshotKvsKey),
+    finalBatch.map(snapshotKvsKey),
     plan.toUnrender.map(snapshotKvsKey),
   );
 
@@ -406,10 +517,12 @@ async function sync(force: boolean): Promise<SyncSummary> {
     "application/json",
   );
 
+  // Earlier flushes already invalidated their batches; only the final
+  // batch, unrendered urls and the sitemap remain.
   const invalidationPaths =
     plan.mode === "diff"
       ? [
-          ...rendered.map(snapshotInvalidationPath),
+          ...finalBatch.map(snapshotInvalidationPath),
           ...plan.toUnrender.map(snapshotInvalidationPath),
           "/sitemap.xml",
         ]

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -2454,6 +2454,51 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/games/prerender-manifest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                url: string;
+                                /** @enum {string} */
+                                kind: "game" | "calendar-month";
+                                slug: string;
+                                updatedAt: string;
+                                publishedAt: string;
+                                hash: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/games/{matchId}": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -4186,6 +4186,67 @@
         }
       }
     },
+    "/api/games/prerender-manifest": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "game",
+                              "calendar-month"
+                            ]
+                          },
+                          "slug": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          },
+                          "publishedAt": {
+                            "type": "string"
+                          },
+                          "hash": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "url",
+                          "kind",
+                          "slug",
+                          "updatedAt",
+                          "publishedAt",
+                          "hash"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "items"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/games/{matchId}": {
       "get": {
         "parameters": [

--- a/apps/web/src/lib/games-queries.ts
+++ b/apps/web/src/lib/games-queries.ts
@@ -1,0 +1,63 @@
+import { queryOptions } from "@tanstack/react-query";
+import { api, callApi } from "./api-client.js";
+
+// Shared query definitions for Play Cricket games, mirroring
+// content-queries.ts. The prerenderer Lambda seeds snapshots through
+// these exact options, so the dehydrated cache entry lands under the key
+// the page components read - keeping them in one module stops the two
+// sides drifting apart. Query keys predate this module and are pinned:
+// other inline consumers (home.tsx, content-editor.tsx) still build
+// ["games", season] / ["game", id] by hand.
+
+const STALE_TIME = 5 * 60 * 1000;
+
+export function gamesListQueryOptions(season: number) {
+  return queryOptions({
+    queryKey: ["games", season],
+    queryFn: () =>
+      callApi(api.GET("/api/games", { params: { query: { season } } })),
+    staleTime: STALE_TIME,
+  });
+}
+
+export function gameQueryOptions(matchId: string) {
+  return queryOptions({
+    queryKey: ["game", matchId],
+    // No 404-to-null mapping: the page renders its not-found state off
+    // the query error (`!game`), unlike the content detail queries.
+    queryFn: () =>
+      callApi(
+        api.GET("/api/games/{matchId}", {
+          params: { path: { matchId } },
+        }),
+      ),
+    staleTime: STALE_TIME,
+  });
+}
+
+export function gameReportQueryOptions(playCricketId: string) {
+  return queryOptions({
+    queryKey: ["content", "game-report", playCricketId],
+    queryFn: async () => {
+      try {
+        return await callApi(
+          api.GET(
+            "/api/content/game-report/by-play-cricket-id/{playCricketId}",
+            {
+              params: { path: { playCricketId } },
+            },
+          ),
+        );
+      } catch (err) {
+        // No published report for this game.
+        if ((err as { status?: number }).status === 404) return null;
+        throw err;
+      }
+    },
+    // Scheduled publishing boundary: a null result can flip to published
+    // the instant its published_at passes, so misses go stale fast while
+    // a real report keeps the full 5 minutes.
+    staleTime: (query) => (query.state.data === null ? 30 * 1000 : STALE_TIME),
+    retry: false,
+  });
+}

--- a/apps/web/src/pages/calendar/calendar-month.tsx
+++ b/apps/web/src/pages/calendar/calendar-month.tsx
@@ -4,12 +4,12 @@ import {
   type FixtureStripItem,
 } from "@/components/theme/fixture-strip.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
-import { api, callApi } from "@/lib/api-client.js";
 import type { paths } from "@/lib/api.gen.js";
 import {
   eventsListQueryOptions,
   parseEventMetadata,
 } from "@/lib/content-queries.js";
+import { gamesListQueryOptions } from "@/lib/games-queries.js";
 import { cn } from "@/lib/utils.js";
 import { expandEventOccurrences } from "@percy-main/shared/content";
 import { useQuery } from "@tanstack/react-query";
@@ -475,12 +475,8 @@ export function Component() {
     : new Date();
   const season = parsed?.year ?? new Date().getFullYear();
 
-  const { data: games } = useQuery({
-    queryKey: ["games", season],
-    queryFn: () =>
-      callApi(api.GET("/api/games", { params: { query: { season } } })),
-    staleTime: 5 * 60 * 1000,
-  });
+  // Shared options so the prerenderer seeds the exact key this reads.
+  const { data: games } = useQuery(gamesListQueryOptions(season));
 
   // DB-backed events (live content editing, #489).
   const { data: eventsData } = useQuery(eventsListQueryOptions());

--- a/apps/web/src/pages/calendar/game-detail.tsx
+++ b/apps/web/src/pages/calendar/game-detail.tsx
@@ -8,6 +8,10 @@ import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { hasWagonWheel, useWagonWheelQuery } from "@/hooks/use-wagon-wheel.js";
 import { api, callApi } from "@/lib/api-client.js";
 import type { paths } from "@/lib/api.gen.js";
+import {
+  gameQueryOptions,
+  gameReportQueryOptions,
+} from "@/lib/games-queries.js";
 import { cn } from "@/lib/utils.js";
 import { useQuery } from "@tanstack/react-query";
 import { AddToCalendarButton } from "add-to-calendar-button-react";
@@ -237,32 +241,9 @@ function BallByBallTrigger({ game }: { game: GameData }) {
 }
 
 function GameDetailContent({ game }: { game: GameData }) {
-  // DB-backed report (live content editing, #479).
-  const { data: apiReport } = useQuery({
-    queryKey: ["content", "game-report", game.id],
-    queryFn: async () => {
-      try {
-        return await callApi(
-          api.GET(
-            "/api/content/game-report/by-play-cricket-id/{playCricketId}",
-            {
-              params: { path: { playCricketId: game.id } },
-            },
-          ),
-        );
-      } catch (err) {
-        // No published report for this game.
-        if ((err as { status?: number }).status === 404) return null;
-        throw err;
-      }
-    },
-    // Scheduled publishing boundary: a null result can flip to published
-    // the instant its published_at passes, so misses go stale fast while
-    // a real report keeps the full 5 minutes.
-    staleTime: (query) =>
-      query.state.data === null ? 30 * 1000 : 5 * 60 * 1000,
-    retry: false,
-  });
+  // DB-backed report (live content editing, #479). Shared options so the
+  // prerenderer seeds the exact key this reads.
+  const { data: apiReport } = useQuery(gameReportQueryOptions(game.id));
 
   const title = `${game.team.name} vs. ${game.opposition.club.name} ${game.opposition.team.name} ${game.home ? "(H)" : "(A)"}`;
 
@@ -484,15 +465,8 @@ export function Component() {
   useStripOgParam();
 
   const { data: game, isLoading } = useQuery({
-    queryKey: ["game", id],
-    queryFn: () =>
-      callApi(
-        api.GET("/api/games/{matchId}", {
-          params: { path: { matchId: id ?? "" } },
-        }),
-      ),
+    ...gameQueryOptions(id ?? ""),
     enabled: !!id,
-    staleTime: 5 * 60 * 1000,
   });
 
   useDocumentMeta(

--- a/apps/web/src/prerender/build-head.test.ts
+++ b/apps/web/src/prerender/build-head.test.ts
@@ -220,4 +220,78 @@ describe("buildHead", () => {
       );
     });
   });
+
+  describe("game", () => {
+    const OG_PNG = "https://api.v2.percymain.org/api/og/game/123456";
+
+    function gameInput(overrides: Partial<HeadInput> = {}): HeadInput {
+      return input({
+        kind: "game",
+        url: "/calendar/game/123456",
+        title: "1st XI vs Tynemouth CC 2nd XI (H) - 12 July 2026",
+        description: "Won (142/6 - 138) - full scorecard.",
+        metadata: {
+          when: "2026-07-12T13:00:00",
+          homeTeam: "Percy Main 1st XI",
+          awayTeam: "Tynemouth CC 2nd XI",
+          locationName: "Percy Main Cricket and Sports Club",
+        },
+        ogImageUrl: OG_PNG,
+        ...overrides,
+      });
+    }
+
+    it("uses the explicit scorecard PNG as OG image with a large card", () => {
+      const head = buildHead(gameInput());
+      expect(head).toContain(
+        `<meta property="og:image" content="${OG_PNG}" />`,
+      );
+      expect(head).toContain(
+        '<meta name="twitter:card" content="summary_large_image" />',
+      );
+      expect(head).toContain('<meta property="og:type" content="website" />');
+      expect(head).toContain(
+        `<link rel="canonical" href="${ORIGIN}/calendar/game/123456" />`,
+      );
+    });
+
+    it("emits SportsEvent JSON-LD with both teams and the venue", () => {
+      const head = buildHead(gameInput());
+      expect(head).toContain('"@type":"SportsEvent"');
+      expect(head).toContain('"startDate":"2026-07-12T13:00:00"');
+      expect(head).toContain(
+        '"homeTeam":{"@type":"SportsTeam","name":"Percy Main 1st XI"}',
+      );
+      expect(head).toContain(
+        '"awayTeam":{"@type":"SportsTeam","name":"Tynemouth CC 2nd XI"}',
+      );
+      expect(head).toContain(
+        '"location":{"@type":"Place","name":"Percy Main Cricket and Sports Club"}',
+      );
+    });
+
+    it("emits no JSON-LD when game metadata does not parse", () => {
+      const head = buildHead(gameInput({ metadata: {} }));
+      expect(head).not.toContain("ld+json");
+    });
+  });
+
+  describe("calendar-month", () => {
+    it("uses the default OG image and emits no JSON-LD", () => {
+      const head = buildHead(
+        input({
+          kind: "calendar-month",
+          url: "/calendar/2026/july",
+          title: "Fixtures & Events - July 2026",
+          description: "Fixtures, results and events for July 2026.",
+        }),
+      );
+      expect(head).toContain(
+        `<meta property="og:image" content="${ORIGIN}/images/og-default.png" />`,
+      );
+      expect(head).toContain('<meta name="twitter:card" content="summary" />');
+      expect(head).toContain('<meta property="og:type" content="website" />');
+      expect(head).not.toContain("ld+json");
+    });
+  });
 });

--- a/apps/web/src/prerender/build-head.ts
+++ b/apps/web/src/prerender/build-head.ts
@@ -3,6 +3,7 @@ import {
   pageMetadataSchema,
   personMetadataSchema,
 } from "@percy-main/shared/content";
+import { gameHeadMetadataSchema } from "./game-meta.js";
 
 // Per-page <head> block for prerendered documents: title, description,
 // canonical, OG/Twitter cards and JSON-LD. Pure string assembly - no DOM,
@@ -15,8 +16,10 @@ const DEFAULT_DESCRIPTION =
   "Percy Main Community Sports Club — football, cricket, and community sports in North Shields. Find fixtures, results, news, and membership info.";
 const DEFAULT_OG_IMAGE_PATH = "/images/og-default.png";
 
-/** Public content kinds the prerenderer snapshots (game reports excluded). */
-export type PrerenderKind = "page" | "news" | "event" | "person";
+/** Public content kinds the prerenderer snapshots (game reports render
+ * on their game page, not standalone). */
+export type PrerenderKind =
+  "page" | "news" | "event" | "person" | "game" | "calendar-month";
 
 export interface HeadInput {
   kind: PrerenderKind;
@@ -29,6 +32,12 @@ export interface HeadInput {
   body?: unknown;
   publishedAt?: string;
   updatedAt?: string;
+  /**
+   * Explicit og:image override (absolute URL) - game pages point at the
+   * API's scorecard PNG endpoint. Keeps this module pure: the caller
+   * resolves the API origin.
+   */
+  ogImageUrl?: string;
 }
 
 function escapeHtml(value: string): string {
@@ -88,6 +97,7 @@ function findLeadImage(body: unknown): string | undefined {
 }
 
 function resolveOgImage(input: HeadInput, origin: string): string {
+  if (input.ogImageUrl) return input.ogImageUrl;
   if (input.kind === "person") {
     const parsed = personMetadataSchema.safeParse(input.metadata);
     if (parsed.success && parsed.data.photo) {
@@ -164,6 +174,28 @@ function buildLdJson(input: HeadInput, origin: string): unknown {
         url: pageUrl,
       };
     }
+    case "game": {
+      const parsed = gameHeadMetadataSchema.safeParse(input.metadata);
+      if (!parsed.success) return undefined;
+      const { when, homeTeam, awayTeam, locationName } = parsed.data;
+      return {
+        "@context": "https://schema.org",
+        "@type": "SportsEvent",
+        name: input.title,
+        ...(input.description ? { description: input.description } : {}),
+        ...(when ? { startDate: when } : {}),
+        sport: "Cricket",
+        homeTeam: { "@type": "SportsTeam", name: homeTeam },
+        awayTeam: { "@type": "SportsTeam", name: awayTeam },
+        ...(locationName
+          ? { location: { "@type": "Place", name: locationName } }
+          : {}),
+        organizer: { "@type": "SportsOrganization", name: SITE_NAME },
+        url: pageUrl,
+      };
+    }
+    case "calendar-month":
+      return undefined;
   }
 }
 

--- a/apps/web/src/prerender/game-meta.test.ts
+++ b/apps/web/src/prerender/game-meta.test.ts
@@ -1,0 +1,108 @@
+import type { paths } from "@/lib/api.gen.js";
+import { describe, expect, it } from "vitest";
+import {
+  gameHeadData,
+  gameHeadMetadataSchema,
+  monthHeadData,
+} from "./game-meta.js";
+
+type GameData =
+  paths["/api/games/{matchId}"]["get"]["responses"]["200"]["content"]["application/json"];
+
+// `when` fixtures carry an explicit offset so parsing is deterministic
+// across machine timezones (real payloads are naive London-local strings;
+// the prerender Lambda pins TZ=Europe/London to match UK browsers).
+
+function game(overrides: Partial<GameData> = {}): GameData {
+  return {
+    id: "123456",
+    matchDate: "12/07/2026",
+    matchTime: "13:00",
+    home: true,
+    team: { id: "T1", name: "1st XI" },
+    opposition: {
+      club: { id: "C9", name: "Tynemouth CC" },
+      team: { id: "T9", name: "2nd XI" },
+    },
+    league: { id: "L1", name: "NTCL" },
+    competition: { id: "CMP", name: "Division 1", type: "League" },
+    groundName: "St Johns Terrace",
+    when: "2026-07-12T13:00:00+01:00",
+    outcome: null,
+    scoreDescription: null,
+    sponsorName: null,
+    sponsorLogoUrl: null,
+    location: { name: "Percy Main Cricket and Sports Club" },
+    result: null,
+    sponsor: null,
+    lineup: null,
+    availabilityRequest: null,
+    ...overrides,
+  };
+}
+
+describe("gameHeadData", () => {
+  it("titles a home fixture with venue marker and date", () => {
+    const head = gameHeadData(game());
+    expect(head.title).toBe("1st XI vs Tynemouth CC 2nd XI (H) - 12 July 2026");
+  });
+
+  it("describes a fixture with kickoff time and sponsor", () => {
+    const head = gameHeadData(
+      game({
+        sponsor: {
+          name: "Acme Scaffolding",
+          logoUrl: null,
+          message: null,
+          website: null,
+          phone: null,
+        },
+      }),
+    );
+    expect(head.description).toContain("1st XI play Tynemouth CC 2nd XI");
+    expect(head.description).toContain("at home");
+    expect(head.description).toContain("1:00pm on Sunday 12 July 2026");
+    expect(head.description).toContain("Match sponsored by Acme Scaffolding.");
+  });
+
+  it("describes a result with outcome and score", () => {
+    const head = gameHeadData(
+      game({ outcome: "W", scoreDescription: "142/6 - 138" }),
+    );
+    expect(head.description).toContain("Won (142/6 - 138)");
+    expect(head.description).toContain("against Tynemouth CC 2nd XI");
+    expect(head.description).toContain("Full scorecard");
+  });
+
+  it("swaps home and away teams for away games", () => {
+    const homeMeta = gameHeadData(game()).metadata;
+    expect(homeMeta.homeTeam).toBe("Percy Main 1st XI");
+    expect(homeMeta.awayTeam).toBe("Tynemouth CC 2nd XI");
+
+    const awayMeta = gameHeadData(game({ home: false })).metadata;
+    expect(awayMeta.homeTeam).toBe("Tynemouth CC 2nd XI");
+    expect(awayMeta.awayTeam).toBe("Percy Main 1st XI");
+  });
+
+  it("produces metadata that round-trips through its schema", () => {
+    const head = gameHeadData(game());
+    const parsed = gameHeadMetadataSchema.safeParse(head.metadata);
+    expect(parsed.success).toBe(true);
+  });
+
+  it("copes with a dateless game (no when)", () => {
+    const head = gameHeadData(game({ when: null, location: null }));
+    expect(head.title).toBe("1st XI vs Tynemouth CC 2nd XI (H)");
+    expect(head.metadata.when).toBeNull();
+    // Falls back to the ground name from the summary.
+    expect(head.metadata.locationName).toBe("St Johns Terrace");
+  });
+});
+
+describe("monthHeadData", () => {
+  it("capitalizes the month and includes the year", () => {
+    const head = monthHeadData(2026, "july");
+    expect(head.title).toBe("Fixtures & Events - July 2026");
+    expect(head.description).toContain("July 2026");
+  });
+});

--- a/apps/web/src/prerender/game-meta.ts
+++ b/apps/web/src/prerender/game-meta.ts
@@ -1,0 +1,100 @@
+import type { paths } from "@/lib/api.gen.js";
+import { formatInTimeZone } from "date-fns-tz";
+import { z } from "zod";
+
+// Head data for prerendered game and calendar-month pages: pure string
+// assembly from the game detail payload, kept separate from build-head
+// so it unit-tests without the document pipeline. The prerenderer Lambda
+// calls gameHeadData/monthHeadData and feeds the result into buildHead;
+// the metadata round-trips through gameHeadMetadataSchema, which is what
+// build-head's SportsEvent JSON-LD consumes.
+
+type GameData =
+  paths["/api/games/{matchId}"]["get"]["responses"]["200"]["content"]["application/json"];
+
+export const gameHeadMetadataSchema = z.object({
+  when: z.string().nullish(),
+  homeTeam: z.string(),
+  awayTeam: z.string(),
+  locationName: z.string().nullish(),
+});
+
+export type GameHeadMetadata = z.infer<typeof gameHeadMetadataSchema>;
+
+const OUTCOME_LABELS: Record<string, string> = {
+  W: "Won",
+  L: "Lost",
+  D: "Draw",
+  T: "Tied",
+  A: "Abandoned",
+  C: "Cancelled",
+  N: "No result",
+};
+
+const TZ = "Europe/London";
+
+export interface GameHeadData {
+  title: string;
+  description: string;
+  metadata: GameHeadMetadata;
+}
+
+export function gameHeadData(game: GameData): GameHeadData {
+  const opposition =
+    `${game.opposition.club.name} ${game.opposition.team.name}`.trim();
+  const venue = game.home ? "H" : "A";
+  const dateLabel = game.when
+    ? formatInTimeZone(new Date(game.when), TZ, "d MMMM yyyy")
+    : null;
+
+  const title = `${game.team.name} vs ${opposition} (${venue})${
+    dateLabel ? ` - ${dateLabel}` : ""
+  }`;
+
+  const where = game.home ? "at home" : "away";
+  const outcomeLabel = game.outcome ? OUTCOME_LABELS[game.outcome] : undefined;
+  let description: string;
+  if (outcomeLabel) {
+    const score = game.scoreDescription ? ` (${game.scoreDescription})` : "";
+    description = `${outcomeLabel}${score} - ${game.team.name} ${where} against ${opposition}${
+      dateLabel ? ` on ${dateLabel}` : ""
+    }. Full scorecard and match details.`;
+  } else {
+    const timeLabel = game.when
+      ? formatInTimeZone(
+          new Date(game.when),
+          TZ,
+          "h:mmaaa 'on' EEEE d MMMM yyyy",
+        )
+      : null;
+    const sponsor = game.sponsor
+      ? ` Match sponsored by ${game.sponsor.name}.`
+      : "";
+    description = `${game.team.name} play ${opposition} ${where}${
+      timeLabel ? `, ${timeLabel}` : ""
+    }.${sponsor} Fixture details and directions.`;
+  }
+
+  const ourName = `Percy Main ${game.team.name}`;
+  return {
+    title,
+    description,
+    metadata: {
+      when: game.when ?? null,
+      homeTeam: game.home ? ourName : opposition,
+      awayTeam: game.home ? opposition : ourName,
+      locationName: game.location?.name ?? game.groundName ?? null,
+    },
+  };
+}
+
+export function monthHeadData(
+  year: number,
+  monthName: string,
+): { title: string; description: string } {
+  const monthLabel = monthName.charAt(0).toUpperCase() + monthName.slice(1);
+  return {
+    title: `Fixtures & Events - ${monthLabel} ${year.toString()}`,
+    description: `Percy Main Community Sports Club cricket fixtures, results and club events for ${monthLabel} ${year.toString()}.`,
+  };
+}

--- a/apps/web/src/prerender/paths.test.ts
+++ b/apps/web/src/prerender/paths.test.ts
@@ -25,6 +25,18 @@ describe("prerender path mapping", () => {
     expect(snapshotKvsKey("/person/jane-smith")).toBe("/person/jane-smith");
   });
 
+  it("maps game and calendar month URLs (numeric segments)", () => {
+    expect(snapshotS3Key("/calendar/game/123456")).toBe(
+      "_prerender/calendar/game/123456.html",
+    );
+    expect(snapshotS3Key("/calendar/2026/july")).toBe(
+      "_prerender/calendar/2026/july.html",
+    );
+    expect(snapshotKvsKey("/calendar/game/123456")).toBe(
+      "/calendar/game/123456",
+    );
+  });
+
   it("derives the invalidation path from the S3 key", () => {
     expect(snapshotInvalidationPath("/club")).toBe("/_prerender/club.html");
   });

--- a/apps/web/src/prerender/reconcile.test.ts
+++ b/apps/web/src/prerender/reconcile.test.ts
@@ -26,7 +26,10 @@ const NAV = [
 ];
 
 function state(
-  items: Record<string, { updatedAt: string; publishedAt: string }>,
+  items: Record<
+    string,
+    { updatedAt: string; publishedAt: string; hash?: string }
+  >,
   hash = navHash(NAV),
 ): PrerenderState {
   return { v: 1, navHash: hash, items };
@@ -168,5 +171,79 @@ describe("nextState", () => {
     expect(Object.keys(result.items)).toEqual(["/club"]);
     expect(result.navHash).toBe("abc");
     expect(result.v).toBe(1);
+  });
+
+  it("persists the content hash when an item carries one", () => {
+    const game = item("/calendar/game/123", { kind: "game", hash: "abc123" });
+    const page = item("/club");
+    const result = nextState([game, page], "nav");
+    expect(result.items["/calendar/game/123"].hash).toBe("abc123");
+    expect("hash" in result.items["/club"]).toBe(false);
+  });
+});
+
+// Games and calendar months diff on an opaque content hash on top of the
+// timestamps - their sources (match_result, sponsorships, matchday) carry
+// no usable updated_at.
+describe("hash-diffed items", () => {
+  const TS = {
+    updatedAt: "2026-06-01T10:00:00.000Z",
+    publishedAt: "2026-06-01T10:00:00.000Z",
+  };
+
+  it("re-renders when only the hash changes", () => {
+    const manifest = [
+      item("/calendar/game/123", { kind: "game", hash: "after" }),
+    ];
+    const plan = planReconcile({
+      manifest,
+      state: state({ "/calendar/game/123": { ...TS, hash: "before" } }),
+      currentNavHash: navHash(NAV),
+    });
+    expect(plan.mode).toBe("diff");
+    expect(plan.toRender.map((entry) => entry.url)).toEqual([
+      "/calendar/game/123",
+    ]);
+  });
+
+  it("skips when timestamps and hash are unchanged", () => {
+    const manifest = [
+      item("/calendar/game/123", { kind: "game", hash: "same" }),
+      item("/calendar/2026/july", { kind: "calendar-month", hash: "m1" }),
+    ];
+    const plan = planReconcile({
+      manifest,
+      state: state({
+        "/calendar/game/123": { ...TS, hash: "same" },
+        "/calendar/2026/july": { ...TS, hash: "m1" },
+      }),
+      currentNavHash: navHash(NAV),
+    });
+    expect(plan.toRender).toEqual([]);
+  });
+
+  it("re-renders a hashed item once against a pre-hash state entry", () => {
+    const manifest = [
+      item("/calendar/game/123", { kind: "game", hash: "new" }),
+    ];
+    const plan = planReconcile({
+      manifest,
+      // State written before hashes existed: no hash key.
+      state: state({ "/calendar/game/123": { ...TS } }),
+      currentNavHash: navHash(NAV),
+    });
+    expect(plan.toRender.map((entry) => entry.url)).toEqual([
+      "/calendar/game/123",
+    ]);
+  });
+
+  it("keeps pure-timestamp diffing for content items without hashes", () => {
+    const manifest = [item("/club")];
+    const plan = planReconcile({
+      manifest,
+      state: state({ "/club": { ...TS } }),
+      currentNavHash: navHash(NAV),
+    });
+    expect(plan.toRender).toEqual([]);
   });
 });

--- a/apps/web/src/prerender/reconcile.ts
+++ b/apps/web/src/prerender/reconcile.ts
@@ -7,10 +7,17 @@
 
 export interface ManifestItem {
   url: string;
-  kind: "page" | "news" | "event" | "person";
+  kind: "page" | "news" | "event" | "person" | "game" | "calendar-month";
   slug: string;
   updatedAt: string;
   publishedAt: string;
+  /**
+   * Opaque content fingerprint for kinds whose sources carry no usable
+   * update timestamps (games compose Play Cricket data with DB overlays;
+   * match_result has no updated_at). When present it joins the diff key;
+   * content kinds omit it and keep pure-timestamp diffing.
+   */
+  hash?: string;
 }
 
 export interface NavItem {
@@ -23,6 +30,7 @@ export interface NavItem {
 interface StateEntry {
   updatedAt: string;
   publishedAt: string;
+  hash?: string;
 }
 
 /**
@@ -92,9 +100,13 @@ export function planReconcile(options: {
 
   const toRender = manifest.filter((item) => {
     const previous = state.items[item.url];
+    // hash: undefined === undefined for content kinds, so they diff on
+    // timestamps alone; a hashed item against a pre-hash state entry
+    // re-renders once and then converges.
     return (
       previous?.updatedAt !== item.updatedAt ||
-      previous.publishedAt !== item.publishedAt
+      previous.publishedAt !== item.publishedAt ||
+      previous.hash !== item.hash
     );
   });
   return { mode: "diff", toRender, toUnrender };
@@ -113,6 +125,7 @@ export function nextState(
     items[item.url] = {
       updatedAt: item.updatedAt,
       publishedAt: item.publishedAt,
+      ...(item.hash !== undefined ? { hash: item.hash } : {}),
     };
   }
   return { v: 1, navHash: currentNavHash, items };

--- a/docs/adrs/053-prerendering-fixtures-and-calendar.md
+++ b/docs/adrs/053-prerendering-fixtures-and-calendar.md
@@ -1,0 +1,43 @@
+# Decision 053: Prerendering Fixtures and Calendar Months via Hash-Diffed Manifest
+
+**Date:** 2026-07-04
+**Status:** Accepted
+
+## Decision
+
+Game pages (`/calendar/game/:id`, current season only) and calendar month pages (`/calendar/:year/:month`, previous + current year) join the publish-time prerender pipeline from ADR 052. A second manifest endpoint, `GET /api/games/prerender-manifest`, lives in the games feature and is merged with the content manifest by the prerenderer Lambda. Because game pages compose Play Cricket data with DB overlays that carry no usable update timestamps, these items diff on an opaque djb2 **content hash** of everything render-relevant (summary fields, sponsorships, matchday result and lineup, game report publish state) instead of timestamps alone. The CloudFront function's game OG-redirect becomes the KVS-miss fallback: a snapshot wins when present, and un-snapshotted games (past seasons, pre-first-render) keep today's redirect so link previews never regress.
+
+## Problem
+
+ADR 052 deliberately excluded game pages ("game reports keep their existing OG-redirect mechanism"). That left the club's most-shared pages - fixtures and results - with three costs: every visitor pays two redirects through the API OG page before the SPA even starts, meta is a generic "Match Result" line, and the calendar month grid is an empty shell on first paint with nothing for crawlers. Extending the pipeline hit two structural obstacles:
+
+1. **No diffable timestamps.** The content manifest re-renders on `updated_at` changes; `match_result` has only `created_at`, sponsorship approval flips a boolean, matchday results and lineups live across two tables, and Play Cricket's own `last_updated` is date-precision only.
+2. **Redirect ordering.** The CloudFront function 302s every `/calendar/game/:id` to the API OG page _before_ the KVS lookup (a test pinned that precedence), so a snapshot would never be served.
+
+## Options considered
+
+1. **Separate games manifest with content hashes (chosen).** New endpoint in the games feature; Lambda merges both manifests; reconcile compares an optional `hash` field alongside timestamps.
+2. **Extend the content manifest enum with games.** Push game rows through `listPrerenderManifest`.
+3. **Add `updated_at` columns everywhere.** Migrate `match_result` (and touch sponsorship/matchday write paths) so timestamp diffing works for games too.
+4. **Time-based re-rendering.** Re-render all game pages on every 15-minute sweep, no diffing.
+
+## Rationale
+
+- Games live in Play Cricket plus four DB tables, not the `content` table; forcing them through the content manifest would tangle a clean query path with a PC API client it doesn't otherwise need. A sibling endpoint keeps each feature self-contained and lets the Lambda treat "games manifest 404" as "feature off" (no PC creds) while any other failure aborts the sync - so a PC outage can never read as "all games vanished" and mass-unrender snapshots.
+- The hash approach needs no migrations and catches every render-relevant change in one mechanism, including ones timestamps can't express (a sponsorship approval, a lineup swap, a game report crossing its scheduled publish time). A false hash collision self-heals on the next forced render-all; a missed change self-heals visually because the SPA refetches over every snapshot.
+- Scope (current season's ~100-130 games + 24 months) keeps a full render-all inside a 900s Lambda timeout; each game render costs a live PC detail call. The sync now flushes KVS routing, state and invalidations every 25 documents, so a timeout resumes from the last flush instead of never converging. Older seasons keep the OG-redirect fallback, which stays correct indefinitely.
+- Results appear via the Play Cricket sync (a separate ECS task), which now pings the prerenderer on exit; sponsorship approval/payment and matchday finish/cancel fire the same fire-and-forget reconcile as content mutations. The 15-minute sweep remains the backstop for everything else (including PC-side edits, caught by the hash).
+
+## Rejected alternatives
+
+- **Extending the content manifest enum**: couples the content feature to the Play Cricket client and gives games slug/published_at semantics they don't have. Becomes attractive only if games ever move into the content table.
+- **Adding `updated_at` columns**: a migration plus discipline across every write path (including the sync's upserts), and still blind to changes in Play Cricket's own data that never touch our DB. Reconsider if hash computation ever becomes a hot path.
+- **Time-based re-rendering**: ~130 PC detail calls every 15 minutes forever, against a free-tier-conscious budget, to avoid a diff that costs two summary calls and a handful of batch queries. No.
+- **All seasons (2015+, ~1300 pages)**: exceeds the Lambda ceiling on every deploy's render-all and hammers the PC API. Reconsider with a chunked/self-invoking render orchestration if historical SEO ever matters; the OG-redirect fallback covers link previews there meanwhile.
+
+## Operational notes
+
+- Month pages hash the month's game subset plus ALL published events (every month snapshot embeds the full dehydrated events list), so one event edit re-renders 24 month pages - cheap and correct.
+- `/calendar` itself stays SPA: it is a client-side redirect to the current month.
+- Play Cricket's `last_updated` is date-precision; a same-day scorecard correction that changes no DB overlay may not flip the hash until the next day. Harmless: the Scorecard component fetches live and the SPA refetches the seeded game query over the snapshot.
+- Rollback: revert the CloudFront function (or delete the game/month KVS keys) and the OG redirect returns instantly; snapshots in S3 are inert.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -6,28 +6,29 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 
 ## Index
 
-| #                                                        | Title                                                             | Date       | Status   |
-| -------------------------------------------------------- | ----------------------------------------------------------------- | ---------- | -------- |
-| [001](001-api-framework.md)                              | API Framework - Fastify over Express                              | 2026-03-14 | Accepted |
-| [002](002-email-provider.md)                             | Email Provider - SES over Mailgun                                 | 2026-03-14 | Accepted |
-| [003](003-baseline-migration-strategy.md)                | Baseline Migration Strategy - Single Consolidated Migration       | 2026-03-14 | Accepted |
-| [004](004-auth-database-type.md)                         | better-auth Database Type - postgres                              | 2026-03-14 | Accepted |
-| [005](005-generated-types-approach.md)                   | Generated DB Types - Placeholder with PostgreSQL Types            | 2026-03-14 | Accepted |
-| [006](006-monorepo-structure.md)                         | Monorepo Structure - Following the Plan                           | 2026-03-14 | Accepted |
-| [007](007-webhook-raw-body.md)                           | Stripe Webhook Raw Body Handling                                  | 2026-03-14 | Accepted |
-| [008](008-vite-proxy-for-local-dev.md)                   | Vite Dev Server Proxy for Local Development                       | 2026-03-14 | Accepted |
-| [009](009-dependency-injection.md)                       | Functional Dependency Injection                                   | 2026-03-14 | Accepted |
-| [010](010-testcontainers.md)                             | Testcontainers for Integration Tests                              | 2026-03-14 | Accepted |
-| [011](011-api-type-safety.md)                            | API Type Safety Between Backend and Frontend                      | 2026-03-16 | Accepted |
-| [012](012-prod-db-access.md)                             | Production DB Access via Tailscale                                | 2026-04-20 | Accepted |
-| [042](042-scout-recognition-sources.md)                  | Scout Recognition Sources - Public-Source Discovery               | 2026-05-14 | Accepted |
-| [043](043-db-role-split-principle-of-least-privilege.md) | DB Role Split - Principle of Least Privilege                      | 2026-05-15 | Accepted |
-| [044](044-matchday-notification-channel-modelling.md)    | Matchday notification channel modelling                           | 2026-05-21 | Accepted |
-| [045](045-matchday-service-worker-push-integration.md)   | Matchday service worker push integration via importScripts        | 2026-05-21 | Accepted |
-| [046](046-vapid-public-key-via-api.md)                   | VAPID public key delivered via API, not bundled                   | 2026-05-21 | Accepted |
-| [047](047-content-editor-blocknote.md)                   | Content Editor - BlockNote with JSON canonical format             | 2026-06-10 | Accepted |
-| [048](048-editor-image-webp-only-sync-processing.md)     | Editor images - WebP-only ladder, synchronous processing          | 2026-06-10 | Accepted |
-| [049](049-ai-content-author-assistant.md)                | AI content-author assistant reuses Scout's tools                  | 2026-06-14 | Accepted |
-| [050](050-profile-self-edit-proposal-tier.md)            | Profile self-editing via a proposal/approval tier                 | 2026-06-23 | Accepted |
-| [051](051-member-slug-backfill-and-profile-fallback.md)  | Member slug backfill, member-backed profile fallback, self-create | 2026-06-24 | Accepted |
-| [052](052-publish-time-prerendering.md)                  | Publish-time prerendering via Lambda + CloudFront KeyValueStore   | 2026-07-03 | Accepted |
+| #                                                        | Title                                                              | Date       | Status   |
+| -------------------------------------------------------- | ------------------------------------------------------------------ | ---------- | -------- |
+| [001](001-api-framework.md)                              | API Framework - Fastify over Express                               | 2026-03-14 | Accepted |
+| [002](002-email-provider.md)                             | Email Provider - SES over Mailgun                                  | 2026-03-14 | Accepted |
+| [003](003-baseline-migration-strategy.md)                | Baseline Migration Strategy - Single Consolidated Migration        | 2026-03-14 | Accepted |
+| [004](004-auth-database-type.md)                         | better-auth Database Type - postgres                               | 2026-03-14 | Accepted |
+| [005](005-generated-types-approach.md)                   | Generated DB Types - Placeholder with PostgreSQL Types             | 2026-03-14 | Accepted |
+| [006](006-monorepo-structure.md)                         | Monorepo Structure - Following the Plan                            | 2026-03-14 | Accepted |
+| [007](007-webhook-raw-body.md)                           | Stripe Webhook Raw Body Handling                                   | 2026-03-14 | Accepted |
+| [008](008-vite-proxy-for-local-dev.md)                   | Vite Dev Server Proxy for Local Development                        | 2026-03-14 | Accepted |
+| [009](009-dependency-injection.md)                       | Functional Dependency Injection                                    | 2026-03-14 | Accepted |
+| [010](010-testcontainers.md)                             | Testcontainers for Integration Tests                               | 2026-03-14 | Accepted |
+| [011](011-api-type-safety.md)                            | API Type Safety Between Backend and Frontend                       | 2026-03-16 | Accepted |
+| [012](012-prod-db-access.md)                             | Production DB Access via Tailscale                                 | 2026-04-20 | Accepted |
+| [042](042-scout-recognition-sources.md)                  | Scout Recognition Sources - Public-Source Discovery                | 2026-05-14 | Accepted |
+| [043](043-db-role-split-principle-of-least-privilege.md) | DB Role Split - Principle of Least Privilege                       | 2026-05-15 | Accepted |
+| [044](044-matchday-notification-channel-modelling.md)    | Matchday notification channel modelling                            | 2026-05-21 | Accepted |
+| [045](045-matchday-service-worker-push-integration.md)   | Matchday service worker push integration via importScripts         | 2026-05-21 | Accepted |
+| [046](046-vapid-public-key-via-api.md)                   | VAPID public key delivered via API, not bundled                    | 2026-05-21 | Accepted |
+| [047](047-content-editor-blocknote.md)                   | Content Editor - BlockNote with JSON canonical format              | 2026-06-10 | Accepted |
+| [048](048-editor-image-webp-only-sync-processing.md)     | Editor images - WebP-only ladder, synchronous processing           | 2026-06-10 | Accepted |
+| [049](049-ai-content-author-assistant.md)                | AI content-author assistant reuses Scout's tools                   | 2026-06-14 | Accepted |
+| [050](050-profile-self-edit-proposal-tier.md)            | Profile self-editing via a proposal/approval tier                  | 2026-06-23 | Accepted |
+| [051](051-member-slug-backfill-and-profile-fallback.md)  | Member slug backfill, member-backed profile fallback, self-create  | 2026-06-24 | Accepted |
+| [052](052-publish-time-prerendering.md)                  | Publish-time prerendering via Lambda + CloudFront KeyValueStore    | 2026-07-03 | Accepted |
+| [053](053-prerendering-fixtures-and-calendar.md)         | Prerendering fixtures and calendar months via hash-diffed manifest | 2026-07-04 | Accepted |

--- a/infra/modules/cdn/spa-rewrite.handler.js
+++ b/infra/modules/cdn/spa-rewrite.handler.js
@@ -50,48 +50,12 @@ export function createHandler(apiBaseUrl, kvsHandle) {
       return { statusCode: 404, statusDescription: "Not Found" };
     }
 
-    // Redirect game pages to API for OG meta tags (unless returning via bypass param)
-    if (apiBaseUrl) {
-      var gameMatch = uri.match(/^\/calendar\/game\/(\d+)$/);
-      var bypass = qs && qs.og && qs.og.value === "1";
-      if (gameMatch && !bypass) {
-        // Forward any non-`og` query params so the OG page can reflect them
-        // back in the bypass redirect. Without this, deep links like
-        // ?bbb=1 (open ball-by-ball modal) get dropped on the round-trip.
-        var forwarded = "";
-        if (qs) {
-          var parts = [];
-          for (var k in qs) {
-            if (k === "og") continue;
-            var entry = qs[k];
-            if (entry && typeof entry.value === "string") {
-              parts.push(
-                encodeURIComponent(k) + "=" + encodeURIComponent(entry.value),
-              );
-            }
-          }
-          if (parts.length) forwarded = "?" + parts.join("&");
-        }
-        return {
-          statusCode: 302,
-          statusDescription: "Found",
-          headers: {
-            location: {
-              value:
-                apiBaseUrl +
-                "/api/og/game/" +
-                gameMatch[1] +
-                "/page" +
-                forwarded,
-            },
-          },
-        };
-      }
-    }
-
     // Extensionless URIs are app routes: prerendered documents when the
     // KVS says a snapshot exists (trailing slash normalised so /club/ and
-    // /club share one cache entry), the SPA shell otherwise.
+    // /club share one cache entry). A snapshot carries its own OG meta,
+    // so it wins over the game OG redirect below; games WITHOUT a
+    // snapshot (past seasons, pre-first-render) keep the redirect so
+    // link previews never regress. Everything else gets the SPA shell.
     if (!uri.includes(".")) {
       var lookupUri = uri;
       if (lookupUri.length > 1 && lookupUri.endsWith("/")) {
@@ -105,9 +69,51 @@ export function createHandler(apiBaseUrl, kvsHandle) {
           request.uri = "/_prerender" + lookupUri + ".html";
           return request;
         } catch (err) {
-          // Key missing (or KVS error): fall through to the SPA shell.
+          // Key missing (or KVS error): fall through.
         }
       }
+
+      // Redirect un-snapshotted game pages to the API for OG meta tags
+      // (unless returning via bypass param)
+      if (apiBaseUrl) {
+        var gameMatch = uri.match(/^\/calendar\/game\/(\d+)$/);
+        var bypass = qs && qs.og && qs.og.value === "1";
+        if (gameMatch && !bypass) {
+          // Forward any non-`og` query params so the OG page can reflect
+          // them back in the bypass redirect. Without this, deep links
+          // like ?bbb=1 (open ball-by-ball modal) get dropped on the
+          // round-trip.
+          var forwarded = "";
+          if (qs) {
+            var parts = [];
+            for (var k in qs) {
+              if (k === "og") continue;
+              var entry = qs[k];
+              if (entry && typeof entry.value === "string") {
+                parts.push(
+                  encodeURIComponent(k) + "=" + encodeURIComponent(entry.value),
+                );
+              }
+            }
+            if (parts.length) forwarded = "?" + parts.join("&");
+          }
+          return {
+            statusCode: 302,
+            statusDescription: "Found",
+            headers: {
+              location: {
+                value:
+                  apiBaseUrl +
+                  "/api/og/game/" +
+                  gameMatch[1] +
+                  "/page" +
+                  forwarded,
+              },
+            },
+          };
+        }
+      }
+
       request.uri = "/index.html";
     }
     return request;

--- a/infra/modules/cdn/spa-rewrite.js
+++ b/infra/modules/cdn/spa-rewrite.js
@@ -53,48 +53,12 @@ async function handler(event) {
     return { statusCode: 404, statusDescription: "Not Found" };
   }
 
-  // Redirect game pages to API for OG meta tags (unless returning via bypass param)
-  if (API_BASE_URL) {
-    var gameMatch = uri.match(/^\/calendar\/game\/(\d+)$/);
-    var bypass = qs && qs.og && qs.og.value === "1";
-    if (gameMatch && !bypass) {
-      // Forward any non-`og` query params so the OG page can reflect them
-      // back in the bypass redirect. Without this, deep links like
-      // ?bbb=1 (open ball-by-ball modal) get dropped on the round-trip.
-      var forwarded = "";
-      if (qs) {
-        var parts = [];
-        for (var k in qs) {
-          if (k === "og") continue;
-          var entry = qs[k];
-          if (entry && typeof entry.value === "string") {
-            parts.push(
-              encodeURIComponent(k) + "=" + encodeURIComponent(entry.value),
-            );
-          }
-        }
-        if (parts.length) forwarded = "?" + parts.join("&");
-      }
-      return {
-        statusCode: 302,
-        statusDescription: "Found",
-        headers: {
-          location: {
-            value:
-              API_BASE_URL +
-              "/api/og/game/" +
-              gameMatch[1] +
-              "/page" +
-              forwarded,
-          },
-        },
-      };
-    }
-  }
-
   // Extensionless URIs are app routes: prerendered documents when the
   // KVS says a snapshot exists (trailing slash normalised so /club/ and
-  // /club share one cache entry), the SPA shell otherwise.
+  // /club share one cache entry). A snapshot carries its own OG meta,
+  // so it wins over the game OG redirect below; games WITHOUT a
+  // snapshot (past seasons, pre-first-render) keep the redirect so
+  // link previews never regress. Everything else gets the SPA shell.
   if (!uri.includes(".")) {
     var lookupUri = uri;
     if (lookupUri.length > 1 && lookupUri.endsWith("/")) {
@@ -108,9 +72,51 @@ async function handler(event) {
         request.uri = "/_prerender" + lookupUri + ".html";
         return request;
       } catch (err) {
-        // Key missing (or KVS error): fall through to the SPA shell.
+        // Key missing (or KVS error): fall through.
       }
     }
+
+    // Redirect un-snapshotted game pages to the API for OG meta tags
+    // (unless returning via bypass param)
+    if (API_BASE_URL) {
+      var gameMatch = uri.match(/^\/calendar\/game\/(\d+)$/);
+      var bypass = qs && qs.og && qs.og.value === "1";
+      if (gameMatch && !bypass) {
+        // Forward any non-`og` query params so the OG page can reflect
+        // them back in the bypass redirect. Without this, deep links
+        // like ?bbb=1 (open ball-by-ball modal) get dropped on the
+        // round-trip.
+        var forwarded = "";
+        if (qs) {
+          var parts = [];
+          for (var k in qs) {
+            if (k === "og") continue;
+            var entry = qs[k];
+            if (entry && typeof entry.value === "string") {
+              parts.push(
+                encodeURIComponent(k) + "=" + encodeURIComponent(entry.value),
+              );
+            }
+          }
+          if (parts.length) forwarded = "?" + parts.join("&");
+        }
+        return {
+          statusCode: 302,
+          statusDescription: "Found",
+          headers: {
+            location: {
+              value:
+                API_BASE_URL +
+                "/api/og/game/" +
+                gameMatch[1] +
+                "/page" +
+                forwarded,
+            },
+          },
+        };
+      }
+    }
+
     request.uri = "/index.html";
   }
   return request;

--- a/infra/modules/cdn/spa-rewrite.test.js
+++ b/infra/modules/cdn/spa-rewrite.test.js
@@ -127,17 +127,48 @@ describe("spa-rewrite CloudFront function", () => {
       expect(result.statusCode).toBeUndefined();
     });
 
-    it("keeps the OG redirect even when a snapshot store exists", async () => {
-      // Game reports are never prerendered; their KVS keys never exist,
-      // and the OG branch runs before the KVS lookup anyway.
+    it("serves the snapshot instead of the OG redirect when one exists", async () => {
+      // Prerendered game pages carry their own OG meta, so the KVS
+      // lookup runs first and a snapshot hit wins outright.
       const kvsHandler = createHandler(
         "https://api.v2.percymain.org",
-        fakeKvs(["/club"]),
+        fakeKvs(["/calendar/game/12345"]),
+      );
+      const result = await kvsHandler(
+        makeEvent("/calendar/game/12345", "www.percymain.org"),
+      );
+      expect(result.uri).toBe("/_prerender/calendar/game/12345.html");
+      expect(result.statusCode).toBeUndefined();
+    });
+
+    it("serves the snapshot even with og=1 (stale bypass links)", async () => {
+      const kvsHandler = createHandler(
+        "https://api.v2.percymain.org",
+        fakeKvs(["/calendar/game/12345"]),
+      );
+      const result = await kvsHandler(
+        makeEvent("/calendar/game/12345", "www.percymain.org", {
+          og: { value: "1" },
+        }),
+      );
+      expect(result.uri).toBe("/_prerender/calendar/game/12345.html");
+    });
+
+    it("keeps the OG redirect for games without a snapshot", async () => {
+      // Past seasons and not-yet-rendered games: the store exists but
+      // has no key for this game, so link previews still work via the
+      // API OG page.
+      const kvsHandler = createHandler(
+        "https://api.v2.percymain.org",
+        fakeKvs(["/club", "/calendar/game/99999"]),
       );
       const result = await kvsHandler(
         makeEvent("/calendar/game/12345", "www.percymain.org"),
       );
       expect(result.statusCode).toBe(302);
+      expect(result.headers.location.value).toBe(
+        "https://api.v2.percymain.org/api/og/game/12345/page",
+      );
     });
   });
 
@@ -171,6 +202,17 @@ describe("spa-rewrite CloudFront function", () => {
         makeEvent("/club/history", "www.percymain.org"),
       );
       expect(result.uri).toBe("/_prerender/club/history.html");
+    });
+
+    it("rewrites calendar month snapshot URLs", async () => {
+      const monthHandler = createHandler(
+        "https://api.v2.percymain.org",
+        fakeKvs(["/calendar/2026/july"]),
+      );
+      const result = await monthHandler(
+        makeEvent("/calendar/2026/july", "www.percymain.org"),
+      );
+      expect(result.uri).toBe("/_prerender/calendar/2026/july.html");
     });
 
     it("normalises a trailing slash before the lookup", async () => {

--- a/infra/modules/prerender/main.tf
+++ b/infra/modules/prerender/main.tf
@@ -159,13 +159,18 @@ data "archive_file" "placeholder" {
 }
 
 resource "aws_lambda_function" "prerenderer" {
-  function_name    = local.function_name
-  role             = aws_iam_role.prerenderer.arn
-  runtime          = "nodejs22.x"
-  handler          = "lambda.handler"
-  architectures    = ["arm64"]
-  memory_size      = 1024
-  timeout          = 300
+  function_name = local.function_name
+  role          = aws_iam_role.prerenderer.arn
+  runtime       = "nodejs22.x"
+  handler       = "lambda.handler"
+  architectures = ["arm64"]
+  # 2048 MB buys proportionally faster CPU (renders are renderToString
+  # bound); 900s covers a render-all of the full corpus - content plus
+  # current-season game pages and calendar months, each game costing a
+  # live Play Cricket detail call. The sync also flushes progress in
+  # batches, so even a timeout resumes rather than starting over.
+  memory_size      = 2048
+  timeout          = 900
   filename         = data.archive_file.placeholder.output_path
   source_code_hash = data.archive_file.placeholder.output_base64sha256
 


### PR DESCRIPTION
## Summary

Extends publish-time prerendering (ADR 052) to the fixtures on the calendar, per ADR 053 (included):

- **Game pages** `/calendar/game/:id` - current season only (~103 pages today). Snapshots carry a real title ("1st XI vs Mitford CC 1st XI (A) - 18 April 2026"), the scorecard PNG as `og:image`, SportsEvent JSON-LD, and dehydrated `["game", id]` + game-report query state. Replaces the double-redirect OG hop for these pages.
- **Calendar month pages** `/calendar/:year/:month` - previous + current year (24 pages). Fixture list on first paint and indexable.

## How it works

- New public `GET /api/games/prerender-manifest` (games feature). Game/month items diff on a **djb2 content hash** of everything render-relevant - `match_result` has no `updated_at`, so timestamp diffing can't work. `ManifestItem`/`StateEntry` gain an optional `hash` compared alongside timestamps (content kinds unaffected).
- The Lambda merges both manifests. Games-manifest **404 = feature off** (no PC creds); any other failure **aborts the sync** so a Play Cricket outage can never read as "all games vanished" and mass-unrender snapshots.
- CloudFront function reordered: **KVS hit wins**; un-snapshotted games (past seasons, pre-first-render) keep the OG-redirect fallback, so link previews never regress. The test pinning the old precedence is flipped.
- Reconcile triggers added at every mutation that changes a game page: sponsorship approve/reject/manual/update, sponsorship payment webhook, matchday finish/cancel, and the Play Cricket sync runner (awaited before `process.exit`; the ECS task already has invoke permission + the ARN env). The 15-minute sweep stays the backstop.
- The sync now flushes KVS routing, state and invalidations every 25 renders - a timeout resumes from the last flush instead of never converging. Lambda: 1024→2048 MB, 300→900s; deploy workflows `--cli-read-timeout` 360→960.

## Verification

- 1349 tests green across the workspace (new: manifest service hash semantics vs mocked db + PC client, reconcile hash diffing, game/month head builders, CDN precedence flip), plus the touched payments integration file against testcontainers.
- End-to-end locally against the real Play Cricket API: manifest returns 103 games + 24 months with byte-stable hashes across calls; `prerender-preview` rendered a real game page (title/og:image/SportsEvent/dehydrated state all correct) and `/calendar/2026/july` with 23 fixture links server-rendered.

## Rollout (each step safe on its own)

1. Merge: API deploys first (endpoint unused until the Lambda code ships), Terraform applies the CF reorder + Lambda bump (behaviour-neutral while no game/month KVS keys exist), then deploy-web's render-all builds the snapshots. **Watch the Lambda log for total render-all duration** on this first run.
2. Spot-check prod: a current-season game URL serves HTML (curl for `og:image` / `SportsEvent`), an old-season game still 302s to the OG page, `/calendar/2026/july` is prerendered, sitemap gains game + month URLs, and sweeps settle at `mode=diff render=0`.
3. Rollback: revert the CF function or delete the game/month KVS keys - the OG redirect returns instantly; snapshots in S3 are inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)