### PR TITLE
fix(deps): resolve Trivy HIGH CVEs (@fastify/static, find-my-way, brace-expansion)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,20 +2,4 @@
 # to force a periodic re-review. Each entry must be justified in a comment.
 # See https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
 #
-# All three current entries are tracked in issue #653; remove them when the
-# dependency bumps land.
-
-# CVE-2026-15074 - @fastify/static route guard bypass via path. Enters via
-# @fastify/swagger-ui 6.1.0, which only serves its own bundled docs-UI assets;
-# fix requires @fastify/static 10.x via a swagger-ui bump (issue #653).
-CVE-2026-15074 exp:2026-08-16
-
-# CVE-2026-47219 - find-my-way DDoS with HTTP2. The API never enables
-# Fastify's http2 option (plain HTTP/1.1 behind CloudFront), so the vector is
-# unreachable today. Patch bump tracked in issue #653.
-CVE-2026-47219 exp:2026-08-16
-
-# CVE-2026-14257 - brace-expansion ReDoS. Runtime copy enters via
-# google-ads-api; no untrusted input reaches glob patterns there. Override or
-# upstream bump tracked in issue #653.
-CVE-2026-14257 exp:2026-08-16
+# (No active suppressions.)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,14 @@ overrides:
   '@ai-sdk/provider-utils@<5.0.6': '>=5.0.6'
   '@ai-sdk/gateway@<4.0.14': '>=4.0.14'
   '@smithy/signature-v4@<5.6.9': '>=5.6.9'
+  '@fastify/static@<10.1.1': '>=10.1.1'
   axios@<1.18.0: '>=1.18.0'
+  brace-expansion@>=5.0.0 <5.0.8: '>=5.0.8'
   esbuild@<0.28.1: '>=0.28.1'
   fast-xml-parser@<5.7.0: '>=5.7.0'
+  find-my-way@<9.7.0: '>=9.7.0'
   form-data@<4.0.6: '>=4.0.6'
+  minimatch@9: '>=10.2.5'
   next@<16.2.11: '>=16.2.11'
   postcss@<8.5.10: '>=8.5.10'
   sharp@<0.35.0: '>=0.35.0'
