### PR TITLE
fix(og): point hero background at pitch.jpg (500s on /api/og/game/:id)

### DIFF
--- a/apps/api/src/features/og-image/service.ts
+++ b/apps/api/src/features/og-image/service.ts
@@ -7,7 +7,7 @@ import sharp, { type OverlayOptions } from "sharp";
 import type { PlayCricketApiClient } from "../play-cricket/api-client.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const HERO_IMAGE_PATH = join(__dirname, "..", "..", "assets", "pitch.png");
+const HERO_IMAGE_PATH = join(__dirname, "..", "..", "assets", "pitch.jpg");
 
 // --- Types ---
 


### PR DESCRIPTION
## Summary
- `GET /api/og/game/:id` (the social-share card image) has returned 500 on every request since PR #119 replaced `apps/api/src/assets/pitch.png` with `pitch.jpg` without updating `og-image/service.ts`. sharp throws `Input file is missing: /app/apps/api/dist/assets/pitch.png` at the hero-background step.
- A crawler sweeping game pages (fetching each page's `og:image`) pushed the failure rate to 7 in 5 min at 22:06 UTC on 11 Aug, tripping the `percy-main-production-alb-target-5xx-errors` alarm. The error had been occurring quietly (1-19/day) for weeks before that.
- One-line fix: `HERO_IMAGE_PATH` now points at `pitch.jpg`, matching what the Dockerfile copies into `dist/assets` and what `matchday/team-news-image.ts` already uses.

## Verification
- Replicated the exact hero pipeline (`resize 1200x630 -> modulate -> tint -> toBuffer`) against `src/assets/pitch.jpg` with a local node script: succeeds, produces a valid PNG.
- `pnpm vitest run src/features/og-image`: 17 passed.
- No other references to `pitch.png` anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Open Graph image hero background asset for improved image handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->