### PR TITLE
fix(api): cover all member-linked tables in member merge

### DIFF
--- a/apps/api/src/features/admin/integration.test.ts
+++ b/apps/api/src/features/admin/integration.test.ts
@@ -2016,14 +2016,14 @@ describe("admin service (integration)", () => {
           .execute();
       }
 
-      await expect(
-        mergeMembers(ctx.db)({
-          keepMemberId: keepId,
-          removeMemberId: removeId,
-        }),
-      ).rejects.toThrow(
+      const mergeAttempt = mergeMembers(ctx.db)({
+        keepMemberId: keepId,
+        removeMemberId: removeId,
+      });
+      await expect(mergeAttempt).rejects.toThrow(
         "Both members have an active financial relief grant. Close one of them before merging.",
       );
+      await expect(mergeAttempt).rejects.toMatchObject({ statusCode: 409 });
 
       // Transaction rolled back - the removed member still exists
       const removed = await ctx.db

--- a/apps/api/src/features/admin/integration.test.ts
+++ b/apps/api/src/features/admin/integration.test.ts
@@ -1,6 +1,6 @@
 import type { DB } from "@percy-main/db";
 import type { Email } from "@percy-main/email";
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   seedTestUser,
@@ -1657,6 +1657,444 @@ describe("admin service (integration)", () => {
           removeMemberId: "nonexistent-b",
         }),
       ).rejects.toThrow("One or both member records not found");
+    });
+
+    it("moves availability, group, parent link, lead and financial relief records", async () => {
+      const suffix = crypto.randomUUID().slice(0, 8);
+      const keepId = `merge-fk-keep-${suffix}`;
+      const removeId = `merge-fk-rm-${suffix}`;
+      const childId = `merge-fk-child-${suffix}`;
+
+      for (const [id, name] of [
+        [keepId, "Keep"],
+        [removeId, "Remove"],
+        [childId, "Child"],
+      ]) {
+        await ctx.db
+          .insertInto("member")
+          .values({ id, email: `${id}@test.com`, name })
+          .execute();
+      }
+      const { userId } = await seedTestUser(ctx.db, { withMember: false });
+
+      const requestId = `avreq-${suffix}`;
+      await ctx.db
+        .insertInto("availability_request")
+        .values({
+          id: requestId,
+          created_by: userId,
+          date_from: "2026-05-01",
+          date_to: "2026-05-31",
+        })
+        .execute();
+      const responseId = `avresp-${suffix}`;
+      await ctx.db
+        .insertInto("availability_response")
+        .values({
+          id: responseId,
+          availability_request_id: requestId,
+          member_id: removeId,
+          match_date: "2026-05-09",
+          status: "available",
+        })
+        .execute();
+
+      const teamId = `team-${suffix}`;
+      await ctx.db
+        .insertInto("play_cricket_team")
+        .values({ id: teamId, name: "1st XI", site_id: `site-${suffix}` })
+        .execute();
+      const fixtureId = `avfix-${suffix}`;
+      await ctx.db
+        .insertInto("availability_fixture")
+        .values({
+          id: fixtureId,
+          availability_request_id: requestId,
+          is_home: true,
+          match_date: "2026-05-09",
+          opposition: "Opposition CC",
+          play_cricket_match_id: `pcm-${suffix}`,
+          play_cricket_team_id: teamId,
+        })
+        .execute();
+      const assignmentId = `avasg-${suffix}`;
+      await ctx.db
+        .insertInto("availability_assignment")
+        .values({
+          id: assignmentId,
+          availability_fixture_id: fixtureId,
+          member_id: removeId,
+          player_name: "Remove",
+          position: 1,
+        })
+        .execute();
+
+      const groupId = `grp-${suffix}`;
+      await ctx.db
+        .insertInto("user_group")
+        .values({ id: groupId, name: `Group ${suffix}` })
+        .execute();
+      await ctx.db
+        .insertInto("user_group_member")
+        .values({ group_id: groupId, member_id: removeId })
+        .execute();
+
+      await ctx.db
+        .insertInto("member_parent_link")
+        .values({ member_id: childId, parent_member_id: removeId })
+        .execute();
+
+      const leadId = `lead-${suffix}`;
+      await ctx.db
+        .insertInto("lead")
+        .values({
+          id: leadId,
+          email: `lead-${suffix}@test.com`,
+          source: "web",
+          member_id: removeId,
+        })
+        .execute();
+
+      const reliefRequestId = `frr-${suffix}`;
+      await ctx.db
+        .insertInto("financial_relief_request")
+        .values({
+          id: reliefRequestId,
+          member_id: removeId,
+          submitted_by_user_id: userId,
+          contact_preference: "none",
+          declaration_confirmed_at: new Date(),
+          privacy_acknowledged_at: new Date(),
+          requested_match_fees: true,
+          requested_membership_full: false,
+          requested_membership_partial: false,
+          status: "approved",
+        })
+        .execute();
+      const grantId = `frg-${suffix}`;
+      await ctx.db
+        .insertInto("financial_relief_grant")
+        .values({
+          id: grantId,
+          member_id: removeId,
+          request_id: reliefRequestId,
+          decided_by: userId,
+          decision: "approved_full",
+          covers_match_fees: true,
+          covers_membership: false,
+          effective_from: new Date(),
+        })
+        .execute();
+
+      const result = await mergeMembers(ctx.db)({
+        keepMemberId: keepId,
+        removeMemberId: removeId,
+      });
+      expect(result).toEqual({ success: true });
+
+      const repointed = {
+        availability_response: await ctx.db
+          .selectFrom("availability_response")
+          .where("id", "=", responseId)
+          .select("member_id")
+          .executeTakeFirst(),
+        availability_assignment: await ctx.db
+          .selectFrom("availability_assignment")
+          .where("id", "=", assignmentId)
+          .select("member_id")
+          .executeTakeFirst(),
+        lead: await ctx.db
+          .selectFrom("lead")
+          .where("id", "=", leadId)
+          .select("member_id")
+          .executeTakeFirst(),
+        financial_relief_request: await ctx.db
+          .selectFrom("financial_relief_request")
+          .where("id", "=", reliefRequestId)
+          .select("member_id")
+          .executeTakeFirst(),
+        financial_relief_grant: await ctx.db
+          .selectFrom("financial_relief_grant")
+          .where("id", "=", grantId)
+          .select("member_id")
+          .executeTakeFirst(),
+      };
+      for (const [table, row] of Object.entries(repointed)) {
+        expect(row?.member_id, table).toBe(keepId);
+      }
+
+      const groupRow = await ctx.db
+        .selectFrom("user_group_member")
+        .where("group_id", "=", groupId)
+        .selectAll()
+        .execute();
+      expect(groupRow).toHaveLength(1);
+      expect(groupRow[0]?.member_id).toBe(keepId);
+
+      const parentLink = await ctx.db
+        .selectFrom("member_parent_link")
+        .where("member_id", "=", childId)
+        .selectAll()
+        .execute();
+      expect(parentLink).toHaveLength(1);
+      expect(parentLink[0]?.parent_member_id).toBe(keepId);
+
+      const removed = await ctx.db
+        .selectFrom("member")
+        .where("id", "=", removeId)
+        .selectAll()
+        .executeTakeFirst();
+      expect(removed).toBeUndefined();
+    });
+
+    it("keeps the kept member's availability response when both answered the same match", async () => {
+      const suffix = crypto.randomUUID().slice(0, 8);
+      const keepId = `merge-avdupe-keep-${suffix}`;
+      const removeId = `merge-avdupe-rm-${suffix}`;
+
+      for (const [id, name] of [
+        [keepId, "Keep"],
+        [removeId, "Remove"],
+      ]) {
+        await ctx.db
+          .insertInto("member")
+          .values({ id, email: `${id}@test.com`, name })
+          .execute();
+      }
+      const { userId } = await seedTestUser(ctx.db, { withMember: false });
+
+      const requestId = `avreq-dupe-${suffix}`;
+      await ctx.db
+        .insertInto("availability_request")
+        .values({
+          id: requestId,
+          created_by: userId,
+          date_from: "2026-06-01",
+          date_to: "2026-06-30",
+        })
+        .execute();
+      await ctx.db
+        .insertInto("availability_response")
+        .values([
+          {
+            id: `avresp-keep-${suffix}`,
+            availability_request_id: requestId,
+            member_id: keepId,
+            match_date: "2026-06-06",
+            status: "available",
+          },
+          {
+            id: `avresp-rm-${suffix}`,
+            availability_request_id: requestId,
+            member_id: removeId,
+            match_date: "2026-06-06",
+            status: "unavailable",
+          },
+        ])
+        .execute();
+
+      await mergeMembers(ctx.db)({
+        keepMemberId: keepId,
+        removeMemberId: removeId,
+      });
+
+      const responses = await ctx.db
+        .selectFrom("availability_response")
+        .where("availability_request_id", "=", requestId)
+        .select(["member_id", "status"])
+        .execute();
+      expect(responses).toHaveLength(1);
+      expect(responses[0]).toEqual({ member_id: keepId, status: "available" });
+    });
+
+    it("dedupes group memberships and drops links between the merged records", async () => {
+      const suffix = crypto.randomUUID().slice(0, 8);
+      const keepId = `merge-link-keep-${suffix}`;
+      const removeId = `merge-link-rm-${suffix}`;
+
+      for (const [id, name] of [
+        [keepId, "Keep"],
+        [removeId, "Remove"],
+      ]) {
+        await ctx.db
+          .insertInto("member")
+          .values({ id, email: `${id}@test.com`, name })
+          .execute();
+      }
+
+      const groupId = `grp-dupe-${suffix}`;
+      await ctx.db
+        .insertInto("user_group")
+        .values({ id: groupId, name: `Group ${suffix}` })
+        .execute();
+      await ctx.db
+        .insertInto("user_group_member")
+        .values([
+          { group_id: groupId, member_id: keepId },
+          { group_id: groupId, member_id: removeId },
+        ])
+        .execute();
+
+      // The removed record is linked as the kept member's parent - this link
+      // would become a self-link and must be dropped, not re-pointed.
+      await ctx.db
+        .insertInto("member_parent_link")
+        .values({ member_id: keepId, parent_member_id: removeId })
+        .execute();
+
+      await mergeMembers(ctx.db)({
+        keepMemberId: keepId,
+        removeMemberId: removeId,
+      });
+
+      const groupRows = await ctx.db
+        .selectFrom("user_group_member")
+        .where("group_id", "=", groupId)
+        .selectAll()
+        .execute();
+      expect(groupRows).toHaveLength(1);
+      expect(groupRows[0]?.member_id).toBe(keepId);
+
+      const links = await ctx.db
+        .selectFrom("member_parent_link")
+        .where((eb) =>
+          eb.or([
+            eb("member_id", "=", keepId),
+            eb("parent_member_id", "=", keepId),
+          ]),
+        )
+        .selectAll()
+        .execute();
+      expect(links).toHaveLength(0);
+    });
+
+    it("throws 409 when both members have an active financial relief grant", async () => {
+      const suffix = crypto.randomUUID().slice(0, 8);
+      const keepId = `merge-grant-keep-${suffix}`;
+      const removeId = `merge-grant-rm-${suffix}`;
+
+      for (const [id, name] of [
+        [keepId, "Keep"],
+        [removeId, "Remove"],
+      ]) {
+        await ctx.db
+          .insertInto("member")
+          .values({ id, email: `${id}@test.com`, name })
+          .execute();
+      }
+      const { userId } = await seedTestUser(ctx.db, { withMember: false });
+
+      for (const memberId of [keepId, removeId]) {
+        const requestId = `frr-${memberId}`;
+        await ctx.db
+          .insertInto("financial_relief_request")
+          .values({
+            id: requestId,
+            member_id: memberId,
+            submitted_by_user_id: userId,
+            contact_preference: "none",
+            declaration_confirmed_at: new Date(),
+            privacy_acknowledged_at: new Date(),
+            requested_match_fees: true,
+            requested_membership_full: false,
+            requested_membership_partial: false,
+            status: "approved",
+          })
+          .execute();
+        await ctx.db
+          .insertInto("financial_relief_grant")
+          .values({
+            id: `frg-${memberId}`,
+            member_id: memberId,
+            request_id: requestId,
+            decided_by: userId,
+            decision: "approved_full",
+            covers_match_fees: true,
+            covers_membership: false,
+            effective_from: new Date(),
+          })
+          .execute();
+      }
+
+      await expect(
+        mergeMembers(ctx.db)({
+          keepMemberId: keepId,
+          removeMemberId: removeId,
+        }),
+      ).rejects.toThrow(
+        "Both members have an active financial relief grant. Close one of them before merging.",
+      );
+
+      // Transaction rolled back - the removed member still exists
+      const removed = await ctx.db
+        .selectFrom("member")
+        .where("id", "=", removeId)
+        .select("id")
+        .executeTakeFirst();
+      expect(removed).toBeDefined();
+    });
+
+    it("backfills missing profile fields without overwriting kept values", async () => {
+      const suffix = crypto.randomUUID().slice(0, 8);
+      const keepId = `merge-fill-keep-${suffix}`;
+      const removeId = `merge-fill-rm-${suffix}`;
+
+      await ctx.db
+        .insertInto("member")
+        .values({
+          id: keepId,
+          email: `${keepId}@test.com`,
+          name: "Keep Name",
+        })
+        .execute();
+      await ctx.db
+        .insertInto("member")
+        .values({
+          id: removeId,
+          email: `${removeId}@test.com`,
+          name: "Remove Name",
+          title: "Mr",
+          address: "3 The Spinney",
+          postcode: "NE29 1AA",
+          dob: "2007-05-23",
+          telephone: "07700900000",
+          member_category: "senior",
+          play_cricket_id: `pc-${suffix}`,
+        })
+        .execute();
+
+      await mergeMembers(ctx.db)({
+        keepMemberId: keepId,
+        removeMemberId: removeId,
+      });
+
+      const kept = await ctx.db
+        .selectFrom("member")
+        .where("id", "=", keepId)
+        .select([
+          "name",
+          "email",
+          "title",
+          "address",
+          "postcode",
+          sql<string>`dob::text`.as("dob"),
+          "telephone",
+          "member_category",
+          "play_cricket_id",
+        ])
+        .executeTakeFirst();
+
+      expect(kept).toEqual({
+        name: "Keep Name",
+        email: `${keepId}@test.com`,
+        title: "Mr",
+        address: "3 The Spinney",
+        postcode: "NE29 1AA",
+        dob: "2007-05-23",
+        telephone: "07700900000",
+        member_category: "senior",
+        play_cricket_id: `pc-${suffix}`,
+      });
     });
   });
 });

