### PR TITLE
feat(content): photo gallery block

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -684,6 +684,15 @@
   @apply h-auto max-w-full rounded-lg;
 }
 
+/* Photo gallery thumbnails fill their fixed tiles (object-cover):
+   out-ranks the generic content img rule above, whose h-auto would
+   otherwise size the img by its own aspect ratio and crop inside the
+   tile. (The gallery stage needs no such rule - its photo sizes
+   naturally, so h-auto is exactly what it wants.) */
+:is(.mdx-content, .bn-editor) .photo-gallery-thumb img {
+  @apply h-full w-full rounded-none object-cover;
+}
+
 :is(.mdx-content, .bn-editor) table {
   @apply w-full border-collapse text-sm;
 }
@@ -1385,6 +1394,12 @@
   :is(.mdx-content, .bn-editor)
   :is(.shadow, .shadow-sm, .shadow-md, .shadow-lg) {
   box-shadow: none;
+}
+/* Exception to the flattening above: the photo gallery's main photo
+   keeps rounded corners and a small shadow, so it reads as a print
+   laid on the page. */
+.fc-theme :is(.mdx-content, .bn-editor) .photo-gallery-stage img {
+  @apply rounded-lg shadow-md;
 }
 .fc-theme :is(.mdx-content, .bn-editor) .bg-white {
   background-color: #fbf3df;

--- a/apps/web/src/components/content-body.test.tsx
+++ b/apps/web/src/components/content-body.test.tsx
@@ -296,6 +296,93 @@ describe("ContentBody", () => {
     expect(html).toContain('src="/uploads/content/img-1/640.jpg"');
   });
 
+  it("renders a photoGallery with a main stage and clickable thumbnails", () => {
+    const picture = (id: string) => ({
+      sources: {
+        webp: `/uploads/content/${id}/320.webp 320w, /uploads/content/${id}/640.webp 640w`,
+      },
+      img: { src: `/uploads/content/${id}/640.jpg`, w: 640, h: 480 },
+    });
+    const html = renderBody([
+      block("photoGallery", {
+        props: {
+          images: JSON.stringify([
+            {
+              picture: picture("a"),
+              alt: "The winning six",
+              caption: "Scenes",
+            },
+            { picture: picture("b") },
+            { picture: picture("c") },
+          ]),
+        },
+      }),
+    ]);
+    // Main stage shows the first photo with its caption.
+    expect(html).toContain('src="/uploads/content/a/640.jpg"');
+    expect(html).toContain("Scenes");
+    // Arrows and one thumbnail per photo.
+    expect(html).toContain('aria-label="Previous photo"');
+    expect(html).toContain('aria-label="Next photo"');
+    expect(html).toContain('aria-label="Show photo 1: The winning six"');
+    expect(html).toContain('aria-label="Show photo 2"');
+    expect(html).toContain('aria-label="Show photo 3"');
+    // The stage <picture> plus one per thumbnail.
+    expect(html.match(/<picture>/g)).toHaveLength(4);
+  });
+
+  it("renders a single-photo gallery without the strip or arrows", () => {
+    const html = renderBody([
+      block("photoGallery", {
+        props: {
+          images: JSON.stringify([
+            {
+              picture: {
+                sources: { webp: "/uploads/content/a/320.webp 320w" },
+                img: { src: "/uploads/content/a/640.jpg", w: 640, h: 480 },
+              },
+            },
+          ]),
+        },
+      }),
+    ]);
+    expect(html).toContain('src="/uploads/content/a/640.jpg"');
+    expect(html).not.toContain("Previous photo");
+    expect(html).not.toContain("Show photo");
+  });
+
+  it("hides the photoGallery when images is missing or malformed", () => {
+    for (const images of ["", "not json", "[]", '[{"alt":"no picture"}]']) {
+      const html = renderBody([block("photoGallery", { props: { images } })]);
+      expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
+    }
+  });
+
+  it("hides the whole photoGallery when any image url is unsafe", () => {
+    const html = renderBody([
+      block("photoGallery", {
+        props: {
+          images: JSON.stringify([
+            {
+              picture: {
+                sources: { webp: "/uploads/content/a/320.webp 320w" },
+                img: { src: "/uploads/content/a/640.jpg", w: 640, h: 480 },
+              },
+            },
+            {
+              picture: {
+                sources: { webp: "javascript:alert(1) 320w" },
+                img: { src: "/uploads/content/b/640.jpg", w: 640, h: 480 },
+              },
+            },
+          ]),
+        },
+      }),
+    ]);
+    expect(html).not.toContain("javascript:");
+    expect(html).toBe('<div class="mdx-content flex flex-col *:mb-4"></div>');
+  });
+
   // ── New custom blocks ──────────────────────────────────────────────────
 
   it("renders all custom block types in a fixture document without crashing", () => {
@@ -321,6 +408,14 @@ describe("ContentBody", () => {
           picture: JSON.stringify(picture),
         },
       }),
+      block("photoGallery", {
+        props: {
+          images: JSON.stringify([
+            { picture, alt: "Gallery photo", caption: "Gallery caption" },
+            { picture },
+          ]),
+        },
+      }),
       block("leagueTable", {
         props: { divisionId: "div-1", name: "Division 1" },
       }),
@@ -341,6 +436,7 @@ describe("ContentBody", () => {
     // Spot-check a handful of expected fragments.
     expect(html).toContain("Head Coach");
     expect(html).toContain("Quiz night");
+    expect(html).toContain("Gallery caption");
     expect(html).toContain("Get in touch");
     expect(html).toContain("Manage cookies");
     expect(html).toContain("v3");

--- a/apps/web/src/components/content-body.tsx
+++ b/apps/web/src/components/content-body.tsx
@@ -4,6 +4,7 @@ import {
   type PictureSource,
 } from "@/components/optimised-image.js";
 import { parsePersonGridEntries } from "@/lib/person-grid.js";
+import { parseGalleryImages } from "@/lib/photo-gallery.js";
 import { cn } from "@/lib/utils.js";
 import {
   contentBodySchema,
@@ -446,6 +447,15 @@ function BlockView({ block }: { block: ContentBlock }) {
       }
       if (!src || !isSafeImageSrc(src)) return null;
       return <mdxComponents.Image src={src} alt={alt} caption={caption} />;
+    }
+
+    case CUSTOM_BLOCK_TYPES.photoGallery: {
+      // props.images is the JSON-stringified [{picture, alt?, caption?}]
+      // array built by the editor from the upload pipeline. All-or-
+      // nothing parse: any malformed or unsafe entry hides the gallery.
+      const images = parseGalleryImages(stringProp(block, "images"));
+      if (images === null) return null;
+      return <mdxComponents.PhotoGallery images={images} />;
     }
 
     case CUSTOM_BLOCK_TYPES.leagueTable: {

--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -4,6 +4,7 @@ import {
   type PictureSource,
 } from "@/components/optimised-image.js";
 import { OutcomeBadge } from "@/components/outcome-badge.js";
+import { PhotoGallery } from "@/components/photo-gallery.js";
 import { RecordsWall as RecordsWallComponent } from "@/components/records-wall.js";
 import { PosterLink, StampButton } from "@/components/theme/bits.js";
 import { Input } from "@/components/ui/input.js";
@@ -624,6 +625,7 @@ function ConsentVersion() {
 export const mdxComponents = {
   Person,
   PersonGrid,
+  PhotoGallery,
   LeagueTable,
   Leaderboard,
   RecordsWall,

--- a/apps/web/src/components/photo-gallery.tsx
+++ b/apps/web/src/components/photo-gallery.tsx
@@ -1,4 +1,4 @@
-import type { GalleryImage } from "@/lib/photo-gallery.js";
+import { galleryThumbLabel, type GalleryImage } from "@/lib/photo-gallery.js";
 import { cn } from "@/lib/utils.js";
 import { useEffect, useRef, useState } from "react";
 import { IoChevronBack, IoChevronForward } from "react-icons/io5";
@@ -97,11 +97,6 @@ export function GalleryArrowButton({
       <Icon aria-hidden />
     </button>
   );
-}
-
-/** Accessible name for a strip thumbnail (shared with the editor). */
-export function galleryThumbLabel(image: GalleryImage, i: number): string {
-  return `Show photo ${String(i + 1)}${image.alt ? `: ${image.alt}` : ""}`;
 }
 
 /**

--- a/apps/web/src/components/photo-gallery.tsx
+++ b/apps/web/src/components/photo-gallery.tsx
@@ -1,0 +1,191 @@
+import type { GalleryImage } from "@/lib/photo-gallery.js";
+import { cn } from "@/lib/utils.js";
+import { useEffect, useRef, useState } from "react";
+import { IoChevronBack, IoChevronForward } from "react-icons/io5";
+import { OptimisedImage } from "./optimised-image.js";
+
+// The photoGallery block's public rendering: one main photo above a
+// thumbnail strip with previous/next arrows. The stage, thumb and arrow
+// pieces are exported for the editor block, which rebuilds the same
+// layout with editing affordances (the PersonCardShell precedent).
+
+/**
+ * The main-photo area. A fixed 3:2 stage so a gallery of mixed
+ * portrait/landscape photos never jumps in height as the selection
+ * changes; the photo sizes naturally and centres, so the page
+ * background (not a letterbox slab) shows around portraits and the
+ * visible photo keeps the content-image rounded corners. The photo is
+ * absolutely positioned: in-flow content could stretch the stage past
+ * its aspect ratio (it's only a preferred height), abspos content
+ * cannot. `[&_picture]:contents` lifts the img out of its <picture>
+ * wrapper so the inset positioning resolves against the stage.
+ */
+export function GalleryStage({ image }: { image: GalleryImage }) {
+  return (
+    <div
+      aria-live="polite"
+      className="photo-gallery-stage relative aspect-[3/2] w-full [&_picture]:contents"
+    >
+      <OptimisedImage
+        picture={image.picture}
+        alt={image.alt ?? ""}
+        // h-auto/w-auto out-rank the width/height attributes so the
+        // max clamps scale the photo instead of squishing it.
+        className="absolute inset-0 m-auto h-auto max-h-full w-auto max-w-full rounded-lg shadow-md"
+        sizes="(max-width: 672px) 100vw, 672px"
+      />
+    </div>
+  );
+}
+
+/** A clickable strip thumbnail. The button carries the accessible name,
+ * so the thumbnail image itself is decorative. */
+export function GalleryThumbButton({
+  image,
+  label,
+  selected,
+  onSelect,
+  ref,
+}: {
+  image: GalleryImage;
+  label: string;
+  selected: boolean;
+  onSelect: () => void;
+  ref?: (el: HTMLButtonElement | null) => void;
+}) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-label={label}
+      aria-current={selected}
+      onClick={onSelect}
+      className={cn(
+        "photo-gallery-thumb h-16 w-24 shrink-0 overflow-hidden rounded-md",
+        selected
+          ? "ring-primary ring-2 ring-offset-1"
+          : "opacity-75 hover:opacity-100",
+      )}
+    >
+      <OptimisedImage
+        picture={image.picture}
+        alt=""
+        className="h-full w-full object-cover"
+        sizes="96px"
+      />
+    </button>
+  );
+}
+
+export function GalleryArrowButton({
+  direction,
+  label,
+  onClick,
+}: {
+  direction: "previous" | "next";
+  label: string;
+  onClick: () => void;
+}) {
+  const Icon = direction === "previous" ? IoChevronBack : IoChevronForward;
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      className="flex size-8 shrink-0 items-center justify-center rounded-full border border-stone-200 bg-white text-stone-600 shadow-sm hover:bg-stone-100 hover:text-stone-900"
+    >
+      <Icon aria-hidden />
+    </button>
+  );
+}
+
+/** Accessible name for a strip thumbnail (shared with the editor). */
+export function galleryThumbLabel(image: GalleryImage, i: number): string {
+  return `Show photo ${String(i + 1)}${image.alt ? `: ${image.alt}` : ""}`;
+}
+
+/**
+ * Public photo gallery. Arrows wrap around; clicking a thumbnail shows
+ * that photo on the stage. A single-photo gallery renders without the
+ * strip. Prerender-safe: the first photo and every thumbnail are in the
+ * initial markup, interaction arrives with hydration.
+ */
+export function PhotoGallery({ images }: { images: GalleryImage[] }) {
+  const [selected, setSelected] = useState(0);
+  const thumbRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  // Guards the scroll effect on mount: "nearest" would still scroll the
+  // page vertically to an offscreen gallery during initial load.
+  const mountedRef = useRef(false);
+  const count = images.length;
+  // Defensive clamp: state is internal so it can't normally exceed the
+  // array, but a stale index must never blank the stage.
+  const index = Math.min(selected, count - 1);
+  const current = images[index];
+
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+    thumbRefs.current[index]?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [index]);
+
+  if (!current) return null;
+
+  return (
+    <figure
+      role="group"
+      aria-roledescription="carousel"
+      aria-label="Photo gallery"
+      className="my-4 flex w-full max-w-2xl flex-col self-center"
+    >
+      <GalleryStage image={current} />
+      {current.caption && (
+        <figcaption className="mt-2 text-sm text-stone-600">
+          {current.caption}
+        </figcaption>
+      )}
+      {count > 1 && (
+        <div className="mt-2 flex items-center gap-2">
+          <GalleryArrowButton
+            direction="previous"
+            label="Previous photo"
+            onClick={() => {
+              setSelected((index - 1 + count) % count);
+            }}
+          />
+          {/* Position keys: a pure projection of immutable stored data,
+              same justification as the renderer's inline keys. p-1 keeps
+              the selection ring inside the scroll clip at the ends. */}
+          <div className="flex flex-1 gap-2 overflow-x-auto p-1">
+            {images.map((image, i) => (
+              <GalleryThumbButton
+                key={`thumb-${String(i)}`}
+                image={image}
+                label={galleryThumbLabel(image, i)}
+                selected={i === index}
+                onSelect={() => {
+                  setSelected(i);
+                }}
+                ref={(el) => {
+                  thumbRefs.current[i] = el;
+                }}
+              />
+            ))}
+          </div>
+          <GalleryArrowButton
+            direction="next"
+            label="Next photo"
+            onClick={() => {
+              setSelected((index + 1) % count);
+            }}
+          />
+        </div>
+      )}
+    </figure>
+  );
+}

--- a/apps/web/src/lib/photo-gallery.test.ts
+++ b/apps/web/src/lib/photo-gallery.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { parseGalleryImages } from "./photo-gallery.js";
+
+const picture = (id: string) => ({
+  sources: {
+    webp: `/uploads/content/${id}/320.webp 320w, /uploads/content/${id}/640.webp 640w`,
+  },
+  img: { src: `/uploads/content/${id}/640.jpg`, w: 640, h: 480 },
+});
+
+describe("parseGalleryImages", () => {
+  it("parses a valid images array, dropping empty alt/caption", () => {
+    const parsed = parseGalleryImages(
+      JSON.stringify([
+        { picture: picture("a"), alt: "The winning six", caption: "Scenes" },
+        { picture: picture("b"), alt: "", caption: "" },
+      ]),
+    );
+    expect(parsed).toEqual([
+      {
+        picture: picture("a"),
+        alt: "The winning six",
+        caption: "Scenes",
+      },
+      { picture: picture("b") },
+    ]);
+  });
+
+  it("strips unknown keys from stored descriptors", () => {
+    const parsed = parseGalleryImages(
+      JSON.stringify([{ picture: { ...picture("a"), extra: "junk" } }]),
+    );
+    expect(parsed).toEqual([{ picture: picture("a") }]);
+  });
+
+  it("returns null for absent, malformed or empty input", () => {
+    expect(parseGalleryImages(undefined)).toBeNull();
+    expect(parseGalleryImages("")).toBeNull();
+    expect(parseGalleryImages("not json")).toBeNull();
+    expect(parseGalleryImages('{"picture":{}}')).toBeNull();
+    expect(parseGalleryImages("[]")).toBeNull();
+  });
+
+  it("rejects the whole gallery when any entry is invalid", () => {
+    for (const bad of [
+      { alt: "no picture" },
+      { picture: { sources: {}, img: { src: "/x.jpg", w: 1 } } }, // no h
+      { picture: { sources: { webp: 5 }, img: { src: "/x.jpg", w: 1, h: 1 } } },
+      { picture: picture("a"), alt: 7 },
+      { picture: picture("a"), caption: false },
+    ]) {
+      expect(
+        parseGalleryImages(JSON.stringify([{ picture: picture("ok") }, bad])),
+      ).toBeNull();
+    }
+  });
+
+  it("rejects unsafe image urls anywhere in a descriptor", () => {
+    const unsafeImg = {
+      picture: {
+        sources: {},
+        img: { src: "javascript:alert(1)", w: 1, h: 1 },
+      },
+    };
+    const unsafeSrcset = {
+      picture: {
+        sources: { webp: "javascript:alert(1) 320w" },
+        img: { src: "/uploads/content/a/640.jpg", w: 640, h: 480 },
+      },
+    };
+    const plainHttp = {
+      picture: {
+        sources: {},
+        img: { src: "http://example.com/pixel.gif", w: 1, h: 1 },
+      },
+    };
+    for (const bad of [unsafeImg, unsafeSrcset, plainHttp]) {
+      expect(parseGalleryImages(JSON.stringify([bad]))).toBeNull();
+    }
+  });
+
+  it("keeps alt and caption verbatim (no trimming mid-typing)", () => {
+    const parsed = parseGalleryImages(
+      JSON.stringify([{ picture: picture("a"), caption: "Half a caption " }]),
+    );
+    expect(parsed?.[0]?.caption).toBe("Half a caption ");
+  });
+});

--- a/apps/web/src/lib/photo-gallery.ts
+++ b/apps/web/src/lib/photo-gallery.ts
@@ -1,0 +1,106 @@
+import type { PictureSource } from "@/components/optimised-image.js";
+
+// The photoGallery block's `images` prop: a JSON-stringified array of
+// { picture, alt?, caption? }, following the contentImage `picture`
+// JSON-string-prop precedent. Shared between the public renderer
+// (content-body.tsx) and the editor block (content-editor.tsx) so both
+// parse identically.
+
+export interface GalleryImage {
+  picture: PictureSource;
+  alt?: string;
+  caption?: string;
+}
+
+/**
+ * Mirrors the public renderer's isSafeImageSrc (and the shared package's
+ * SAFE_IMAGE_SRC): images render only from https or site-relative paths
+ * (uploads live under /uploads/*).
+ */
+const SAFE_IMAGE_SRC = /^(?:https:|\/(?!\/))/i;
+
+function safeSrcset(srcset: unknown): srcset is string {
+  if (typeof srcset !== "string") return false;
+  return srcset
+    .split(",")
+    .map((part) => part.trim().split(/\s+/)[0])
+    .every((url) => url !== undefined && SAFE_IMAGE_SRC.test(url));
+}
+
+/** Validate one stored picture descriptor, rebuilding it cleanly so no
+ * extra stored keys ride along. The descriptor is stored content, so
+ * every URL in it is checked - same rules as content-body's
+ * parsePicture. */
+function parsePictureValue(value: unknown): PictureSource | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as {
+    sources?: unknown;
+    img?: { src?: unknown; w?: unknown; h?: unknown };
+  };
+  if (
+    typeof candidate.img?.src !== "string" ||
+    !SAFE_IMAGE_SRC.test(candidate.img.src) ||
+    typeof candidate.img.w !== "number" ||
+    typeof candidate.img.h !== "number" ||
+    typeof candidate.sources !== "object" ||
+    candidate.sources === null
+  ) {
+    return null;
+  }
+  const sources: Record<string, string> = {};
+  for (const [format, srcset] of Object.entries(candidate.sources)) {
+    if (!safeSrcset(srcset)) return null;
+    sources[format] = srcset;
+  }
+  return {
+    sources,
+    img: {
+      src: candidate.img.src,
+      w: candidate.img.w,
+      h: candidate.img.h,
+    },
+  };
+}
+
+/**
+ * Parse a JSON-stringified photoGallery images prop. Returns null for
+ * anything that is not a wholly valid, non-empty array of
+ * { picture, alt?, caption? } - malformed stored content degrades to
+ * nothing, never crashes, per the renderer's conventions. Empty arrays
+ * are null so the renderer and editor agree on the empty state.
+ * Alt and caption are kept verbatim (the editor round-trips images
+ * through this parser on every keystroke); empty strings are dropped
+ * (NULL-for-unset).
+ */
+export function parseGalleryImages(
+  raw: string | undefined,
+): GalleryImage[] | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+
+  const images: GalleryImage[] = [];
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null) return null;
+    const { picture, alt, caption } = item as {
+      picture?: unknown;
+      alt?: unknown;
+      caption?: unknown;
+    };
+    const parsedPicture = parsePictureValue(picture);
+    if (parsedPicture === null) return null;
+    if (alt !== undefined && typeof alt !== "string") return null;
+    if (caption !== undefined && typeof caption !== "string") return null;
+    images.push({
+      picture: parsedPicture,
+      ...(alt ? { alt } : {}),
+      ...(caption ? { caption } : {}),
+    });
+  }
+  return images.length > 0 ? images : null;
+}

