### PR TITLE
feat(games): homepage scoreboard with recent results and live scores

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -95,6 +95,9 @@ VAPID_SUBJECT=mailto:support@notifications.percymain.org
 SLACK_WEBHOOK_URL=
 PLAY_CRICKET_API_TOKEN=
 PLAY_CRICKET_SITE_ID=
+# Optional override; defaults to the real Play Cricket API. Point at a local
+# mock server to exercise the games feature (incl. live scores) offline.
+# PLAY_CRICKET_API_BASE=http://localhost:4010
 
 # Scout (AI analyst — alex-only)
 # Run `pnpm --filter @percy-main/db db:setup-scout` to create the local

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -226,6 +226,9 @@ const configSchema = z.object({
   SLACK_WEBHOOK_URL: z.url().optional(),
   PLAY_CRICKET_API_TOKEN: z.string().optional(),
   PLAY_CRICKET_SITE_ID: z.string().optional(),
+  // Defaulted so it never needs setting in real environments; overridable
+  // locally to point the games feature at a mock Play Cricket server.
+  PLAY_CRICKET_API_BASE: z.url().default("https://www.play-cricket.com/api/v2"),
 
   // Google Ads (offline conversion uploads)
   GOOGLE_ADS_DEVELOPER_TOKEN: z.string().optional(),

--- a/apps/api/src/features/games/recent.test.ts
+++ b/apps/api/src/features/games/recent.test.ts
@@ -573,6 +573,62 @@ describe("listRecentGames", () => {
     expect(result.items[1]).toMatchObject({ id: "2" });
   });
 
+  it("orders a just-finished morning game below a later same-day result", async () => {
+    // 21:30 London. The 10:00 junior game's result is only on match_detail;
+    // the 18:00 midweek game already reached result_summary. Newest first.
+    const now = new Date("2040-07-04T20:30:00Z");
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          summaryMatch({
+            id: 81,
+            season: "2040",
+            match_date: "04/07/2040",
+            match_time: "10:00",
+          }),
+        ],
+      }),
+      getResultSummary: vi.fn().mockResolvedValue({
+        result_summary: [
+          resultRow({
+            id: 3,
+            match_date: "04/07/2040",
+            match_time: "18:00",
+          }),
+        ],
+      }),
+      getLiveMatchDetail: vi.fn().mockResolvedValue({
+        match_details: [
+          liveDetail({
+            id: 81,
+            result: "W",
+            result_description: "Percy Main CC - 1st XI - Won",
+            result_applied_to: "68498",
+            innings: [
+              {
+                team_batting_id: "80273",
+                runs: "143",
+                wickets: "10",
+                overs: "38.1",
+                declared: false,
+              },
+              {
+                team_batting_id: "68498",
+                runs: "144",
+                wickets: "5",
+                overs: "31.2",
+                declared: false,
+              },
+            ],
+          }),
+        ],
+      }),
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+    expect(result.items.map((item) => item.id)).toEqual(["3", "81"]);
+  });
+
   it("degrades to live-without-score when the detail call fails", async () => {
     const now = new Date("2037-07-04T14:00:00Z");
     const api = createMockApi({

--- a/apps/api/src/features/games/recent.test.ts
+++ b/apps/api/src/features/games/recent.test.ts
@@ -1,0 +1,626 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
+import {
+  buildResultNote,
+  listRecentGames,
+  londonNow,
+  parseTimeToMinutes,
+  type RecentGameInnings,
+} from "./recent.ts";
+
+const SITE_ID = "134";
+
+// The module-level match-summary cache in service.ts is keyed by season
+// with a 30-minute TTL, so every listRecentGames test pins its own year
+// to keep Play Cricket fixtures isolated within this run.
+
+function summaryMatch(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7000001,
+    status: "New",
+    published: "Yes",
+    last_updated: "01/07/2030",
+    season: "2030",
+    match_date: "01/07/2030",
+    match_time: "13:00",
+    league_name: "NTCL",
+    league_id: "15363",
+    competition_name: "Division 4 North",
+    competition_id: "135699",
+    competition_type: "League",
+    game_type: "Standard",
+    ground_name: "St Johns Terrace",
+    home_club_name: "Percy Main CC",
+    home_team_name: "1st XI",
+    home_team_id: "68498",
+    home_club_id: SITE_ID,
+    away_club_name: "Mitford CC",
+    away_team_name: "1st XI",
+    away_team_id: "80273",
+    away_club_id: "4385",
+    ...overrides,
+  };
+}
+
+function resultRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7000001,
+    status: "New",
+    published: "Yes",
+    last_updated: "02/07/2030",
+    league_name: "NTCL",
+    league_id: "15363",
+    competition_name: "Division 4 North",
+    competition_id: "135699",
+    competition_type: "League",
+    match_type: "Limited Overs",
+    game_type: "Standard",
+    match_date: "01/07/2030",
+    match_time: "13:00",
+    home_team_name: "1st XI",
+    home_team_id: "68498",
+    home_club_name: "Percy Main CC",
+    home_club_id: SITE_ID,
+    away_team_name: "1st XI",
+    away_team_id: "80273",
+    away_club_name: "Mitford CC",
+    away_club_id: "4385",
+    batted_first: "68498",
+    result: "W",
+    result_description: "Percy Main CC - 1st XI - Won",
+    result_applied_to: "68498",
+    innings: [
+      {
+        team_batting_id: "68498",
+        innings_number: 1,
+        runs: "220",
+        wickets: "6",
+        overs: "45.0",
+        declared: false,
+        forfeited_innings: false,
+      },
+      {
+        team_batting_id: "80273",
+        innings_number: 1,
+        runs: "180",
+        wickets: "10",
+        overs: "41.3",
+        declared: false,
+        forfeited_innings: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function liveDetail(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7000001,
+    home_team_name: "1st XI",
+    home_team_id: "68498",
+    home_club_name: "Percy Main CC",
+    home_club_id: SITE_ID,
+    away_team_name: "1st XI",
+    away_team_id: "80273",
+    away_club_name: "Mitford CC",
+    away_club_id: "4385",
+    result: "",
+    result_description: "",
+    result_applied_to: "",
+    game_type: "Standard",
+    match_type: "Limited Overs",
+    innings: [],
+    ...overrides,
+  };
+}
+
+function createMockApi(
+  overrides: Partial<PlayCricketApiClient> = {},
+): PlayCricketApiClient {
+  return {
+    getTeams: vi.fn().mockResolvedValue({ teams: [] }),
+    getMatchesSummary: vi.fn().mockResolvedValue({ matches: [] }),
+    getMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
+    getLiveMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
+    getPlayers: vi.fn().mockResolvedValue({ players: [] }),
+    getLeagueTable: vi.fn().mockResolvedValue({}),
+    getMatchesForSite: vi.fn().mockResolvedValue({ matches: [] }),
+    getResultSummaryForSite: vi.fn().mockResolvedValue({ result_summary: [] }),
+    getResultSummary: vi.fn().mockResolvedValue({ result_summary: [] }),
+    ...overrides,
+  };
+}
+
+const log = {
+  warn: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as never;
+
+describe("londonNow", () => {
+  it("reports London wall-clock during BST", () => {
+    const t = londonNow(new Date("2030-07-06T13:30:00Z"));
+    expect(t).toEqual({
+      datePc: "06/07/2030",
+      minutes: 14 * 60 + 30,
+      year: 2030,
+    });
+  });
+
+  it("reports London wall-clock during GMT", () => {
+    const t = londonNow(new Date("2030-01-06T13:30:00Z"));
+    expect(t).toEqual({
+      datePc: "06/01/2030",
+      minutes: 13 * 60 + 30,
+      year: 2030,
+    });
+  });
+});
+
+describe("parseTimeToMinutes", () => {
+  it("parses HH:mm", () => {
+    expect(parseTimeToMinutes("13:00")).toBe(780);
+    expect(parseTimeToMinutes("9:30")).toBe(570);
+  });
+  it("rejects junk", () => {
+    expect(parseTimeToMinutes("")).toBeNull();
+    expect(parseTimeToMinutes(null)).toBeNull();
+    expect(parseTimeToMinutes("1pm")).toBeNull();
+  });
+});
+
+describe("buildResultNote", () => {
+  const inn = (
+    teamBattingId: string,
+    runs: number,
+    wickets: number,
+  ): RecentGameInnings => ({
+    teamBattingId,
+    teamName: "T" + teamBattingId,
+    runs,
+    wickets,
+    overs: "40.0",
+    declared: false,
+    allOut: wickets >= 10,
+  });
+
+  it("winner batting second: wickets margin", () => {
+    expect(
+      buildResultNote(
+        "W",
+        "Standard",
+        [inn("A", 143, 10), inn("B", 144, 5)],
+        "B",
+      ),
+    ).toBe("Won by 5 wickets");
+  });
+
+  it("singular wicket", () => {
+    expect(
+      buildResultNote(
+        "L",
+        "Standard",
+        [inn("A", 185, 10), inn("B", 188, 9)],
+        "B",
+      ),
+    ).toBe("Lost by 1 wicket");
+  });
+
+  it("winner batting first: runs margin", () => {
+    expect(
+      buildResultNote(
+        "W",
+        "Standard",
+        [inn("A", 220, 6), inn("B", 180, 10)],
+        "A",
+      ),
+    ).toBe("Won by 40 runs");
+  });
+
+  it("fixed outcomes", () => {
+    expect(buildResultNote("A", "Standard", [], "")).toBe("Abandoned");
+    expect(buildResultNote("C", "Standard", [], "")).toBe("Cancelled");
+    expect(buildResultNote("N", "Standard", [], "")).toBe("No result");
+    expect(buildResultNote("D", "Standard", [], "")).toBe("Match drawn");
+    expect(buildResultNote("T", "Standard", [], "")).toBe("Match tied");
+  });
+
+  it("no margin for Pairs, odd innings counts, or unknown winner", () => {
+    expect(
+      buildResultNote("W", "Pairs", [inn("A", 64, 2), inn("B", 60, 3)], "A"),
+    ).toBeNull();
+    expect(buildResultNote("W", "Standard", [inn("A", 64, 2)], "A")).toBeNull();
+    expect(
+      buildResultNote("W", "Standard", [inn("A", 64, 2), inn("B", 60, 3)], ""),
+    ).toBeNull();
+  });
+});
+
+describe("listRecentGames", () => {
+  it("returns the most recent results, newest first", async () => {
+    // Quiet Wednesday, no games today.
+    const now = new Date("2030-07-10T10:00:00Z");
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({ matches: [] }),
+      getResultSummary: vi.fn().mockResolvedValue({
+        result_summary: [
+          resultRow({ id: 1, match_date: "28/06/2030" }),
+          resultRow({
+            id: 2,
+            match_date: "06/07/2030",
+            match_time: "18:00",
+            result_applied_to: "80273",
+            result_description: "Mitford CC - 1st XI - Won",
+            innings: [
+              {
+                team_batting_id: "68498",
+                runs: "185",
+                wickets: "10",
+                overs: "39.4",
+                declared: false,
+              },
+              {
+                team_batting_id: "80273",
+                runs: "188",
+                wickets: "9",
+                overs: "41.5",
+                declared: false,
+              },
+            ],
+          }),
+          resultRow({ id: 3, match_date: "05/07/2030" }),
+          resultRow({ id: 4, match_date: "21/06/2030" }),
+        ],
+      }),
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+
+    expect(result.hasLive).toBe(false);
+    expect(result.items.map((i) => i.id)).toEqual(["2", "3", "1"]);
+
+    const [latest] = result.items;
+    expect(latest.status).toBe("result");
+    expect(latest.outcome).toBe("L");
+    expect(latest.note).toBe("Lost by 1 wicket");
+    expect(latest.home).toBe(true);
+    expect(latest.opposition.club.name).toBe("Mitford CC");
+    expect(latest.innings).toEqual([
+      {
+        teamBattingId: "68498",
+        teamName: "Percy Main CC",
+        runs: 185,
+        wickets: 10,
+        overs: "39.4",
+        declared: false,
+        allOut: true,
+      },
+      {
+        teamBattingId: "80273",
+        teamName: "Mitford CC",
+        runs: 188,
+        wickets: 9,
+        overs: "41.5",
+        declared: false,
+        allOut: false,
+      },
+    ]);
+  });
+
+  it("maps outcome from the away side's perspective", async () => {
+    const now = new Date("2031-07-10T10:00:00Z");
+    const api = createMockApi({
+      getResultSummary: vi.fn().mockResolvedValue({
+        result_summary: [
+          resultRow({
+            id: 9,
+            match_date: "05/07/2031",
+            home_club_id: "4385",
+            home_club_name: "Mitford CC",
+            away_club_id: SITE_ID,
+            away_club_name: "Percy Main CC",
+            // Percy Main (away, team 80273 slot) won.
+            home_team_id: "80273",
+            away_team_id: "68498",
+            batted_first: "80273",
+            result_applied_to: "68498",
+            innings: [
+              {
+                team_batting_id: "80273",
+                runs: "143",
+                wickets: "10",
+                overs: "38.1",
+                declared: false,
+              },
+              {
+                team_batting_id: "68498",
+                runs: "144",
+                wickets: "5",
+                overs: "31.2",
+                declared: false,
+              },
+            ],
+          }),
+        ],
+      }),
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+    const [item] = result.items;
+    expect(item.home).toBe(false);
+    expect(item.outcome).toBe("W");
+    expect(item.note).toBe("Won by 5 wickets");
+    expect(item.opposition.club.name).toBe("Mitford CC");
+  });
+
+  it("surfaces a started same-day game as live, ahead of results", async () => {
+    // Sat 06/07/2032 15:00 London (14:00Z), game started 13:00.
+    const now = new Date("2032-07-03T14:00:00Z");
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          summaryMatch({
+            id: 42,
+            season: "2032",
+            match_date: "03/07/2032",
+            match_time: "13:00",
+          }),
+        ],
+      }),
+      getResultSummary: vi.fn().mockResolvedValue({
+        result_summary: [resultRow({ id: 1, match_date: "28/06/2032" })],
+      }),
+      getLiveMatchDetail: vi.fn().mockResolvedValue({
+        match_details: [
+          liveDetail({
+            id: 42,
+            innings: [
+              {
+                team_batting_id: "68498",
+                runs: "185",
+                wickets: "10",
+                overs: "39.4",
+                declared: false,
+              },
+              {
+                team_batting_id: "80273",
+                runs: "112",
+                wickets: "4",
+                overs: "28.0",
+                declared: false,
+              },
+            ],
+          }),
+        ],
+      }),
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+
+    expect(result.hasLive).toBe(true);
+    expect(result.items[0]).toMatchObject({
+      id: "42",
+      status: "live",
+      outcome: null,
+      note: "Mitford CC need 74 more to win",
+    });
+    expect(result.items[0].innings).toHaveLength(2);
+    expect(result.items[1]).toMatchObject({ id: "1", status: "result" });
+  });
+
+  it("labels a live first innings and a scoreless in-play game", async () => {
+    const now = new Date("2033-07-02T14:00:00Z");
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          summaryMatch({
+            id: 50,
+            season: "2033",
+            match_date: "02/07/2033",
+            match_time: "13:00",
+          }),
+          summaryMatch({
+            id: 51,
+            season: "2033",
+            match_date: "02/07/2033",
+            match_time: "13:30",
+            home_team_name: "2nd XI",
+            home_team_id: "68499",
+            away_team_name: "2nd XI",
+            away_team_id: "80274",
+          }),
+        ],
+      }),
+      getLiveMatchDetail: vi.fn().mockImplementation((matchId: string) =>
+        Promise.resolve(
+          matchId === "50"
+            ? {
+                match_details: [
+                  liveDetail({
+                    id: 50,
+                    innings: [
+                      {
+                        team_batting_id: "68498",
+                        runs: "64",
+                        wickets: "2",
+                        overs: "7.3",
+                        declared: false,
+                      },
+                    ],
+                  }),
+                ],
+              }
+            : { match_details: [liveDetail({ id: 51 })] },
+        ),
+      ),
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+
+    expect(result.hasLive).toBe(true);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0]).toMatchObject({
+      id: "50",
+      status: "live",
+      note: "First innings in progress",
+    });
+    expect(result.items[1]).toMatchObject({
+      id: "51",
+      status: "live",
+      note: "In play",
+      innings: [],
+    });
+  });
+
+  it("drops a scoreless game once the in-play window has passed", async () => {
+    // 22:10 London; the 10:00 junior game never posted a score.
+    const now = new Date("2034-07-01T21:10:00Z");
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          summaryMatch({
+            id: 60,
+            season: "2034",
+            match_date: "01/07/2034",
+            match_time: "10:00",
+          }),
+        ],
+      }),
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+    expect(result.items).toEqual([]);
+    expect(result.hasLive).toBe(false);
+  });
+
+  it("does not mark a game live before its start time", async () => {
+    const now = new Date("2035-07-07T10:00:00Z"); // 11:00 London
+    const getLiveMatchDetail = vi.fn().mockResolvedValue({ match_details: [] });
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          summaryMatch({
+            id: 70,
+            season: "2035",
+            match_date: "07/07/2035",
+            match_time: "13:00",
+          }),
+        ],
+      }),
+      getLiveMatchDetail,
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+    expect(result.items).toEqual([]);
+    expect(result.hasLive).toBe(false);
+    expect(getLiveMatchDetail).not.toHaveBeenCalled();
+  });
+
+  it("promotes a just-finished game to a result before result_summary catches up", async () => {
+    const now = new Date("2036-07-05T17:00:00Z");
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          summaryMatch({
+            id: 80,
+            season: "2036",
+            match_date: "05/07/2036",
+            match_time: "13:00",
+          }),
+        ],
+      }),
+      getResultSummary: vi.fn().mockResolvedValue({
+        result_summary: [resultRow({ id: 2, match_date: "28/06/2036" })],
+      }),
+      getLiveMatchDetail: vi.fn().mockResolvedValue({
+        match_details: [
+          liveDetail({
+            id: 80,
+            result: "W",
+            result_description: "Percy Main CC - 1st XI - Won",
+            result_applied_to: "68498",
+            innings: [
+              {
+                team_batting_id: "80273",
+                runs: "143",
+                wickets: "10",
+                overs: "38.1",
+                declared: false,
+              },
+              {
+                team_batting_id: "68498",
+                runs: "144",
+                wickets: "5",
+                overs: "31.2",
+                declared: false,
+              },
+            ],
+          }),
+        ],
+      }),
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+
+    expect(result.hasLive).toBe(false);
+    expect(result.items[0]).toMatchObject({
+      id: "80",
+      status: "result",
+      outcome: "W",
+      note: "Won by 5 wickets",
+    });
+    expect(result.items[1]).toMatchObject({ id: "2" });
+  });
+
+  it("degrades to live-without-score when the detail call fails", async () => {
+    const now = new Date("2037-07-04T14:00:00Z");
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockResolvedValue({
+        matches: [
+          summaryMatch({
+            id: 90,
+            season: "2037",
+            match_date: "04/07/2037",
+            match_time: "13:00",
+          }),
+        ],
+      }),
+      getLiveMatchDetail: vi.fn().mockRejectedValue(new Error("pc down")),
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+    expect(result.hasLive).toBe(true);
+    expect(result.items[0]).toMatchObject({
+      id: "90",
+      status: "live",
+      note: "In play",
+      innings: [],
+    });
+  });
+
+  it("returns [] instead of failing when Play Cricket is down entirely", async () => {
+    const now = new Date("2038-07-04T14:00:00Z");
+    const api = createMockApi({
+      getMatchesSummary: vi.fn().mockRejectedValue(new Error("pc down")),
+      getResultSummary: vi.fn().mockRejectedValue(new Error("pc down")),
+    });
+
+    const result = await listRecentGames(api, SITE_ID)(log, now);
+    expect(result).toEqual({ items: [], hasLive: false });
+  });
+
+  it("caches result_summary between calls", async () => {
+    const now = new Date("2039-07-08T10:00:00Z");
+    const getResultSummary = vi.fn().mockResolvedValue({
+      result_summary: [resultRow({ id: 5, match_date: "05/07/2039" })],
+    });
+    const api = createMockApi({ getResultSummary });
+
+    const recent = listRecentGames(api, SITE_ID);
+    await recent(log, now);
+    await recent(log, now);
+
+    expect(getResultSummary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/features/games/recent.ts
+++ b/apps/api/src/features/games/recent.ts
@@ -1,0 +1,484 @@
+import type { FastifyBaseLogger } from "fastify";
+import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
+import type {
+  LiveMatchDetail,
+  ResultSummaryMatch,
+} from "../play-cricket/api-schemas.ts";
+import {
+  fetchMatchSummaries,
+  parseMatchDateTime,
+  resolveOutcome,
+  type MatchSummary,
+  type Outcome,
+} from "./service.ts";
+
+// The homepage scoreboard: the club's most recent results, with any game
+// that is in play right now shown live. Everything here reads Play Cricket
+// directly (result_summary.json + match_detail.json) rather than the
+// DB match_result rows, because those only refresh on the weekly sync -
+// far too stale for a "latest scores" strip.
+//
+// Unlike other services this one takes no `db`: every displayed fact comes
+// from Play Cricket. Games whose result exists only as a manual matchday
+// entry (no PC scorecard) don't appear here; they still show on the
+// calendar pages, which merge DB results.
+
+// --- Types ---
+
+export interface RecentGameInnings {
+  teamBattingId: string;
+  teamName: string;
+  runs: number;
+  wickets: number;
+  overs: string;
+  declared: boolean;
+  allOut: boolean;
+}
+
+export interface RecentGameItem {
+  id: string;
+  status: "live" | "result";
+  when: string | null;
+  home: boolean;
+  team: { id: string; name: string };
+  opposition: {
+    club: { id: string; name: string };
+    team: { id: string; name: string };
+  };
+  league: { id: string; name: string };
+  competition: { id: string; name: string; type: string };
+  outcome: Outcome | null;
+  /** "Won by 5 wickets", "Mitford CC need 74 more to win", "In play", ... */
+  note: string | null;
+  /** Batting order preserved. Empty while nothing has been scored. */
+  innings: RecentGameInnings[];
+}
+
+export interface RecentGamesResult {
+  items: RecentGameItem[];
+  hasLive: boolean;
+}
+
+// --- Tunables ---
+
+const MAX_ITEMS = 3;
+/** Cap match_detail lookups per request; candidates beyond this many
+ * simultaneous same-day games are (senior teams first) simply skipped. */
+const MAX_LIVE_LOOKUPS = 4;
+/** A scheduled game with no scores yet stays "in play" for this long after
+ * its start time, then drops off (rained-off games never post scores). */
+const IN_PLAY_WINDOW_MINUTES = 8 * 60;
+const RESULTS_TTL_MS = 5 * 60_000;
+const LIVE_DETAIL_TTL_MS = 60_000;
+
+// --- London wall-clock helpers ---
+//
+// Play Cricket serves dates (DD/MM/YYYY) and times (HH:mm) in UK local
+// time with no zone marker. Rather than converting to UTC instants (which
+// needs a tz database), all "is this game on right now?" comparisons happen
+// in London wall-clock terms via Intl.
+
+export interface LondonNow {
+  /** DD/MM/YYYY, matching Play Cricket's match_date format. */
+  datePc: string;
+  /** Minutes since local midnight. */
+  minutes: number;
+  year: number;
+}
+
+export function londonNow(now: Date): LondonNow {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(now);
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  return {
+    datePc: `${get("day")}/${get("month")}/${get("year")}`,
+    minutes: Number(get("hour")) * 60 + Number(get("minute")),
+    year: Number(get("year")),
+  };
+}
+
+/** "13:00" -> 780; null for missing/malformed times. */
+export function parseTimeToMinutes(time: string | null | undefined) {
+  if (!time) return null;
+  const m = /^(\d{1,2}):(\d{2})$/.exec(time);
+  if (!m) return null;
+  return Number(m[1]) * 60 + Number(m[2]);
+}
+
+/** DD/MM/YYYY + HH:mm -> sortable "YYYY-MM-DDTHH:mm"; null if malformed. */
+function pcSortKey(matchDate: string, matchTime: string): string | null {
+  if (!/^\d{2}\/\d{2}\/\d{4}$/.test(matchDate)) return null;
+  const [dd, mm, yyyy] = matchDate.split("/");
+  const time = /^\d{2}:\d{2}$/.test(matchTime) ? matchTime : "00:00";
+  return `${yyyy}-${mm}-${dd}T${time}`;
+}
+
+// Mirrors the homepage UpcomingStrip ordering: senior XIs lead when several
+// games are on at once.
+function teamPriority(teamName: string): number {
+  if (/1st/i.test(teamName)) return 2;
+  if (/2nd/i.test(teamName)) return 1;
+  return 0;
+}
+
+// --- Innings + note building ---
+
+function toInnings(
+  raw: Array<{
+    team_batting_id: string;
+    runs: string;
+    wickets: string;
+    overs: string;
+    declared: boolean | null;
+  }>,
+  teamNameById: Map<string, string>,
+): RecentGameInnings[] {
+  return raw
+    .filter((inn) => inn.runs !== "" || inn.overs !== "")
+    .map((inn) => {
+      const runs = parseInt(inn.runs) || 0;
+      const wickets = parseInt(inn.wickets) || 0;
+      return {
+        teamBattingId: inn.team_batting_id,
+        teamName: teamNameById.get(inn.team_batting_id) ?? "",
+        runs,
+        wickets,
+        overs: inn.overs,
+        declared: inn.declared ?? false,
+        allOut: wickets >= 10,
+      };
+    });
+}
+
+/**
+ * Margin text from the winner's side of a completed two-innings game,
+ * phrased from Percy Main's perspective ("Won by 43 runs"). Returns null
+ * whenever the margin can't be derived safely (Pairs scoring, multi-innings
+ * games, missing data) - the outcome stamp still tells the story.
+ */
+export function buildResultNote(
+  outcome: Outcome | null,
+  gameType: string,
+  innings: RecentGameInnings[],
+  winnerTeamId: string,
+): string | null {
+  switch (outcome) {
+    case "A":
+      return "Abandoned";
+    case "C":
+      return "Cancelled";
+    case "N":
+      return "No result";
+    case "D":
+      return "Match drawn";
+    case "T":
+      return "Match tied";
+    case null:
+      return null;
+    default:
+      break;
+  }
+
+  if (gameType !== "Standard" || innings.length !== 2 || !winnerTeamId) {
+    return null;
+  }
+  const verb = outcome === "W" ? "Won" : "Lost";
+  const [first, second] = innings;
+  if (second.teamBattingId === winnerTeamId) {
+    const wickets = 10 - second.wickets;
+    if (wickets > 0 && wickets <= 10) {
+      return `${verb} by ${String(wickets)} wicket${wickets === 1 ? "" : "s"}`;
+    }
+    return null;
+  }
+  if (first.teamBattingId === winnerTeamId) {
+    const runs = first.runs - second.runs;
+    if (runs > 0) {
+      return `${verb} by ${String(runs)} run${runs === 1 ? "" : "s"}`;
+    }
+  }
+  return null;
+}
+
+function buildLiveNote(
+  innings: RecentGameInnings[],
+  gameType: string,
+): string | null {
+  if (innings.length === 0) return "In play";
+  if (innings.length === 1) return "First innings in progress";
+  if (innings.length === 2 && gameType === "Standard") {
+    const [first, second] = innings;
+    const need = first.runs + 1 - second.runs;
+    if (need > 0 && second.teamName) {
+      return `${second.teamName} need ${String(need)} more to win`;
+    }
+  }
+  return "In play";
+}
+
+// --- Item builders ---
+
+function buildResultItem(
+  row: ResultSummaryMatch,
+  siteId: string,
+): RecentGameItem {
+  const home = row.home_club_id === siteId;
+  const ourTeamId = home ? row.home_team_id : row.away_team_id;
+  const teamNameById = new Map([
+    [row.home_team_id, row.home_club_name],
+    [row.away_team_id, row.away_club_name],
+  ]);
+  const innings = toInnings(row.innings, teamNameById);
+  const outcome = resolveOutcome(
+    row.result,
+    row.result_applied_to,
+    row.result_description,
+    ourTeamId,
+  );
+
+  return {
+    id: String(row.id),
+    status: "result",
+    when: parseMatchDateTime(row.match_date, row.match_time || null),
+    home,
+    team: {
+      id: ourTeamId,
+      name: home ? row.home_team_name : row.away_team_name,
+    },
+    opposition: home
+      ? {
+          club: { id: row.away_club_id, name: row.away_club_name },
+          team: { id: row.away_team_id, name: row.away_team_name },
+        }
+      : {
+          club: { id: row.home_club_id, name: row.home_club_name },
+          team: { id: row.home_team_id, name: row.home_team_name },
+        },
+    league: { id: row.league_id, name: row.league_name },
+    competition: {
+      id: row.competition_id,
+      name: row.competition_name,
+      type: row.competition_type,
+    },
+    outcome,
+    note: buildResultNote(
+      outcome,
+      row.game_type,
+      innings,
+      row.result_applied_to,
+    ),
+    innings,
+  };
+}
+
+function detailTeamNames(detail: LiveMatchDetail): Map<string, string> {
+  return new Map([
+    [detail.home_team_id, detail.home_club_name],
+    [detail.away_team_id, detail.away_club_name],
+  ]);
+}
+
+function buildLiveItem(
+  match: MatchSummary,
+  detail: LiveMatchDetail | null,
+): RecentGameItem {
+  const innings = detail
+    ? toInnings(detail.innings, detailTeamNames(detail))
+    : [];
+  return {
+    id: match.id,
+    status: "live",
+    when: parseMatchDateTime(match.matchDate, match.matchTime),
+    home: match.home,
+    team: match.team,
+    opposition: match.opposition,
+    league: match.league,
+    competition: match.competition,
+    outcome: null,
+    note: buildLiveNote(innings, detail?.game_type ?? ""),
+    innings,
+  };
+}
+
+/** A candidate that turned out to have finished - Play Cricket's
+ * result_summary usually lags the detail endpoint by a few minutes, so
+ * synthesise the result item from the detail we already fetched. */
+function buildJustFinishedItem(
+  match: MatchSummary,
+  detail: LiveMatchDetail,
+): RecentGameItem {
+  const innings = toInnings(detail.innings, detailTeamNames(detail));
+  const outcome = resolveOutcome(
+    detail.result,
+    detail.result_applied_to,
+    detail.result_description,
+    match.team.id,
+  );
+  return {
+    id: match.id,
+    status: "result",
+    when: parseMatchDateTime(match.matchDate, match.matchTime),
+    home: match.home,
+    team: match.team,
+    opposition: match.opposition,
+    league: match.league,
+    competition: match.competition,
+    outcome,
+    note: buildResultNote(
+      outcome,
+      detail.game_type,
+      innings,
+      detail.result_applied_to,
+    ),
+    innings,
+  };
+}
+
+// --- Service factory ---
+
+interface CacheEntry<T> {
+  data: T;
+  fetchedAt: number;
+}
+
+/**
+ * Curried factory (one instance per route registration; the closures are
+ * this process's caches). No `db` parameter by design - see module header.
+ */
+export function listRecentGames(api: PlayCricketApiClient, siteId: string) {
+  let resultsCache:
+    (CacheEntry<ResultSummaryMatch[]> & { season: number }) | null = null;
+  const liveDetailCache = new Map<string, CacheEntry<LiveMatchDetail | null>>();
+
+  async function getResults(
+    season: number,
+    log: FastifyBaseLogger,
+  ): Promise<ResultSummaryMatch[]> {
+    if (
+      resultsCache?.season === season &&
+      Date.now() - resultsCache.fetchedAt < RESULTS_TTL_MS
+    ) {
+      return resultsCache.data;
+    }
+    try {
+      const response = await api.getResultSummary(season);
+      resultsCache = {
+        data: response.result_summary,
+        fetchedAt: Date.now(),
+        season,
+      };
+      return response.result_summary;
+    } catch (err) {
+      log.warn({ err }, "play_cricket_result_summary_unavailable");
+      // Stale results beat an empty homepage section.
+      if (resultsCache?.season === season) {
+        return resultsCache.data;
+      }
+      return [];
+    }
+  }
+
+  async function getLiveDetail(
+    matchId: string,
+    log: FastifyBaseLogger,
+  ): Promise<LiveMatchDetail | null> {
+    const cached = liveDetailCache.get(matchId);
+    if (cached && Date.now() - cached.fetchedAt < LIVE_DETAIL_TTL_MS) {
+      return cached.data;
+    }
+    try {
+      const response = await api.getLiveMatchDetail(matchId);
+      const detail = response.match_details[0] ?? null;
+      liveDetailCache.set(matchId, { data: detail, fetchedAt: Date.now() });
+      return detail;
+    } catch (err) {
+      log.warn({ err, matchId }, "play_cricket_live_detail_unavailable");
+      // Serve stale if present; otherwise the card degrades to scoreless.
+      return cached?.data ?? null;
+    }
+  }
+
+  return async (
+    log: FastifyBaseLogger,
+    now = new Date(),
+  ): Promise<RecentGamesResult> => {
+    const today = londonNow(now);
+    const season = today.year;
+
+    const [summaries, results] = await Promise.all([
+      fetchMatchSummaries(api, siteId, season).catch((err: unknown) => {
+        log.warn({ err }, "play_cricket_matches_summary_unavailable");
+        return [] as MatchSummary[];
+      }),
+      getResults(season, log),
+    ]);
+
+    const resultedIds = new Set(
+      results.filter((row) => row.result !== "").map((row) => String(row.id)),
+    );
+
+    // Same-day games that have started and have no posted result yet.
+    const candidates = summaries
+      .map((match) => ({
+        match,
+        startMinutes: parseTimeToMinutes(match.matchTime),
+      }))
+      .filter(
+        (c): c is { match: MatchSummary; startMinutes: number } =>
+          c.match.matchDate === today.datePc &&
+          !resultedIds.has(c.match.id) &&
+          c.startMinutes !== null &&
+          today.minutes >= c.startMinutes,
+      )
+      .sort(
+        (a, b) =>
+          teamPriority(b.match.team.name) - teamPriority(a.match.team.name) ||
+          a.startMinutes - b.startMinutes,
+      )
+      .slice(0, MAX_LIVE_LOOKUPS);
+
+    const liveItems: RecentGameItem[] = [];
+    const justFinished: RecentGameItem[] = [];
+    for (const { match, startMinutes } of candidates) {
+      const detail = await getLiveDetail(match.id, log);
+      if (detail && detail.result_description !== "") {
+        justFinished.push(buildJustFinishedItem(match, detail));
+        continue;
+      }
+      const item = buildLiveItem(match, detail);
+      const elapsed = today.minutes - startMinutes;
+      if (item.innings.length === 0 && elapsed > IN_PLAY_WINDOW_MINUTES) {
+        continue;
+      }
+      liveItems.push(item);
+    }
+
+    const finishedIds = new Set(justFinished.map((item) => item.id));
+    const resultItems = results
+      .filter((row) => row.result !== "" && !finishedIds.has(String(row.id)))
+      .map((row) => ({
+        row,
+        sortKey: pcSortKey(row.match_date, row.match_time),
+      }))
+      .filter(
+        (entry): entry is { row: ResultSummaryMatch; sortKey: string } =>
+          entry.sortKey !== null,
+      )
+      .sort((a, b) => b.sortKey.localeCompare(a.sortKey))
+      .map((entry) => buildResultItem(entry.row, siteId));
+
+    const items = [...liveItems, ...justFinished, ...resultItems].slice(
+      0,
+      MAX_ITEMS,
+    );
+    return { items, hasLive: liveItems.length > 0 };
+  };
+}

--- a/apps/api/src/features/games/recent.ts
+++ b/apps/api/src/features/games/recent.ts
@@ -461,6 +461,10 @@ export function listRecentGames(api: PlayCricketApiClient, siteId: string) {
       liveItems.push(item);
     }
 
+    // Just-finished games merge into the completed results and share their
+    // newest-first ordering (by start datetime) rather than being pinned to
+    // the front - a morning game confirmed via match_detail must not
+    // outrank an evening result that already reached result_summary.
     const finishedIds = new Set(justFinished.map((item) => item.id));
     const resultItems = results
       .filter((row) => row.result !== "" && !finishedIds.has(String(row.id)))
@@ -472,13 +476,13 @@ export function listRecentGames(api: PlayCricketApiClient, siteId: string) {
         (entry): entry is { row: ResultSummaryMatch; sortKey: string } =>
           entry.sortKey !== null,
       )
-      .sort((a, b) => b.sortKey.localeCompare(a.sortKey))
       .map((entry) => buildResultItem(entry.row, siteId));
 
-    const items = [...liveItems, ...justFinished, ...resultItems].slice(
-      0,
-      MAX_ITEMS,
+    const allResults = [...justFinished, ...resultItems].sort((a, b) =>
+      (b.when ?? "").localeCompare(a.when ?? ""),
     );
+
+    const items = [...liveItems, ...allResults].slice(0, MAX_ITEMS);
     return { items, hasLive: liveItems.length > 0 };
   };
 }

--- a/apps/api/src/features/games/routes.ts
+++ b/apps/api/src/features/games/routes.ts
@@ -1,11 +1,13 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { createApiClient } from "../play-cricket/api-client.ts";
+import { listRecentGames } from "./recent.ts";
 import {
   gameDetailParamsSchema,
   gameDetailResponseSchema,
   gamesListResponseSchema,
   gamesListSchema,
   gamesPrerenderManifestResponseSchema,
+  recentGamesResponseSchema,
   wagonWheelResponseSchema,
 } from "./schemas.ts";
 import {
@@ -29,11 +31,13 @@ export const gamesRoutes: FastifyPluginAsyncZod = async (app) => {
   const api = createApiClient({
     apiToken: config.PLAY_CRICKET_API_TOKEN,
     siteId: config.PLAY_CRICKET_SITE_ID,
+    baseUrl: config.PLAY_CRICKET_API_BASE,
   });
 
   const siteId = config.PLAY_CRICKET_SITE_ID;
 
   const list = listGames(app.db, api, siteId);
+  const recent = listRecentGames(api, siteId);
   const detail = getGame(app.db, api, siteId);
   const wagonWheel = getWagonWheel(app.db);
   const prerenderManifest = listGamesPrerenderManifest(app.db, api, siteId);
@@ -50,6 +54,20 @@ export const gamesRoutes: FastifyPluginAsyncZod = async (app) => {
       const { season } = request.query;
       const effectiveSeason = season ?? new Date().getFullYear();
       return await list(effectiveSeason);
+    },
+  );
+
+  // Homepage scoreboard: latest results + any game in play right now.
+  // Registered before /games/:matchId so the static segment wins.
+  app.get(
+    "/games/recent",
+    {
+      schema: {
+        response: { 200: recentGamesResponseSchema },
+      },
+    },
+    async (request) => {
+      return await recent(request.log);
     },
   );
 

--- a/apps/api/src/features/games/schemas.ts
+++ b/apps/api/src/features/games/schemas.ts
@@ -122,6 +122,46 @@ export const gameDetailResponseSchema = gameListItemSchema.extend({
   availabilityRequest: availabilityRequestSummarySchema,
 });
 
+// --- Recent games (homepage scoreboard) ---
+
+const recentGameInningsSchema = z.object({
+  teamBattingId: z.string(),
+  teamName: z.string(),
+  runs: z.number(),
+  wickets: z.number(),
+  overs: z.string(),
+  declared: z.boolean(),
+  allOut: z.boolean(),
+});
+
+export const recentGameItemSchema = z.object({
+  id: z.string(),
+  status: z.enum(["live", "result"]),
+  when: z.string().nullable(),
+  home: z.boolean(),
+  team: teamIdNameSchema,
+  opposition: z.object({
+    club: teamIdNameSchema,
+    team: teamIdNameSchema,
+  }),
+  league: teamIdNameSchema,
+  competition: z.object({
+    id: z.string(),
+    name: z.string(),
+    type: z.string(),
+  }),
+  outcome: outcomeSchema,
+  // "Won by 5 wickets" / "Mitford CC need 74 more to win" / "In play" ...
+  note: z.string().nullable(),
+  // Batting order preserved; empty while a live game has no scores yet.
+  innings: z.array(recentGameInningsSchema),
+});
+
+export const recentGamesResponseSchema = z.object({
+  items: z.array(recentGameItemSchema),
+  hasLive: z.boolean(),
+});
+
 // --- Prerender manifest ---
 
 // Consumed by the prerenderer Lambda (apps/web/server/prerender), merged

--- a/apps/api/src/features/games/service.test.ts
+++ b/apps/api/src/features/games/service.test.ts
@@ -96,10 +96,12 @@ function createMockApi(
     getTeams: vi.fn().mockResolvedValue({ teams: [] }),
     getMatchesSummary,
     getMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
+    getLiveMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
     getPlayers: vi.fn().mockResolvedValue({ players: [] }),
     getLeagueTable: vi.fn().mockResolvedValue({}),
     getMatchesForSite: vi.fn().mockResolvedValue({ matches: [] }),
     getResultSummaryForSite: vi.fn().mockResolvedValue({ result_summary: [] }),
+    getResultSummary: vi.fn().mockResolvedValue({ result_summary: [] }),
   };
 }
 

--- a/apps/api/src/features/games/service.ts
+++ b/apps/api/src/features/games/service.ts
@@ -99,7 +99,7 @@ export interface GameDetail extends GameListItem {
 
 // --- Helpers ---
 
-function resolveOutcome(
+export function resolveOutcome(
   result: string,
   resultAppliedTo: string,
   resultDescription: string,
@@ -122,7 +122,7 @@ function resolveOutcome(
   return null;
 }
 
-function parseMatchDateTime(
+export function parseMatchDateTime(
   matchDate: string,
   matchTime: string | null,
 ): string | null {
@@ -640,9 +640,9 @@ export function getWagonWheel(db: Kysely<DB>) {
   };
 }
 
-// --- Internal: cached fetch ---
+// --- Internal: cached fetch (shared with recent.ts) ---
 
-async function fetchMatchSummaries(
+export async function fetchMatchSummaries(
   api: PlayCricketApiClient,
   siteId: string,
   season: number,

--- a/apps/api/src/features/play-cricket/api-client.ts
+++ b/apps/api/src/features/play-cricket/api-client.ts
@@ -1,7 +1,9 @@
 import {
+  GetLiveMatchDetailResponse,
   GetMatchDetailResponse,
   GetMatchSummaryResponse,
   GetPlayersResponse,
+  GetResultSummaryResponse,
   GetTeamsResponse,
 } from "./api-schemas.ts";
 
@@ -10,6 +12,8 @@ const API_BASE = "https://www.play-cricket.com/api/v2";
 export interface PlayCricketApiConfig {
   apiToken: string;
   siteId: string;
+  /** Override the API origin — used to point at a mock server locally. */
+  baseUrl?: string;
 }
 
 /**
@@ -35,7 +39,7 @@ async function fetchPlayCricket(
   path: string,
   params?: Record<string, string>,
 ): Promise<unknown> {
-  const url = new URL(`${API_BASE}${path}`);
+  const url = new URL(`${config.baseUrl ?? API_BASE}${path}`);
   url.searchParams.set("api_token", config.apiToken);
   if (params) {
     for (const [key, value] of Object.entries(params)) {
@@ -64,6 +68,18 @@ export function createApiClient(config: PlayCricketApiConfig) {
         match_id: matchId,
       });
       return GetMatchDetailResponse.parse(json);
+    },
+
+    /**
+     * Same endpoint as getMatchDetail, parsed leniently — for reading a
+     * possibly in-play match where the full scorecard fields may be
+     * incomplete. See GetLiveMatchDetailResponse.
+     */
+    async getLiveMatchDetail(matchId: string) {
+      const json = await fetchPlayCricket(config, "/match_detail.json", {
+        match_id: matchId,
+      });
+      return GetLiveMatchDetailResponse.parse(json);
     },
 
     async getMatchesSummary(season: number) {
@@ -130,6 +146,20 @@ export function createApiClient(config: PlayCricketApiConfig) {
         site_id: siteId,
         season: String(season),
       });
+    },
+
+    /**
+     * Typed result summary for our own site. Play Cricket updates this
+     * within minutes of a scorer posting a result, so it's the freshest
+     * "recent results" source — unlike match_result rows, which wait for
+     * the weekly sync.
+     */
+    async getResultSummary(season: number) {
+      const json = await fetchPlayCricket(config, "/result_summary.json", {
+        site_id: config.siteId,
+        season: String(season),
+      });
+      return GetResultSummaryResponse.parse(json);
     },
   };
 }

--- a/apps/api/src/features/play-cricket/api-schemas.ts
+++ b/apps/api/src/features/play-cricket/api-schemas.ts
@@ -183,6 +183,107 @@ export const GetMatchDetailResponse = z.object({
   match_details: z.array(MatchDetail),
 });
 
+// --- Result summary (played matches with innings totals) ---
+//
+// /result_summary.json?site_id=...&season=... — one row per played match,
+// updated by Play Cricket within minutes of a scorer posting a result.
+// Only the fields the recent-games feature consumes are encoded; unknown
+// keys are stripped by z.object.
+
+export const ResultSummaryInnings = z.object({
+  team_batting_id: z.string(),
+  innings_number: z.number().optional(),
+  runs: z.string().optional().default(""),
+  wickets: z.string().optional().default(""),
+  overs: z.string().optional().default(""),
+  declared: z.boolean().nullable().default(false),
+  forfeited_innings: z.boolean().nullable().default(false),
+});
+
+export const ResultSummaryMatch = z.object({
+  id: z.number(),
+  status: z.string().optional().default(""),
+  published: z.string().optional().default(""),
+  last_updated: z.string().optional().default(""),
+  league_name: z.string().optional().default(""),
+  league_id: z.string().optional().default(""),
+  competition_name: z.string().optional().default(""),
+  competition_id: z.string().optional().default(""),
+  competition_type: z.string().optional().default(""),
+  match_type: z.string().optional().default(""),
+  // "Standard" hardball or "Pairs" Women's Softball — Pairs margins don't
+  // follow runs/wickets semantics, so the recent-games note skips them.
+  game_type: z.string().optional().default(""),
+  match_date: z.string(),
+  match_time: z.string().optional().default(""),
+  home_team_name: z.string(),
+  home_team_id: z.string(),
+  home_club_name: z.string(),
+  home_club_id: z.string(),
+  away_team_name: z.string(),
+  away_team_id: z.string(),
+  away_club_name: z.string(),
+  away_club_id: z.string(),
+  batted_first: z.string().optional().default(""),
+  result: z.string().optional().default(""),
+  result_description: z.string().optional().default(""),
+  result_applied_to: z.string().optional().default(""),
+  innings: z.array(ResultSummaryInnings).optional().default([]),
+});
+
+export type ResultSummaryMatch = z.output<typeof ResultSummaryMatch>;
+
+export const GetResultSummaryResponse = z.object({
+  result_summary: z.array(ResultSummaryMatch),
+});
+
+// --- Lenient match detail for live (in-play) reads ---
+//
+// The full MatchDetail schema requires scorecard fields (extras, bat, bowl,
+// fow) that Play Cricket may serve incompletely mid-innings. The live
+// scoreboard only needs running totals and the (empty-until-final) result
+// fields, so it parses this forgiving subset instead — a malformed innings
+// entry must degrade to "in play, no score" rather than fail the request.
+
+// Play Cricket emits null for not-yet-populated live fields; collapse
+// null/undefined to "" so consumers see one empty shape.
+const liveString = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? "");
+
+const LiveMatchDetailInnings = z.object({
+  team_batting_id: liveString,
+  runs: liveString,
+  wickets: liveString,
+  overs: liveString,
+  declared: z.boolean().nullable().default(false),
+});
+
+export const LiveMatchDetail = z.object({
+  id: z.number(),
+  home_team_name: z.string(),
+  home_team_id: z.string(),
+  home_club_name: z.string(),
+  home_club_id: liveString,
+  away_team_name: z.string(),
+  away_team_id: z.string(),
+  away_club_name: z.string(),
+  away_club_id: liveString,
+  result: liveString,
+  result_description: liveString,
+  result_applied_to: liveString,
+  game_type: liveString,
+  match_type: liveString,
+  innings: z.array(LiveMatchDetailInnings).optional().default([]),
+});
+
+export type LiveMatchDetail = z.output<typeof LiveMatchDetail>;
+
+export const GetLiveMatchDetailResponse = z.object({
+  match_details: z.array(LiveMatchDetail),
+});
+
 // --- Teams ---
 
 export const GetPlayersResponse = z.object({

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -386,8 +386,10 @@ function createMockApi(
     getMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
     getPlayers: vi.fn().mockResolvedValue({ players: [] }),
     getLeagueTable: vi.fn().mockResolvedValue({}),
+    getLiveMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
     getMatchesForSite: vi.fn().mockResolvedValue({ matches: [] }),
     getResultSummaryForSite: vi.fn().mockResolvedValue({ result_summary: [] }),
+    getResultSummary: vi.fn().mockResolvedValue({ result_summary: [] }),
     ...overrides,
   };
 }

--- a/apps/api/src/features/play-cricket/sync.test.ts
+++ b/apps/api/src/features/play-cricket/sync.test.ts
@@ -183,10 +183,12 @@ describe("runSync", () => {
       getMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
       getPlayers: vi.fn().mockResolvedValue({ players: [] }),
       getLeagueTable: vi.fn().mockResolvedValue({}),
+      getLiveMatchDetail: vi.fn().mockResolvedValue({ match_details: [] }),
       getMatchesForSite: vi.fn().mockResolvedValue({ matches: [] }),
       getResultSummaryForSite: vi
         .fn()
         .mockResolvedValue({ result_summary: [] }),
+      getResultSummary: vi.fn().mockResolvedValue({ result_summary: [] }),
       ...overrides,
     };
   }

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -2454,6 +2454,85 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/games/recent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                /** @enum {string} */
+                                status: "live" | "result";
+                                when: string | null;
+                                home: boolean;
+                                team: {
+                                    id: string;
+                                    name: string;
+                                };
+                                opposition: {
+                                    club: {
+                                        id: string;
+                                        name: string;
+                                    };
+                                    team: {
+                                        id: string;
+                                        name: string;
+                                    };
+                                };
+                                league: {
+                                    id: string;
+                                    name: string;
+                                };
+                                competition: {
+                                    id: string;
+                                    name: string;
+                                    type: string;
+                                };
+                                /** @enum {string|null} */
+                                outcome: "W" | "L" | "D" | "T" | "A" | "C" | "N" | null;
+                                note: string | null;
+                                innings: {
+                                    teamBattingId: string;
+                                    teamName: string;
+                                    runs: number;
+                                    wickets: number;
+                                    overs: string;
+                                    declared: boolean;
+                                    allOut: boolean;
+                                }[];
+                            }[];
+                            hasLive: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/games/prerender-manifest": {
         parameters: {
             query?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -4186,6 +4186,221 @@
         }
       }
     },
+    "/api/games/recent": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "live",
+                              "result"
+                            ]
+                          },
+                          "when": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "home": {
+                            "type": "boolean"
+                          },
+                          "team": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "opposition": {
+                            "type": "object",
+                            "properties": {
+                              "club": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "name"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "team": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "name"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "club",
+                              "team"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "league": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "competition": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "outcome": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "W",
+                              "L",
+                              "D",
+                              "T",
+                              "A",
+                              "C",
+                              "N"
+                            ]
+                          },
+                          "note": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "innings": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "teamBattingId": {
+                                  "type": "string"
+                                },
+                                "teamName": {
+                                  "type": "string"
+                                },
+                                "runs": {
+                                  "type": "number"
+                                },
+                                "wickets": {
+                                  "type": "number"
+                                },
+                                "overs": {
+                                  "type": "string"
+                                },
+                                "declared": {
+                                  "type": "boolean"
+                                },
+                                "allOut": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "teamBattingId",
+                                "teamName",
+                                "runs",
+                                "wickets",
+                                "overs",
+                                "declared",
+                                "allOut"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "status",
+                          "when",
+                          "home",
+                          "team",
+                          "opposition",
+                          "league",
+                          "competition",
+                          "outcome",
+                          "note",
+                          "innings"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "hasLive": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "hasLive"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/games/prerender-manifest": {
       "get": {
         "responses": {

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1304,6 +1304,210 @@
   color: var(--fc-paper);
 }
 
+/* --- Scoreboard (homepage recent results / live scores) --- */
+.fc-sb-grid {
+  display: grid;
+  gap: 22px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: stretch;
+}
+/* Never let a lone card span the full plate on desktop. */
+@media (min-width: 981px) {
+  .fc-sb-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .fc-sb-grid:has(> :last-child:nth-child(1)) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 980px) {
+  .fc-sb-grid {
+    grid-template-columns: 1fr;
+  }
+}
+.fc-sbcard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: var(--fc-paper);
+  color: var(--fc-navy);
+  border: 2.5px solid var(--fc-over);
+  padding: 16px 18px 14px;
+  text-decoration: none;
+  transition: transform 0.2s;
+}
+.fc-sbcard:hover {
+  transform: translateY(-3px);
+}
+.fc-sbcard--live {
+  border: 3px solid var(--fc-orange);
+  box-shadow: 4px 4px 0 rgb(239 74 30 / 45%);
+}
+.fc-sb-eyebrow {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  font-family: var(--font-primary);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  font-size: 10.5px;
+  color: rgb(27 42 85 / 70%);
+  padding-bottom: 10px;
+  margin-bottom: 12px;
+  border-bottom: 2px solid rgb(27 42 85 / 18%);
+  white-space: nowrap;
+}
+.fc-sb-eyebrow span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fc-sb-lamp {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--fc-orange);
+  letter-spacing: 0.22em;
+}
+.fc-sb-lamp i {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--fc-orange);
+  animation: fc-sb-lamp-pulse 1.6s ease-in-out infinite;
+}
+@keyframes fc-sb-lamp-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.35;
+    transform: scale(0.8);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fc-sb-lamp i {
+    animation: none;
+  }
+}
+.fc-sb-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 5px 0;
+}
+.fc-sb-teamwrap {
+  min-width: 0;
+}
+.fc-sb-team {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  font-family: var(--fc-display);
+  text-transform: uppercase;
+  font-size: 21px;
+  line-height: 0.95;
+  letter-spacing: 0.01em;
+}
+.fc-sb-bat {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fc-orange);
+  align-self: center;
+  flex-shrink: 0;
+}
+.fc-sb-teammeta {
+  font-family: var(--font-primary);
+  font-weight: 700;
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgb(27 42 85 / 58%);
+  margin-top: 4px;
+}
+.fc-sb-scorewrap {
+  text-align: right;
+  flex-shrink: 0;
+}
+.fc-sb-score {
+  font-family: var(--fc-display);
+  font-size: 38px;
+  line-height: 0.9;
+  letter-spacing: 0.01em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.fc-sb-overs {
+  font-family: var(--font-primary);
+  font-weight: 700;
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgb(27 42 85 / 58%);
+  margin-top: 3px;
+}
+.fc-sb-noscore {
+  font-family: var(--font-primary);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgb(27 42 85 / 50%);
+}
+.fc-sb-foot {
+  margin-top: auto;
+  padding-top: 10px;
+  min-height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-top: 2px solid rgb(27 42 85 / 18%);
+  font-family: var(--font-primary);
+  font-weight: 700;
+  font-size: 12.5px;
+  line-height: 1.25;
+  color: rgb(27 42 85 / 80%);
+}
+.fc-sb-livenote {
+  color: var(--fc-orange);
+}
+.fc-sb-follow {
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  font-size: 11px;
+  white-space: nowrap;
+}
+/* The scorer's rubber stamp: rotated, grunge-masked ink over the foot rule. */
+.fc-sb-stamp {
+  font-family: var(--fc-display);
+  text-transform: uppercase;
+  font-size: 20px;
+  line-height: 1;
+  letter-spacing: 0.1em;
+  border: 3px solid currentColor;
+  border-radius: 2px;
+  padding: 5px 11px 4px;
+  transform: rotate(-7deg) translateY(-6px);
+  flex-shrink: 0;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.55' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23g)' opacity='0.94'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.55' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23g)' opacity='0.94'/%3E%3C/svg%3E");
+}
+.fc-sb-stamp--won {
+  color: var(--fc-orange);
+}
+.fc-sb-stamp--lost {
+  color: var(--fc-navy);
+  opacity: 0.8;
+}
+.fc-sb-stamp--neutral {
+  color: rgb(27 42 85 / 55%);
+}
+
 /* --- Bold tiles (sports grid) --- */
 .fc-tile {
   display: block;

--- a/apps/web/src/components/theme/scoreboard.tsx
+++ b/apps/web/src/components/theme/scoreboard.tsx
@@ -1,4 +1,5 @@
 import type { paths } from "@/lib/api.gen.js";
+import { cn } from "@/lib/utils.js";
 import { formatInTimeZone } from "date-fns-tz";
 import { Link } from "react-router";
 
@@ -107,7 +108,7 @@ function ScoreboardCard({ item }: { item: RecentGameItem }) {
   return (
     <Link
       to={`/calendar/game/${item.id}`}
-      className={`fc-sbcard${live ? "fc-sbcard--live" : ""}`}
+      className={cn("fc-sbcard", live && "fc-sbcard--live")}
     >
       <div className="fc-sb-eyebrow">
         {live ? (

--- a/apps/web/src/components/theme/scoreboard.tsx
+++ b/apps/web/src/components/theme/scoreboard.tsx
@@ -1,0 +1,187 @@
+import type { paths } from "@/lib/api.gen.js";
+import { formatInTimeZone } from "date-fns-tz";
+import { Link } from "react-router";
+
+type RecentGamesResponse =
+  paths["/api/games/recent"]["get"]["responses"]["200"]["content"]["application/json"];
+export type RecentGameItem = RecentGamesResponse["items"][number];
+type RecentGameInnings = RecentGameItem["innings"][number];
+
+const OUTCOME_STAMPS: Record<
+  NonNullable<RecentGameItem["outcome"]>,
+  { label: string; tone: "won" | "lost" | "neutral" }
+> = {
+  W: { label: "Won", tone: "won" },
+  L: { label: "Lost", tone: "lost" },
+  D: { label: "Draw", tone: "neutral" },
+  T: { label: "Tied", tone: "neutral" },
+  A: { label: "Aban", tone: "neutral" },
+  C: { label: "Canc", tone: "neutral" },
+  N: { label: "N/R", tone: "neutral" },
+};
+
+/**
+ * Play Cricket disambiguates club names with a county suffix
+ * ("Civil Service CC, Northumberland") - too long for a scorecard line.
+ * Also bind the trailing token (usually "CC") to the word before it so a
+ * wrap never orphans it.
+ */
+function displayClubName(name: string): string {
+  const short = name.split(",")[0].trim();
+  return short.replace(/ (\S+)$/, "\u00A0$1");
+}
+
+function formatScore(innings: RecentGameInnings): string {
+  const wickets = innings.allOut ? "" : `/${String(innings.wickets)}`;
+  const declared = innings.declared ? "d" : "";
+  return `${String(innings.runs)}${wickets}${declared}`;
+}
+
+interface SideRow {
+  key: string;
+  clubName: string;
+  meta: string;
+  batting: boolean;
+  innings: RecentGameInnings | null;
+}
+
+/**
+ * A card shows one row per side, in batting order where known. Sides that
+ * haven't batted follow the innings rows; on a live card the last innings
+ * row is the side currently batting.
+ */
+function buildRows(item: RecentGameItem): SideRow[] {
+  const us = {
+    key: "us",
+    teamId: item.team.id,
+    clubName: "Percy Main",
+    meta: [item.team.name, item.home ? "Home" : "Away"]
+      .filter(Boolean)
+      .join(" · "),
+  };
+  const them = {
+    key: "them",
+    teamId: item.opposition.team.id,
+    clubName: displayClubName(item.opposition.club.name),
+    meta: item.opposition.team.name,
+  };
+  // Batting order wins where innings exist; otherwise home side reads first,
+  // as a scorecard would list it.
+  const sides = item.home ? [us, them] : [them, us];
+
+  const sideByTeamId = new Map(sides.map((side) => [side.teamId, side]));
+
+  const rows: SideRow[] = [];
+  for (const [index, innings] of item.innings.entries()) {
+    const side = sideByTeamId.get(innings.teamBattingId);
+    const batting = item.status === "live" && index === item.innings.length - 1;
+    rows.push({
+      key: side?.key ?? `innings-${String(index)}`,
+      clubName: side ? side.clubName : displayClubName(innings.teamName),
+      meta: side
+        ? [side.meta, batting ? "Batting" : ""].filter(Boolean).join(" · ")
+        : "",
+      batting,
+      innings,
+    });
+  }
+  for (const side of sides) {
+    if (!rows.some((row) => row.key === side.key)) {
+      rows.push({
+        key: side.key,
+        clubName: side.clubName,
+        meta: side.meta,
+        batting: false,
+        innings: null,
+      });
+    }
+  }
+  return rows;
+}
+
+function ScoreboardCard({ item }: { item: RecentGameItem }) {
+  const live = item.status === "live";
+  const stamp = item.outcome ? OUTCOME_STAMPS[item.outcome] : null;
+  const competition = item.competition.name || item.league.name;
+
+  return (
+    <Link
+      to={`/calendar/game/${item.id}`}
+      className={`fc-sbcard${live ? "fc-sbcard--live" : ""}`}
+    >
+      <div className="fc-sb-eyebrow">
+        {live ? (
+          <span className="fc-sb-lamp">
+            <i aria-hidden="true" />
+            Live
+          </span>
+        ) : (
+          <span>
+            {item.when
+              ? formatInTimeZone(
+                  new Date(item.when),
+                  "Europe/London",
+                  "EEE d MMM",
+                )
+              : ""}
+          </span>
+        )}
+        <span>{competition}</span>
+      </div>
+
+      {buildRows(item).map((row) => (
+        <div key={row.key} className="fc-sb-line">
+          <div className="fc-sb-teamwrap">
+            <div className="fc-sb-team">
+              {row.batting && <span className="fc-sb-bat" aria-hidden="true" />}
+              {row.clubName}
+            </div>
+            {row.meta && <div className="fc-sb-teammeta">{row.meta}</div>}
+          </div>
+          <div className="fc-sb-scorewrap">
+            {row.innings ? (
+              <>
+                <div className="fc-sb-score">{formatScore(row.innings)}</div>
+                {row.innings.overs && (
+                  <div className="fc-sb-overs">{row.innings.overs} overs</div>
+                )}
+              </>
+            ) : (
+              <div className="fc-sb-noscore">{live ? "Yet to bat" : "–"}</div>
+            )}
+          </div>
+        </div>
+      ))}
+
+      <div className="fc-sb-foot">
+        {live ? (
+          <>
+            <span className="fc-sb-livenote">{item.note ?? "In play"}</span>
+            <span className="fc-sb-follow">Follow &rarr;</span>
+          </>
+        ) : (
+          <>
+            <span>{item.note}</span>
+            {stamp && (
+              <span className={`fc-sb-stamp fc-sb-stamp--${stamp.tone}`}>
+                {stamp.label}
+              </span>
+            )}
+          </>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+/** The homepage scoreboard card grid. Purely presentational - the section
+ * wrapper (Plate + mast + query) lives with the page that hosts it. */
+export function ScoreboardStrip({ items }: { items: RecentGameItem[] }) {
+  return (
+    <div className="fc-sb-grid">
+      {items.map((item) => (
+        <ScoreboardCard key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -2454,6 +2454,85 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/games/recent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            items: {
+                                id: string;
+                                /** @enum {string} */
+                                status: "live" | "result";
+                                when: string | null;
+                                home: boolean;
+                                team: {
+                                    id: string;
+                                    name: string;
+                                };
+                                opposition: {
+                                    club: {
+                                        id: string;
+                                        name: string;
+                                    };
+                                    team: {
+                                        id: string;
+                                        name: string;
+                                    };
+                                };
+                                league: {
+                                    id: string;
+                                    name: string;
+                                };
+                                competition: {
+                                    id: string;
+                                    name: string;
+                                    type: string;
+                                };
+                                /** @enum {string|null} */
+                                outcome: "W" | "L" | "D" | "T" | "A" | "C" | "N" | null;
+                                note: string | null;
+                                innings: {
+                                    teamBattingId: string;
+                                    teamName: string;
+                                    runs: number;
+                                    wickets: number;
+                                    overs: string;
+                                    declared: boolean;
+                                    allOut: boolean;
+                                }[];
+                            }[];
+                            hasLive: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/games/prerender-manifest": {
         parameters: {
             query?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -4186,6 +4186,221 @@
         }
       }
     },
+    "/api/games/recent": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "live",
+                              "result"
+                            ]
+                          },
+                          "when": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "home": {
+                            "type": "boolean"
+                          },
+                          "team": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "opposition": {
+                            "type": "object",
+                            "properties": {
+                              "club": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "name"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "team": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "name"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "club",
+                              "team"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "league": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "competition": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "outcome": {
+                            "nullable": true,
+                            "type": "string",
+                            "enum": [
+                              "W",
+                              "L",
+                              "D",
+                              "T",
+                              "A",
+                              "C",
+                              "N"
+                            ]
+                          },
+                          "note": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "innings": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "teamBattingId": {
+                                  "type": "string"
+                                },
+                                "teamName": {
+                                  "type": "string"
+                                },
+                                "runs": {
+                                  "type": "number"
+                                },
+                                "wickets": {
+                                  "type": "number"
+                                },
+                                "overs": {
+                                  "type": "string"
+                                },
+                                "declared": {
+                                  "type": "boolean"
+                                },
+                                "allOut": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "teamBattingId",
+                                "teamName",
+                                "runs",
+                                "wickets",
+                                "overs",
+                                "declared",
+                                "allOut"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "status",
+                          "when",
+                          "home",
+                          "team",
+                          "opposition",
+                          "league",
+                          "competition",
+                          "outcome",
+                          "note",
+                          "innings"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "hasLive": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "hasLive"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/games/prerender-manifest": {
       "get": {
         "responses": {

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -10,6 +10,7 @@ import {
 import { FixtureStrip } from "@/components/theme/fixture-strip.js";
 import { Plate } from "@/components/theme/plate.js";
 import { RisoHeading } from "@/components/theme/riso-heading.js";
+import { ScoreboardStrip } from "@/components/theme/scoreboard.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client.js";
 import { getCategoryColor } from "@/lib/category-colors.js";
@@ -267,6 +268,48 @@ function UpcomingStrip() {
   );
 }
 
+// Poll while a game is in play so the homepage score tracks the scorer;
+// otherwise rely on the usual refetch-on-focus. The API caches Play
+// Cricket reads for ~60s, so 30s polling costs little upstream.
+const SCOREBOARD_LIVE_POLL_MS = 30_000;
+
+function ScoreboardSection() {
+  const { data } = useQuery({
+    queryKey: ["games", "recent"],
+    queryFn: () => callApi(api.GET("/api/games/recent")),
+    staleTime: 15_000,
+    refetchInterval: (query) =>
+      query.state.data?.hasLive ? SCOREBOARD_LIVE_POLL_MS : false,
+  });
+
+  if (!data || data.items.length === 0) return null;
+
+  return (
+    <Plate variant="navy" flush>
+      <SectionMast
+        title="The Scoreboard"
+        note={
+          data.hasLive
+            ? "Live now - scores update over by over."
+            : "Straight from the scorers."
+        }
+        front="var(--fc-paper)"
+        back="var(--fc-orange)"
+        blend="normal"
+      />
+      <ScoreboardStrip items={data.items} />
+      <div className="mt-7">
+        <Link
+          to="/calendar"
+          className="font-secondary tracking-wide text-[#f1e5c9] uppercase hover:underline"
+        >
+          All results &rarr;
+        </Link>
+      </div>
+    </Plate>
+  );
+}
+
 function LatestNewsSection() {
   const { data, isError } = useQuery(newsListQueryOptions({ page: 1 }));
   const people = usePeople();
@@ -373,7 +416,10 @@ export function Component() {
         </div>
       </Plate>
 
-      {/* PLATE 02 — WHAT'S ON */}
+      {/* PLATE 02 — THE SCOREBOARD */}
+      <ScoreboardSection />
+
+      {/* PLATE 03 — WHAT'S ON */}
       <UpcomingStrip />
 
       {/* PLATE 04 — THE NUMBERS */}


### PR DESCRIPTION
## What

The front page now opens with **The Scoreboard**: the club's 2-3 most recent results, with any game in play right now shown **live** - score, overs, chase target - polling every 30s while play continues.


### Backend - `GET /api/games/recent`

- Results come from Play Cricket's `result_summary.json`, which updates within minutes of a scorer posting - the DB `match_result` rows only refresh on the weekly sync and are far too stale for this strip.
- Live detection: a same-day fixture whose start time (London wall-clock) has passed and which has no posted result is checked against `match_detail.json`, parsed with a new lenient schema (`LiveMatchDetail`) so incomplete mid-innings payloads degrade to "in play, no score" instead of failing the request.
- A game that just finished (result on detail, not yet in result_summary) is promoted to a result immediately.
- Notes are computed server-side: "Won by 5 wickets" / "Lost by 43 runs" margins, "Mitford CC need 74 more to win" chase targets (Standard games only - Pairs/softball margins don't follow runs/wickets semantics and fall back to the outcome stamp).
- Resilience: 5-min result cache and 60s live-detail cache with stale-on-error fallback; a full Play Cricket outage returns an empty list (logged at warn) and the homepage section hides itself.
- New defaulted config `PLAY_CRICKET_API_BASE` lets the games feature run against a local mock server (documented in `.env.example`).

### Frontend

- New `ScoreboardStrip` in the riso print language: paper scorecards pinned to a navy plate, Anton numerals, batting order preserved, rubber-stamped WON/LOST/ABAN outcomes, pulsing live lamp (respects `prefers-reduced-motion`), home side first on scoreless cards.
- react-query polling keyed off `hasLive` (30s live, refetch-on-focus otherwise). The section renders nothing while loading, on error, or with no items - the home page is not prerendered, so this stays a pure client-side strip.

## Testing

- 20 new unit tests for the service (BST/GMT wall-clock, margins, live detection, just-finished promotion, outage degradation, caching).
- Exercised end-to-end against a mock Play Cricket server through the full lifecycle: scheduled -> scoreless in-play -> first innings -> chase (verified the 30s poll updates the DOM without a reload) -> finished (card flips to a result with the LOST stamp).
- Also verified against the real Play Cricket API: last weekend's three results render with correct margins and batting order.
- `pnpm typecheck` / `lint` / `build` green; 646 API + 666 web tests pass.

## Notes for review

- The service deliberately takes no `db` - every displayed fact comes from Play Cricket. Games whose result exists only as a manual matchday entry don't appear in the strip (they still show on calendar pages).
- Scoreless games stay "in play" for at most 8h after their start time, so a rained-off game that never posts a score drops off the same evening.
- Screenshots + a full build report (decisions, uncertainties, follow-ups) are in `.claude/tmp/recent-results/` locally (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

