### PR TITLE
fix(deps): bump js-yaml and postcss override floors for new advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,11 +17,11 @@ overrides:
   fast-xml-parser@<5.7.0: '>=5.7.0'
   find-my-way@<9.7.0: '>=9.7.0'
   form-data@<4.0.6: '>=4.0.6'
-  js-yaml@>=4.0.0 <4.3.0: '>=4.3.0'
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   minimatch@9: '>=10.2.5'
   nanoid@>=3.0.0 <3.3.17: ^3.3.17
   next@<16.2.11: '>=16.2.11'
-  postcss@<8.5.10: '>=8.5.10'
+  postcss@<8.5.23: '>=8.5.23'
   sharp@<0.35.0: '>=0.35.0'
   ws@<8.21.0: '>=8.21.0'
   yaml@<2.8.3: '>=2.8.3'
@@ -6451,8 +6451,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -7346,10 +7346,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -10754,7 +10750,7 @@ snapshots:
 
   '@newrelic/rrweb-snapshot@1.1.2':
     dependencies:
-      postcss: 8.5.19
+      postcss: 8.5.26
 
   '@newrelic/rrweb-types@1.1.2': {}
 
@@ -12144,7 +12140,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -13746,7 +13742,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -15065,7 +15061,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -16117,12 +16113,6 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.5.19:
-    dependencies:
-      nanoid: 3.3.18
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,11 +52,13 @@ overrides:
   # floor guards against dedupe re-resolving the vulnerable patch (#653).
   find-my-way@<9.7.0: ">=9.7.0"
   form-data@<4.0.6: ">=4.0.6"
-  # GHSA-52cp-r559-cp3m (merge-key quadratic CPU): @redocly/openapi-core 1.x
+  # GHSA-52cp-r559-cp3m (merge-key quadratic CPU) + GHSA-5p4m-2wfm-xmqj
+  # (!!omap quadratic CPU, fixed in 4.3.1): @redocly/openapi-core 1.x
   # hard-pins js-yaml (4.1.1, 4.2.0 at latest); only 2.x moves to js-yaml 5.
-  # Scoped to 4.x so a future 3.x consumer isn't force-broken. Drop once
-  # openapi-typescript depends on @redocly/openapi-core 2.x.
-  "js-yaml@>=4.0.0 <4.3.0": ">=4.3.0"
+  # Caret, not >=: js-yaml 5.x is out now, and a bare floor would hoist past
+  # the 4.x line openapi-core pins. Drop once openapi-typescript depends on
+  # @redocly/openapi-core 2.x.
+  "js-yaml@>=4.0.0 <4.3.1": "^4.3.1"
   # CVE-2026-14257 continued: glob@10 (runtime via google-gax -> rimraf)
   # pins minimatch ^9, which pins vulnerable brace-expansion ^2 with no
   # fixed 2.x release. minimatch 10 keeps the API surface glob@10 uses and
@@ -70,7 +72,10 @@ overrides:
   # CVE-2026-64641/-64642/-64645/-64649 fixes; sharp rides in as next's
   # optional dep and needs its own floor (GHSA-f88m-g3jw-g9cj).
   next@<16.2.11: ">=16.2.11"
-  postcss@<8.5.10: ">=8.5.10"
+  # CVE-2026-69153: 8.5.23 completes the sourceMappingURL fix that 8.5.10
+  # (GHSA-6g55-p6wh-862q) only partially shipped; the vulnerable copy rides
+  # in via @newrelic/rrweb-snapshot.
+  postcss@<8.5.23: ">=8.5.23"
   sharp@<0.35.0: ">=0.35.0"
   ws@<8.21.0: ">=8.21.0"
   yaml@<2.8.3: ">=2.8.3"


### PR DESCRIPTION
Resolves two open Dependabot alerts by raising existing security-override floors in `pnpm-workspace.yaml`:

- **[Alert 154](https://github.com/percy-main/website-v2/security/dependabot/154)** (high, dev-scoped): GHSA-5p4m-2wfm-xmqj, js-yaml 4.x quadratic CPU in `!!omap` resolution. Floor raised 4.3.0 -> 4.3.1, and the replacement is now caret-scoped (`^4.3.1`): js-yaml 5.x has since been released, so the previous bare `>=` style would hoist past the 4.x line that `@redocly/openapi-core` 1.x hard-pins.
- **[Alert 153](https://github.com/percy-main/website-v2/security/dependabot/153)** (medium, runtime): CVE-2026-69153, postcss `<=8.5.22` incomplete fix for attacker-controlled `sourceMappingURL` reading arbitrary `.map` files. Floor raised 8.5.10 -> 8.5.23; the vulnerable 8.5.19 copy (via `@newrelic/rrweb-snapshot`) re-resolves to 8.5.26.

Lockfile diff is scoped to exactly these two packages (+1 -2: js-yaml 4.3.1 in, js-yaml 4.3.0 and postcss 8.5.19 out).

Verified locally: `pnpm install` resolves clean, `openapi:generate` (exercises the js-yaml chain) produces no diff, and the web build (exercises postcss) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package requirements for improved compatibility and security.
  * Ensured supported versions of YAML parsing and CSS processing tools are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->