### PR TITLE
feat(matchday): open full player note in a modal when truncated

### DIFF
--- a/apps/matchday/src/pages/official-availability-date.tsx
+++ b/apps/matchday/src/pages/official-availability-date.tsx
@@ -1,5 +1,11 @@
 import { Button } from "@/components/ui/button.js";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.js";
 import { fmtDate } from "@/features/format.js";
 import { useDebouncedValue } from "@/hooks/use-debounced-value.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
@@ -12,7 +18,7 @@ import {
   UserPlusIcon,
   XIcon,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Link, useParams } from "react-router";
 
 type PerDateData =
@@ -611,9 +617,10 @@ function AvailableList({
                 {p.dependent_id && <JuniorBadge />}
               </p>
               {p.note && (
-                <p className="text-text-secondary truncate text-xs">
-                  "{p.note}"
-                </p>
+                <PlayerNote
+                  note={p.note}
+                  playerName={p.member_name ?? "Player"}
+                />
               )}
               {p.overridden_by && (
                 <p className="text-warning text-[10px] font-semibold tracking-wide uppercase">
@@ -678,6 +685,68 @@ function AvailableList({
   );
 }
 
+/**
+ * A player's availability note, truncated to one line as before. When the
+ * text actually overflows (checked against the rendered element, so short
+ * notes don't grow a pointless control) a small "More" button opens the
+ * full note in a modal.
+ */
+function PlayerNote({
+  note,
+  playerName,
+}: {
+  note: string;
+  playerName: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [truncated, setTruncated] = useState(false);
+  const noteRef = useRef<HTMLParagraphElement>(null);
+
+  useLayoutEffect(() => {
+    const el = noteRef.current;
+    if (!el) return;
+    const check = () => {
+      setTruncated(el.scrollWidth > el.clientWidth);
+    };
+    check();
+    // Re-check when the row resizes (rotation, desktop column reflow) -
+    // truncation can appear or disappear without the note changing.
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+    };
+  }, [note]);
+
+  return (
+    <div className="flex min-w-0 items-center gap-1.5">
+      <p ref={noteRef} className="text-text-secondary min-w-0 truncate text-xs">
+        "{note}"
+      </p>
+      {truncated && (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label={`Read full note from ${playerName}`}
+          className="text-navy -mx-1 -my-1 shrink-0 rounded p-1 text-[11px] font-semibold underline dark:text-white"
+        >
+          More
+        </button>
+      )}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="w-[calc(100%-1.5rem)] max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{playerName}'s note</DialogTitle>
+          </DialogHeader>
+          <p className="text-text-secondary mt-3 text-sm whitespace-pre-wrap">
+            "{note}"
+          </p>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
 function JuniorBadge() {
   return (
     <span className="bg-info-bg text-navy ml-1.5 rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase dark:text-white">
@@ -714,7 +783,10 @@ function UnavailableList({
               {p.dependent_id && <JuniorBadge />}
             </p>
             {p.note && (
-              <p className="text-text-secondary truncate text-xs">"{p.note}"</p>
+              <PlayerNote
+                note={p.note}
+                playerName={p.member_name ?? "Player"}
+              />
             )}
             {p.overridden_by && (
               <p className="text-warning text-[10px] font-semibold tracking-wide uppercase">


### PR DESCRIPTION
## What

Player availability notes on the official per-date picker (`/official/availability/:requestId/date/:date`) were truncated to one line with no way to read the full text.

Notes keep the current one-line truncated rendering, but when the text actually overflows a small underlined **More** button appears next to the ellipsis and opens the full note in a modal (the app's existing `Dialog`, titled "{player}'s note", `whitespace-pre-wrap` so multi-line notes keep their breaks).

## How

New `PlayerNote` component used by both the Available and Unavailable pools (covers the mobile tabbed view and the desktop 3-column view):

- Truncation is detected on the rendered element (`scrollWidth > clientWidth`), so short notes like "On holiday" don't grow a pointless control.
- A `ResizeObserver` re-checks on resize/rotation, so the button appears/disappears correctly as layout changes.
- The button carries `aria-label="Read full note from {player}"` since "More" alone is ambiguous to screen readers.

## Testing

- Verified end-to-end in the browser against the real page at mobile (390px) and desktop widths with stubbed API data: long notes truncate and show More, short/no-note rows don't, modal opens/closes cleanly, and resizing between layouts re-evaluates truncation both ways.
- `pnpm typecheck`, `pnpm lint`, `pnpm format` all clean. (No test files exist in `apps/matchday`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Player availability notes now appear in a compact, single-line format.
  * Added a “More” option for longer notes to view the complete text in a modal.
  * Consistent note display is now available in both Available and Unavailable lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->