--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -1915,6 +1915,61 @@ export function mergeMembers(db: Kysely<DB>) {
         throw error;
       }
 
+      // A member can hold at most one active relief grant / open relief
+      // request (partial unique indexes). Merging two needs a human decision.
+      const openRequestStatuses = [
+        "submitted",
+        "in_review",
+        "more_info_needed",
+      ];
+      const [
+        keepActiveGrant,
+        removeActiveGrant,
+        keepOpenRequest,
+        removeOpenRequest,
+      ] = await Promise.all([
+        trx
+          .selectFrom("financial_relief_grant")
+          .where("member_id", "=", keepMemberId)
+          .where("closed_at", "is", null)
+          .select("id")
+          .executeTakeFirst(),
+        trx
+          .selectFrom("financial_relief_grant")
+          .where("member_id", "=", removeMemberId)
+          .where("closed_at", "is", null)
+          .select("id")
+          .executeTakeFirst(),
+        trx
+          .selectFrom("financial_relief_request")
+          .where("member_id", "=", keepMemberId)
+          .where("status", "in", openRequestStatuses)
+          .select("id")
+          .executeTakeFirst(),
+        trx
+          .selectFrom("financial_relief_request")
+          .where("member_id", "=", removeMemberId)
+          .where("status", "in", openRequestStatuses)
+          .select("id")
+          .executeTakeFirst(),
+      ]);
+
+      if (keepActiveGrant && removeActiveGrant) {
+        const error = new Error(
+          "Both members have an active financial relief grant. Close one of them before merging.",
+        ) as Error & { statusCode: number };
+        error.statusCode = 409;
+        throw error;
+      }
+
+      if (keepOpenRequest && removeOpenRequest) {
+        const error = new Error(
+          "Both members have an open financial relief request. Resolve one of them before merging.",
+        ) as Error & { statusCode: number };
+        error.statusCode = 409;
+        throw error;
+      }
+
       // Re-point all foreign keys from removeMember to keepMember
       await trx
         .updateTable("membership")
