### PR TITLE
feat(matchday): custom fixtures - create and pick squads for non-Play-Cricket games

### DIFF
--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -17,9 +17,12 @@ import {
   deleteExpense,
   finishMatch,
   getMatch,
+  getMatchPublic,
   getMyRecentMilestones,
   getMyUpcomingMatches,
   getPastUnfinishedMatchdays,
+  getTeamNewsData,
+  listCustomFixtures,
   listMatches,
   listPendingExpenses,
   listTeams,
@@ -369,6 +372,156 @@ describe("matchday service (integration)", () => {
     });
   });
 
+  // Assertions are membership-based (toContain / not.toContain) rather
+  // than exact-array: the container DB is shared across this file, and
+  // other tests seed matchdays without a PC match id, which are custom
+  // fixtures by definition.
+  describe("listCustomFixtures", () => {
+    it("returns custom matchdays and hides PC-backed, cancelled, and stale ones", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `customfix-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+
+      const customId = await seedMatchday({ teamId, createdBy: userId });
+      const pcBackedId = await seedMatchday({
+        teamId: await seedTeam(),
+        createdBy: userId,
+      });
+      await ctx.db
+        .updateTable("matchday")
+        .set({ play_cricket_match_id: `pcm-${crypto.randomUUID()}` })
+        .where("id", "=", pcBackedId)
+        .execute();
+      const cancelledId = await seedMatchday({
+        teamId: await seedTeam(),
+        createdBy: userId,
+        status: "cancelled",
+      });
+      const staleId = await seedMatchday({
+        teamId: await seedTeam(),
+        createdBy: userId,
+        matchDate: format(subDays(new Date(), 60), "yyyy-MM-dd"),
+      });
+
+      const result = await listCustomFixtures(ctx.db)();
+      const ids = result.map((r) => r.matchdayId);
+
+      expect(ids).toContain(customId);
+      expect(ids).not.toContain(pcBackedId);
+      expect(ids).not.toContain(cancelledId);
+      expect(ids).not.toContain(staleId);
+
+      const row = result.find((r) => r.matchdayId === customId);
+      expect(row?.opposition).toBe("Opposition CC");
+      expect(row?.teamId).toBe(teamId);
+      expect(row?.teamName).toMatch(/^Team /);
+      expect(row?.status).toBe("pending");
+      expect(row?.resultType).toBeNull();
+    });
+
+    it("keeps recently played custom matchdays inside the window", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `recentfix-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const recentId = await seedMatchday({
+        teamId,
+        createdBy: userId,
+        matchDate: format(subDays(new Date(), 7), "yyyy-MM-dd"),
+        status: "finished",
+      });
+
+      const result = await listCustomFixtures(ctx.db)();
+      expect(result.map((r) => r.matchdayId)).toContain(recentId);
+    });
+  });
+
+  describe("getMatchPublic", () => {
+    it("projects stored start time and home/away for custom fixtures", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `pubproj-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: userId });
+      await ctx.db
+        .updateTable("matchday")
+        .set({ is_home: false, match_time: "18:30" })
+        .where("id", "=", matchdayId)
+        .execute();
+
+      const result = await getMatchPublic(ctx.db)(matchdayId);
+      expect(result.away).toBe(true);
+      expect(result.startTime).toBe("18:30");
+    });
+
+    it("keeps start time and home/away null when not stored", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `pubnull-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: userId });
+
+      const result = await getMatchPublic(ctx.db)(matchdayId);
+      expect(result.away).toBeNull();
+      expect(result.startTime).toBeNull();
+    });
+  });
+
+  describe("getTeamNewsData", () => {
+    async function seedCustomWithPlayer() {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `teamnews-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+      const matchdayId = await seedMatchday({ teamId, createdBy: userId });
+      await ctx.db
+        .updateTable("matchday")
+        .set({ is_home: false, match_time: "13:30" })
+        .where("id", "=", matchdayId)
+        .execute();
+      await ctx.db
+        .insertInto("matchday_player")
+        .values({
+          id: `mdp-${crypto.randomUUID()}`,
+          matchday_id: matchdayId,
+          player_name: "A Player",
+          status: "selected",
+        })
+        .execute();
+      return { userId, matchdayId };
+    }
+
+    it("falls back to stored home/away and time when there is no PC match", async () => {
+      const { userId, matchdayId } = await seedCustomWithPlayer();
+
+      const data = await getTeamNewsData(ctx.db, {
+        apiClient: null,
+        siteId: null,
+      })(userId, "admin", matchdayId, {});
+
+      expect(data.isHome).toBe(false);
+      expect(data.matchTime).toBe("13:30");
+    });
+
+    it("lets explicit overrides win over stored values", async () => {
+      const { userId, matchdayId } = await seedCustomWithPlayer();
+
+      const data = await getTeamNewsData(ctx.db, {
+        apiClient: null,
+        siteId: null,
+      })(userId, "admin", matchdayId, { isHome: true, matchTime: "12:00" });
+
+      expect(data.isHome).toBe(true);
+      expect(data.matchTime).toBe("12:00");
+    });
+  });
+
   describe("createMatchday", () => {
     it("creates a matchday for an accessible team", async () => {
       const { userId } = await seedTestUser(ctx.db, {
@@ -393,6 +546,33 @@ describe("matchday service (integration)", () => {
         .executeTakeFirst();
       expect(row?.opposition).toBe("Rival CC");
       expect(row?.status).toBe("pending");
+    });
+
+    it("persists home/away and start time for custom fixtures", async () => {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `custom-md-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+      const teamId = await seedTeam();
+
+      const result = await createMatchday(ctx.db)(userId, "admin", {
+        teamId,
+        matchDate: "2026-09-01",
+        opposition: "Friendly CC",
+        competitionType: "Friendly",
+        isHome: false,
+        matchTime: "18:00",
+      });
+
+      const row = await ctx.db
+        .selectFrom("matchday")
+        .where("id", "=", result.id)
+        .selectAll()
+        .executeTakeFirst();
+      expect(row?.play_cricket_match_id).toBeNull();
+      expect(row?.is_home).toBe(false);
+      expect(row?.match_time).toBe("18:00");
+      expect(row?.competition_type).toBe("Friendly");
     });
 
     it("rejects duplicate matchday for same team and date", async () => {

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -13,6 +13,7 @@ import {
   cancelMatchdaySchema,
   createMatchdayResponseSchema,
   createMatchdaySchema,
+  customFixturesResponseSchema,
   expenseIdParamSchema,
   finishMatchResponseSchema,
   finishMatchSchema,
@@ -62,6 +63,7 @@ import {
   getPastUnfinishedMatchdays,
   getTeamNewsData,
   getUpcomingMatches,
+  listCustomFixtures,
   listMatches,
   listPendingExpenses,
   listTeams,
@@ -186,6 +188,23 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
         request.params.matchdayPlayerId,
         request.log,
       );
+    },
+  );
+
+  // Custom (non-Play-Cricket) fixtures for the PWA fixtures list.
+  // Signed-in members only — same audience as /matchday/:matchId/public,
+  // which is where the list links to.
+  const customFixtures = listCustomFixtures(app.db);
+  app.get(
+    "/matchday/custom-fixtures",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        response: { 200: customFixturesResponseSchema },
+      },
+    },
+    async () => {
+      return await customFixtures();
     },
   );
 