@@ -1926,8 +1930,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@9.3.0':
-    resolution: {integrity: sha512-9YMYRpCOtMBrqKYWcqiw7ykOrn4D0jogHpJrFS0KGeSuOwzKMM5/mjj7B0CFLVoQ6htqKYw//Zs7APn9DBq05w==}
+  '@fastify/static@10.1.2':
+    resolution: {integrity: sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==}
 
   '@fastify/swagger-ui@6.1.0':
     resolution: {integrity: sha512-vbhHlJvzXujGco+6yumjt4cwptzb+0ZezPvApFSI+62IdJCfHtjpJrFIT+ln3BCB+KVFiUkI1Y+L9adIGmvdHQ==}
@@ -5292,9 +5296,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5471,8 +5475,8 @@ packages:
     resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
     engines: {node: '>=20'}
 
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+  content-disposition@2.0.1:
+    resolution: {integrity: sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==}
     engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
@@ -6053,8 +6057,8 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  find-my-way@9.6.0:
-    resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up@5.0.0:
@@ -7104,10 +7108,6 @@ packages:
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
-
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -10383,18 +10383,19 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
-  '@fastify/static@9.3.0':
+  '@fastify/static@10.1.2':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
+      '@fastify/error': 4.2.0
       '@fastify/send': 4.1.0
-      content-disposition: 1.1.0
+      content-disposition: 2.0.1
       fastify-plugin: 6.0.0
       fastq: 1.20.1
       glob: 13.0.6
 
   '@fastify/swagger-ui@6.1.0':
     dependencies:
-      '@fastify/static': 9.3.0
+      '@fastify/static': 10.1.2
       fastify-plugin: 6.0.0
       openapi-types: 12.1.3
       rfdc: 1.4.1
@@ -13833,7 +13834,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14002,7 +14003,7 @@ snapshots:
       semver: 7.8.5
       uint8array-extras: 1.5.0
 
-  content-disposition@1.1.0: {}
+  content-disposition@2.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -14660,7 +14661,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.2.0
       fast-json-stringify: 7.0.0
-      find-my-way: 9.6.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -14698,7 +14699,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-my-way@9.6.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
@@ -14866,7 +14867,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -15979,17 +15980,13 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.16
 
   minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.2
-
-  minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,10 +29,29 @@ overrides:
   # (check-ssr-sigv4a, #623). signature-v4a 3.5.5 needs >=5.6.9 while the
   # aws-sdk pins resolve 5.6.8; dedupe won't cross the split on its own.
   "@smithy/signature-v4@<5.6.9": ">=5.6.9"
+  # CVE-2026-15074: @fastify/swagger-ui 6.1.0 still pins @fastify/static
+  # ^9.x; no swagger-ui release depends on 10.x yet. Drop this once one
+  # does (#653).
+  "@fastify/static@<10.1.1": ">=10.1.1"
   axios@<1.18.0: ">=1.18.0"
+  # CVE-2026-14257 (ReDoS): scoped to the 5.x line only. brace-expansion 5
+  # dropped the default export (named `expand` only), so forcing it onto
+  # minimatch 5/9 breaks them at runtime; those lines have no fixed
+  # release. The runtime 2.x copy is eliminated by the minimatch override
+  # below instead; remaining 1.x/2.x copies are dev-only chains that never
+  # reach the API image (#653).
+  "brace-expansion@>=5.0.0 <5.0.8": ">=5.0.8"
   esbuild@<0.28.1: ">=0.28.1"
   fast-xml-parser@<5.7.0: ">=5.7.0"
+  # CVE-2026-47219: fastify's ^9.6.0 range already admits the fix; the
+  # floor guards against dedupe re-resolving the vulnerable patch (#653).
+  find-my-way@<9.7.0: ">=9.7.0"
   form-data@<4.0.6: ">=4.0.6"
+  # CVE-2026-14257 continued: glob@10 (runtime via google-gax -> rimraf)
+  # pins minimatch ^9, which pins vulnerable brace-expansion ^2 with no
+  # fixed 2.x release. minimatch 10 keeps the API surface glob@10 uses and
+  # moves to brace-expansion 5 (#653).
+  minimatch@9: ">=10.2.5"
   # @react-email/ui hard-pins next, so the floor must be forced past the
   # CVE-2026-64641/-64642/-64645/-64649 fixes; sharp rides in as next's
   # optional dep and needs its own floor (GHSA-f88m-g3jw-g9cj).


### PR DESCRIPTION
Closes #653.

Removes the three `.trivyignore` suppressions added to unblock #652 and fixes the underlying CVEs via pnpm overrides (following the existing security-override pattern in `pnpm-workspace.yaml`):

| CVE | Package | Before | After | How |
| --- | --- | --- | --- | --- |
| CVE-2026-15074 | @fastify/static | 9.3.0 | 10.1.2 | Override. No @fastify/swagger-ui release depends on 10.x yet (latest 6.1.0 pins ^9.1.2); drop the override once one does. |
| CVE-2026-47219 | find-my-way | 9.6.0 | 9.7.0 | Floor override; already within fastify's ^9.6.0 range. |
| CVE-2026-14257 | brace-expansion | 2.1.2 + 5.0.7 | 5.0.8 | Two scoped overrides, see below. |

**brace-expansion subtlety**: 5.0.8 dropped the default export (named `expand` only), and empirical testing showed it breaks minimatch 5/9 at runtime, so a blanket override was not safe. Instead:
- `brace-expansion@>=5.0.0 <5.0.8 -> >=5.0.8` fixes the 5.x copy (its consumers are minimatch 10, built for it).
- `minimatch@9 -> >=10.2.5` eliminates the runtime 2.x copy at the layer above: glob@10 (the google-gax -> rimraf chain) pinned minimatch ^9 which pins brace-expansion ^2, and no fixed 2.x exists. minimatch 10 keeps the API surface glob@10 uses (verified: glob brace patterns + rimraf glob deletion through the real installed graph).
- The remaining 1.1.16/2.1.2 copies sit only under devDependency chains (eslint tooling, openapi-typescript, vite-plugin-pwa/workbox, testcontainers) that never enter the runtime image, matching the scope in #653.

Lockfile diff is minimal: the four intended swaps plus @fastify/static 10's own deps (@fastify/error 4.2.0, content-disposition 1.1.0 -> 2.0.1). No other transitive movement.

## Verification

- Typecheck, lint, build: pass
- API unit tests: 500 passed; integration tests: 516 passed (35 files)
- swagger-ui smoke test against @fastify/static 10: docs entry point, CSS/JS assets, and spec JSON all serve; path traversal rejected. One behavior change: `/api/docs/static/index.html` now 302s to `/api/docs/` (static 10's index redirect); the registered entry point is unaffected. Dev-only surface either way.
- Local Trivy scan of the rebuilt image with the exact CI gate flags (`--scanners vuln,secret --severity CRITICAL,HIGH --ignore-unfixed`): clean, exit 0, with zero active suppressions.

Note for reviewers: a stale local layer cache initially showed libexpat 2.8.1-r0 HIGHs from the base image; a `--pull --no-cache` rebuild confirmed current node:24-alpine ships 2.8.2-r0. CI's buildx re-resolves the base digest per build, so the gate should not see this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Removed outdated vulnerability suppressions from security scanning.
  * Enforced secure minimum versions for several dependencies to address known vulnerabilities and improve protection against affected package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->