### PR TITLE
fix(deps): bump brace-expansion, fast-uri, nanoid past HIGH CVEs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,13 +11,15 @@ overrides:
   '@smithy/signature-v4@<5.6.9': '>=5.6.9'
   '@fastify/static@<10.1.1': '>=10.1.1'
   axios@<1.18.0: '>=1.18.0'
-  brace-expansion@>=5.0.0 <5.0.8: '>=5.0.8'
+  brace-expansion@>=5.0.0 <5.0.9: '>=5.0.9'
   esbuild@<0.28.1: '>=0.28.1'
+  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
   fast-xml-parser@<5.7.0: '>=5.7.0'
   find-my-way@<9.7.0: '>=9.7.0'
   form-data@<4.0.6: '>=4.0.6'
   js-yaml@>=4.0.0 <4.3.0: '>=4.3.0'
   minimatch@9: '>=10.2.5'
+  nanoid@>=3.0.0 <3.3.17: ^3.3.17
   next@<16.2.11: '>=16.2.11'
   postcss@<8.5.10: '>=8.5.10'
   sharp@<0.35.0: '>=0.35.0'
@@ -5297,8 +5299,8 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -6008,8 +6010,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastify-plugin@6.0.0:
     resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
@@ -7137,8 +7139,8 @@ packages:
   nan@2.27.0:
     resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10337,7 +10339,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
 
   '@fastify/cookie@11.1.2':
     dependencies:
@@ -13514,7 +13516,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13835,7 +13837,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14620,7 +14622,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -14629,7 +14631,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -14641,7 +14643,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastify-plugin@6.0.0: {}
 
@@ -15371,7 +15373,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color
@@ -15981,7 +15983,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
@@ -16008,7 +16010,7 @@ snapshots:
   nan@2.27.0:
     optional: true
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanostores@1.3.0: {}
 
@@ -16359,7 +16361,7 @@ snapshots:
 
   postcss@8.5.19:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,14 +34,19 @@ overrides:
   # does (#653).
   "@fastify/static@<10.1.1": ">=10.1.1"
   axios@<1.18.0: ">=1.18.0"
-  # CVE-2026-14257 (ReDoS): scoped to the 5.x line only. brace-expansion 5
-  # dropped the default export (named `expand` only), so forcing it onto
-  # minimatch 5/9 breaks them at runtime; those lines have no fixed
-  # release. The runtime 2.x copy is eliminated by the minimatch override
-  # below instead; remaining 1.x/2.x copies are dev-only chains that never
-  # reach the API image (#653).
-  "brace-expansion@>=5.0.0 <5.0.8": ">=5.0.8"
+  # CVE-2026-14257 (ReDoS) + CVE-2026-69152 (DoS via unbounded intermediate
+  # arrays): scoped to the 5.x line only. brace-expansion 5 dropped the
+  # default export (named `expand` only), so forcing it onto minimatch 5/9
+  # breaks them at runtime. The runtime 2.x copy is eliminated by the
+  # minimatch override below instead; remaining 1.x/2.x copies are dev-only
+  # chains that never reach the API image (#653).
+  "brace-expansion@>=5.0.0 <5.0.9": ">=5.0.9"
   esbuild@<0.28.1: ">=0.28.1"
+  # CVE-2026-18446 (host confusion via backslash in URI authority): scoped
+  # to the 3.x line, the only one in the graph (ajv/fastify chain); caret,
+  # not >=, or the override itself would hoist to 4.x. The 4.x fix is 4.1.2
+  # if a consumer ever pulls that line in.
+  "fast-uri@>=3.0.0 <3.1.5": "^3.1.5"
   fast-xml-parser@<5.7.0: ">=5.7.0"
   # CVE-2026-47219: fastify's ^9.6.0 range already admits the fix; the
   # floor guards against dedupe re-resolving the vulnerable patch (#653).
@@ -57,6 +62,10 @@ overrides:
   # fixed 2.x release. minimatch 10 keeps the API surface glob@10 uses and
   # moves to brace-expansion 5 (#653).
   minimatch@9: ">=10.2.5"
+  # CVE-2026-67213 (DoS via infinite loop in ID generation): scoped to 3.x
+  # with a caret so the override cannot hoist past it; nanoid 4+ is
+  # ESM-only and would break CJS dependents if forced.
+  "nanoid@>=3.0.0 <3.3.17": "^3.3.17"
   # @react-email/ui hard-pins next, so the floor must be forced past the
   # CVE-2026-64641/-64642/-64645/-64649 fixes; sharp rides in as next's
   # optional dep and needs its own floor (GHSA-f88m-g3jw-g9cj).


### PR DESCRIPTION
## Summary

The `deploy-api` Trivy gate is failing on main, blocking release ([failed run](https://github.com/percy-main/website-v2/actions/runs/31541574848)). Three HIGH vulnerabilities in transitive packages baked into the API image:

| Package | CVE | Installed | Fixed |
|---|---|---|---|
| brace-expansion | CVE-2026-69152 (DoS via unbounded intermediate arrays) | 5.0.8 | 5.0.9 |
| fast-uri | CVE-2026-18446 (host confusion via backslash in URI authority) | 3.1.4 | 3.1.5 |
| nanoid | CVE-2026-67213 (DoS via infinite loop in ID generation) | 3.3.16 | 3.3.17 |

## Changes

- Widen the existing brace-expansion 5.x security override floor to `>=5.0.9`
- Add scoped security overrides for fast-uri (`^3.1.5`) and nanoid (`^3.3.17`), following the established pattern in `pnpm-workspace.yaml`
- Lockfile-only resolution changes otherwise: exactly the three targeted bumps, nothing else

The new replacements use caret ranges rather than `>=` floors: a bare `>=` floor resolves to the latest version overall, which hoists fast-uri to 4.x and nanoid to 6.x (ESM-only) and breaks their CJS dependents (observed locally before switching to carets).

Dependabot's #677 batch also contains these bumps, but it carries 53 production updates; this PR is the minimal unblock. #677 will rebase over it.

## Verification

- Fresh `--pull --no-cache` API image build scanned locally with CI's exact Trivy flags (`--scanners vuln,secret --severity CRITICAL,HIGH --exit-code 1 --ignore-unfixed`): exit 0, zero findings
- API unit tests: 675/675 pass
- `pnpm peers check` complaints are pre-existing (eslint-plugin-react, openapi-typescript) and unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)