### PR TITLE
fix: batting leaderboards show zero not outs (how_out format mismatch)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,8 +2,20 @@
 # to force a periodic re-review. Each entry must be justified in a comment.
 # See https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
 #
-# No active suppressions. The previous CVE-2026-33671 (picomatch) entry covered
-# a copy bundled inside the base image's npm; apps/api/Dockerfile now strips npm
-# and the pnpm store from the runtime image, so that copy no longer exists and
-# the suppression is unnecessary. Add new entries here with a justification and
-# an `exp:` date.
+# All three current entries are tracked in issue #653; remove them when the
+# dependency bumps land.
+
+# CVE-2026-15074 - @fastify/static route guard bypass via path. Enters via
+# @fastify/swagger-ui 6.1.0, which only serves its own bundled docs-UI assets;
+# fix requires @fastify/static 10.x via a swagger-ui bump (issue #653).
+CVE-2026-15074 exp:2026-08-16
+
+# CVE-2026-47219 - find-my-way DDoS with HTTP2. The API never enables
+# Fastify's http2 option (plain HTTP/1.1 behind CloudFront), so the vector is
+# unreachable today. Patch bump tracked in issue #653.
+CVE-2026-47219 exp:2026-08-16
+
+# CVE-2026-14257 - brace-expansion ReDoS. Runtime copy enters via
+# google-ads-api; no untrusted input reaches glob patterns there. Override or
+# upstream bump tracked in issue #653.
+CVE-2026-14257 exp:2026-08-16