--- a/apps/web/src/lib/photo-gallery.ts
+++ b/apps/web/src/lib/photo-gallery.ts
@@ -12,6 +12,13 @@ export interface GalleryImage {
   caption?: string;
 }
 
+/** Accessible name for a gallery strip thumbnail. Shared by the public
+ * gallery and the editor block; lives here rather than in the component
+ * files so they only export components (Fast Refresh). */
+export function galleryThumbLabel(image: GalleryImage, i: number): string {
+  return `Show photo ${String(i + 1)}${image.alt ? `: ${image.alt}` : ""}`;
+}
+
 /**
  * Mirrors the public renderer's isSafeImageSrc (and the shared package's
  * SAFE_IMAGE_SRC): images render only from https or site-relative paths

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -71,6 +71,7 @@ import {
   parsePersonGridEntries,
   type PersonGridEntry,
 } from "@/lib/person-grid.js";
+import { parseGalleryImages, type GalleryImage } from "@/lib/photo-gallery.js";
 import { usePeopleList } from "@/lib/use-people.js";
 import { cn } from "@/lib/utils.js";
 import {
@@ -109,6 +110,10 @@ import {
   visibleNodes,
 } from "./pages-tab.lib.js";
 import { PersonEditor, PersonGridEditor } from "./person-editors.js";
+import {
+  PhotoGalleryEditor,
+  UploadConsentContext,
+} from "./photo-gallery-editor.js";
 import {
   blocksToLines,
   detailLines,
@@ -376,6 +381,39 @@ const contentImageBlock = createReactBlockSpec(
             </div>
           </BlockSettings>
         </figure>
+      );
+    },
+  },
+);
+
+const photoGalleryBlock = createReactBlockSpec(
+  {
+    type: CUSTOM_BLOCK_TYPES.photoGallery,
+    propSchema: {
+      // JSON-stringified [{picture, alt?, caption?}] built from the
+      // upload pipeline (the contentImage picture prop, pluralised).
+      images: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ block, editor }) => {
+      const images = parseGalleryImages(block.props.images) ?? [];
+      const write = (next: GalleryImage[]) => {
+        editor.updateBlock(block, {
+          props: {
+            ...block.props,
+            // Empty gallery stores "" (NULL-for-unset), which parses to
+            // null - the editor shows the dashed add-photos card and the
+            // public renderer hides the block.
+            images: next.length > 0 ? JSON.stringify(next) : "",
+          },
+        });
+      };
+      return (
+        <div className="my-2 w-full">
+          <PhotoGalleryEditor images={images} onWrite={write} />
+        </div>
       );
     },
   },
@@ -777,6 +815,7 @@ export const schema = BlockNoteSchema.create({
     [CUSTOM_BLOCK_TYPES.gamePreview]: gamePreviewBlock(),
     [CUSTOM_BLOCK_TYPES.eventPreview]: eventPreviewBlock(),
     [CUSTOM_BLOCK_TYPES.contentImage]: contentImageBlock(),
+    [CUSTOM_BLOCK_TYPES.photoGallery]: photoGalleryBlock(),
     [CUSTOM_BLOCK_TYPES.leagueTable]: leagueTableBlock(),
     [CUSTOM_BLOCK_TYPES.leaderboard]: leaderboardBlock(),
     [CUSTOM_BLOCK_TYPES.recordsWall]: recordsWallBlock(),
@@ -1336,6 +1375,18 @@ function buildSlashItems(editor: Editor, startImageUpload: () => void) {
       aliases: ["image", "photo", "picture"],
       icon: <span aria-hidden>📷</span>,
       onItemClick: startImageUpload,
+    },
+    {
+      title: "Photo gallery",
+      subtext: "A set of photos with a main view and thumbnail strip",
+      group: "Club content",
+      aliases: ["gallery", "photos", "album", "carousel", "slideshow"],
+      icon: <span aria-hidden>🖼️</span>,
+      onItemClick: () => {
+        insertOrUpdateBlockForSlashMenu(editor, {
+          type: CUSTOM_BLOCK_TYPES.photoGallery,
+        });
+      },
     },
     {
       title: "League table",
@@ -3566,6 +3617,55 @@ function ContentAiLauncher({
   );
 }
 
+/**
+ * The slash-menu "Upload photo" flow: consent gate -> hidden file input
+ * -> upload pipeline -> insert a contentImage block at the cursor. The
+ * caller renders the returned handlers onto its own <input type="file">.
+ */
+function useSlashImageUpload(editor: Editor, consentConfirmed: boolean) {
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const startImageUpload = () => {
+    setUploadError(null);
+    if (!consentConfirmed) {
+      setUploadError(
+        "Tick the photo consent box above before uploading images.",
+      );
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  const onFileChosen = async (file: File) => {
+    try {
+      const uploaded = await uploadContentImage(file, {});
+      const cursor = editor.getTextCursorPosition();
+      editor.insertBlocks(
+        [
+          {
+            type: CUSTOM_BLOCK_TYPES.contentImage,
+            props: {
+              src: uploaded.picture.img.src,
+              alt: "",
+              caption: "",
+              picture: JSON.stringify(uploaded.picture),
+            },
+          },
+        ],
+        cursor.block,
+        "after",
+      );
+    } catch (err) {
+      setUploadError(
+        err instanceof Error ? err.message : "Upload failed - try again",
+      );
+    }
+  };
+
+  return { uploadError, fileInputRef, startImageUpload, onFileChosen };
+}
+
 function LoadedEditor({
   kind,
   item,
@@ -3593,11 +3693,9 @@ function LoadedEditor({
     initialForm(item, newParentId),
   );
   const [consentConfirmed, setConsentConfirmed] = useState(false);
-  const [uploadError, setUploadError] = useState<string | null>(null);
   const [lastSavedAt, setLastSavedAt] = useState<string | null>(
     item?.updatedAt ?? null,
   );
-  const fileInputRef = useRef<HTMLInputElement>(null);
   // Whether the author has manually edited the slug (handler-only flag:
   // it never affects what's on screen, only how title edits behave).
   const slugTouchedRef = useRef(item !== null);
@@ -3709,42 +3807,8 @@ function LoadedEditor({
     [kind, queryClient],
   );
 
-  const startImageUpload = () => {
-    setUploadError(null);
-    if (!consentConfirmed) {
-      setUploadError(
-        "Tick the photo consent box above before uploading images.",
-      );
-      return;
-    }
-    fileInputRef.current?.click();
-  };
-
-  const onFileChosen = async (file: File) => {
-    try {
-      const uploaded = await uploadContentImage(file, {});
-      const cursor = editor.getTextCursorPosition();
-      editor.insertBlocks(
-        [
-          {
-            type: CUSTOM_BLOCK_TYPES.contentImage,
-            props: {
-              src: uploaded.picture.img.src,
-              alt: "",
-              caption: "",
-              picture: JSON.stringify(uploaded.picture),
-            },
-          },
-        ],
-        cursor.block,
-        "after",
-      );
-    } catch (err) {
-      setUploadError(
-        err instanceof Error ? err.message : "Upload failed - try again",
-      );
-    }
-  };
+  const { uploadError, fileInputRef, startImageUpload, onFileChosen } =
+    useSlashImageUpload(editor, consentConfirmed);
 
   const slashItems = () => buildSlashItems(editor, startImageUpload);
 
@@ -3853,13 +3917,18 @@ function LoadedEditor({
         </div>
 
         <div className="lg:col-span-2">
-          <EditorPane
-            editor={editor}
-            slashItems={slashItems}
-            onDirty={() => {
-              dirtyRef.current = true;
-            }}
-          />
+          {/* Blocks with their own upload affordance (photo gallery)
+              read the consent tick through context - they render inside
+              the BlockNote canvas and can't take page props. */}
+          <UploadConsentContext.Provider value={consentConfirmed}>
+            <EditorPane
+              editor={editor}
+              slashItems={slashItems}
+              onDirty={() => {
+                dirtyRef.current = true;
+              }}
+            />
+          </UploadConsentContext.Provider>
         </div>
       </div>
     </div>

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -110,16 +110,14 @@ import {
   visibleNodes,
 } from "./pages-tab.lib.js";
 import { PersonEditor, PersonGridEditor } from "./person-editors.js";
-import {
-  PhotoGalleryEditor,
-  UploadConsentContext,
-} from "./photo-gallery-editor.js";
+import { PhotoGalleryEditor } from "./photo-gallery-editor.js";
 import {
   blocksToLines,
   detailLines,
   diffLines,
   type DiffLine,
 } from "./revision-diff.js";
+import { UploadConsentContext } from "./upload-consent-context.js";
 
 // ── Custom blocks ───────────────────────────────────────────────────────
 //

--- a/apps/web/src/pages/admin/photo-gallery-editor.test.tsx
+++ b/apps/web/src/pages/admin/photo-gallery-editor.test.tsx
@@ -2,10 +2,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import type { GalleryImage } from "@/lib/photo-gallery.js";
-import {
-  PhotoGalleryEditor,
-  UploadConsentContext,
-} from "./photo-gallery-editor.js";
+import { PhotoGalleryEditor } from "./photo-gallery-editor.js";
+import { UploadConsentContext } from "./upload-consent-context.js";
 
 const image = (
   id: string,

--- a/apps/web/src/pages/admin/photo-gallery-editor.test.tsx
+++ b/apps/web/src/pages/admin/photo-gallery-editor.test.tsx
@@ -1,0 +1,85 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { GalleryImage } from "@/lib/photo-gallery.js";
+import {
+  PhotoGalleryEditor,
+  UploadConsentContext,
+} from "./photo-gallery-editor.js";
+
+const image = (
+  id: string,
+  extras: Partial<GalleryImage> = {},
+): GalleryImage => ({
+  picture: {
+    sources: {
+      webp: `/uploads/content/${id}/320.webp 320w`,
+    },
+    img: { src: `/uploads/content/${id}/640.jpg`, w: 640, h: 480 },
+  },
+  ...extras,
+});
+
+function renderGallery(images: GalleryImage[]): string {
+  return renderToStaticMarkup(
+    <UploadConsentContext.Provider value={false}>
+      <PhotoGalleryEditor
+        images={images}
+        onWrite={() => {
+          /* static render - never fired */
+        }}
+      />
+    </UploadConsentContext.Provider>,
+  );
+}
+
+describe("PhotoGalleryEditor", () => {
+  it("renders only the dashed add-photos card for an empty gallery", () => {
+    const html = renderGallery([]);
+    expect(html).toContain('aria-label="Add photos to the gallery"');
+    expect(html).toContain("Add photos");
+    expect(html).not.toContain("Caption for photo");
+  });
+
+  it("renders the selected photo's stage, caption input and toolbar", () => {
+    const html = renderGallery([
+      image("a", { alt: "The winning six", caption: "Scenes" }),
+      image("b"),
+    ]);
+    expect(html).toContain('src="/uploads/content/a/640.jpg"');
+    expect(html).toContain('aria-label="Caption for photo 1"');
+    expect(html).toContain('value="Scenes"');
+    expect(html).toContain("Photo 1 of 2");
+    expect(html).toContain("Move left");
+    expect(html).toContain("Move right");
+    expect(html).toContain("Remove photo");
+    expect(html).not.toContain("undefined");
+  });
+
+  it("renders a selectable thumbnail per photo plus the add tile", () => {
+    const html = renderGallery([
+      image("a", { alt: "The winning six" }),
+      image("b"),
+    ]);
+    expect(html).toContain('aria-label="Show photo 1: The winning six"');
+    expect(html).toContain('aria-label="Show photo 2"');
+    expect(html).toContain('aria-label="Add photos to the gallery"');
+  });
+
+  it("marks the selected thumbnail with aria-current", () => {
+    const html = renderGallery([image("a"), image("b")]);
+    expect(html).toContain('aria-current="true"');
+  });
+
+  it("disables both move buttons for a single-photo gallery", () => {
+    const html = renderGallery([image("a")]);
+    // Exactly the two move buttons are disabled: a lone photo can't
+    // move, and the add tile stays enabled.
+    expect(html.match(/disabled=""/g)).toHaveLength(2);
+  });
+
+  it("exposes the alt text field behind the settings gear", () => {
+    const html = renderGallery([image("a", { alt: "The winning six" })]);
+    expect(html).toContain('aria-label="Photo settings"');
+  });
+});

--- a/apps/web/src/pages/admin/photo-gallery-editor.tsx
+++ b/apps/web/src/pages/admin/photo-gallery-editor.tsx
@@ -1,0 +1,264 @@
+import {
+  GalleryStage,
+  GalleryThumbButton,
+  galleryThumbLabel,
+} from "@/components/photo-gallery.js";
+import { Button } from "@/components/ui/button.js";
+import { Input } from "@/components/ui/input.js";
+import { Label } from "@/components/ui/label.js";
+import { uploadContentImage } from "@/lib/content-images.js";
+import type { GalleryImage } from "@/lib/photo-gallery.js";
+import { createContext, use, useId, useRef, useState } from "react";
+import {
+  BlockSettings,
+  EMPTY_CARD_CLASSES,
+  EmptyCardPrompt,
+  INLINE_TEXT_INPUT_CLASSES,
+} from "./block-controls.js";
+import { EditorBlockPreview } from "./editor-block-preview.js";
+
+// WYSIWYG editor for the photoGallery block: the rendered gallery is the
+// editor (the person grid precedent). The stage shows the selected photo
+// with its caption edited in place; thumbnails select; a toolbar under
+// the caption reorders and removes; the trailing dashed tile uploads
+// more photos through the standard consent + EXIF-strip pipeline.
+
+/**
+ * Whether the author has ticked the photo consent box. Provided by the
+ * editor page around the BlockNote canvas; block components can't take
+ * props from the page, so consent reaches the gallery's upload tile via
+ * context (the same way blocks reach react-query).
+ */
+export const UploadConsentContext = createContext(false);
+
+/** Thumb-sized dashed tile that adds photos to the gallery. */
+function AddPhotosTile({
+  uploading,
+  onClick,
+}: {
+  uploading: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label="Add photos to the gallery"
+      disabled={uploading}
+      onClick={onClick}
+      className="flex h-16 w-24 shrink-0 flex-col items-center justify-center rounded-md border-2 border-dashed border-stone-300 text-stone-500 hover:border-stone-400 hover:bg-stone-50"
+    >
+      {uploading ? (
+        <span className="text-xs">Uploading…</span>
+      ) : (
+        <span aria-hidden className="text-2xl leading-none text-stone-400">
+          +
+        </span>
+      )}
+    </button>
+  );
+}
+
+/** Drop empty alt/caption rather than storing "" (NULL-for-unset). */
+function normalise(image: GalleryImage): GalleryImage {
+  return {
+    picture: image.picture,
+    ...(image.alt ? { alt: image.alt } : {}),
+    ...(image.caption ? { caption: image.caption } : {}),
+  };
+}
+
+export function PhotoGalleryEditor({
+  images,
+  onWrite,
+}: {
+  images: GalleryImage[];
+  onWrite: (next: GalleryImage[]) => void;
+}) {
+  const consentConfirmed = use(UploadConsentContext);
+  const [selected, setSelected] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const altInputId = useId();
+
+  const count = images.length;
+  // Selection outlives removals: clamp rather than reset.
+  const index = Math.min(selected, Math.max(count - 1, 0));
+  const current = images[index];
+
+  const startUpload = () => {
+    setError(null);
+    if (!consentConfirmed) {
+      setError("Tick the photo consent box above before uploading images.");
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  const onFilesChosen = async (files: File[]) => {
+    setUploading(true);
+    setError(null);
+    // allSettled keeps selection order and, on a partial failure, keeps
+    // the photos that did upload while surfacing the first error.
+    const results = await Promise.allSettled(
+      files.map((file) => uploadContentImage(file, {})),
+    );
+    const added: GalleryImage[] = [];
+    let failure: unknown = null;
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        added.push({ picture: result.value.picture });
+      } else {
+        failure ??= result.reason;
+      }
+    }
+    if (failure !== null) {
+      setError(
+        failure instanceof Error
+          ? failure.message
+          : "Upload failed - try again",
+      );
+    }
+    setUploading(false);
+    if (added.length > 0) {
+      onWrite([...images, ...added]);
+      setSelected(count);
+    }
+  };
+
+  const updateImage = (i: number, updates: Partial<GalleryImage>) => {
+    onWrite(
+      images.map((image, j) =>
+        j === i ? normalise({ ...image, ...updates }) : image,
+      ),
+    );
+  };
+
+  const move = (from: number, to: number) => {
+    if (to < 0 || to >= count) return;
+    const next = [...images];
+    const [moved] = next.splice(from, 1);
+    if (!moved) return;
+    next.splice(to, 0, moved);
+    onWrite(next);
+    setSelected(to);
+  };
+
+  const remove = (i: number) => {
+    onWrite(images.filter((_, j) => j !== i));
+    setSelected(Math.min(index, Math.max(count - 2, 0)));
+  };
+
+  return (
+    <div className="relative w-full">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          const files = Array.from(e.target.files ?? []);
+          e.target.value = "";
+          if (files.length > 0) void onFilesChosen(files);
+        }}
+      />
+
+      {current ? (
+        <>
+          <EditorBlockPreview>
+            <GalleryStage image={current} />
+          </EditorBlockPreview>
+          {/* Edited in place, styled like the public figcaption. */}
+          <input
+            aria-label={`Caption for photo ${String(index + 1)}`}
+            placeholder="Add a caption for this photo (optional)…"
+            value={current.caption ?? ""}
+            onChange={(e) => {
+              updateImage(index, { caption: e.target.value });
+            }}
+            className={INLINE_TEXT_INPUT_CLASSES("mt-2 text-sm text-stone-600")}
+          />
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <span className="text-xs text-stone-500">
+              Photo {index + 1} of {count}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={index === 0}
+              onClick={() => {
+                move(index, index - 1);
+              }}
+            >
+              Move left
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={index === count - 1}
+              onClick={() => {
+                move(index, index + 1);
+              }}
+            >
+              Move right
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                remove(index);
+              }}
+            >
+              Remove photo
+            </Button>
+          </div>
+          <div className="mt-2 flex gap-2 overflow-x-auto p-1">
+            {images.map((image, i) => (
+              <GalleryThumbButton
+                key={`thumb-${String(i)}`}
+                image={image}
+                label={galleryThumbLabel(image, i)}
+                selected={i === index}
+                onSelect={() => {
+                  setSelected(i);
+                }}
+              />
+            ))}
+            <AddPhotosTile uploading={uploading} onClick={startUpload} />
+          </div>
+          <BlockSettings label="Photo settings" title="Photo">
+            <div className="flex flex-col gap-1">
+              <Label htmlFor={altInputId}>
+                Alt text for photo {index + 1} (screen readers)
+              </Label>
+              <Input
+                id={altInputId}
+                placeholder="Describe the photo"
+                value={current.alt ?? ""}
+                onChange={(e) => {
+                  updateImage(index, { alt: e.target.value });
+                }}
+              />
+              <span className="text-xs text-stone-500">
+                Read aloud by screen readers - not shown on the page.
+              </span>
+            </div>
+          </BlockSettings>
+        </>
+      ) : (
+        <button
+          type="button"
+          aria-label="Add photos to the gallery"
+          disabled={uploading}
+          onClick={startUpload}
+          className={EMPTY_CARD_CLASSES}
+        >
+          <EmptyCardPrompt prompt={uploading ? "Uploading…" : "Add photos"} />
+        </button>
+      )}
+
+      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin/photo-gallery-editor.tsx
+++ b/apps/web/src/pages/admin/photo-gallery-editor.tsx
@@ -1,14 +1,13 @@
 import {
   GalleryStage,
   GalleryThumbButton,
-  galleryThumbLabel,
 } from "@/components/photo-gallery.js";
 import { Button } from "@/components/ui/button.js";
 import { Input } from "@/components/ui/input.js";
 import { Label } from "@/components/ui/label.js";
 import { uploadContentImage } from "@/lib/content-images.js";
-import type { GalleryImage } from "@/lib/photo-gallery.js";
-import { createContext, use, useId, useRef, useState } from "react";
+import { galleryThumbLabel, type GalleryImage } from "@/lib/photo-gallery.js";
+import { use, useId, useRef, useState } from "react";
 import {
   BlockSettings,
   EMPTY_CARD_CLASSES,
@@ -16,20 +15,13 @@ import {
   INLINE_TEXT_INPUT_CLASSES,
 } from "./block-controls.js";
 import { EditorBlockPreview } from "./editor-block-preview.js";
+import { UploadConsentContext } from "./upload-consent-context.js";
 
 // WYSIWYG editor for the photoGallery block: the rendered gallery is the
 // editor (the person grid precedent). The stage shows the selected photo
 // with its caption edited in place; thumbnails select; a toolbar under
 // the caption reorders and removes; the trailing dashed tile uploads
 // more photos through the standard consent + EXIF-strip pipeline.
-
-/**
- * Whether the author has ticked the photo consent box. Provided by the
- * editor page around the BlockNote canvas; block components can't take
- * props from the page, so consent reaches the gallery's upload tile via
- * context (the same way blocks reach react-query).
- */
-export const UploadConsentContext = createContext(false);
 
 /** Thumb-sized dashed tile that adds photos to the gallery. */
 function AddPhotosTile({
@@ -108,8 +100,8 @@ export function PhotoGalleryEditor({
     for (const result of results) {
       if (result.status === "fulfilled") {
         added.push({ picture: result.value.picture });
-      } else {
-        failure ??= result.reason;
+      } else if (failure === null) {
+        failure = result.reason;
       }
     }
     if (failure !== null) {

--- a/apps/web/src/pages/admin/revision-diff.test.ts
+++ b/apps/web/src/pages/admin/revision-diff.test.ts
@@ -126,6 +126,20 @@ describe("blocksToLines", () => {
         block("contentImage", { alt: "x", caption: "", src: "/uploads/b.jpg" }),
       ),
     );
+    // A caption change inside a photo gallery (images is canonical)
+    expect(
+      blocksToLines(
+        block("photoGallery", {
+          images: '[{"picture":{},"caption":"Before"}]',
+        }),
+      ),
+    ).not.toEqual(
+      blocksToLines(
+        block("photoGallery", {
+          images: '[{"picture":{},"caption":"After"}]',
+        }),
+      ),
+    );
     // An event preview repointed at a different event, same display name
     expect(
       blocksToLines(

--- a/apps/web/src/pages/admin/revision-diff.ts
+++ b/apps/web/src/pages/admin/revision-diff.ts
@@ -130,6 +130,12 @@ function blockLines(block: unknown, depth: number): string[] {
       );
       break;
     }
+    case CUSTOM_BLOCK_TYPES.photoGallery: {
+      // The raw images JSON covers every render-relevant prop in one
+      // string: photo identity, order, alts and captions all diff.
+      lines.push(`${indent}[Photo gallery: ${stringProp(props, "images")}]`);
+      break;
+    }
     case CUSTOM_BLOCK_TYPES.gamePreview:
       lines.push(
         `${indent}[Game preview: ${stringProp(props, "playCricketId")}]`,

--- a/apps/web/src/pages/admin/upload-consent-context.ts
+++ b/apps/web/src/pages/admin/upload-consent-context.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+/**
+ * Whether the author has ticked the photo consent box. Provided by the
+ * editor page around the BlockNote canvas; block components can't take
+ * props from the page, so consent reaches blocks with their own upload
+ * affordance (the photo gallery's add-photos tile) via context - the
+ * same way blocks reach react-query. Lives outside the component files
+ * so Fast Refresh can preserve their state.
+ */
+export const UploadConsentContext = createContext(false);

--- a/apps/web/src/prerender/build-head.test.ts
+++ b/apps/web/src/prerender/build-head.test.ts
@@ -127,6 +127,47 @@ describe("buildHead", () => {
       );
     });
 
+    it("uses the first photoGallery photo as the lead OG image", () => {
+      const head = buildHead({
+        ...news,
+        body: [
+          { id: "1", type: "paragraph", props: {}, children: [] },
+          {
+            id: "2",
+            type: "photoGallery",
+            props: {
+              images: JSON.stringify([
+                {
+                  picture: {
+                    sources: {},
+                    img: {
+                      src: "/uploads/content/g1/1280.webp",
+                      w: 1280,
+                      h: 853,
+                    },
+                  },
+                },
+                {
+                  picture: {
+                    sources: {},
+                    img: {
+                      src: "/uploads/content/g2/1280.webp",
+                      w: 1280,
+                      h: 853,
+                    },
+                  },
+                },
+              ]),
+            },
+            children: [],
+          },
+        ],
+      });
+      expect(head).toContain(
+        `<meta property="og:image" content="${ORIGIN}/uploads/content/g1/1280.webp" />`,
+      );
+    });
+
     it("falls back to plain src when the picture descriptor is malformed", () => {
       const head = buildHead({
         ...news,

--- a/apps/web/src/prerender/build-head.ts
+++ b/apps/web/src/prerender/build-head.ts
@@ -63,8 +63,9 @@ function absolutize(src: string, origin: string): string {
 
 /**
  * Lead image for a news article: the first contentImage block's picture
- * fallback (or plain src). Walks top-level blocks only - a lead image
- * nested inside another block isn't a lead image.
+ * fallback (or plain src), or the first photo of the first photoGallery
+ * block - whichever block comes first. Walks top-level blocks only - a
+ * lead image nested inside another block isn't a lead image.
  */
 function findLeadImage(body: unknown): string | undefined {
   if (typeof body !== "object" || body === null) return undefined;
@@ -73,25 +74,37 @@ function findLeadImage(body: unknown): string | undefined {
     : (body as { blocks?: unknown }).blocks;
   if (!Array.isArray(blocks)) return undefined;
   for (const block of blocks) {
-    if (
-      typeof block !== "object" ||
-      block === null ||
-      (block as { type?: unknown }).type !== "contentImage"
-    ) {
-      continue;
-    }
+    if (typeof block !== "object" || block === null) continue;
+    const type = (block as { type?: unknown }).type;
     const props = (block as { props?: Record<string, unknown> }).props ?? {};
-    if (typeof props.picture === "string" && props.picture) {
-      try {
-        const picture = JSON.parse(props.picture) as {
-          img?: { src?: unknown };
-        };
-        if (typeof picture.img?.src === "string") return picture.img.src;
-      } catch {
-        // fall through to plain src
+    if (type === "contentImage") {
+      if (typeof props.picture === "string" && props.picture) {
+        try {
+          const picture = JSON.parse(props.picture) as {
+            img?: { src?: unknown };
+          };
+          if (typeof picture.img?.src === "string") return picture.img.src;
+        } catch {
+          // fall through to plain src
+        }
+      }
+      if (typeof props.src === "string" && props.src) return props.src;
+    }
+    if (type === "photoGallery") {
+      if (typeof props.images === "string" && props.images) {
+        try {
+          const images = JSON.parse(props.images) as Array<{
+            picture?: { img?: { src?: unknown } };
+          }>;
+          const first = Array.isArray(images) ? images[0] : undefined;
+          if (typeof first?.picture?.img?.src === "string") {
+            return first.picture.img.src;
+          }
+        } catch {
+          // a malformed gallery is never a lead image
+        }
       }
     }
-    if (typeof props.src === "string" && props.src) return props.src;
   }
   return undefined;
 }

--- a/packages/shared/src/content/block-catalog.ts
+++ b/packages/shared/src/content/block-catalog.ts
@@ -174,6 +174,14 @@ export const BLOCK_CATALOG: readonly BlockCatalogEntry[] = [
     }),
   },
   {
+    type: CUSTOM_BLOCK_TYPES.photoGallery,
+    description:
+      "A photo gallery: one main photo with a thumbnail strip. NOT author-writable - photos must go through the editor's upload pipeline.",
+    contentKind: "none",
+    agentWritable: false,
+    propsSchema: z.object({ images: z.string().optional() }),
+  },
+  {
     type: CUSTOM_BLOCK_TYPES.leagueTable,
     description:
       "A live league standings table. `divisionId` is the Play-Cricket division id (find it via the pc_* tools); `name` is an optional heading.",

--- a/packages/shared/src/content/block-types.ts
+++ b/packages/shared/src/content/block-types.ts
@@ -30,6 +30,11 @@ export const CUSTOM_BLOCK_TYPES = {
   // descriptor from the upload API so public pages render the responsive
   // ladder without any lookup.
   contentImage: "contentImage",
+  // A set of uploaded photos rendered as one main photo above a clickable
+  // thumbnail strip. props.images carries a JSON-stringified array of
+  // { picture, alt?, caption? } where picture is the upload API's
+  // PictureSource descriptor (the contentImage precedent, pluralised).
+  photoGallery: "photoGallery",
   leagueTable: "leagueTable",
   leaderboard: "leaderboard",
   recordsWall: "recordsWall",


### PR DESCRIPTION
## What

A new `photoGallery` custom content block: one main photo with a strip of thumbnails below it. Left/right arrows (wrap-around) or clicking a thumbnail swaps the main photo.

### Public rendering

- Fixed 3:2 stage so mixed portrait/landscape galleries never jump in height; the photo sizes naturally and centres, so the page background shows around portraits (no letterbox slab) and the visible photo keeps rounded corners plus a small shadow (an explicit exception to the fc-theme content flattening - it reads as a print laid on the page).
- Per-photo caption under the stage; selected thumbnail is ringed and scrolled into view; single-photo galleries render without the strip.
- Prerender-safe: first photo and all thumbnails are in the initial markup, interaction arrives with the SPA.

### Editor (WYSIWYG, person-grid pattern)

- The rendered gallery is the editor: thumbnails select, caption edited in place, per-photo alt text behind the settings gear, toolbar for move left/right + remove.
- Trailing dashed tile uploads photos (multi-select, parallel) through the existing consent + EXIF-strip + responsive-ladder pipeline. Consent state reaches the block via a context around the BlockNote canvas.
- Slash menu: "Photo gallery" under Club content.

### Storage and safety

- `props.images` is a JSON-stringified `[{picture, alt?, caption?}]` (the contentImage `picture` precedent, pluralised), parsed all-or-nothing by a shared parser that enforces the renderer's https/site-relative URL rules on every src and srcset entry.
- Catalog entry is `agentWritable: false` (the AI author cannot drive uploads), keeping the block-catalog sync test green.

### Supporting changes

- News OG lead image: a gallery's first photo now counts, in document order with contentImage.
- Revision diff renders a `[Photo gallery: ...]` label covering every render-relevant prop.
- Extracted `useSlashImageUpload` from `LoadedEditor` (size lint).

## Test plan

- Unit tests: parser (URL safety, malformed input, verbatim captions), public renderer (stage + thumbs, single-photo, malformed/unsafe hidden, all-blocks fixture), editor markup, build-head lead image, revision diff coverage.
- Verified end-to-end against the local stack: created a news article, inserted the block via the slash menu, uploaded photos, and exercised the public page (thumbnail swap, arrows, portrait letterboxing, fixed stage height, rounded corners + shadow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)