@@ -1940,17 +1995,181 @@ export function mergeMembers(db: Kysely<DB>) {
         .where("member_id", "=", removeMemberId)
         .execute();
 
-      // Preserve stripe_customer_id if keepMember doesn't have one
-      if (!keepMember.stripe_customer_id && removeMember.stripe_customer_id) {
+      await trx
+        .updateTable("lead")
+        .set({ member_id: keepMemberId })
+        .where("member_id", "=", removeMemberId)
+        .execute();
+
+      await trx
+        .updateTable("financial_relief_grant")
+        .set({ member_id: keepMemberId })
+        .where("member_id", "=", removeMemberId)
+        .execute();
+
+      await trx
+        .updateTable("financial_relief_request")
+        .set({ member_id: keepMemberId })
+        .where("member_id", "=", removeMemberId)
+        .execute();
+
+      // availability_response is unique on (availability_request_id,
+      // member_id, match_date) - where both members answered, keep the kept
+      // member's response and drop the duplicate before re-pointing.
+      await trx
+        .deleteFrom("availability_response")
+        .where("member_id", "=", removeMemberId)
+        .where((eb) =>
+          eb.exists(
+            eb
+              .selectFrom("availability_response as keep_response")
+              .select("keep_response.id")
+              .where("keep_response.member_id", "=", keepMemberId)
+              .whereRef(
+                "keep_response.availability_request_id",
+                "=",
+                "availability_response.availability_request_id",
+              )
+              .whereRef(
+                "keep_response.match_date",
+                "=",
+                "availability_response.match_date",
+              ),
+          ),
+        )
+        .execute();
+
+      await trx
+        .updateTable("availability_response")
+        .set({ member_id: keepMemberId })
+        .where("member_id", "=", removeMemberId)
+        .execute();
+
+      // availability_assignment is unique on (availability_fixture_id,
+      // member_id) - same dedupe-then-re-point.
+      await trx
+        .deleteFrom("availability_assignment")
+        .where("member_id", "=", removeMemberId)
+        .where((eb) =>
+          eb.exists(
+            eb
+              .selectFrom("availability_assignment as keep_assignment")
+              .select("keep_assignment.id")
+              .where("keep_assignment.member_id", "=", keepMemberId)
+              .whereRef(
+                "keep_assignment.availability_fixture_id",
+                "=",
+                "availability_assignment.availability_fixture_id",
+              ),
+          ),
+        )
+        .execute();
+
+      await trx
+        .updateTable("availability_assignment")
+        .set({ member_id: keepMemberId })
+        .where("member_id", "=", removeMemberId)
+        .execute();
+
+      // user_group_member has PK (group_id, member_id) and would otherwise be
+      // silently dropped by ON DELETE CASCADE.
+      await trx
+        .deleteFrom("user_group_member")
+        .where("member_id", "=", removeMemberId)
+        .where("group_id", "in", (qb) =>
+          qb
+            .selectFrom("user_group_member")
+            .select("group_id")
+            .where("member_id", "=", keepMemberId),
+        )
+        .execute();
+
+      await trx
+        .updateTable("user_group_member")
+        .set({ member_id: keepMemberId })
+        .where("member_id", "=", removeMemberId)
+        .execute();
+
+      // member_parent_link cascades on both columns. Links between the two
+      // merged records would become self-links - drop them first.
+      await trx
+        .deleteFrom("member_parent_link")
+        .where("member_id", "in", [keepMemberId, removeMemberId])
+        .where("parent_member_id", "in", [keepMemberId, removeMemberId])
+        .execute();
+
+      await trx
+        .deleteFrom("member_parent_link")
+        .where("member_id", "=", removeMemberId)
+        .where("parent_member_id", "in", (qb) =>
+          qb
+            .selectFrom("member_parent_link")
+            .select("parent_member_id")
+            .where("member_id", "=", keepMemberId),
+        )
+        .execute();
+
+      await trx
+        .updateTable("member_parent_link")
+        .set({ member_id: keepMemberId })
+        .where("member_id", "=", removeMemberId)
+        .execute();
+
+      await trx
+        .deleteFrom("member_parent_link")
+        .where("parent_member_id", "=", removeMemberId)
+        .where("member_id", "in", (qb) =>
+          qb
+            .selectFrom("member_parent_link")
+            .select("member_id")
+            .where("parent_member_id", "=", keepMemberId),
+        )
+        .execute();
+
+      await trx
+        .updateTable("member_parent_link")
+        .set({ parent_member_id: keepMemberId })
+        .where("parent_member_id", "=", removeMemberId)
+        .execute();
+
+      // Delete the duplicate, then backfill profile fields the kept record is
+      // missing. Delete-first matters: play_cricket_id, slug and email are
+      // unique, so the removed row must be gone before its values are copied.
+      await trx.deleteFrom("member").where("id", "=", removeMemberId).execute();
+
+      const backfillColumns = [
+        "name",
+        "title",
+        "email",
+        "address",
+        "postcode",
+        "dob",
+        "telephone",
+        "emergency_contact_name",
+        "emergency_contact_telephone",
+        "member_category",
+        "play_cricket_id",
+        "slug",
+        "stripe_customer_id",
+      ] as const;
+
+      const backfill: Partial<
+        Record<(typeof backfillColumns)[number], string>
+      > = {};
+      for (const column of backfillColumns) {
+        const removeValue = removeMember[column];
+        if (keepMember[column] === null && removeValue !== null) {
+          backfill[column] = removeValue;
+        }
+      }
+
+      if (Object.keys(backfill).length > 0) {
         await trx
           .updateTable("member")
-          .set({ stripe_customer_id: removeMember.stripe_customer_id })
+          .set(backfill)
           .where("id", "=", keepMemberId)
           .execute();
       }
-
-      // Delete the duplicate member record
-      await trx.deleteFrom("member").where("id", "=", removeMemberId).execute();
     });
 
     return { success: true };

