### PR TITLE
ci: run Trivy image scan only when PRs touch image-affecting files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,46 @@ jobs:
           directory: apps/web
           blocking: warning
 
+  changes:
+    # Path filter for image-scan. Lives in its own job so image-scan can
+    # be skipped at the job level: a job skipped via `if:` reports
+    # conclusion "skipped", which branch protection counts as passing for
+    # the required `image-scan` check. (A workflow-level `paths:` filter
+    # would leave the check stuck at "Expected" and block merge instead.)
+    runs-on: ubuntu-latest
+    permissions:
+      # paths-filter lists PR files via the API on pull_request events,
+      # so no checkout is needed - but it does need PR read access.
+      pull-requests: read
+    outputs:
+      image: ${{ steps.filter.outputs.image }}
+    steps:
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            # Everything that can change what Trivy finds in the API
+            # image: the base image / build steps (Dockerfile), the
+            # installed dep tree (pnpm-lock.yaml is the source of truth
+            # under --frozen-lockfile; overrides live in
+            # pnpm-workspace.yaml; root package.json for packageManager /
+            # engines), the suppression list, and this workflow itself.
+            image:
+              - "apps/api/Dockerfile"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
+              - "package.json"
+              - ".trivyignore"
+              - ".github/workflows/ci.yml"
+
   image-scan:
     # Build the API container the same way deploy.yml does and run Trivy
-    # against it. Keeps CVEs in transitive deps + the base image visible at
-    # PR time, instead of surfacing only when the deploy gate runs on main.
+    # against it - but only when the PR touches something that can change
+    # the scan result (see the `changes` filter above). Feature PRs no
+    # longer go red for CVEs published against deps they didn't touch;
+    # newly-introduced vulnerable deps are still caught here (lockfile
+    # PRs) and by dependency-review below, and the deploy.yml gate on
+    # main remains the unconditional backstop before anything ships.
     # No push — image stays local to the runner.
     #
     # Buildx + GHA registry-side cache: turborepo's docker-equivalent.
@@ -88,6 +124,8 @@ jobs:
     # whose RUN/COPY inputs match the prior cache; `cache-to: mode=max`
     # exports all intermediate layers, not just the final one, so the
     # build stage's `pnpm install` survives across PRs. See #339.
+    needs: changes
+    if: needs.changes.outputs.image == 'true'
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read


### PR DESCRIPTION
## Why

The `image-scan` job built and Trivy-scanned the API container on every PR. When a CVE dropped against the base image or an untouched transitive dep, every open PR went red on changes it didn't introduce, and the fix (a dep bump) ended up bundled with feature work.

## What

- New `changes` job in `ci.yml` using `dorny/paths-filter` (same SHA-pinned version as `deploy.yml`), with one filter covering everything that can change the scan result:
  - `apps/api/Dockerfile` (base image + build steps)
  - `pnpm-lock.yaml` (source of truth for installed versions under `--frozen-lockfile`)
  - `pnpm-workspace.yaml` (security overrides)
  - root `package.json`
  - `.trivyignore`
  - `.github/workflows/ci.yml` itself
- `image-scan` now has `needs: changes` + `if: needs.changes.outputs.image == 'true'`, so feature PRs skip the Docker build and scan entirely.

## Why job-level `if:` and not workflow `paths:`

`image-scan` is a required branch-protection check. A job skipped via a job-level `if:` reports "skipped", which GitHub counts as passing for required checks. A workflow-level `paths:` filter would leave the check stuck at "Expected" and block every merge.

## What still catches vulnerable deps

- Any dep change touches `pnpm-lock.yaml`, so the image scan runs on exactly the PRs that can change the dep tree.
- `dependency-review` scans manifest diffs on every PR regardless (fails on high+).
- The `deploy.yml` Trivy gate on main stays unconditional as the backstop before anything ships.

## Trade-offs

- A CVE published against untouched deps now surfaces at the deploy gate on main (post-merge) instead of on PRs. If that starts ambushing deploys, a nightly scheduled scan of main that opens an issue is the follow-up.
- Trivy's secret scanner no longer sees PR-introduced app code at PR time (deploy gate + GitHub secret scanning still cover it).
- If the `changes` job itself errors, `image-scan` skips and the required check passes; the deploy gate backstops this. Optionally `changes` could also be added to the required checks list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * API image vulnerability scans now run only when relevant files change.
  * Pull requests that do not affect the API image are no longer blocked by unrelated vulnerability findings.
  * Changes to dependencies and image configuration continue to trigger vulnerability scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->