--- a/apps/api/src/features/matchday/schemas.test.ts
+++ b/apps/api/src/features/matchday/schemas.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { createMatchdaySchema, teamNewsImageQuerySchema } from "./schemas.ts";
+
+const base = {
+  teamId: "team-1",
+  matchDate: "2026-09-01",
+  opposition: "Rival CC",
+};
+
+describe("createMatchdaySchema matchTime", () => {
+  it.each(["00:00", "09:30", "23:59"])("accepts %s", (matchTime) => {
+    expect(createMatchdaySchema.safeParse({ ...base, matchTime }).success).toBe(
+      true,
+    );
+  });
+
+  // The PWA form's <input type="time"> can't produce these, but the
+  // endpoint is callable directly - out-of-range values must not
+  // persist onto the team sheet.
+  it.each(["24:00", "29:99", "12:60", "9:30", "12:5", "noon"])(
+    "rejects %s",
+    (matchTime) => {
+      expect(
+        createMatchdaySchema.safeParse({ ...base, matchTime }).success,
+      ).toBe(false);
+    },
+  );
+
+  it("accepts an omitted matchTime", () => {
+    expect(createMatchdaySchema.safeParse(base).success).toBe(true);
+  });
+});
+
+describe("teamNewsImageQuerySchema isHome", () => {
+  it("parses 'true' and 'false' to booleans", () => {
+    expect(teamNewsImageQuerySchema.parse({ isHome: "true" }).isHome).toBe(
+      true,
+    );
+    expect(teamNewsImageQuerySchema.parse({ isHome: "false" }).isHome).toBe(
+      false,
+    );
+  });
+
+  it("leaves isHome undefined when absent", () => {
+    expect(teamNewsImageQuerySchema.parse({}).isHome).toBeUndefined();
+  });
+
+  it("rejects values that used to coerce silently to away", () => {
+    expect(teamNewsImageQuerySchema.safeParse({ isHome: "yes" }).success).toBe(
+      false,
+    );
+    expect(teamNewsImageQuerySchema.safeParse({ isHome: "1" }).success).toBe(
+      false,
+    );
+  });
+});

--- a/apps/api/src/features/matchday/schemas.ts
+++ b/apps/api/src/features/matchday/schemas.ts
@@ -79,7 +79,7 @@ export const createMatchdaySchema = z.object({
   isHome: z.boolean().optional(),
   matchTime: z
     .string()
-    .regex(/^\d{2}:\d{2}$/, "Must be HH:MM format")
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Must be HH:MM (24-hour) format")
     .optional(),
 });
 