--- a/apps/api/src/features/admin/service.ts
+++ b/apps/api/src/features/admin/service.ts
@@ -1893,19 +1893,19 @@ export function mergeMembers(db: Kysely<DB>) {
     }
 
     await db.transaction().execute(async (trx) => {
-      // Fetch inside transaction to avoid TOCTOU race
-      const [keepMember, removeMember] = await Promise.all([
-        trx
-          .selectFrom("member")
-          .where("id", "=", keepMemberId)
-          .selectAll()
-          .executeTakeFirst(),
-        trx
-          .selectFrom("member")
-          .where("id", "=", removeMemberId)
-          .selectAll()
-          .executeTakeFirst(),
-      ]);
+      // Lock both rows for the duration of the merge: inserts into
+      // referencing tables take a key-share lock on the member row, so this
+      // blocks concurrent inserts that the re-points below would miss (they
+      // would otherwise be cascade-deleted or hit an FK error).
+      const lockedMembers = await trx
+        .selectFrom("member")
+        .where("id", "in", [keepMemberId, removeMemberId])
+        .selectAll()
+        .forUpdate()
+        .execute();
+
+      const keepMember = lockedMembers.find((m) => m.id === keepMemberId);
+      const removeMember = lockedMembers.find((m) => m.id === removeMemberId);
 
       if (!keepMember || !removeMember) {
         const error = new Error(

--- a/apps/web/src/pages/admin/duplicates-tab.tsx
+++ b/apps/web/src/pages/admin/duplicates-tab.tsx
@@ -298,12 +298,34 @@ function MergePreviewModal({
                     the kept record
                   </li>
                 )}
+                <li>
+                  Any availability responses, squad selections, parent links and
+                  group memberships will be moved to the kept record
+                </li>
                 {!preview.keep.member.stripe_customer_id &&
                   preview.remove.member.stripe_customer_id && (
                     <li>
                       Stripe customer ID will be copied from the removed record
                     </li>
                   )}
+                {(
+                  [
+                    "name",
+                    "title",
+                    "address",
+                    "postcode",
+                    "dob",
+                    "telephone",
+                  ] as const
+                ).some(
+                  (field) =>
+                    !preview.keep.member[field] && preview.remove.member[field],
+                ) && (
+                  <li>
+                    Profile details missing from the kept record (e.g. address,
+                    date of birth, phone) will be copied from the removed record
+                  </li>
+                )}
                 <li>The duplicate member record will be deleted</li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary

Merging two members through the admin duplicates UI failed with:

```
update or delete on table "member" violates foreign key constraint
"availability_response_member_id_fkey" on table "availability_response"
```

`mergeMembers` only re-pointed `membership`, `dependent`, `charge` and `matchday_player`. Seven other tables reference `member`:

- `availability_response`, `availability_assignment`, `lead`, `financial_relief_request`, `financial_relief_grant` are `NO ACTION` FKs, so any of them blocks the merge with the error above
- `member_parent_link` (both columns) and `user_group_member` are `ON DELETE CASCADE`, so the merge silently destroyed parent links and group memberships

## Changes

- Re-point all seven remaining tables inside the merge transaction
- Dedupe where unique constraints would collide: availability responses (same request + match date, kept member's response wins), availability assignments (same fixture), group memberships (same group), parent links (same parent/child); links between the two merged records are dropped rather than becoming self-links
- Throw a friendly 409 when both members hold an active financial relief grant or an open relief request, since the partial unique indexes allow only one per member and that conflict needs a human decision
- Backfill profile fields the kept record is missing (name, title, email, address, postcode, dob, telephone, emergency contacts, member_category, play_cricket_id, slug) from the removed record, extending the existing stripe_customer_id behaviour. Without this, keeping the sparser record silently discarded the real DOB/address/phone. Backfill runs after the removed row is deleted because play_cricket_id, slug and email are unique
- Update the merge dialog's "What will happen" list to mention the moved records and the profile backfill

## Testing

- 5 new integration tests: full re-point across all newly covered tables, availability response dedupe, group/parent-link dedupe with self-link removal, 409 on dual active grants (with rollback assertion), and profile backfill without overwriting kept values
- `pnpm run typecheck`, `pnpm run lint`, `pnpm format`, `pnpm --filter api test` (667 passed), `pnpm --filter api test:integration` (513 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)