--- a/apps/api/src/features/cricket-leaderboard/integration.test.ts
+++ b/apps/api/src/features/cricket-leaderboard/integration.test.ts
@@ -70,6 +70,7 @@ async function seedBattingPerformance(overrides: {
   gameType?: string;
   timesOut?: number;
   dismissalPenalty?: number;
+  didBat?: boolean;
 }) {
   const notOut = overrides.notOut ?? false;
   await ctx.db
@@ -84,6 +85,7 @@ async function seedBattingPerformance(overrides: {
       season: overrides.season,
       runs: overrides.runs,
       balls: overrides.balls ?? 30,
+      did_bat: overrides.didBat ?? true,
       not_out: notOut,
       // Default to "dismissed once if not_out=false, never if not_out=true" so
       // existing hardball seeds continue to behave the same after the softball
@@ -177,6 +179,61 @@ describe("cricket leaderboard service (integration)", () => {
       expect(entry.average).toBeNull();
       // Strike rate: 150/90 * 100 = 166.67
       expect(entry.strikeRate).toBeCloseTo(166.67, 1);
+    });
+
+    it("excludes did-not-bat appearance rows from innings and not-outs", async () => {
+      await seedTeams();
+
+      const playerId = `player-${crypto.randomUUID()}`;
+      // Three real innings (one not out) plus a DNB appearance
+      await seedBattingPerformance({
+        playerId,
+        playerName: "C Batsman",
+        teamId: SENIOR_TEAM_ID,
+        season: 2024,
+        runs: 40,
+      });
+      await seedBattingPerformance({
+        playerId,
+        playerName: "C Batsman",
+        teamId: SENIOR_TEAM_ID,
+        season: 2024,
+        runs: 25,
+      });
+      await seedBattingPerformance({
+        playerId,
+        playerName: "C Batsman",
+        teamId: SENIOR_TEAM_ID,
+        season: 2024,
+        runs: 35,
+        notOut: true,
+      });
+      await seedBattingPerformance({
+        playerId,
+        playerName: "C Batsman",
+        teamId: SENIOR_TEAM_ID,
+        season: 2024,
+        runs: 0,
+        balls: 0,
+        didBat: false,
+        timesOut: 0,
+      });
+
+      const result = await listBattingLeaderboard(ctx.db)({
+        season: 2024,
+        limit: 50,
+        gameType: "Standard",
+      });
+
+      const entry = result.entries.find((e) => e.playerId === playerId);
+      assert(entry, "Expected batting entry for player");
+      // The DNB row is an appearance, not an innings - and must not be
+      // counted as a not-out either (its times_out is also 0)
+      expect(entry.innings).toBe(3);
+      expect(entry.notOuts).toBe(1);
+      expect(entry.runs).toBe(100);
+      // 100 runs / 2 dismissals = 50.00
+      expect(entry.average).toBe(50);
     });
 
     it("calculates batting average when 3+ innings", async () => {

--- a/apps/api/src/features/cricket-leaderboard/service.ts
+++ b/apps/api/src/features/cricket-leaderboard/service.ts
@@ -12,6 +12,8 @@ export function listBattingLeaderboard(db: Kysely<DB>) {
       .innerJoin("play_cricket_team as t", "t.id", "b.team_id")
       .leftJoin("member as m", "m.play_cricket_id", "b.player_id")
       .where("b.game_type", "=", params.gameType)
+      // "Did not bat" appearance rows are not innings
+      .where("b.did_bat", "=", true)
       .groupBy(["b.player_id", "m.slug"])
       .select(["b.player_id as playerId", "m.slug"])
       .select((eb) => [

--- a/apps/api/src/features/fantasy/calculate-scores-integration.test.ts
+++ b/apps/api/src/features/fantasy/calculate-scores-integration.test.ts
@@ -60,8 +60,10 @@ async function seedBatting(
     fours?: number;
     sixes?: number;
     notOut?: boolean;
+    didBat?: boolean;
   } = {},
 ) {
+  const didBat = opts.didBat ?? true;
   await ctx.db
     .insertInto("match_performance_batting")
     .values({
@@ -76,7 +78,8 @@ async function seedBatting(
       balls: opts.balls ?? 40,
       fours: opts.fours ?? 5,
       sixes: opts.sixes ?? 2,
-      how_out: opts.notOut ? "not out" : "caught",
+      how_out: !didBat ? "did not bat" : opts.notOut ? "not out" : "caught",
+      did_bat: didBat,
       not_out: opts.notOut ?? false,
       competition_type: "League",
     })
@@ -392,6 +395,35 @@ describe("calculateFantasyScores (integration)", () => {
     expect(first?.total_points).toBe(second?.total_points);
   });
 
+  it("did-not-bat appearance earns the team win bonus but no batting points", async () => {
+    const matchId = `m-dnb-${crypto.randomUUID()}`;
+    const dnbId = `p-dnb-${crypto.randomUUID()}`;
+
+    await seedMatch(matchId); // our team wins
+    await seedBatting(matchId, dnbId, {
+      didBat: false,
+      runs: 0,
+      balls: 0,
+      fours: 0,
+      sixes: 0,
+    });
+
+    await calculateFantasyScores(ctx.db)(SEASON);
+
+    const score = await ctx.db
+      .selectFrom("fantasy_player_score")
+      .where("play_cricket_id", "=", dnbId)
+      .where("match_id", "=", matchId)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+
+    // In the XI of the winning team, so the win bonus applies - but no
+    // batting points and crucially no duck penalty for their 0 runs
+    expect(score.batting_points).toBe(0);
+    expect(score.team_points).toBe(SCORING.team.winBonus);
+    expect(score.total_points).toBe(SCORING.team.winBonus);
+  });
+
   it("retracts scores when the backing performance disappears", async () => {
     const matchId = `m-retract-${crypto.randomUUID()}`;
     const stayerId = `p-stay-${crypto.randomUUID()}`;
@@ -399,8 +431,8 @@ describe("calculateFantasyScores (integration)", () => {
 
     await seedMatch(matchId);
     await seedBatting(matchId, stayerId, { runs: 30 });
-    // Duck for a player whose row later turns out not to be an innings
-    // (e.g. the "did not bat" repair in the Play Cricket sync data fix)
+    // Duck for a player whose row is later removed entirely (e.g. a
+    // corrected Play Cricket scorecard after a mis-credited innings)
     await seedBatting(matchId, goneId, { runs: 0, fours: 0, sixes: 0 });
 
     await seedFantasyPlayer(stayerId);

--- a/apps/api/src/features/fantasy/calculate-scores-integration.test.ts
+++ b/apps/api/src/features/fantasy/calculate-scores-integration.test.ts
@@ -392,6 +392,71 @@ describe("calculateFantasyScores (integration)", () => {
     expect(first?.total_points).toBe(second?.total_points);
   });
 
+  it("retracts scores when the backing performance disappears", async () => {
+    const matchId = `m-retract-${crypto.randomUUID()}`;
+    const stayerId = `p-stay-${crypto.randomUUID()}`;
+    const goneId = `p-gone-${crypto.randomUUID()}`;
+
+    await seedMatch(matchId);
+    await seedBatting(matchId, stayerId, { runs: 30 });
+    // Duck for a player whose row later turns out not to be an innings
+    // (e.g. the "did not bat" repair in the Play Cricket sync data fix)
+    await seedBatting(matchId, goneId, { runs: 0, fours: 0, sixes: 0 });
+
+    await seedFantasyPlayer(stayerId);
+    await seedFantasyPlayer(goneId);
+    const { userId } = await seedTestUser(ctx.db, {
+      email: `retract-${crypto.randomUUID()}@test.com`,
+    });
+    const teamId = await seedFantasyTeam(userId, [
+      { playerId: stayerId, slotType: "batting" },
+      { playerId: goneId, slotType: "batting" },
+    ]);
+
+    await calculateFantasyScores(ctx.db)(SEASON);
+
+    const before = await ctx.db
+      .selectFrom("fantasy_player_score")
+      .where("match_id", "=", matchId)
+      .selectAll()
+      .execute();
+    expect(before).toHaveLength(2);
+
+    const teamBefore = await ctx.db
+      .selectFrom("fantasy_team_score")
+      .where("fantasy_team_id", "=", teamId)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+
+    await ctx.db
+      .deleteFrom("match_performance_batting")
+      .where("match_id", "=", matchId)
+      .where("player_id", "=", goneId)
+      .execute();
+
+    await calculateFantasyScores(ctx.db)(SEASON);
+
+    const after = await ctx.db
+      .selectFrom("fantasy_player_score")
+      .where("match_id", "=", matchId)
+      .selectAll()
+      .execute();
+    expect(after).toHaveLength(1);
+    expect(after[0]?.play_cricket_id).toBe(stayerId);
+
+    // Team total must shed the retracted player's contribution: their duck
+    // penalty (-10) and win bonus (+10) cancelled out, so removing them
+    // changes the total by 0 here - assert the exact recomputed value.
+    // Stayer: 30 runs + 5 fours + 2*2 sixes + 10 win bonus = 49
+    const teamAfter = await ctx.db
+      .selectFrom("fantasy_team_score")
+      .where("fantasy_team_id", "=", teamId)
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(teamAfter.total_points).toBe(49);
+    expect(teamBefore.total_points).toBe(49);
+  });
+
   it("calculates team scores with slot-based filtering", async () => {
     const matchId = `m-team-${crypto.randomUUID()}`;
     const batterId = `p-bat-${crypto.randomUUID()}`;

--- a/apps/api/src/features/fantasy/calculate-scores.ts
+++ b/apps/api/src/features/fantasy/calculate-scores.ts
@@ -4,7 +4,9 @@
  * Calculates and stores per-player and per-team fantasy scores
  * for each gameweek based on match performance data.
  *
- * Designed to be idempotent — safe to re-run at any time.
+ * Designed to be idempotent — safe to re-run at any time. Re-running also
+ * retracts score rows whose backing performance data has since disappeared
+ * (scorecard corrections, repaired sync data).
  *
  * Team scoring is slot-based: batting slots only earn batting+fielding+team,
  * bowling slots only earn bowling+fielding+team, and the all-rounder slot
@@ -360,6 +362,33 @@ export function calculateFantasyScores(db: Kysely<DB>) {
       });
     }
 
+    // Retract score rows whose backing performance no longer exists
+    // (scorecard corrections, repaired sync data). Upserts alone can't
+    // remove them, and the team scoring below reads player scores back
+    // from the DB, so stale rows would keep polluting team totals.
+    const computedScoreKeys = new Set(
+      playerScores.map((ps) => `${ps.gameweek}|${ps.playerId}|${ps.matchId}`),
+    );
+    const existingScoreRows = await db
+      .selectFrom("fantasy_player_score")
+      .where("season", "=", season)
+      .select(["id", "gameweek_id", "play_cricket_id", "match_id"])
+      .execute();
+    const staleScoreIds = existingScoreRows
+      .filter(
+        (row) =>
+          !computedScoreKeys.has(
+            `${row.gameweek_id}|${row.play_cricket_id}|${row.match_id}`,
+          ),
+      )
+      .map((row) => row.id);
+    if (staleScoreIds.length > 0) {
+      await db
+        .deleteFrom("fantasy_player_score")
+        .where("id", "in", staleScoreIds)
+        .execute();
+    }
+
     // Upsert player scores
     let playerScoresUpserted = 0;
     for (const ps of playerScores) {
@@ -447,6 +476,20 @@ export function calculateFantasyScores(db: Kysely<DB>) {
       .execute();
 
     const gameweeks = gameweeksResult.map((r) => r.gameweek_id);
+
+    // Retract team scores for gameweeks that no longer have any player
+    // scores (mirrors the player-score retraction above).
+    let staleTeamScores = db
+      .deleteFrom("fantasy_team_score")
+      .where("season", "=", season);
+    if (gameweeks.length > 0) {
+      staleTeamScores = staleTeamScores.where(
+        "gameweek_id",
+        "not in",
+        gameweeks,
+      );
+    }
+    await staleTeamScores.execute();
 
     // Fetch all player scores for the season
     const allPlayerScoresForTeams = await db

--- a/apps/api/src/features/fantasy/calculate-scores.ts
+++ b/apps/api/src/features/fantasy/calculate-scores.ts
@@ -159,6 +159,7 @@ export function calculateFantasyScores(db: Kysely<DB>) {
             "fours",
             "sixes",
             "not_out",
+            "did_bat",
           ])
           .execute(),
         db
@@ -316,15 +317,19 @@ export function calculateFantasyScores(db: Kysely<DB>) {
       const info = matchInfo.get(app.matchId);
       const teamWon = info?.winnerTeamId === app.teamId;
 
-      const battingPts = bat
-        ? calculateBattingPoints({
-            runs: bat.runs,
-            balls: bat.balls,
-            fours: bat.fours,
-            sixes: bat.sixes,
-            notOut: bat.not_out,
-          }).total
-        : 0;
+      // A "did not bat" row is an appearance, not an innings: the player
+      // still earns team points (they were in the XI) but no batting
+      // points and no duck penalty.
+      const battingPts =
+        bat?.did_bat === true
+          ? calculateBattingPoints({
+              runs: bat.runs,
+              balls: bat.balls,
+              fours: bat.fours,
+              sixes: bat.sixes,
+              notOut: bat.not_out,
+            }).total
+          : 0;
 
       const bowlingPts = bowl
         ? calculateBowlingPoints({

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -831,12 +831,11 @@ describe("play-cricket sync (integration)", () => {
       .selectAll()
       .execute();
 
-    // 3 batters in the fixture, but "did not bat" (player 1003) must be
-    // dropped: a DNB row is not an innings.
-    expect(batting).toHaveLength(2);
+    expect(batting).toHaveLength(3);
     const aBatsman = batting.find((b) => b.player_id === "1001");
     assert(aBatsman, "Expected batting record for player 1001");
     expect(aBatsman.runs).toBe(85);
+    expect(aBatsman.did_bat).toBe(true);
     expect(aBatsman.not_out).toBe(false);
     expect(aBatsman.times_out).toBe(1);
 
@@ -844,8 +843,18 @@ describe("play-cricket sync (integration)", () => {
     const bKeeper = batting.find((b) => b.player_id === "1002");
     assert(bKeeper, "Expected batting record for player 1002");
     expect(bKeeper.runs).toBe(60);
+    expect(bKeeper.did_bat).toBe(true);
     expect(bKeeper.not_out).toBe(true);
     expect(bKeeper.times_out).toBe(0);
+
+    // "did not bat" is stored as an appearance, not an innings: no
+    // dismissal, and not not-out either
+    const dnb = batting.find((b) => b.player_id === "1003");
+    assert(dnb, "Expected appearance record for player 1003");
+    expect(dnb.did_bat).toBe(false);
+    expect(dnb.not_out).toBe(false);
+    expect(dnb.times_out).toBe(0);
+    expect(dnb.runs).toBe(0);
 
     // Check bowling (our team bowled in innings 1)
     const bowling = await ctx.db

--- a/apps/api/src/features/play-cricket/integration.test.ts
+++ b/apps/api/src/features/play-cricket/integration.test.ts
@@ -499,7 +499,7 @@ function makeMatchDetail(matchId: number) {
                 position: "2",
                 batsman_name: "Y Batsman",
                 batsman_id: "2002",
-                how_out: "ro",
+                how_out: "run out",
                 fielder_name: "A Batsman",
                 fielder_id: "1001",
                 runs: "30",
@@ -544,7 +544,7 @@ function makeMatchDetail(matchId: number) {
                 position: "1",
                 batsman_name: "A Batsman",
                 batsman_id: "1001",
-                how_out: "caught",
+                how_out: "ct",
                 fielder_name: "X Bowler",
                 fielder_id: "2001",
                 bowler_name: "Z Bowler",
@@ -558,11 +558,21 @@ function makeMatchDetail(matchId: number) {
                 position: "2",
                 batsman_name: "B Keeper",
                 batsman_id: "1002",
-                how_out: "no",
+                how_out: "not out",
                 runs: "60",
                 fours: "7",
                 sixes: "1",
                 balls: "70",
+              },
+              {
+                position: "3",
+                batsman_name: "C Bowler",
+                batsman_id: "1003",
+                how_out: "did not bat",
+                runs: "0",
+                fours: "0",
+                sixes: "0",
+                balls: "0",
               },
             ],
             bowl: [],
@@ -821,16 +831,21 @@ describe("play-cricket sync (integration)", () => {
       .selectAll()
       .execute();
 
+    // 3 batters in the fixture, but "did not bat" (player 1003) must be
+    // dropped: a DNB row is not an innings.
     expect(batting).toHaveLength(2);
     const aBatsman = batting.find((b) => b.player_id === "1001");
     assert(aBatsman, "Expected batting record for player 1001");
     expect(aBatsman.runs).toBe(85);
     expect(aBatsman.not_out).toBe(false);
+    expect(aBatsman.times_out).toBe(1);
 
+    // Play Cricket sends "not out" as full text, not "no"
     const bKeeper = batting.find((b) => b.player_id === "1002");
     assert(bKeeper, "Expected batting record for player 1002");
     expect(bKeeper.runs).toBe(60);
     expect(bKeeper.not_out).toBe(true);
+    expect(bKeeper.times_out).toBe(0);
 
     // Check bowling (our team bowled in innings 1)
     const bowling = await ctx.db

--- a/apps/api/src/features/play-cricket/service.ts
+++ b/apps/api/src/features/play-cricket/service.ts
@@ -306,6 +306,8 @@ export function getPlayerCareerStats(db: Kysely<DB>) {
     const battingBySeasonRows = await db
       .selectFrom("match_performance_batting")
       .where("player_id", "=", playCricketId)
+      // "Did not bat" appearance rows are not innings
+      .where("did_bat", "=", true)
       .select([
         "season",
         "game_type",
@@ -550,6 +552,8 @@ export function getPlayerSeasonStats(db: Kysely<DB>) {
       .where("player_id", "=", playCricketId)
       .where("season", "=", season)
       .where("game_type", "=", gameType)
+      // "Did not bat" appearance rows are not innings
+      .where("did_bat", "=", true)
       .selectAll()
       .execute();
 

--- a/apps/api/src/features/play-cricket/sync.test.ts
+++ b/apps/api/src/features/play-cricket/sync.test.ts
@@ -5,6 +5,7 @@ import { createNoopLogger } from "../../lib/worker-logger.ts";
 import type { PlayCricketApiClient } from "./api-client.ts";
 import {
   didBat,
+  hasScorecardEntry,
   isJuniorTeam,
   isNotOut,
   parseDismissalType,
@@ -113,6 +114,33 @@ describe("sync helpers", () => {
       ).toBe(true);
       expect(
         didBat({ how_out: null, runs: "0", balls: "0", times_out: "1" }),
+      ).toBe(true);
+    });
+  });
+
+  describe("hasScorecardEntry", () => {
+    it("returns true for explicit how_out, including did not bat", () => {
+      expect(hasScorecardEntry({ how_out: "ct" })).toBe(true);
+      expect(hasScorecardEntry({ how_out: "not out" })).toBe(true);
+      // DNB rows are stored (as did_bat = false appearances)
+      expect(hasScorecardEntry({ how_out: "did not bat" })).toBe(true);
+      expect(hasScorecardEntry({ how_out: "absent" })).toBe(true);
+    });
+
+    it("returns false for placeholder rows with no how_out and no stats", () => {
+      expect(hasScorecardEntry({ how_out: null })).toBe(false);
+      expect(hasScorecardEntry({ how_out: "" })).toBe(false);
+      expect(hasScorecardEntry({ how_out: "", runs: "0", balls: "0" })).toBe(
+        false,
+      );
+    });
+
+    it("returns true for softball batters (null how_out with stats)", () => {
+      expect(hasScorecardEntry({ how_out: null, runs: "5", balls: "8" })).toBe(
+        true,
+      );
+      expect(
+        hasScorecardEntry({ how_out: null, runs: "0", times_out: "1" }),
       ).toBe(true);
     });
   });

--- a/apps/api/src/features/play-cricket/sync.test.ts
+++ b/apps/api/src/features/play-cricket/sync.test.ts
@@ -43,28 +43,42 @@ describe("sync helpers", () => {
       expect(isNotOut(undefined)).toBe(true);
     });
 
-    it("returns true for not-out codes", () => {
+    it("returns true for not-out codes, both abbreviated and full text", () => {
       expect(isNotOut("no")).toBe(true);
-      expect(isNotOut("dnb")).toBe(true);
+      expect(isNotOut("not out")).toBe(true);
+      expect(isNotOut("Not Out")).toBe(true);
       expect(isNotOut("rtd")).toBe(true);
+      expect(isNotOut("retired hurt")).toBe(true);
+      expect(isNotOut("retired not out")).toBe(true);
       expect(isNotOut("")).toBe(true);
     });
 
-    it("returns false for dismissal codes", () => {
+    it("returns false for dismissal codes, both abbreviated and full text", () => {
+      expect(isNotOut("ct")).toBe(false);
       expect(isNotOut("caught")).toBe(false);
+      expect(isNotOut("b")).toBe(false);
       expect(isNotOut("bowled")).toBe(false);
       expect(isNotOut("lbw")).toBe(false);
+      expect(isNotOut("st")).toBe(false);
+      expect(isNotOut("hit wicket")).toBe(false);
+      expect(isNotOut("timed out")).toBe(false);
+      expect(isNotOut("obstructing the field")).toBe(false);
     });
 
-    // run out is considered "not out" for batting average purposes
-    it("returns true for run out", () => {
-      expect(isNotOut("ro")).toBe(true);
+    it("returns false for run out and retired out - both are dismissals", () => {
+      expect(isNotOut("ro")).toBe(false);
+      expect(isNotOut("run out")).toBe(false);
+      expect(isNotOut("retired out")).toBe(false);
+      expect(isNotOut("ret out")).toBe(false);
     });
   });
 
   describe("didBat", () => {
-    it("returns false when how_out is dnb regardless of stats", () => {
+    it("returns false when how_out says the player never batted", () => {
       expect(didBat({ how_out: "dnb" })).toBe(false);
+      expect(didBat({ how_out: "did not bat" })).toBe(false);
+      expect(didBat({ how_out: "Did Not Bat" })).toBe(false);
+      expect(didBat({ how_out: "absent" })).toBe(false);
       // Even if Play Cricket sends quantitative fields for a DNB row, "dnb"
       // is the explicit signal that they didn't take strike.
       expect(didBat({ how_out: "dnb", runs: "5", balls: "10" })).toBe(false);

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -22,13 +22,20 @@ function isJuniorTeam(teamName: string): boolean {
   return JUNIOR_PATTERNS.some((p) => p.test(teamName));
 }
 
+// Play Cricket sends how_out in a mixed format: abbreviations for
+// bowler-credited dismissals ("ct", "b", "lbw", "st") but full text for
+// everything else ("not out", "did not bat", "run out", "retired not out").
+// Both spellings are listed as insurance against the API switching format.
+// "retired out" and "run out" are deliberately absent: both count as
+// dismissals for batting-average purposes.
 const NOT_OUT_CODES = new Set([
   "no",
-  "dnb",
+  "not out",
   "rtd",
-  "ro",
-  "ret out",
+  "retired",
+  "retired hurt",
   "rtno",
+  "retired not out",
   "",
 ]);
 
@@ -36,6 +43,10 @@ function isNotOut(howOut: string | null | undefined): boolean {
   if (!howOut) return true;
   return NOT_OUT_CODES.has(howOut.toLowerCase().trim());
 }
+
+// Players listed on the scorecard who never took strike. Filtered out before
+// insert - a DNB row is not an innings and must never count as one.
+const DID_NOT_BAT_CODES = new Set(["dnb", "did not bat", "absent"]);
 
 // In Pairs (Women's Softball) every batter rotates after their allotted balls
 // without a per-player dismissal code, so `how_out` is null for everyone who
@@ -48,7 +59,7 @@ function didBat(bat: {
   times_out?: string | null;
 }): boolean {
   const code = (bat.how_out ?? "").toLowerCase().trim();
-  if (code === "dnb") return false;
+  if (DID_NOT_BAT_CODES.has(code)) return false;
   if (code !== "") return true;
   // Empty / null how_out: must have at least one quantitative signal that
   // this player took strike.

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -44,20 +44,24 @@ function isNotOut(howOut: string | null | undefined): boolean {
   return NOT_OUT_CODES.has(howOut.toLowerCase().trim());
 }
 
-// Players listed on the scorecard who never took strike. Filtered out before
-// insert - a DNB row is not an innings and must never count as one.
+// Players listed on the scorecard who never took strike. Stored with
+// did_bat = false: they count as match appearances (fantasy team win bonus,
+// career-matches record) but never as innings - anything aggregating
+// innings or not-outs must filter on did_bat.
 const DID_NOT_BAT_CODES = new Set(["dnb", "did not bat", "absent"]);
+
+interface BatEntry {
+  how_out?: string | null;
+  runs?: string | null;
+  balls?: string | null;
+  times_out?: string | null;
+}
 
 // In Pairs (Women's Softball) every batter rotates after their allotted balls
 // without a per-player dismissal code, so `how_out` is null for everyone who
 // played. We can't use it as the sole "did this player bat" signal — fall
 // back to runs, balls, and times_out, which softball does populate.
-function didBat(bat: {
-  how_out?: string | null;
-  runs?: string | null;
-  balls?: string | null;
-  times_out?: string | null;
-}): boolean {
+function didBat(bat: BatEntry): boolean {
   const code = (bat.how_out ?? "").toLowerCase().trim();
   if (DID_NOT_BAT_CODES.has(code)) return false;
   if (code !== "") return true;
@@ -71,6 +75,15 @@ function didBat(bat: {
     (Number.isFinite(balls) && balls > 0) ||
     (Number.isFinite(timesOut) && timesOut > 0)
   );
+}
+
+// Whether the scorecard actually says anything about this player. Rows with
+// no how_out and no quantitative signal are placeholder padding (common in
+// Pairs cards) and are not stored at all — unlike explicit "did not bat"
+// rows, which are stored as appearances.
+function hasScorecardEntry(bat: BatEntry): boolean {
+  const code = (bat.how_out ?? "").toLowerCase().trim();
+  return code !== "" || didBat(bat);
 }
 
 function parseDismissalType(
@@ -107,7 +120,13 @@ interface FieldingAgg {
 
 // --- Exported for testing ---
 
-export { didBat, isJuniorTeam, isNotOut, parseDismissalType };
+export {
+  didBat,
+  hasScorecardEntry,
+  isJuniorTeam,
+  isNotOut,
+  parseDismissalType,
+};
 
 // --- Main sync logic ---
 
@@ -257,14 +276,19 @@ async function storeBattingPerformances(
   dismissalPenalty: number,
 ): Promise<void> {
   for (const bat of innings) {
-    if (!didBat(bat)) continue;
+    if (!hasScorecardEntry(bat)) continue;
+
+    // "Did not bat" rows are appearances, not innings: no dismissal, and
+    // not_out = false because there was no innings to be not out in.
+    const didBatFlag = didBat(bat);
 
     // For Pairs games trust the API's per-batter times_out (can be 2+); for
     // Standard, derive it from not_out so the column stays consistent across
     // formats. The unified average formula relies on this column for both.
     const apiTimesOut = parseInt(bat.times_out ?? "");
-    const timesOut =
-      gameType === "Pairs" && Number.isFinite(apiTimesOut)
+    const timesOut = !didBatFlag
+      ? 0
+      : gameType === "Pairs" && Number.isFinite(apiTimesOut)
         ? apiTimesOut
         : isNotOut(bat.how_out)
           ? 0
@@ -273,7 +297,7 @@ async function storeBattingPerformances(
     // null for every batter so the old how_out-based check would mark a
     // dismissed Pairs batter as not out, which would corrupt any consumer
     // still reading the legacy column.
-    const notOut = timesOut === 0;
+    const notOut = didBatFlag && timesOut === 0;
 
     await db
       .insertInto("match_performance_batting")
@@ -291,6 +315,7 @@ async function storeBattingPerformances(
         fours: parseInt(bat.fours) || 0,
         sixes: parseInt(bat.sixes) || 0,
         how_out: bat.how_out ?? "",
+        did_bat: didBatFlag,
         not_out: notOut,
         times_out: timesOut,
         dismissal_penalty: dismissalPenalty,
@@ -305,6 +330,7 @@ async function storeBattingPerformances(
           fours: parseInt(bat.fours) || 0,
           sixes: parseInt(bat.sixes) || 0,
           how_out: bat.how_out ?? "",
+          did_bat: didBatFlag,
           not_out: notOut,
           times_out: timesOut,
           dismissal_penalty: dismissalPenalty,

--- a/docs/adrs/056-dnb-rows-stay-in-batting-table.md
+++ b/docs/adrs/056-dnb-rows-stay-in-batting-table.md
@@ -1,0 +1,67 @@
+# Decision 056: "Did not bat" rows stay in the batting table with a did_bat flag
+
+**Date:** 2026-07-26
+**Status:** Accepted
+
+## Decision
+
+Play Cricket scorecard entries whose `how_out` says the player never took
+strike ("did not bat", "dnb", "absent") are stored in
+`match_performance_batting` with `did_bat = false`, `times_out = 0`,
+`not_out = false`. They function as the appearance record: a player in the
+XI who never batted still played the match. Aggregations that count innings
+or not-outs must filter `did_bat = true`; aggregations that count matches
+played or appearances must not.
+
+## Problem
+
+The how_out format-mismatch fix (PR #652) surfaced a modelling question.
+DNB rows had been stored as innings-with-a-dismissal (inflating innings and
+deflating averages), so the obvious fix was to delete them and stop
+inserting them. But they are the only per-match record that a player was in
+the team, and two consumers legitimately need that:
+
+- the fantasy team win bonus (a selected player who never batted was still
+  in the winning XI)
+- the "most career matches" record, which counts distinct matches from the
+  batting table
+
+Deleting DNB rows silently broke both.
+
+## Options considered
+
+1. **Delete DNB rows; stop inserting them.** Keeps the batting table pure
+   ("every row is an innings") but destroys appearance data.
+2. **A separate `match_appearance` table** fed from the match detail
+   `players` array, backfilled from existing data. Semantically cleanest:
+   performance tables stay pure, appearances are first-class.
+3. **Keep DNB rows, flagged with a `did_bat` boolean** (chosen).
+
+## Rationale
+
+The Play Cricket `bat` array with its DNB entries _is_ the appearance
+record, and it is provably complete across all 26 seasons of synced data
+(2,626 DNB/absent rows). A separate table would duplicate exactly that
+information, add a second sync path and backfill to maintain, and depend on
+the `players` array being reliably populated for every match, which the
+`bat` array has already proven. One boolean column plus three `where`
+clauses (leaderboard, two profile aggregates) was the whole cost.
+
+## Rejected alternatives
+
+- **Deleting DNB rows** - breaks the fantasy win bonus and the career
+  matches record, and forfeits appearance data we cannot cheaply
+  reconstruct for past seasons once deleted.
+- **`match_appearance` table** - right shape in the abstract, but pure
+  duplication of data the batting table already carries, with more moving
+  parts. Becomes attractive if we ever need appearance data the `bat` array
+  does not carry (e.g. captaincy per match, substitute fielders), or if
+  Play Cricket stops listing non-batters in the `bat` array.
+
+## Consequences
+
+- Any new query over `match_performance_batting` must decide explicitly
+  whether it is counting innings (`did_bat = true`) or appearances (no
+  filter). The column comment and this ADR are the reference.
+- `not_out` is false on DNB rows: they are not innings, so they are neither
+  out nor not out; only `did_bat = true` rows carry innings semantics.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -34,3 +34,4 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 | [053](053-prerendering-fixtures-and-calendar.md)         | Prerendering fixtures and calendar months via hash-diffed manifest | 2026-07-04 | Accepted |
 | [054](054-typescript-7-native-with-v6-api-alias.md)      | TypeScript 7 native compiler, v6 JS API aliased for tooling        | 2026-07-08 | Accepted |
 | [055](055-content-assistant-edit-ops-and-sidebar.md)     | Content assistant edit-op protocol + persistent sidebar            | 2026-07-09 | Accepted |
+| [056](056-dnb-rows-stay-in-batting-table.md)             | "Did not bat" rows stay in the batting table with a did_bat flag   | 2026-07-26 | Accepted |

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -612,6 +612,7 @@ export interface MatchPerformanceBatting {
   balls: Generated<number>;
   competition_type: Generated<string>;
   created_at: Generated<string>;
+  did_bat: Generated<boolean>;
   dismissal_penalty: Generated<number>;
   fours: Generated<number>;
   game_type: Generated<string>;

--- a/packages/db/src/migrations/2026-07-26T09:18:22.611Z.ts
+++ b/packages/db/src/migrations/2026-07-26T09:18:22.611Z.ts
@@ -1,0 +1,44 @@
+import { type Kysely, sql } from "kysely";
+
+// Data fix for the how_out format mismatch in the Play Cricket sync.
+//
+// Play Cricket sends how_out as full text ("not out", "did not bat",
+// "retired not out") but the sync only recognised abbreviations ("no",
+// "dnb", "rtno"), so every hardball innings - including genuine not-outs
+// and players who never batted - was stored with times_out = 1 and
+// not_out = false. Effects: leaderboards showed zero not-outs, averages
+// divided by innings instead of dismissals, and "did not bat" rows
+// inflated innings + dismissal counts.
+//
+// how_out is stored verbatim on every row, so the bad rows can be repaired
+// in place - no resync needed (the sync only revisits the last 7 days
+// anyway). Rows with how_out = 'pairs inning' (32 rows, 2013 junior pairs
+// games) are left untouched: that label carries no dismissal information.
+//
+// The UPDATE is scoped to game_type = 'Standard': Pairs rows take
+// times_out from the API's per-batter field, which was always correct.
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Players listed on the scorecard who never took strike are not innings.
+  // The fixed sync no longer inserts these.
+  await sql`
+    DELETE FROM match_performance_batting
+    WHERE LOWER(TRIM(how_out)) IN ('did not bat', 'dnb', 'absent')
+  `.execute(db);
+
+  // Repair not-out innings wrongly recorded as dismissals.
+  await sql`
+    UPDATE match_performance_batting
+    SET times_out = 0, not_out = true
+    WHERE game_type = 'Standard'
+      AND LOWER(TRIM(how_out)) IN
+        ('no', 'not out', 'rtd', 'retired', 'retired hurt', 'rtno', 'retired not out')
+      AND times_out <> 0
+  `.execute(db);
+}
+
+export async function down(): Promise<void> {
+  // Irreversible data fix: the deleted "did not bat" rows and the corrupted
+  // times_out/not_out values are not worth reconstructing. A full resync
+  // from Play Cricket would rebuild the table if ever needed.
+}

--- a/packages/db/src/migrations/2026-07-26T09:18:22.611Z.ts
+++ b/packages/db/src/migrations/2026-07-26T09:18:22.611Z.ts
@@ -8,21 +8,33 @@ import { type Kysely, sql } from "kysely";
 // and players who never batted - was stored with times_out = 1 and
 // not_out = false. Effects: leaderboards showed zero not-outs, averages
 // divided by innings instead of dismissals, and "did not bat" rows
-// inflated innings + dismissal counts.
+// counted as an innings plus a dismissal each.
+//
+// "Did not bat" rows stay in the table: they are the appearance record
+// (fantasy team win bonus, career-matches record - a player in the XI who
+// never took strike still played the match). The new did_bat flag lets
+// innings/not-out aggregations exclude them without string-matching
+// how_out everywhere.
 //
 // how_out is stored verbatim on every row, so the bad rows can be repaired
 // in place - no resync needed (the sync only revisits the last 7 days
 // anyway). Rows with how_out = 'pairs inning' (32 rows, 2013 junior pairs
 // games) are left untouched: that label carries no dismissal information.
 //
-// The UPDATE is scoped to game_type = 'Standard': Pairs rows take
+// The not-out repair is scoped to game_type = 'Standard': Pairs rows take
 // times_out from the API's per-batter field, which was always correct.
 
 export async function up(db: Kysely<unknown>): Promise<void> {
-  // Players listed on the scorecard who never took strike are not innings.
-  // The fixed sync no longer inserts these.
+  await db.schema
+    .alterTable("match_performance_batting")
+    .addColumn("did_bat", "boolean", (col) => col.notNull().defaultTo(true))
+    .execute();
+
+  // Appearances, not innings: no dismissal, and not_out = false because
+  // there was no innings to be not out in.
   await sql`
-    DELETE FROM match_performance_batting
+    UPDATE match_performance_batting
+    SET did_bat = false, times_out = 0, not_out = false
     WHERE LOWER(TRIM(how_out)) IN ('did not bat', 'dnb', 'absent')
   `.execute(db);
 
@@ -37,8 +49,11 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   `.execute(db);
 }
 
-export async function down(): Promise<void> {
-  // Irreversible data fix: the deleted "did not bat" rows and the corrupted
-  // times_out/not_out values are not worth reconstructing. A full resync
-  // from Play Cricket would rebuild the table if ever needed.
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // The times_out/not_out repair is an irreversible data fix; only the
+  // added column is dropped.
+  await db.schema
+    .alterTable("match_performance_batting")
+    .dropColumn("did_bat")
+    .execute();
 }


### PR DESCRIPTION
## Problem

Every batting leaderboard row showed 0 not outs, deflating averages (e.g. John Allan: site showed 727/16 = 45.44; Play Cricket says 727/14 = 51.93 with 2 not outs).

## Root cause

Play Cricket sends `how_out` in a mixed format: abbreviations for bowler-credited dismissals (`ct`, `b`, `lbw`, `st`) but **full text for everything else** (`not out`, `did not bat`, `run out`, `retired not out`). The sync's `NOT_OUT_CODES` and `didBat()` only matched abbreviations (`no`, `dnb`, ...) that never occur in the real API, so:

- all 1,953 `not out` innings (and 101 `retired not out`) were stored with `times_out = 1`, `not_out = false`
- 2,620 `did not bat` + 6 `absent` rows were counted as innings **with a dismissal each**, inflating innings and dismissal counts
- fantasy duck penalties fired on not-out 0s and DNB rows
- records pages never showed the `*` on not-out high scores

## Fix

1. **`sync.ts`**: `NOT_OUT_CODES` now matches the real full-text values (short codes kept as insurance). Removed `ro` / `ret out` from the not-out set: run out and retired out are dismissals for average purposes (they only ever "worked" because the API never sends those abbreviations).
2. **DNB rows stay, flagged ([ADR 056](docs/adrs/056-dnb-rows-stay-in-batting-table.md))**: a player in the XI who never batted still played the match, so `did not bat` / `absent` entries are stored with `did_bat = false`, `times_out = 0`, `not_out = false`. They keep the fantasy team win bonus and the career-matches record correct, but innings/not-out aggregations (leaderboard, player profile) filter `did_bat = true`. Fantasy gives them team points but no batting points and no duck penalty.
3. **Data-fix migration**: `how_out` is stored verbatim on every row, so everything repairs in place - no resync needed. Adds `did_bat`, flags 2,626 DNB/absent rows, repairs 2,054 not-out rows (verified with read-only dry-run counts against prod). Pairs rows are untouched (their `times_out` comes from the API per-batter field, which was always correct), as are the 32 ambiguous 2013 `pairs inning` rows.
4. **`calculate-scores.ts`**: the fantasy recalc (full current season, runs on every sync) was upsert-only, so score rows whose backing performance disappears (scorecard corrections) lingered forever - and team scoring reads player scores back from the DB, so they kept polluting team totals. The recalc now retracts stale rows. All fantasy corrections happen automatically on the first sync after deploy; no manual recalc step.

John Allan lands at exactly 16 innings / 2 not outs / 51.93 average, matching Play Cricket.

## Tests

- Unit tests for `isNotOut`/`didBat`/`hasScorecardEntry` cover both formats, and correct a wrong assertion that claimed run out is not-out "for batting average purposes"
- Sync integration fixture uses real API values (`ct`, `not out`, `run out`, `did not bat`) and asserts the DNB row is stored as a flagged appearance with no dismissal
- Leaderboard integration test: DNB rows excluded from innings and not-outs
- Fantasy integration tests: DNB appearance earns exactly the win bonus (no duck penalty); deleting a backing performance and re-running retracts the stale score row
- Full API suite passes (675 unit + integration), typecheck + lint clean

## CI note

The `image-scan` failure was 3 pre-existing HIGH CVEs unrelated to this PR (new advisories against the current image). Suppressed in `.trivyignore` with `exp:2026-08-16` per repo convention; dependency bumps tracked in #653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of “did not bat” and absent cricket scorecard entries.
  - Batting statistics now exclude players who did not bat while preserving appearance records.
  - Fantasy scoring awards applicable team bonuses without adding batting points for DNB appearances.
  - Fantasy scores are automatically retracted when underlying performance data is removed.

- **Bug Fixes**
  - Corrected dismissal, not-out, innings, averages, and leaderboard calculations.
  - Improved recognition of varied scorecard dismissal and absence formats.

- **Documentation**
  - Added an ADR documenting DNB data handling and aggregation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->