@@ -118,8 +118,11 @@ export const searchMembersSchema = z.object({
 // matchday's stored is_home/match_time (set for custom fixtures), then
 // to the joined play-cricket fixture (home_club_id / match_time).
 export const teamNewsImageQuerySchema = z.object({
+  // Enum, not bare string: anything else used to coerce silently to
+  // `false` (= away), which is exactly the wrong-venue image bug this
+  // override exists to prevent.
   isHome: z
-    .string()
+    .enum(["true", "false"])
     .optional()
     .transform((v) => (v === undefined ? undefined : v === "true")),
   matchTime: z.string().optional(),

--- a/apps/api/src/features/matchday/schemas.ts
+++ b/apps/api/src/features/matchday/schemas.ts
@@ -72,6 +72,15 @@ export const createMatchdaySchema = z.object({
   opposition: z.string().min(1),
   competitionType: z.string().optional(),
   playCricketMatchId: z.string().optional(),
+  // Custom (non-Play-Cricket) fixtures have no upstream record to
+  // derive home/away or start time from, so the create form supplies
+  // them. Play-Cricket-backed matchdays omit both and keep deriving
+  // them from the matches-summary lookup.
+  isHome: z.boolean().optional(),
+  matchTime: z
+    .string()
+    .regex(/^\d{2}:\d{2}$/, "Must be HH:MM format")
+    .optional(),
 });
 
 export const addPlayerSchema = z.object({
@@ -105,8 +114,9 @@ export const searchMembersSchema = z.object({
 
 // ── Team news image schemas ──
 
-// Both are pure overrides. When absent, the route derives them from
-// the joined play-cricket fixture (home_club_id / match_time).
+// Both are pure overrides. When absent, the route falls back to the
+// matchday's stored is_home/match_time (set for custom fixtures), then
+// to the joined play-cricket fixture (home_club_id / match_time).
 export const teamNewsImageQuerySchema = z.object({
   isHome: z
     .string()
@@ -168,6 +178,8 @@ const matchdayItemSchema = z.object({
   opposition: z.string(),
   competition_type: z.string().nullable(),
   play_cricket_match_id: z.string().nullable(),
+  is_home: z.boolean().nullable(),
+  match_time: z.string().nullable(),
   status: z.string(),
   created_by: z.string(),
   created_at: z.string(),
@@ -324,6 +336,25 @@ const teamSchema = z.object({
 });
 
 export const listTeamsResponseSchema = z.array(teamSchema);
+
+// Custom fixtures — matchdays with no Play-Cricket match behind them
+// (friendlies and other club-arranged games). Served to every signed-in
+// member so the matchday app's fixtures list can union them into the
+// Play-Cricket feed; the shape mirrors what that list renders.
+const customFixtureSchema = z.object({
+  matchdayId: z.string(),
+  matchDate: z.string(),
+  matchTime: z.string().nullable(),
+  opposition: z.string(),
+  teamId: z.string(),
+  teamName: z.string().nullable(),
+  isHome: z.boolean().nullable(),
+  competitionType: z.string().nullable(),
+  status: z.string(),
+  resultType: z.string().nullable(),
+});
+
+export const customFixturesResponseSchema = z.array(customFixtureSchema);
 
 const upcomingMatchSchema = z.object({
   matchId: z.string(),

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -291,6 +291,8 @@ export function getMatchPublic(db: Kysely<DB>) {
         "matchday.competition_type",
         "matchday.status",
         "matchday.result_type",
+        "matchday.is_home",
+        "matchday.match_time",
         "play_cricket_team.name as team_name",
       ])
       .executeTakeFirst();
@@ -355,17 +357,20 @@ export function getMatchPublic(db: Kysely<DB>) {
     return {
       id: match.id,
       matchDate: match.match_date,
-      // Home/away, ground, match time, and score summary live on the
-      // joined play_cricket_match record, which this service doesn't
-      // load yet. Phase 2.1 cleanup if we need them. For now: null —
-      // the schema is `.nullable()` so callers know to render the
-      // field as "—" or hide it rather than treat `false` as truth.
-      startTime: null as string | null,
+      // Start time and home/away come from the matchday's own columns,
+      // which are only populated for custom (non-Play-Cricket)
+      // fixtures. For PC-backed matchdays they stay null - deriving
+      // them means joining the play_cricket_match record, which this
+      // service doesn't load yet (Phase 2.1 cleanup if we need it).
+      // Ground and score summary likewise. The schema is `.nullable()`
+      // so callers render "—" or hide the field rather than treat
+      // `false` as truth.
+      startTime: match.match_time,
       teamName: match.team_name,
       opposition: match.opposition,
       ground: null as string | null,
       competition: match.competition_type,
-      away: null as boolean | null,
+      away: match.is_home === null ? null : !match.is_home,
       status: match.status as "pending" | "confirmed" | "finished",
       result: match.result_type,
       scoreSummary: null as string | null,
@@ -914,6 +919,62 @@ export function getUpcomingMatches(
 }
 
 /**
+ * Custom fixtures — matchdays created by officials with no
+ * Play-Cricket match behind them (friendlies and other club-arranged
+ * games). The matchday app's fixtures tab unions these into the
+ * Play-Cricket feed, so they're visible to any signed-in member —
+ * mirroring the team-sheet route, which is already member-visible.
+ * The trailing window keeps recently played games listed alongside
+ * Play-Cricket results rather than vanishing at midnight.
+ */
+export function listCustomFixtures(db: Kysely<DB>) {
+  return async () => {
+    const windowStart = formatDate(
+      subDays(startOfDay(new Date()), 30),
+      "yyyy-MM-dd",
+    );
+
+    const rows = await db
+      .selectFrom("matchday")
+      .leftJoin(
+        "play_cricket_team",
+        "play_cricket_team.id",
+        "matchday.play_cricket_team_id",
+      )
+      .where("matchday.play_cricket_match_id", "is", null)
+      .where("matchday.status", "!=", "cancelled")
+      .where("matchday.match_date", ">=", windowStart)
+      .select([
+        "matchday.id",
+        "matchday.match_date",
+        "matchday.match_time",
+        "matchday.opposition",
+        "matchday.is_home",
+        "matchday.competition_type",
+        "matchday.status",
+        "matchday.result_type",
+        "matchday.play_cricket_team_id",
+        "play_cricket_team.name as team_name",
+      ])
+      .orderBy("matchday.match_date", "asc")
+      .execute();
+
+    return rows.map((r) => ({
+      matchdayId: r.id,
+      matchDate: r.match_date,
+      matchTime: r.match_time,
+      opposition: r.opposition,
+      teamId: r.play_cricket_team_id,
+      teamName: r.team_name,
+      isHome: r.is_home,
+      competitionType: r.competition_type,
+      status: r.status,
+      resultType: r.result_type,
+    }));
+  };
+}
+
+/**
  * Past unfinished matchdays for a team — matchdays whose match_date is
  * before today and whose status is still pending or confirmed. Lets
  * officials find and finish/cancel matchdays they started but never
@@ -1038,6 +1099,8 @@ export function createMatchday(db: Kysely<DB>) {
           opposition: data.opposition,
           competition_type: data.competitionType ?? null,
           play_cricket_match_id: data.playCricketMatchId ?? null,
+          is_home: data.isHome ?? null,
+          match_time: data.matchTime ?? null,
           status: "pending",
           created_by: userId,
         })
@@ -2783,13 +2846,17 @@ export function getTeamNewsData(db: Kysely<DB>, ctx: TeamNewsImageContext) {
       }
     }
 
-    // Resolve isHome + matchTime. Honour explicit caller overrides;
-    // otherwise look the fixture up via the play-cricket matches-summary
-    // endpoint (the match-detail endpoint's schema drops match_time -
-    // both fields live on the summary row). If play-cricket is wired
-    // and the lookup fails, propagate the error: a wrong home/away
-    // image is exactly the bug we're trying to stop shipping.
+    // Resolve isHome + matchTime. Honour explicit caller overrides,
+    // then the matchday's own columns (populated for custom fixtures
+    // created without a Play-Cricket match); otherwise look the fixture
+    // up via the play-cricket matches-summary endpoint (the
+    // match-detail endpoint's schema drops match_time - both fields
+    // live on the summary row). If play-cricket is wired and the
+    // lookup fails, propagate the error: a wrong home/away image is
+    // exactly the bug we're trying to stop shipping.
     let { isHome, matchTime } = overrides;
+    isHome ??= match.is_home ?? undefined;
+    matchTime ??= match.match_time ?? undefined;
     if (
       (isHome === undefined || matchTime === undefined) &&
       match.play_cricket_match_id &&

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -4322,6 +4322,52 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/matchday/custom-fixtures": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            matchdayId: string;
+                            matchDate: string;
+                            matchTime: string | null;
+                            opposition: string;
+                            teamId: string;
+                            teamName: string | null;
+                            isHome: boolean | null;
+                            competitionType: string | null;
+                            status: string;
+                            resultType: string | null;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/matchday": {
         parameters: {
             query?: never;
@@ -4357,6 +4403,8 @@ export interface paths {
                                 opposition: string;
                                 competition_type: string | null;
                                 play_cricket_match_id: string | null;
+                                is_home: boolean | null;
+                                match_time: string | null;
                                 status: string;
                                 created_by: string;
                                 created_at: string;
@@ -4395,6 +4443,8 @@ export interface paths {
                         opposition: string;
                         competitionType?: string;
                         playCricketMatchId?: string;
+                        isHome?: boolean;
+                        matchTime?: string;
                     };
                 };
             };
@@ -4451,6 +4501,8 @@ export interface paths {
                                 opposition: string;
                                 competition_type: string | null;
                                 play_cricket_match_id: string | null;
+                                is_home: boolean | null;
+                                match_time: string | null;
                                 status: string;
                                 created_by: string;
                                 created_at: string;

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -4649,7 +4649,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    isHome?: string;
+                    isHome?: "true" | "false";
                     matchTime?: string;
                 };
                 header?: never;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -7505,6 +7505,75 @@
         }
       }
     },
+    "/api/matchday/custom-fixtures": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "matchdayId": {
+                        "type": "string"
+                      },
+                      "matchDate": {
+                        "type": "string"
+                      },
+                      "matchTime": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "opposition": {
+                        "type": "string"
+                      },
+                      "teamId": {
+                        "type": "string"
+                      },
+                      "teamName": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "isHome": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "competitionType": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "resultType": {
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "matchdayId",
+                      "matchDate",
+                      "matchTime",
+                      "opposition",
+                      "teamId",
+                      "teamName",
+                      "isHome",
+                      "competitionType",
+                      "status",
+                      "resultType"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/matchday": {
       "get": {
         "parameters": [
@@ -7588,6 +7657,14 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "is_home": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "match_time": {
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "status": {
                             "type": "string"
                           },
@@ -7657,6 +7734,8 @@
                           "opposition",
                           "competition_type",
                           "play_cricket_match_id",
+                          "is_home",
+                          "match_time",
                           "status",
                           "created_by",
                           "created_at",
@@ -7712,6 +7791,13 @@
                   },
                   "playCricketMatchId": {
                     "type": "string"
+                  },
+                  "isHome": {
+                    "type": "boolean"
+                  },
+                  "matchTime": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
                   }
                 },
                 "required": [
@@ -7795,6 +7881,14 @@
                           "nullable": true,
                           "type": "string"
                         },
+                        "is_home": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "match_time": {
+                          "nullable": true,
+                          "type": "string"
+                        },
                         "status": {
                           "type": "string"
                         },
@@ -7864,6 +7958,8 @@
                         "opposition",
                         "competition_type",
                         "play_cricket_match_id",
+                        "is_home",
+                        "match_time",
                         "status",
                         "created_by",
                         "created_at",

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -7797,7 +7797,7 @@
                   },
                   "matchTime": {
                     "type": "string",
-                    "pattern": "^\\d{2}:\\d{2}$"
+                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$"
                   }
                 },
                 "required": [
@@ -8348,7 +8348,11 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
             },
             "in": "query",
             "name": "isHome",

--- a/apps/matchday/src/pages/fixtures.tsx
+++ b/apps/matchday/src/pages/fixtures.tsx
@@ -1,43 +1,61 @@
 import { DateSquare } from "@/components/primitives/date-square.js";
 import { StatusPill } from "@/components/primitives/status-pill.js";
+import { Button } from "@/components/ui/button.js";
 import {
   gameIsoDate,
   oppositionName,
   played,
   type Game,
 } from "@/features/games.js";
-import { api, callApi } from "@/lib/api-client.js";
+import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
+import { canManageMatchday, useSession } from "@/lib/auth-client.js";
 import { cn } from "@/lib/utils.js";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, PlusIcon } from "lucide-react";
 import { Link, useSearchParams } from "react-router";
 
+type CustomFixture = ApiResponse<"/api/matchday/custom-fixtures">[number];
+
+/**
+ * One row in the fixtures list — either a Play-Cricket game or a custom
+ * matchday (a club-arranged game with no Play-Cricket record). The
+ * shared fields drive filtering/bucketing; `item` keeps the full
+ * payload for rendering and links each kind to its own detail page.
+ */
+interface Entry {
+  key: string;
+  iso: string | null;
+  teamName: string;
+  isPlayed: boolean;
+  item: { kind: "pc"; game: Game } | { kind: "custom"; fixture: CustomFixture };
+}
+
 const FILTERS = [
-  { key: "all", label: "All", pred: (_: Game) => true },
+  { key: "all", label: "All", pred: (_: string) => true },
   {
     key: "1st",
     label: "1st XI",
-    pred: (g: Game) => g.team.name.toLowerCase().includes("1st"),
+    pred: (name: string) => name.toLowerCase().includes("1st"),
   },
   {
     key: "2nd",
     label: "2nd XI",
-    pred: (g: Game) => g.team.name.toLowerCase().includes("2nd"),
+    pred: (name: string) => name.toLowerCase().includes("2nd"),
   },
   {
     key: "mid",
     label: "Midweek XI",
-    pred: (g: Game) => /midweek/i.test(g.team.name),
+    pred: (name: string) => /midweek/i.test(name),
   },
   {
     key: "womens",
     label: "Women's Softball",
-    pred: (g: Game) => /women/i.test(g.team.name),
+    pred: (name: string) => /women/i.test(name),
   },
   {
     key: "juniors",
     label: "Juniors",
-    pred: (g: Game) => /under|junior|colts|\bU\d{2}\b/i.test(g.team.name),
+    pred: (name: string) => /under|junior|colts|\bU\d{2}\b/i.test(name),
   },
 ] as const;
 
@@ -57,6 +75,8 @@ export default function Fixtures() {
   const filter: FilterKey =
     FILTERS.find((f) => f.key === filterParam)?.key ?? "all";
   const openSet = parseOpen(searchParams.get("open"));
+  const { data: session } = useSession();
+  const canCreate = canManageMatchday(session?.user);
 
   const setFilter = (next: FilterKey) => {
     setSearchParams(
@@ -85,13 +105,36 @@ export default function Fixtures() {
     );
   };
 
-  const { data, isLoading, isError } = useQuery({
+  const gamesQuery = useQuery({
     queryKey: ["games"],
     queryFn: () => callApi(api.GET("/api/games")),
   });
-  const games = data ?? [];
+  const customQuery = useQuery({
+    queryKey: ["matchday", "custom-fixtures"],
+    queryFn: () => callApi(api.GET("/api/matchday/custom-fixtures")),
+  });
+  const isLoading = gamesQuery.isLoading || customQuery.isLoading;
+  // One feed failing shouldn't blank the other — only report an error
+  // when there's nothing at all to show.
+  const isError = gamesQuery.isError && customQuery.isError;
+  const entries: Entry[] = [
+    ...(gamesQuery.data ?? []).map((g) => ({
+      key: `pc-${g.id}`,
+      iso: gameIsoDate(g),
+      teamName: g.team.name,
+      isPlayed: played(g),
+      item: { kind: "pc" as const, game: g },
+    })),
+    ...(customQuery.data ?? []).map((f) => ({
+      key: `md-${f.matchdayId}`,
+      iso: f.matchDate,
+      teamName: f.teamName ?? "",
+      isPlayed: f.resultType !== null,
+      item: { kind: "custom" as const, fixture: f },
+    })),
+  ];
   const selected = FILTERS.find((f) => f.key === filter) ?? FILTERS[0];
-  const filtered = games.filter(selected.pred);
+  const filtered = entries.filter((e) => selected.pred(e.teamName));
   const groups = groupByBucket(filtered);
   return (
     <div className="mx-auto w-full max-w-2xl pb-6">
@@ -115,6 +158,15 @@ export default function Fixtures() {
           </button>
         ))}
       </div>
+      {canCreate && (
+        <div className="flex justify-end px-4 pb-2">
+          <Button asChild tone="outline" size="sm">
+            <Link to="/matchday/new">
+              <PlusIcon /> New match
+            </Link>
+          </Button>
+        </div>
+      )}
       {isLoading && <FixtureSkeleton />}
       {isError && (
         <p className="text-text-secondary px-4 py-6 text-sm">
@@ -154,7 +206,13 @@ export default function Fixtures() {
                   />
                 </button>
                 {isOpen &&
-                  items.map((g) => <FixtureItem key={g.id} game={g} />)}
+                  items.map((e) =>
+                    e.item.kind === "pc" ? (
+                      <FixtureItem key={e.key} game={e.item.game} />
+                    ) : (
+                      <CustomFixtureItem key={e.key} fixture={e.item.fixture} />
+                    ),
+                  )}
               </section>
             );
           })}
@@ -185,7 +243,9 @@ function FixtureItem({ game }: { game: Game }) {
         </div>
       </div>
       {played(game) ? (
-        <FixtureResultPill game={game} />
+        <StatusPill tone={resultTone(game.outcome)} size="lg">
+          {game.scoreDescription ?? game.outcome ?? "—"}
+        </StatusPill>
       ) : (
         <StatusPill tone="neutral">{game.matchTime ?? "TBC"}</StatusPill>
       )}
@@ -193,22 +253,45 @@ function FixtureItem({ game }: { game: Game }) {
   );
 }
 
-function FixtureResultPill({ game }: { game: Game }) {
-  const o = game.outcome;
-  const tone =
-    o === "W"
-      ? ("success" as const)
-      : o === "L"
-        ? ("danger" as const)
-        : o === "D" || o === "T"
-          ? ("warning" as const)
-          : ("neutral" as const);
-  const label = game.scoreDescription ?? o ?? "—";
+/**
+ * A custom matchday row. No Play-Cricket game page exists for these, so
+ * it links to the team sheet — which carries manage links for officials.
+ */
+function CustomFixtureItem({ fixture }: { fixture: CustomFixture }) {
   return (
-    <StatusPill tone={tone} size="lg">
-      {label}
-    </StatusPill>
+    <Link
+      to={`/matchday/${fixture.matchdayId}`}
+      className="border-border-light bg-surface grid grid-cols-[44px_1fr_auto] items-center gap-3 border-t px-4 py-3 first:border-t-0"
+    >
+      <DateSquare iso={fixture.matchDate} dayLabel="month" />
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium">{fixture.opposition}</div>
+        <div className="text-text-secondary mt-0.5 text-xs">
+          {[
+            fixture.teamName,
+            fixture.isHome === null ? null : fixture.isHome ? "Home" : "Away",
+            fixture.competitionType,
+          ]
+            .filter(Boolean)
+            .join(" · ")}
+        </div>
+      </div>
+      {fixture.resultType !== null ? (
+        <StatusPill tone={resultTone(fixture.resultType)} size="lg">
+          {fixture.resultType}
+        </StatusPill>
+      ) : (
+        <StatusPill tone="neutral">{fixture.matchTime ?? "TBC"}</StatusPill>
+      )}
+    </Link>
   );
+}
+
+function resultTone(o: string | null) {
+  if (o === "W") return "success" as const;
+  if (o === "L") return "danger" as const;
+  if (o === "D" || o === "T") return "warning" as const;
+  return "neutral" as const;
 }
 
 function FixtureSkeleton() {
@@ -248,46 +331,43 @@ function sameSet<T>(a: Set<T>, b: ReadonlySet<T>): boolean {
   return true;
 }
 
-function groupByBucket(games: Game[]): Record<BucketKey, Game[]> {
+function groupByBucket(entries: Entry[]): Record<BucketKey, Entry[]> {
   // All comparisons happen on the ISO-normalised date — Play-Cricket
   // gives us DD/MM/YYYY which `new Date(...)` parses inconsistently
-  // across browsers and breaks string-sort.
+  // across browsers and breaks string-sort. Custom fixtures are ISO
+  // already.
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const nextWeekEnd = new Date(today);
   nextWeekEnd.setDate(nextWeekEnd.getDate() + 7);
 
-  const byIso = new Map<string, string | null>();
-  for (const g of games) byIso.set(g.id, gameIsoDate(g));
-  const isoFor = (g: Game) => byIso.get(g.id) ?? null;
-  const compare = (a: Game, b: Game) =>
-    (isoFor(a) ?? "").localeCompare(isoFor(b) ?? "");
+  const compare = (a: Entry, b: Entry) =>
+    (a.iso ?? "").localeCompare(b.iso ?? "");
 
-  const dateOf = (g: Game) => {
-    const iso = isoFor(g);
-    if (!iso) return null;
-    const d = new Date(iso);
+  const dateOf = (e: Entry) => {
+    if (!e.iso) return null;
+    const d = new Date(e.iso);
     if (isNaN(d.getTime())) return null;
     d.setHours(0, 0, 0, 0);
     return d;
   };
 
-  const out: Record<BucketKey, Game[]> = {
+  const out: Record<BucketKey, Entry[]> = {
     recent: [],
     next: [],
     future: [],
   };
-  for (const g of games) {
-    const d = dateOf(g);
+  for (const e of entries) {
+    const d = dateOf(e);
     // Anything in the past or already played belongs in Recent -
     // including past-date matches whose result hasn't been entered
     // yet, which previously leaked into "This week".
-    if (played(g) || (d && d < today)) {
-      out.recent.push(g);
+    if (e.isPlayed || (d && d < today)) {
+      out.recent.push(e);
       continue;
     }
-    if (!d || d < nextWeekEnd) out.next.push(g);
-    else out.future.push(g);
+    if (!d || d < nextWeekEnd) out.next.push(e);
+    else out.future.push(e);
   }
   out.next.sort(compare);
   out.future.sort(compare);

--- a/apps/matchday/src/pages/matchday-new.tsx
+++ b/apps/matchday/src/pages/matchday-new.tsx
@@ -27,9 +27,12 @@ export default function MatchdayNew() {
   const canCreate = canManageMatchday(session?.user);
 
   const [teamId, setTeamId] = useState("");
-  const [matchDate, setMatchDate] = useState(() =>
-    new Date().toISOString().slice(0, 10),
-  );
+  // Local calendar date, not toISOString(): UTC-based slicing defaults
+  // the form to yesterday when opened between midnight and 1am BST.
+  const [matchDate, setMatchDate] = useState(() => {
+    const now = new Date();
+    return `${String(now.getFullYear())}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  });
   const [opposition, setOpposition] = useState("");
   const [isHome, setIsHome] = useState(true);
   const [matchTime, setMatchTime] = useState("");
@@ -231,6 +234,7 @@ function Chip({
   return (
     <button
       type="button"
+      aria-pressed={selected}
       onClick={onClick}
       className={cn(
         "rounded-full border px-3 py-1.5 text-xs font-medium",

--- a/apps/matchday/src/pages/matchday-new.tsx
+++ b/apps/matchday/src/pages/matchday-new.tsx
@@ -1,0 +1,271 @@
+import { StickyActionBar } from "@/components/shell/sticky-action-bar.js";
+import { Button } from "@/components/ui/button.js";
+import { api, callApi } from "@/lib/api-client.js";
+import { canManageMatchday, useSession } from "@/lib/auth-client.js";
+import { cn } from "@/lib/utils.js";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeftIcon } from "lucide-react";
+import { useState } from "react";
+import { Link, useNavigate } from "react-router";
+
+/**
+ * Create a custom matchday — a fixture that doesn't exist on
+ * Play-Cricket (friendlies, club games). Posts to the same
+ * POST /api/matchday the fixture-detail "Pick team" button uses, just
+ * without a playCricketMatchId, then drops straight into the squad
+ * editor. Home/away and start time are captured here because there's
+ * no upstream record to derive them from — they feed the team sheet
+ * and the team-news image.
+ */
+
+const COMPETITION_TYPES = ["Friendly", "League", "Cup"] as const;
+
+export default function MatchdayNew() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const { data: session } = useSession();
+  const canCreate = canManageMatchday(session?.user);
+
+  const [teamId, setTeamId] = useState("");
+  const [matchDate, setMatchDate] = useState(() =>
+    new Date().toISOString().slice(0, 10),
+  );
+  const [opposition, setOpposition] = useState("");
+  const [isHome, setIsHome] = useState(true);
+  const [matchTime, setMatchTime] = useState("");
+  const [competitionType, setCompetitionType] = useState<string>("Friendly");
+
+  const teams = useQuery({
+    queryKey: ["matchday", "teams"],
+    queryFn: () => callApi(api.GET("/api/matchday/teams")),
+    enabled: canCreate,
+  });
+
+  const create = useMutation({
+    mutationFn: () =>
+      callApi(
+        api.POST("/api/matchday", {
+          body: {
+            teamId,
+            matchDate,
+            opposition: opposition.trim(),
+            isHome,
+            ...(matchTime ? { matchTime } : {}),
+            ...(competitionType ? { competitionType } : {}),
+          },
+        }),
+      ),
+    onSuccess: (data) => {
+      void qc.invalidateQueries({ queryKey: ["matchday"] });
+      void qc.invalidateQueries({ queryKey: ["games"] });
+      void navigate(`/matchday/${data.id}/edit`);
+    },
+  });
+
+  // Session resolves before any queries fire; only block once we know
+  // the member definitely lacks matchday access.
+  if (session && !canCreate) {
+    return (
+      <div className="p-6 text-center">
+        <p className="text-text-secondary text-sm">
+          You need matchday access to create a match.
+        </p>
+        <Button asChild tone="outline" className="mt-3">
+          <Link to="/fixtures">Back to fixtures</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const teamList = teams.data ?? [];
+  const canSubmit =
+    !!teamId &&
+    !!matchDate &&
+    opposition.trim().length > 0 &&
+    !create.isPending;
+
+  return (
+    <div className="mx-auto w-full max-w-2xl pb-24">
+      <header className="border-border flex items-center gap-3 border-b p-3">
+        <Link
+          to="/fixtures"
+          className="text-text-secondary hover:bg-surface-raised grid size-9 place-items-center rounded-md"
+          aria-label="Back"
+        >
+          <ArrowLeftIcon className="size-5" />
+        </Link>
+        <strong className="text-sm">New match</strong>
+      </header>
+
+      <div className="space-y-4 px-4 py-6">
+        <section>
+          <p className="text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase">
+            Team
+          </p>
+          {teams.isPending && (
+            <div className="border-border bg-surface-raised text-text-secondary mt-2 rounded-2xl border p-4 text-sm">
+              Loading teams…
+            </div>
+          )}
+          {!teams.isPending && teamList.length === 0 && (
+            <div className="border-border bg-surface-raised text-text-secondary mt-2 rounded-2xl border p-4 text-sm">
+              No teams available. You need to be an official for at least one
+              team.
+            </div>
+          )}
+          {teamList.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {teamList.map((t) => (
+                <Chip
+                  key={t.id}
+                  label={t.name ?? "Unnamed team"}
+                  selected={teamId === t.id}
+                  onClick={() => setTeamId(t.id)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="grid grid-cols-2 gap-3">
+          <Field
+            label="Date"
+            type="date"
+            value={matchDate}
+            onChange={setMatchDate}
+          />
+          <Field
+            label="Start time (optional)"
+            type="time"
+            value={matchTime}
+            onChange={setMatchTime}
+          />
+        </section>
+
+        <section>
+          <label className="flex flex-col gap-1">
+            <span className="text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase">
+              Opposition
+            </span>
+            <input
+              type="text"
+              value={opposition}
+              onChange={(e) => setOpposition(e.currentTarget.value)}
+              placeholder="e.g. Tynemouth CC"
+              className="border-border bg-surface h-11 rounded-lg border px-3 text-sm"
+            />
+          </label>
+        </section>
+
+        <section>
+          <p className="text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase">
+            Venue
+          </p>
+          <div className="mt-2 flex gap-2">
+            <Chip
+              label="Home"
+              selected={isHome}
+              onClick={() => setIsHome(true)}
+            />
+            <Chip
+              label="Away"
+              selected={!isHome}
+              onClick={() => setIsHome(false)}
+            />
+          </div>
+        </section>
+
+        <section>
+          <p className="text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase">
+            Competition
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {COMPETITION_TYPES.map((c) => (
+              <Chip
+                key={c}
+                label={c}
+                selected={competitionType === c}
+                // Tapping the selected chip clears it — competition
+                // type is optional and drives which match-fee rule
+                // applies, so "none" must stay reachable.
+                onClick={() =>
+                  setCompetitionType(competitionType === c ? "" : c)
+                }
+              />
+            ))}
+          </div>
+        </section>
+
+        {create.isError && (
+          <p className="text-danger text-sm">
+            {create.error.message || "Couldn't create the match. Try again."}
+          </p>
+        )}
+      </div>
+
+      <StickyActionBar outerClassName="md:border-t-0">
+        <Button asChild tone="outline">
+          <Link to="/fixtures">Cancel</Link>
+        </Button>
+        <Button
+          tone="primary"
+          disabled={!canSubmit}
+          onClick={() => create.mutate()}
+        >
+          {create.isPending ? "Creating…" : "Create & pick squad"}
+        </Button>
+      </StickyActionBar>
+    </div>
+  );
+}
+
+function Chip({
+  label,
+  selected,
+  onClick,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-full border px-3 py-1.5 text-xs font-medium",
+        selected
+          ? "border-navy bg-navy text-white"
+          : "border-border bg-surface text-text-secondary",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function Field({
+  label,
+  type,
+  value,
+  onChange,
+}: {
+  label: string;
+  type: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase">
+        {label}
+      </span>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.currentTarget.value)}
+        className="border-border bg-surface h-11 rounded-lg border px-3 text-sm"
+      />
+    </label>
+  );
+}

--- a/apps/matchday/src/pages/team-sheet.tsx
+++ b/apps/matchday/src/pages/team-sheet.tsx
@@ -4,7 +4,11 @@ import { fmtDate } from "@/features/format.js";
 import { CrownIcon, GloveIcon } from "@/features/icons/cricket-icons.js";
 import { shareOrDownloadTeamNewsImage } from "@/features/team-news-image.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
-import { canViewMatchdayAdmin, useSession } from "@/lib/auth-client.js";
+import {
+  canManageMatchday,
+  canViewMatchdayAdmin,
+  useSession,
+} from "@/lib/auth-client.js";
 import { cn } from "@/lib/utils.js";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ArrowLeftIcon, ImageIcon, ShareIcon } from "lucide-react";
@@ -31,6 +35,11 @@ export default function TeamSheet() {
   const { data: session } = useSession();
   const myUserId = session?.user.id;
   const isOfficial = canViewMatchdayAdmin(session?.user);
+  // Custom (non-Play-Cricket) fixtures link here from the fixtures
+  // list, so this page is an official's entry point to managing them —
+  // PC fixtures get the same links via /fixture/:id, which custom
+  // matchdays don't have.
+  const canManage = canManageMatchday(session?.user);
   const {
     data: md,
     isLoading,
@@ -123,6 +132,21 @@ export default function TeamSheet() {
           </div>
         )}
       </header>
+
+      {/* No status gate: mirrors /fixture/:id, where Manage squad/game
+          stay available after finishing (wrap-up keeps mark-paid). The
+          public endpoint 404s cancelled matchdays, so no cancelled
+          state reaches this render. */}
+      {canManage && (
+        <div className="flex gap-2 px-4 pb-4">
+          <Button asChild tone="outline" size="sm" className="flex-1">
+            <Link to={`/matchday/${md.id}/edit`}>Manage squad</Link>
+          </Button>
+          <Button asChild tone="outline" size="sm" className="flex-1">
+            <Link to={`/matchday/${md.id}/wrap`}>Manage game</Link>
+          </Button>
+        </div>
+      )}
 
       <h2 className="bg-surface-raised text-text-secondary px-4 py-1.5 text-[11px] font-semibold tracking-[0.06em] uppercase">
         Squad · {md.squad.length}

--- a/apps/matchday/src/router.tsx
+++ b/apps/matchday/src/router.tsx
@@ -42,6 +42,13 @@ const routes: RouteObject[] = [
               () => import("./pages/fixture-detail.js"),
             ),
           },
+          // Static segment — registered alongside matchday/:matchdayId;
+          // the router ranks "new" above the param route so team-sheet
+          // never swallows it.
+          {
+            path: "matchday/new",
+            Component: lazyWithReload(() => import("./pages/matchday-new.js")),
+          },
           {
             path: "matchday/:matchdayId",
             Component: lazyWithReload(() => import("./pages/team-sheet.js")),

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -4322,6 +4322,52 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/matchday/custom-fixtures": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            matchdayId: string;
+                            matchDate: string;
+                            matchTime: string | null;
+                            opposition: string;
+                            teamId: string;
+                            teamName: string | null;
+                            isHome: boolean | null;
+                            competitionType: string | null;
+                            status: string;
+                            resultType: string | null;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/matchday": {
         parameters: {
             query?: never;
@@ -4357,6 +4403,8 @@ export interface paths {
                                 opposition: string;
                                 competition_type: string | null;
                                 play_cricket_match_id: string | null;
+                                is_home: boolean | null;
+                                match_time: string | null;
                                 status: string;
                                 created_by: string;
                                 created_at: string;
@@ -4395,6 +4443,8 @@ export interface paths {
                         opposition: string;
                         competitionType?: string;
                         playCricketMatchId?: string;
+                        isHome?: boolean;
+                        matchTime?: string;
                     };
                 };
             };
@@ -4451,6 +4501,8 @@ export interface paths {
                                 opposition: string;
                                 competition_type: string | null;
                                 play_cricket_match_id: string | null;
+                                is_home: boolean | null;
+                                match_time: string | null;
                                 status: string;
                                 created_by: string;
                                 created_at: string;

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -4649,7 +4649,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    isHome?: string;
+                    isHome?: "true" | "false";
                     matchTime?: string;
                 };
                 header?: never;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -7505,6 +7505,75 @@
         }
       }
     },
+    "/api/matchday/custom-fixtures": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "matchdayId": {
+                        "type": "string"
+                      },
+                      "matchDate": {
+                        "type": "string"
+                      },
+                      "matchTime": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "opposition": {
+                        "type": "string"
+                      },
+                      "teamId": {
+                        "type": "string"
+                      },
+                      "teamName": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "isHome": {
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      "competitionType": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "resultType": {
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "matchdayId",
+                      "matchDate",
+                      "matchTime",
+                      "opposition",
+                      "teamId",
+                      "teamName",
+                      "isHome",
+                      "competitionType",
+                      "status",
+                      "resultType"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/matchday": {
       "get": {
         "parameters": [
@@ -7588,6 +7657,14 @@
                             "nullable": true,
                             "type": "string"
                           },
+                          "is_home": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "match_time": {
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "status": {
                             "type": "string"
                           },
@@ -7657,6 +7734,8 @@
                           "opposition",
                           "competition_type",
                           "play_cricket_match_id",
+                          "is_home",
+                          "match_time",
                           "status",
                           "created_by",
                           "created_at",
@@ -7712,6 +7791,13 @@
                   },
                   "playCricketMatchId": {
                     "type": "string"
+                  },
+                  "isHome": {
+                    "type": "boolean"
+                  },
+                  "matchTime": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
                   }
                 },
                 "required": [
@@ -7795,6 +7881,14 @@
                           "nullable": true,
                           "type": "string"
                         },
+                        "is_home": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "match_time": {
+                          "nullable": true,
+                          "type": "string"
+                        },
                         "status": {
                           "type": "string"
                         },
@@ -7864,6 +7958,8 @@
                         "opposition",
                         "competition_type",
                         "play_cricket_match_id",
+                        "is_home",
+                        "match_time",
                         "status",
                         "created_by",
                         "created_at",

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -7797,7 +7797,7 @@
                   },
                   "matchTime": {
                     "type": "string",
-                    "pattern": "^\\d{2}:\\d{2}$"
+                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$"
                   }
                 },
                 "required": [
@@ -8348,7 +8348,11 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
             },
             "in": "query",
             "name": "isHome",

--- a/packages/db/src/__generated__/db.ts
+++ b/packages/db/src/__generated__/db.ts
@@ -556,7 +556,9 @@ export interface Matchday {
   finished_at: string | null;
   finished_by: string | null;
   id: string;
+  is_home: boolean | null;
   match_date: string;
+  match_time: string | null;
   opposition: string;
   play_cricket_match_id: string | null;
   play_cricket_team_id: string;

--- a/packages/db/src/migrations/2026-08-20T16:18:59.903Z.ts
+++ b/packages/db/src/migrations/2026-08-20T16:18:59.903Z.ts
@@ -1,0 +1,24 @@
+import { type Kysely } from "kysely";
+
+/**
+ * Custom (non-Play-Cricket) fixtures: matchdays created without a
+ * play_cricket_match_id have no upstream record to derive home/away or
+ * start time from, so captains supply them at creation. Nullable - PC
+ * matchdays keep deriving both from the matches-summary lookup.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("matchday")
+    .addColumn("is_home", "boolean")
+    .execute();
+
+  await db.schema
+    .alterTable("matchday")
+    .addColumn("match_time", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable("matchday").dropColumn("is_home").execute();
+  await db.schema.alterTable("matchday").dropColumn("match_time").execute();
+}

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@aws-sdk/client-sesv2": "^3.1106.0",
     "date-fns": "^4.4.0",
-    "html-to-text": "^10.0.0",
+    "html-to-text": "^10.0.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-email": "^6.9.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,8 +782,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0
       html-to-text:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^10.0.1
+        version: 10.0.1
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -5484,8 +5484,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   deepmerge@4.3.1:
@@ -6131,8 +6131,8 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  html-to-text@10.0.0:
-    resolution: {integrity: sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==}
+  html-to-text@10.0.1:
+    resolution: {integrity: sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg==}
     engines: {node: '>=20.19.0'}
 
   html-to-text@9.0.5:
@@ -13861,7 +13861,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   deepmerge@4.3.1: {}
 
@@ -14745,10 +14745,10 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-to-text@10.0.0:
+  html-to-text@10.0.1:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.12.0(selderee@0.12.0)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       dom-serializer: 2.0.0
       htmlparser2: 10.1.0
       selderee: 0.12.0


### PR DESCRIPTION
## What

Officials can now create a **custom fixture** - a match that doesn't exist on Play Cricket (friendlies, club-arranged games) - and run the full matchday flow for it: squad picking, team sheet, team-news image, wrap-up, fees.

## How

- **New `/matchday/new` form** in the matchday PWA (entry: "New match" button on the Fixtures tab, officials only): team picker, date, opposition, home/away, start time, competition type. Posts to the existing `POST /api/matchday` with `playCricketMatchId` omitted, then navigates straight into the squad editor.
- **Migration**: nullable `is_home` + `match_time` columns on `matchday`. Only set for custom fixtures - PC-backed matchdays keep deriving both from the matches-summary lookup. The team-news image resolution order is now: explicit query overrides -> stored columns -> Play-Cricket lookup, so an away custom game no longer silently renders as a home game with no start time. `GET /matchday/:id/public` (team sheet) projects them too.
- **Fixtures tab union**: new `GET /api/matchday/custom-fixtures` (any signed-in member, same audience as the team-sheet endpoint) returns non-cancelled matchdays with no PC id from 30 days back onwards. The PWA fixtures list merges these into the existing buckets. Custom rows link to the team sheet (`/matchday/:id`) since there's no `/fixture/:id` page for them.
- **Team sheet**: now shows "Manage squad" / "Manage game" buttons for officials, making it a management entry point for custom fixtures (PC fixtures get the same links via `/fixture/:id`).

## Notes

- The union deliberately does **not** touch `/api/games`: that endpoint also feeds the public website, and a custom fixture would produce dead `/calendar/game/:id` links there. Public visibility is out of scope per discussion.
- `GET /api/matchday/teams/:teamId/upcoming` turned out to have no frontend consumer, so the union landed at the fixtures-tab feed instead of that service.
- Custom fixtures can't be scouted and don't participate in availability requests (both keyed on PC fixtures) - unchanged behaviour, just noting the boundary.

## Tests

- Integration: `createMatchday` persists `isHome`/`matchTime`; `listCustomFixtures` window/exclusion behaviour; `getMatchPublic` projection; team-news fallback + override precedence. Full integration suite green (523 tests), unit suite green (675), typecheck + lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create custom fixtures with team, venue, competition, home/away status, and optional start time.
  * View custom fixtures alongside Play-Cricket fixtures with filtering, date grouping, statuses, results, and dedicated details.
  * Added matchday management controls for eligible team officials.
  * Fixture details now display stored match time and home/away information.

* **Bug Fixes**
  * Improved fixture and team-news data handling when external fixture information is unavailable.
  * Excludes cancelled, stale, and externally managed fixtures from custom listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->