### PR TITLE
fix(api): do not exit the process on unhandled AbortError rejections

### DIFF
--- a/apps/api/src/lib/abort-errors.test.ts
+++ b/apps/api/src/lib/abort-errors.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isAbortError } from "./abort-errors.ts";
+
+describe("isAbortError", () => {
+  it("matches a DOMException AbortError", () => {
+    expect(
+      isAbortError(
+        new DOMException("This operation was aborted", "AbortError"),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a plain Error named AbortError", () => {
+    const error = new Error("The operation was aborted");
+    error.name = "AbortError";
+    expect(isAbortError(error)).toBe(true);
+  });
+
+  it("matches the reason from an aborted AbortController", () => {
+    const controller = new AbortController();
+    controller.abort();
+    expect(isAbortError(controller.signal.reason)).toBe(true);
+  });
+
+  it("rejects other errors", () => {
+    expect(isAbortError(new Error("boom"))).toBe(false);
+    expect(isAbortError(new DOMException("timed out", "TimeoutError"))).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-object reasons", () => {
+    expect(isAbortError("AbortError")).toBe(false);
+    expect(isAbortError(null)).toBe(false);
+    expect(isAbortError(undefined)).toBe(false);
+    expect(isAbortError(42)).toBe(false);
+  });
+});

--- a/apps/api/src/lib/abort-errors.ts
+++ b/apps/api/src/lib/abort-errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Detects aborted-operation errors (DOMException or Error with
+ * name "AbortError") that libraries leak as floating-promise
+ * rejections when an in-flight operation is cancelled - e.g.
+ * better-auth's dash plugin when a client disconnects mid-request.
+ *
+ * These are request-scoped, not process-corrupting, so the
+ * process-level unhandledRejection handler logs them and keeps
+ * serving instead of exiting (2026-07-17: one aborted dash request
+ * crashed the API task and took prod down for ~40s).
+ */
+export function isAbortError(reason: unknown): boolean {
+  return (
+    typeof reason === "object" &&
+    reason !== null &&
+    "name" in reason &&
+    reason.name === "AbortError"
+  );
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@percy-main/db";
 import { buildApp } from "./app.ts";
 import { parseConfig } from "./config.ts";
+import { isAbortError } from "./lib/abort-errors.ts";
 
 const config = parseConfig(process.env);
 const { client: db, dialect } = createClient(config.DATABASE_URL);
@@ -15,7 +16,17 @@ const app = await buildApp({ db, dialect, config });
 // Both handlers exit(1) because attaching a listener disables Node's
 // default crash behaviour — without exiting we'd silently keep running
 // in a corrupted state instead of letting ECS restart us cleanly.
+//
+// Exception: AbortError rejections. better-auth's dash plugin leaks
+// them as floating promises when an in-flight operation is cancelled
+// (client disconnect / upstream abort). They are request-scoped, so
+// exiting would hand any browser tab-close a ~40s prod outage while
+// ECS replaces the single task.
 process.on("unhandledRejection", (reason: unknown) => {
+  if (isAbortError(reason)) {
+    app.log.error({ err: reason }, "unhandled_rejection_aborted_operation");
+    return;
+  }
   app.log.fatal({ err: reason }, "unhandled_rejection");
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

During tonight's incident (2026-07-17 21:12 UTC), a cancelled `/api/auth/dash/list-users` request leaked a `DOMException AbortError` as an unhandled promise rejection from `@better-auth/infra`'s dash plugin. Our process-level `unhandledRejection` handler exits(1) on every rejection, so the API container died, ECS replaced the single task, the ALB had no healthy targets for ~40s, and the prerenderer's scheduled sync hit a 503 in that window - which is what fired the `percy-main-production-prerenderer-errors` alarm.

A client closing a tab mid-request must not be able to take prod down.

## Changes

- `lib/abort-errors.ts`: `isAbortError()` - matches DOMException/Error values named `AbortError` (including `AbortSignal.reason`)
- `server.ts`: the `unhandledRejection` handler logs AbortErrors at error level (`unhandled_rejection_aborted_operation`) and keeps serving; every other rejection still logs fatal and exits(1), preserving the crash-don't-limp behaviour for genuinely unknown state
- Unit tests for the matcher (DOMException, renamed Error, aborted controller reason, negative cases)

## Notes

- `@better-auth/infra` 0.3.6 is out (we run 0.3.5); the floating promise is theirs, so an upgrade may fix the source - this guard protects us either way.

## Testing

- `pnpm run typecheck`, `pnpm run lint`, `pnpm format`, `pnpm --filter api test` (672 passed, 52 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)