### PR TITLE
security(ci): gate credentialed Terraform PR plans behind reviewer approval

### DIFF
--- a/.claude/skills/work-on-ci/SKILL.md
+++ b/.claude/skills/work-on-ci/SKILL.md
@@ -23,7 +23,11 @@ Use this skill when adding, modifying, or debugging anything under `.github/work
     │                                # then Terraform shared/production, then build/push images, deploy.
     ├── _lint-test-build.yml         # Reusable. format-check / lint / typecheck / unit-tests /
     │                                # integration-tests / build / openapi-drift, plus publish-test-results.
-    ├── terraform.yml                # PR plan-only for infra/ changes (no apply).
+    ├── terraform.yml                # PR checks for infra/ changes (no apply): uncredentialed
+    │                                # fmt/validate + OIDC-subject guard run automatically; the
+    │                                # credentialed plan waits for approval on the terraform-plan
+    │                                # environment (ADR 057) and is the ONLY PR-triggered job
+    │                                # allowed cloud credentials or secrets.
     ├── terraform-drift.yml          # Scheduled drift detection.
     ├── deploy-api-manual.yml        # Manual API redeploy (workflow_dispatch).
     ├── deploy-web-manual.yml        # Manual web redeploy.

--- a/.github/scripts/check-oidc-trust.mjs
+++ b/.github/scripts/check-oidc-trust.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// Semantic guard for GitHub OIDC trust policies in infra/ (#626 / ADR 057).
+//
+// The grep tripwire in terraform.yml only catches the literal
+// ':pull_request' text. This script closes the gaps a textual match
+// leaves open:
+//   - a wildcard subject ("repo:org/repo:*") that trusts every PR run
+//     without ever mentioning pull_request;
+//   - an AssumeRoleWithWebIdentity grant with no :sub condition at all;
+//   - a missing :aud condition (token not pinned to sts.amazonaws.com);
+//   - widening the plan role's Secrets Manager resource scope.
+//
+// Every OIDC subject in infra/ must appear verbatim on the allowlist
+// below; adding a new trusted subject is a conscious edit here, in the
+// same PR as the trust-policy change, where a reviewer sees both.
+//
+// Regex-based on purpose: the runner has no HCL parser, and the block
+// shapes matched are the ones terraform fmt produces in this repo.
+// Parsing failures and unknown file types report as errors, so the
+// guard fails closed.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = process.argv[2] ?? "infra";
+
+const ALLOWED_SUBJECTS = new Set([
+  // Protected branch: deploy pipeline + scheduled drift detection.
+  "repo:${var.github_repo}:ref:refs/heads/main",
+  // Reviewer-gated GitHub environments.
+  "repo:${var.github_repo}:environment:production",
+  "repo:${var.github_repo}:environment:terraform-plan",
+]);
+
+const SUB_VARIABLE =
+  'variable\\s*=\\s*"token\\.actions\\.githubusercontent\\.com:sub"';
+
+const errors = [];
+const tfFiles = [];
+
+(function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === ".terraform" || entry === "node_modules") continue;
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      walk(path);
+    } else if (entry.endsWith(".tf")) {
+      tfFiles.push(path);
+    } else if (entry.endsWith(".tf.json")) {
+      errors.push(
+        `${path}: .tf.json is not scanned by this guard - convert to HCL or extend check-oidc-trust.mjs`,
+      );
+    }
+  }
+})(ROOT);
+
+function blockLabel(block) {
+  return block
+    .slice(0, block.indexOf("\n"))
+    .replace(/\s*\{\s*$/, "")
+    .trim();
+}
+
+let subConditionCount = 0;
+
+for (const file of tfFiles) {
+  const text = readFileSync(file, "utf8");
+  // Top-level blocks start at column 0 (terraform fmt guarantees nested
+  // content is indented), so splitting before each column-0 token keeps
+  // a block header and its body in one chunk.
+  const blocks = text.split(/^(?=\S)/m);
+
+  for (const block of blocks) {
+    const grantsOidc = block.includes("sts:AssumeRoleWithWebIdentity");
+    const subMatches = [...block.matchAll(new RegExp(SUB_VARIABLE, "g"))];
+
+    if (grantsOidc && subMatches.length === 0) {
+      errors.push(
+        `${file}: "${blockLabel(block)}" grants sts:AssumeRoleWithWebIdentity without a :sub condition`,
+      );
+    }
+    if (
+      grantsOidc &&
+      !/token\.actions\.githubusercontent\.com:aud"[\s\S]*?"sts\.amazonaws\.com"/.test(
+        block,
+      )
+    ) {
+      errors.push(
+        `${file}: "${blockLabel(block)}" lacks an :aud condition pinned to sts.amazonaws.com`,
+      );
+    }
+
+    for (const match of subMatches) {
+      subConditionCount += 1;
+      const rest = block.slice(match.index + match[0].length);
+      const valuesMatch = rest.match(/values\s*=\s*\[([\s\S]*?)\]/);
+      if (!valuesMatch) {
+        errors.push(
+          `${file}: "${blockLabel(block)}" has a :sub condition with no parseable values list`,
+        );
+        continue;
+      }
+      for (const [, subject] of valuesMatch[1].matchAll(
+        /"((?:[^"\\]|\\.)*)"/g,
+      )) {
+        if (!ALLOWED_SUBJECTS.has(subject)) {
+          errors.push(
+            `${file}: OIDC subject "${subject}" is not on the allowlist in check-oidc-trust.mjs. ` +
+              `Unreviewed PR subjects (:pull_request, wildcards) must never be trusted with cloud ` +
+              `credentials (ADR 057); a genuinely new gated subject must be added to the allowlist ` +
+              `in the same PR.`,
+          );
+        }
+      }
+    }
+  }
+}
+
+if (subConditionCount === 0) {
+  errors.push(
+    `no OIDC :sub conditions found under ${ROOT}/ - the trust policies this guard protects ` +
+      `have moved or been rewritten; update check-oidc-trust.mjs to match`,
+  );
+}
+
+// The plan role keeps secretsmanager:GetSecretValue deliberately (plans
+// read plan-time secrets - ADR 057), but only on percy-main secrets.
+const sharedMain = join(ROOT, "environments", "shared", "main.tf");
+const sharedText = readFileSync(sharedMain, "utf8");
+const secretsRead = sharedText.match(
+  /Sid\s*=\s*"SecretsRead"[\s\S]*?Resource\s*=\s*"([^"]+)"/,
+);
+if (!secretsRead) {
+  errors.push(
+    `${sharedMain}: SecretsRead statement not found - if the plan role's Secrets Manager ` +
+      `grant moved, update check-oidc-trust.mjs to assert its scope`,
+  );
+} else if (!secretsRead[1].endsWith(":secret:*percy-main*")) {
+  errors.push(
+    `${sharedMain}: SecretsRead resource scope changed to "${secretsRead[1]}" - the plan ` +
+      `role's GetSecretValue must stay scoped to :secret:*percy-main*`,
+  );
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(`::error::${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `OK: ${subConditionCount} OIDC :sub condition(s) across ${tfFiles.length} .tf files, ` +
+    `all subjects on the allowlist; SecretsRead scope intact`,
+);

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,12 +50,16 @@ jobs:
         # the GitHub OIDC `:pull_request` subject - that subject means
         # "any unreviewed PR run". Credentialed plans go through the
         # reviewer-gated terraform-plan environment subject instead.
+        # Deliberately matched across ALL file types (tf, tf.json,
+        # tftpl, ...) since trust policies can be authored in any of
+        # them; the leading colon keeps prose mentions of pull
+        # requests from tripping it.
         run: |
-          if grep -rn --include='*.tf' 'pull_request' infra/; then
-            echo "::error::infra/ references the OIDC 'pull_request' subject (matches above). Unreviewed PR runs must not be trusted with cloud credentials - use the reviewer-gated terraform-plan environment subject (ADR 057)."
+          if grep -rn ':pull_request' infra/; then
+            echo "::error::infra/ references the OIDC ':pull_request' subject (matches above). Unreviewed PR runs must not be trusted with cloud credentials - use the reviewer-gated terraform-plan environment subject (ADR 057)."
             exit 1
           fi
-          echo "OK: no pull_request OIDC subjects in infra/"
+          echo "OK: no ':pull_request' OIDC subjects in infra/"
 
   validate:
     # Uncredentialed `terraform validate` per environment. See the

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -5,10 +5,13 @@ on:
     paths:
       - "infra/**"
 
+# Baseline for all jobs. The credentialed plan job widens this for
+# itself; the validate / static-check jobs run PR-controlled Terraform
+# (a PR can point required_providers at an arbitrary plugin binary, and
+# `terraform validate` executes provider plugins), so they must never
+# see an OIDC token, AWS credentials, or secrets (#626 / ADR 057).
 permissions:
-  id-token: write
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,13 +24,86 @@ defaults:
 env:
   AWS_REGION: eu-west-2
   TF_VERSION: "1.7"
-  # NR provider — newrelic_cloud_aws_link_account in shared (#201).
-  NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
-  TF_VAR_newrelic_account_id: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
 
 jobs:
+  static-checks:
+    # Uncredentialed fast feedback: runs automatically on every infra
+    # PR with no cloud credentials and no secrets.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform fmt
+        run: terraform fmt -check -diff -recursive infra/
+
+      - name: Forbid OIDC trust for pull_request subjects
+        # Guardrail for #626 / ADR 057: nothing in infra/ may reference
+        # the GitHub OIDC `:pull_request` subject - that subject means
+        # "any unreviewed PR run". Credentialed plans go through the
+        # reviewer-gated terraform-plan environment subject instead.
+        run: |
+          if grep -rn --include='*.tf' 'pull_request' infra/; then
+            echo "::error::infra/ references the OIDC 'pull_request' subject (matches above). Unreviewed PR runs must not be trusted with cloud credentials - use the reviewer-gated terraform-plan environment subject (ADR 057)."
+            exit 1
+          fi
+          echo "OK: no pull_request OIDC subjects in infra/"
+
+  validate:
+    # Uncredentialed `terraform validate` per environment. See the
+    # workflow-level permissions comment: this job executes
+    # PR-controlled provider plugins, so it deliberately has no
+    # id-token, no AWS credentials, and no secrets in env.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        environment: [shared, production]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init (no backend)
+        working-directory: infra/environments/${{ matrix.environment }}
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        working-directory: infra/environments/${{ matrix.environment }}
+        run: terraform validate
+
   plan:
     runs-on: ubuntu-latest
+    # Reviewer gate (#626 / ADR 057): plan evaluates PR-controlled
+    # configuration with credentials that can read state and secrets,
+    # so every run waits for approval on the terraform-plan environment
+    # and the plan role's OIDC trust only accepts the environment
+    # subject. Read the infra diff before approving.
+    environment: terraform-plan
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    env:
+      # NR provider - newrelic_cloud_aws_link_account in shared (#201).
+      # Job-scoped rather than workflow-level so the uncredentialed
+      # jobs above never see the secret.
+      NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+      TF_VAR_newrelic_account_id: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
     # Bound execution well under the 1h OIDC credential lifetime. The
     # 2026-06-15 stale lock came from a dependabot plan (shared) that hung
     # and ran to the 6h default limit; by then its creds had expired, so
@@ -47,6 +123,8 @@ jobs:
         environment: [shared, production]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -70,7 +70,17 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    env:
+      # Placeholder, NOT the real secret: the newrelic provider block in
+      # shared marks api_key required, and validate checks provider
+      # config schemas. Validate never configures providers or calls
+      # any API, so any non-empty value satisfies the schema while
+      # keeping this job secret-free.
+      NEW_RELIC_API_KEY: "validate-only-placeholder"
     strategy:
+      # Report both environments independently; a shared-only failure
+      # cancelling production (or vice versa) hides signal.
+      fail-fast: false
       matrix:
         environment: [shared, production]
     steps:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -61,6 +61,16 @@ jobs:
           fi
           echo "OK: no ':pull_request' OIDC subjects in infra/"
 
+      - name: Verify OIDC trust policies (semantic)
+        # Companion to the grep tripwire above (CodeRabbit, #698): parses
+        # every IAM trust policy in infra/ and fails on any OIDC subject
+        # outside an exact allowlist (catches wildcards and hardcoded
+        # repos, not just the :pull_request text), on any
+        # AssumeRoleWithWebIdentity grant missing a :sub or :aud
+        # condition, and on widening of the plan role's Secrets Manager
+        # resource scope.
+        run: node .github/scripts/check-oidc-trust.mjs
+
   validate:
     # Uncredentialed `terraform validate` per environment. See the
     # workflow-level permissions comment: this job executes

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -135,6 +135,11 @@ module "rds" {
   #     for one-off auditor / vendor access).
   # Until cutover the list is empty and the secret keeps its existing
   # IAM-only access.
+  #
+  # The two Terraform roles are only assumable from gated contexts
+  # (reviewer-approved terraform-plan environment runs, main, or the
+  # production environment - ADR 057), so this exemption is not
+  # reachable from unreviewed PR code.
   master_secret_break_glass_principal_arns = var.app_rw_active ? concat(
     [
       local.shared.db_break_glass_role_arn,

--- a/infra/environments/staging/main.tf
+++ b/infra/environments/staging/main.tf
@@ -132,10 +132,10 @@ module "ecs" {
     SCOUT_MODEL_REPORT            = "deepseek-v4-flash"
     SCOUT_ATTACHMENT_DERIVE_MODEL = "claude-haiku-4-5-20251001"
     # Content-author AI assistant ("Generate with AI" over the content editor).
-    CONTENT_AI_PROVIDER           = "deepseek"
-    CONTENT_AI_MODEL              = "deepseek-v4-pro"
-    VOYAGE_EMBED_MODEL            = "voyage-4"
-    VOYAGE_RERANK_MODEL           = "rerank-2.5"
+    CONTENT_AI_PROVIDER = "deepseek"
+    CONTENT_AI_MODEL    = "deepseek-v4-pro"
+    VOYAGE_EMBED_MODEL  = "voyage-4"
+    VOYAGE_RERANK_MODEL = "rerank-2.5"
     # Arize Phoenix LLM tracing - isolated from NR. The collector endpoint
     # is the bare Phoenix Cloud space URL; the API code appends /v1/traces.
     # Project name is per-env so staging traces don't collide with prod.


### PR DESCRIPTION
## Summary

Part 2 of 2 for #626 (critical), companion to #697. Closes #626.

- The plan job now targets the **terraform-plan** GitHub environment (required reviewer: @alsiola, already created), so unreviewed PR code never receives an OIDC token. Approving the run is the moment of trust - read the infra diff first.
- New **uncredentialed** jobs run automatically on every infra PR: `static-checks` (terraform fmt + OIDC-subject guard) and `validate` (`init -backend=false` + `terraform validate` per environment). They carry no id-token, no AWS credentials, and no secrets - `terraform validate` executes PR-controlled provider plugins, so `NEW_RELIC_API_KEY` moved from workflow-level env into the plan job.
- The guard fails any PR that reintroduces an OIDC `:pull_request` trust subject in `infra/` (the acceptance-criteria policy test - the trust edge, not the permission set, is what this fix removes).
- Checkouts set `persist-credentials: false`; permissions are per-job.
- `infra/environments/production/main.tf` gains an ADR 057 cross-ref comment - deliberate, so this PR triggers the gated plan and acts as the end-to-end test of the new trust path.

## Merge runbook (order is load-bearing)

1. Merge #697 and wait for the main deploy to apply the trust-policy change.
2. **Update this branch** from main (button or merge origin/main) - until then `static-checks` fails here because `infra/` still contains the old `pull_request` subject on the pre-update merge ref.
3. `static-checks` + `validate` go green automatically; the plan job shows **Waiting** on the terraform-plan environment.
4. Approve the run: plan succeeding proves the role is assumable via the `environment:terraform-plan` subject - that is the issue's verification step.
5. Mark ready and merge.

Note: between #697's apply and this PR's merge, infra PR plans fail closed on role assumption (old workflow still sends the now-untrusted `pull_request` subject). Keep the window short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Terraform formatting, initialization, validation, and trust-policy checks for pull requests.
  * Added reviewer-gated Terraform planning for controlled infrastructure changes.

* **Security**
  * Improved workflow permissions and credential isolation to prevent unreviewed code from accessing cloud credentials or secrets.

* **Documentation**
  * Updated infrastructure workflow documentation to clarify checks, planning controls, and credential access boundaries.

* **Style**
  * Reformatted staging environment variable declarations without changing configuration values or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->