### PR TITLE
ci: lint workflows with actionlint and guard the tf-unlock invariant

### DIFF
--- a/.claude/skills/work-on-ci/SKILL.md
+++ b/.claude/skills/work-on-ci/SKILL.md
@@ -171,7 +171,17 @@ Before pushing:
 ```sh
 pnpm format                  # workflow YAML is prettier-formatted
 pnpm format:check            # confirm
+
+# actionlint - the same digest the `actionlint` job in ci.yml runs, so
+# a clean run here means a clean run in CI (#700).
+docker run --rm --volume "$PWD:/repo" --workdir /repo \
+  rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+  -color
+
+node .github/scripts/check-tf-unlock-scope.mjs   # tf-unlock state-lock invariant (#631)
 ```
+
+actionlint runs shellcheck over every `run:` block. Fix findings in the workflow; if a finding is genuinely wrong (deliberate word-splitting, JMESPath backticks inside a `--query`), suppress it with an inline `# shellcheck disable=<code>` directive carrying a reason. There is no `.github/actionlint.yaml` and blanket rule disables do not belong in one.
 
 Optional but recommended for non-trivial changes:
 

--- a/.github/scripts/check-tf-unlock-scope.mjs
+++ b/.github/scripts/check-tf-unlock-scope.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// Semantic guard for the Terraform state-lock invariant (#631).
+//
+// WHERE THE INVARIANT IS DEFINED: `.github/actions/tf-unlock/action.yml`
+// (the `only-current-runner` input). In short: no automatic unlock may
+// release a lock it did not create. Terraform workflows serialize on
+// DIFFERENT concurrency groups over ONE shared backend - PR plans queue
+// per environment on `terraform-plan-<env>`, pushes to main and manual
+// applies on `deploy-production`, drift on its own group. The groups
+// deliberately overlap, so the state lock (not the concurrency group) is
+// what stops two runs racing. A broad `runner@*` force-unlock from one
+// workflow can therefore clobber a live lock held by another, and two
+// writers on one state file is how state gets corrupted.
+// `only-current-runner: "true"` scopes the cleanup to the lock this job
+// itself took, which makes it provably non-clobbering.
+//
+// WHY A SCRIPT AND NOT ACTIONLINT: actionlint has no custom-rule
+// mechanism. Its config file (`.github/actionlint.yaml`) only configures
+// self-hosted runner labels, config variables, and path-based ignore
+// patterns. It does validate local composite-action usage - it will
+// report a *missing required input* - but it has no way to assert that a
+// supplied input holds a particular value. So the presence half of this
+// invariant is expressible in actionlint (by marking the input
+// required); the value half is not. This companion check covers both,
+// in the spirit of check-oidc-trust.mjs.
+//
+// WHY NOT A GREP: a grep can tell you the string `only-current-runner`
+// appears somewhere in a file. It cannot tie an input to the step that
+// owns it, distinguish a `with:` block from a comment, or notice a new
+// call site that sets nothing at all. This parses the workflow YAML and
+// asks the structural question directly.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { basename, join } from "node:path";
+import { parseDocument, visit } from "yaml";
+
+const WORKFLOWS = process.argv[2] ?? ".github/workflows";
+const ACTION = process.argv[3] ?? ".github/actions/tf-unlock/action.yml";
+
+const TF_UNLOCK = "./.github/actions/tf-unlock";
+const INPUT = "only-current-runner";
+
+// The operator-driven unlock workflow is the ONE place a broad sweep is
+// legitimate: it inspects the lock and only releases it when the
+// operator passes back the exact lock ID it just showed them. As added
+// by #701 that workflow does its own conditional delete-item rather than
+// calling the composite action, so this exemption currently matches
+// nothing. It is here so the rule reads the way the invariant is worded,
+// and so adopting the composite action there later does not trip the
+// guard. The file being absent is fine - the set is only consulted for
+// workflows that exist.
+const EXEMPT_WORKFLOWS = new Set(["terraform-unlock-manual.yml"]);
+
+const errors = [];
+
+/** Byte offset -> 1-based line number, for GitHub file annotations. */
+function lineAt(text, offset) {
+  let line = 1;
+  for (let i = 0; i < offset && i < text.length; i += 1) {
+    if (text[i] === "\n") line += 1;
+  }
+  return line;
+}
+
+/**
+ * GitHub stringifies action inputs, so an unquoted YAML `true` and a
+ * quoted `"true"` are the same thing at runtime. Anything else - most
+ * importantly `"false"`, but equally a `${{ }}` expression whose value a
+ * reviewer cannot see - is not.
+ */
+function isLiteralTrue(value) {
+  return value === true || value === "true";
+}
+
+// --- The action's own declaration -----------------------------------
+
+let actionDoc;
+try {
+  actionDoc = parseDocument(readFileSync(ACTION, "utf8"));
+} catch (error) {
+  errors.push(
+    `${ACTION}: could not be read or parsed (${error.message}) - the tf-unlock action this ` +
+      `guard protects has moved; update check-tf-unlock-scope.mjs to match`,
+  );
+}
+
+if (actionDoc) {
+  const input = actionDoc.getIn(["inputs", INPUT], true);
+  if (!input) {
+    errors.push(
+      `${ACTION}: no "${INPUT}" input - the state-lock scoping switch this guard protects has ` +
+        `been renamed or removed (#631); update check-tf-unlock-scope.mjs to match`,
+    );
+  }
+}
+
+// --- Every call site in every workflow -------------------------------
+
+let callSites = 0;
+
+for (const entry of readdirSync(WORKFLOWS).sort()) {
+  if (!entry.endsWith(".yml") && !entry.endsWith(".yaml")) continue;
+
+  const path = join(WORKFLOWS, entry);
+  const text = readFileSync(path, "utf8");
+  const doc = parseDocument(text);
+
+  if (doc.errors.length > 0) {
+    errors.push(`${path}: YAML parse error - ${doc.errors[0].message}`);
+    continue;
+  }
+
+  visit(doc, {
+    Map(_key, step) {
+      const uses = step.get("uses");
+      if (typeof uses !== "string") return;
+      // Tolerate a trailing slash; anything else must match exactly.
+      if (uses.trim().replace(/\/+$/, "") !== TF_UNLOCK) return;
+
+      callSites += 1;
+      if (EXEMPT_WORKFLOWS.has(basename(path))) return;
+
+      const withMap = step.get("with");
+      const scalar = withMap?.get?.(INPUT, true);
+      const line = lineAt(text, scalar?.range?.[0] ?? step.range[0]);
+      const where = `${path}:${line}: step "${step.get("name") ?? uses}"`;
+
+      // Absent is not flagged here: the action's own default decides
+      // what absence means, and that default is reviewed on the action
+      // itself. What must never happen is a call site explicitly opting
+      // OUT of the scoping.
+      if (scalar !== undefined && !isLiteralTrue(scalar.value)) {
+        errors.push(
+          `${where} sets ${INPUT}: ${JSON.stringify(scalar.value)}. Every automatic tf-unlock ` +
+            `call site must pass the literal "true" (#631): a broad runner@* sweep can ` +
+            `force-unlock a lock held by a different, still-live terraform run and corrupt ` +
+            `state. Cross-run recovery belongs in terraform-unlock-manual.yml, where an ` +
+            `operator confirms the lock ID first.`,
+        );
+      }
+    },
+  });
+}
+
+// Fail closed: if the call sites have moved or been renamed, this guard
+// is silently protecting nothing.
+if (callSites === 0) {
+  errors.push(
+    `no "uses: ${TF_UNLOCK}" call sites found under ${WORKFLOWS}/ - the steps this guard ` +
+      `protects have moved or been rewritten; update check-tf-unlock-scope.mjs to match`,
+  );
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(`::error::${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `OK: ${callSites} tf-unlock call site(s) across ${WORKFLOWS}/, none opting out of ` +
+    `${INPUT} scoping`,
+);

--- a/.github/scripts/check-tf-unlock-scope.mjs
+++ b/.github/scripts/check-tf-unlock-scope.mjs
@@ -21,8 +21,15 @@
 // report a *missing required input* - but it has no way to assert that a
 // supplied input holds a particular value. So the presence half of this
 // invariant is expressible in actionlint (by marking the input
-// required); the value half is not. This companion check covers both,
-// in the spirit of check-oidc-trust.mjs.
+// required); the value half is not. This companion check covers the
+// value half, in the spirit of check-oidc-trust.mjs.
+//
+// WHAT IT DELIBERATELY DOES NOT DO: require the input to be present. A
+// call site that omits it inherits the action's declared default, and
+// that default is reviewed on the action itself, in one place, rather
+// than restated at ten call sites. What must never happen - and what
+// this guard makes impossible to merge - is a call site explicitly
+// opting OUT of the scoping.
 //
 // WHY NOT A GREP: a grep can tell you the string `only-current-runner`
 // appears somewhere in a file. It cannot tie an input to the step that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,67 @@ jobs:
       - uses: ./.github/actions/setup-deps
       - run: node .github/scripts/check-unsafe-ddl.mjs "origin/${{ github.base_ref }}"
 
+  actionlint:
+    # Lints every workflow file (#700): misspelled or unknown keys, bad
+    # `needs` / `if` expressions, contexts that cannot resolve where they
+    # are used, missing inputs on the local composite actions under
+    # .github/actions/, and shellcheck over every `run:` block. PR-only:
+    # a workflow that does not lint should never reach main, and there is
+    # nothing here worth re-running on the deploy path.
+    #
+    # Runs the official image published from the actionlint repo, pinned
+    # by digest. A tag is mutable, a digest is not - the same reasoning
+    # behind the SHA pin on every `uses:` in this repo - and the image
+    # bundles the shellcheck build actionlint expects, so a local
+    # `docker run` of this digest reproduces CI exactly rather than
+    # grading against whatever shellcheck happens to be installed.
+    #
+    # Dependabot does NOT track this pin: its github-actions ecosystem
+    # reads `uses:` refs, not image references inside a `run:` step. To
+    # bump, pick a release from github.com/rhysd/actionlint/releases,
+    # run `docker pull rhysd/actionlint:<version>`, and update the tag
+    # and the digest below together.
+    #
+    # Findings are fixed in the workflow files themselves. The only
+    # suppressions are inline `# shellcheck disable=<code>` directives
+    # carrying a reason, which is why there is no .github/actionlint.yaml
+    # blanket-disabling rules.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Lint workflow files
+        env:
+          ACTIONLINT_IMAGE: rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        run: |
+          docker run --rm \
+            --volume "$PWD:/repo" \
+            --workdir /repo \
+            "$ACTIONLINT_IMAGE" \
+            -color
+
+  tf-unlock-scope-check:
+    # Guardrail for the Terraform state-lock invariant (#631): no
+    # automatic unlock may release a lock it did not create. The
+    # invariant, and the concurrency-group overlap that makes it matter,
+    # are defined and explained on the `only-current-runner` input in
+    # .github/actions/tf-unlock/action.yml - this job only enforces it.
+    #
+    # It is a script rather than an actionlint rule because actionlint
+    # has no custom-rule mechanism: it can require that a local action's
+    # input is *present*, but not that it holds a particular value. The
+    # script header spells that out in full.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # setup-deps installs the workspace, which is where the script gets
+      # the root `yaml` devDep it parses the workflow files with.
+      - uses: ./.github/actions/setup-deps
+      - run: node .github/scripts/check-tf-unlock-scope.mjs
+
   react-doctor:
     # Diff-only scan of apps/web on the PR. Any PR-introduced finding
     # (warning or error) blocks merge — matches the project-wide

--- a/.github/workflows/deploy-api-manual.yml
+++ b/.github/workflows/deploy-api-manual.yml
@@ -75,7 +75,7 @@ jobs:
           IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker build \
             --push \
-            -t $IMAGE \
+            -t "$IMAGE" \
             -f apps/api/Dockerfile \
             .
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
@@ -150,14 +150,14 @@ jobs:
         id: migrate
         run: |
           NETWORK_CONFIG=$(aws ecs describe-services \
-            --cluster $ECS_CLUSTER \
-            --services $ECS_SERVICE \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
             --query 'services[0].networkConfiguration' \
             --output json)
 
           # Migration uses its own task def (#130), command baked in.
           TASK_ARN=$(aws ecs run-task \
-            --cluster $ECS_CLUSTER \
+            --cluster "$ECS_CLUSTER" \
             --task-definition ${{ steps.task-def.outputs.migration-task-definition-arn }} \
             --launch-type FARGATE \
             --network-configuration "$NETWORK_CONFIG" \
@@ -166,11 +166,11 @@ jobs:
 
           echo "Migration task: $TASK_ARN"
           echo "task_arn=$TASK_ARN" >> "$GITHUB_OUTPUT"
-          aws ecs wait tasks-stopped --cluster $ECS_CLUSTER --tasks $TASK_ARN
+          aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN"
 
           EXIT_CODE=$(aws ecs describe-tasks \
-            --cluster $ECS_CLUSTER \
-            --tasks $TASK_ARN \
+            --cluster "$ECS_CLUSTER" \
+            --tasks "$TASK_ARN" \
             --query 'tasks[0].containers[0].exitCode' \
             --output text)
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
@@ -226,15 +226,15 @@ jobs:
       - name: Update ECS service
         run: |
           aws ecs update-service \
-            --cluster $ECS_CLUSTER \
-            --service $ECS_SERVICE \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE" \
             --task-definition ${{ steps.task-def.outputs.task-definition-arn }} \
             --force-new-deployment
 
           echo "Waiting for deployment to stabilize..."
           aws ecs wait services-stable \
-            --cluster $ECS_CLUSTER \
-            --services $ECS_SERVICE
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE"
 
       - name: Verify deployed task definition matches the one we registered
         # Mirrors the same step in deploy.yml - services-stable returns
@@ -243,6 +243,10 @@ jobs:
         env:
           REGISTERED: ${{ steps.task-def.outputs.task-definition-arn }}
         run: |
+          # SC2016: the backticks are JMESPath literal syntax inside a
+          # --query string, not shell command substitution. The single
+          # quotes are exactly what keeps the shell out of them.
+          # shellcheck disable=SC2016
           ACTIVE=$(aws ecs describe-services \
             --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
             --query 'services[0].deployments[?status==`PRIMARY`].taskDefinition' \
@@ -263,6 +267,10 @@ jobs:
             --desired-status STOPPED --query 'taskArns[]' --output text)
           MATCHED=""
           if [ -n "$STOPPED_TASK" ]; then
+            # SC2086: STOPPED_TASK is a tab-separated list of ARNs from
+            # `--output text`, and --tasks takes them as separate args.
+            # Quoting it would pass the whole list as one bogus ARN.
+            # shellcheck disable=SC2086
             MATCHED=$(aws ecs describe-tasks --cluster "$ECS_CLUSTER" --tasks $STOPPED_TASK \
               --query "sort_by(tasks[?taskDefinitionArn=='$REGISTERED'], &stoppedAt)[-1].taskArn" \
               --output text)

--- a/.github/workflows/deploy-terraform-manual.yml
+++ b/.github/workflows/deploy-terraform-manual.yml
@@ -102,7 +102,7 @@ jobs:
         # See ADR 035 — apply-time plan recorded for audit.
         run: |
           terraform plan -no-color -out=tfplan 2>&1 | tee plan.txt
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if plan didn't release its own
         if: always() && steps.plan.outcome != 'success'
@@ -133,7 +133,7 @@ jobs:
         working-directory: infra/environments/shared
         run: |
           terraform apply -auto-approve -no-color tfplan 2>&1 | tee apply.log
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if apply didn't release its own
         if: always() && steps.apply.outcome != 'success'
@@ -247,7 +247,7 @@ jobs:
         working-directory: infra/environments/production
         run: |
           terraform plan -no-color -out=tfplan 2>&1 | tee plan.txt
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if plan didn't release its own
         if: always() && steps.plan.outcome != 'success'
@@ -276,7 +276,7 @@ jobs:
         working-directory: infra/environments/production
         run: |
           terraform apply -auto-approve -no-color tfplan 2>&1 | tee apply.log
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if apply didn't release its own
         if: always() && steps.apply.outcome != 'success'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,7 +141,7 @@ jobs:
         # PR plan rather than failing instantly on lock contention.
         run: |
           terraform plan -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if plan didn't release its own
         # Belt-and-braces against a runner being killed mid-plan.
@@ -172,7 +172,7 @@ jobs:
         working-directory: infra/environments/shared
         run: |
           terraform apply -auto-approve -lock-timeout=2m -no-color tfplan 2>&1 | tee apply.log
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if apply didn't release its own
         if: always() && steps.apply.outcome != 'success'
@@ -264,7 +264,7 @@ jobs:
         working-directory: infra/environments/production
         run: |
           terraform plan -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if plan didn't release its own
         if: always() && steps.plan.outcome != 'success'
@@ -290,7 +290,7 @@ jobs:
         working-directory: infra/environments/production
         run: |
           terraform apply -auto-approve -lock-timeout=2m -no-color tfplan 2>&1 | tee apply.log
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if apply didn't release its own
         if: always() && steps.apply.outcome != 'success'
@@ -383,7 +383,7 @@ jobs:
           IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker build \
             --push \
-            -t $IMAGE \
+            -t "$IMAGE" \
             -f apps/api/Dockerfile \
             .
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
@@ -472,8 +472,8 @@ jobs:
         id: migrate
         run: |
           NETWORK_CONFIG=$(aws ecs describe-services \
-            --cluster $ECS_CLUSTER \
-            --services $ECS_SERVICE \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
             --query 'services[0].networkConfiguration' \
             --output json)
 
@@ -481,7 +481,7 @@ jobs:
           # `node apps/api/dist/migrate.js` command baked in. No
           # containerOverrides needed.
           TASK_ARN=$(aws ecs run-task \
-            --cluster $ECS_CLUSTER \
+            --cluster "$ECS_CLUSTER" \
             --task-definition ${{ steps.task-def.outputs.migration-task-definition-arn }} \
             --launch-type FARGATE \
             --network-configuration "$NETWORK_CONFIG" \
@@ -490,11 +490,11 @@ jobs:
 
           echo "Migration task: $TASK_ARN"
           echo "task_arn=$TASK_ARN" >> "$GITHUB_OUTPUT"
-          aws ecs wait tasks-stopped --cluster $ECS_CLUSTER --tasks $TASK_ARN
+          aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN"
 
           EXIT_CODE=$(aws ecs describe-tasks \
-            --cluster $ECS_CLUSTER \
-            --tasks $TASK_ARN \
+            --cluster "$ECS_CLUSTER" \
+            --tasks "$TASK_ARN" \
             --query 'tasks[0].containers[0].exitCode' \
             --output text)
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
@@ -555,15 +555,15 @@ jobs:
       - name: Update ECS service
         run: |
           aws ecs update-service \
-            --cluster $ECS_CLUSTER \
-            --service $ECS_SERVICE \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE" \
             --task-definition ${{ steps.task-def.outputs.task-definition-arn }} \
             --force-new-deployment
 
           echo "Waiting for deployment to stabilize..."
           aws ecs wait services-stable \
-            --cluster $ECS_CLUSTER \
-            --services $ECS_SERVICE
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE"
 
       - name: Verify deployed task definition matches the one we registered
         # `aws ecs wait services-stable` only checks runningCount ==
@@ -576,6 +576,10 @@ jobs:
         env:
           REGISTERED: ${{ steps.task-def.outputs.task-definition-arn }}
         run: |
+          # SC2016: the backticks are JMESPath literal syntax inside a
+          # --query string, not shell command substitution. The single
+          # quotes are exactly what keeps the shell out of them.
+          # shellcheck disable=SC2016
           ACTIVE=$(aws ecs describe-services \
             --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
             --query 'services[0].deployments[?status==`PRIMARY`].taskDefinition' \
@@ -600,6 +604,10 @@ jobs:
             --desired-status STOPPED --query 'taskArns[]' --output text)
           MATCHED=""
           if [ -n "$STOPPED_TASK" ]; then
+            # SC2086: STOPPED_TASK is a tab-separated list of ARNs from
+            # `--output text`, and --tasks takes them as separate args.
+            # Quoting it would pass the whole list as one bogus ARN.
+            # shellcheck disable=SC2086
             MATCHED=$(aws ecs describe-tasks --cluster "$ECS_CLUSTER" --tasks $STOPPED_TASK \
               --query "sort_by(tasks[?taskDefinitionArn=='$REGISTERED'], &stoppedAt)[-1].taskArn" \
               --output text)

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -177,7 +177,7 @@ jobs:
         # rather than failing immediately on lock contention.
         run: |
           terraform plan -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
-          exit ${PIPESTATUS[0]}
+          exit "${PIPESTATUS[0]}"
         continue-on-error: true
 
       - name: Release stale state lock if plan didn't release its own

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prettier-plugin-tailwindcss": "^0.8.1",
     "turbo": "^2.10.10",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "typescript-eslint": "^8.66.0"
+    "typescript-eslint": "^8.66.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       typescript-eslint:
         specifier: ^8.66.0
         version: 8.67.0(@typescript/typescript6@6.0.2)(eslint@10.6.0(jiti@2.7.0))
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   apps/api:
     dependencies:


### PR DESCRIPTION
Closes #700

## Summary

Two new PR-only guardrail jobs in `.github/workflows/ci.yml`:

- **`actionlint`** lints every workflow file on every PR.
- **`tf-unlock-scope-check`** enforces the Terraform state-lock invariant from #631 via a new `.github/scripts/check-tf-unlock-scope.mjs`.

Plus the workflow fixes needed to make actionlint pass on today's tree.

## How actionlint is pinned, and why

It runs the **official image published from the actionlint repo**, pinned by digest inside a `run:` step:

```
rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
```

Rationale against the alternatives:

| Option | Verdict |
| --- | --- |
| Official image, digest-pinned | **Chosen.** First-party, immutable (same guarantee as the 40-char SHA pins on every `uses:` here), and it bundles the shellcheck build actionlint expects, so a local `docker run` of this digest reproduces CI byte for byte instead of grading against whatever shellcheck the runner happens to ship. |
| `download-actionlint.bash` | The documented form curls the script from a mutable `main` ref and pipes it to bash. Pinning the script to a commit still means piping a fetched script to bash for no gain over a digest. |
| Third-party wrapper action (e.g. `raven-actions/actionlint`) | Dependabot would bump the action SHA, but the actionlint version it installs is a separate input it would not touch, so the maintenance win is half-real, and it adds a third-party action to a repo that pins everything precisely to keep that surface small. |
| Committed binary | Ruled out by the issue. |

The one real cost: Dependabot's `github-actions` ecosystem reads `uses:` refs, not image references inside a `run:` step, so this pin is **not** auto-bumped. The bump procedure (`docker pull rhysd/actionlint:<version>`, update tag and digest together) is documented on the job itself.

## actionlint findings on main: fixed vs suppressed

Baseline against `main` was **37 findings, all shellcheck** (35x SC2086, 2x SC2016). No non-shellcheck findings, so the workflows were structurally sound.

**Fixed (33)** - real unquoted expansions, now quoted:

- `exit ${PIPESTATUS[0]}` in the terraform plan/apply steps (`deploy.yml` x4, `deploy-terraform-manual.yml` x4, `terraform.yml` x1)
- `-t $IMAGE` in the docker build steps (`deploy.yml`, `deploy-api-manual.yml`)
- `--cluster $ECS_CLUSTER` / `--services $ECS_SERVICE` / `--tasks $TASK_ARN` across the migration, service-update and wait steps (`deploy.yml`, `deploy-api-manual.yml`)

All behaviour-preserving.

**Suppressed (4)** - inline `# shellcheck disable=<code>` with a reason on the line it applies to, never repo-wide:

- `SC2086` on `--tasks $STOPPED_TASK` (`deploy.yml`, `deploy-api-manual.yml`). `$STOPPED_TASK` is a tab-separated ARN list from `--output text` and `--tasks` needs them as separate arguments. Quoting it would pass the whole list as one bogus ARN, i.e. shellcheck's fix would be the bug.
- `SC2016` on the `--query 'services[0].deployments[?status==`PRIMARY`].taskDefinition'` strings (same two files). The backticks are JMESPath literal syntax; the single quotes are exactly what keeps the shell out of them.

**There is no `.github/actionlint.yaml`.** Nothing needed a config-level exclusion, and adding an empty-but-for-ignores config would be the blunt instrument this issue exists to avoid.

## Evaluation: can actionlint express the #631 tf-unlock invariant?

**No, not the part that matters.** Concretely:

- actionlint has **no custom-rule mechanism**. Its config file supports only `self-hosted-runner` labels, `config-variables`, and path-scoped `ignore` patterns (regexes over error messages). None of those can assert anything about a workflow's content.
- It **does** understand local composite actions: it reads `.github/actions/*/action.yml` and reports a call site that omits a `required: true` input. So "the input must be **present** at every call site" is expressible natively, by marking `only-current-runner` required.
- It has **no way to assert the value** an input is given. "Present" does not distinguish `"true"` from `"false"`, and `"false"` is the dangerous one.

So a dedicated check is the clean home, and this PR implements it as `.github/scripts/check-tf-unlock-scope.mjs`, deliberately modelled on the existing `.github/scripts/check-oidc-trust.mjs` semantic guard.

What it does:

- Parses the workflow YAML with the `yaml` package (added as a root devDep; zero new packages in the lockfile, `yaml@2.9.0` was already resolved transitively) rather than grepping. A grep can tell you the string appears in a file; it cannot tie an input to the step that owns it, tell a `with:` block from a comment, or notice a new call site that sets nothing at all. That distinction is the reason this issue exists.
- Finds every `uses: ./.github/actions/tf-unlock` step, and **fails any call site outside `terraform-unlock-manual.yml` that sets `only-current-runner` to anything other than a literal `true`** - including a `${{ }}` expression, whose value a reviewer cannot see.
- Reports `file:line` so failures land as GitHub file annotations.
- **Fails closed**: if no call sites are found, or the action file or its `only-current-runner` input has been renamed or removed, the guard errors rather than silently protecting nothing.
- Exempts `terraform-unlock-manual.yml` by name and does not care whether it exists. As #701 writes it that workflow does its own conditional `delete-item` instead of calling the composite action, so the exemption currently matches nothing; it is there so the rule reads the way the invariant is worded, and so adopting the composite action there later does not trip the guard.

Verified against **both** trees: green on `main`, and green on #701's post-merge tree (10 call sites in each).

## Where the concurrency invariant is documented

The invariant is defined and explained on the `only-current-runner` input in `.github/actions/tf-unlock/action.yml`, which #701 expands considerably. Both the `tf-unlock-scope-check` job comment in `ci.yml` and the script header point there and to #631 rather than restating it, so there is one source of truth.

## Assumptions

- The guardrail belongs in `ci.yml`, not `_lint-test-build.yml`: linting workflow files on the deploy path would re-run a check whose only useful moment is before merge.
- Quoting the ECS/task variables is behaviour-preserving. None of them can contain whitespace in practice; the change is about not leaving a rule half-obeyed, so that a future genuinely-dangerous expansion is not lost in existing noise.
- `.github/scripts/` is eslint-ignored, so the new script is not linted, consistent with `check-unsafe-ddl.mjs`.
- Added a short actionlint section to `.claude/skills/work-on-ci/SKILL.md` (the exact digest to run locally, and the inline-suppression rule) so the next person to touch a workflow finds out before CI tells them.

## Open questions

1. **Scope of the invariant check, and merge order with #701.** The invariant as worded in #700 is "every call site outside the manual workflow **sets** `only-current-runner: "true"`". That is not yet true on `main`: of the 10 call sites, `terraform-drift.yml` (1) and `deploy-terraform-manual.yml` (4) already set it, while `deploy.yml` (4) and `terraform.yml` (1) do not - which is exactly what #701 fixes, alongside flipping the action's default from `"false"` to `"true"`.

   So the strict "must be set explicitly" form would be **red on this branch today** with 5 violations, and could only go green by duplicating #701's edits here - which would mean shipping a production deploy-pipeline behaviour change inside a CI-lint PR, and guaranteeing a conflict with a teammate's open PR. I deliberately did not do that.

   What landed instead is the form that is correct in **every** merge order: **no automatic call site may opt out.** Once #701 lands, the action default is `"true"`, so omission is safe by construction and this check is the complete invariant. Before #701 lands it still catches the regression that matters (someone adding or flipping a call site to `"false"`).

   If you would rather have the stricter "must be explicit at every call site" form, it is a small addition to the script, but it should land **in or after #701**, not here. Happy either way - flagging it because it is a real narrowing of what #700 literally asked for.

2. **Should `only-current-runner` also be marked `required: true`** on the composite action? That would make actionlint itself enforce the presence half at every call site, with the script covering the value half. It would also force `terraform-unlock-manual.yml` (and any future caller) to state its choice explicitly, which reads as a feature. Not done here because it changes the action's contract and #701 owns that file right now.

## Verification

`pnpm format` run; `pnpm format:check` clean; working tree clean after the commit.

actionlint over the final tree (exit 0, no output is the clean result):

```
$ docker run --rm --volume "$PWD:/repo" --workdir /repo \
    rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color
$ echo $?
0
```

Baseline for comparison, same command against `main` before the fixes:

```
$ ... | wc -l
37
$ ... | grep -oE '\[[a-z-]+\]$' | sort | uniq -c
  37 [shellcheck]
$ ... | grep -oE 'SC[0-9]+' | sort | uniq -c
   2 SC2016
  35 SC2086
```

tf-unlock guard, on this branch:

```
$ node .github/scripts/check-tf-unlock-scope.mjs
OK: 10 tf-unlock call site(s) across .github/workflows/, none opting out of only-current-runner scoping
$ echo $?
0
```

Forward-compatibility, run against #701's workflows and `action.yml` extracted from `fix/631-scope-tf-unlock-to-current-runner`:

```
OK: 10 tf-unlock call site(s) across <tmp>/t701/workflows/, none opting out of only-current-runner scoping
exit=0
```

Failure modes, each exercised on a scratch copy and reverted:

| Injected fault | Result |
| --- | --- |
| `only-current-runner: "false"` on a `deploy.yml` call site | exit 1, `::error::...deploy.yml:286: step "Release stale state lock if plan didn't release its own" sets only-current-runner: "false". ...` |
| `only-current-runner: ${{ inputs.scope }}` on a `terraform.yml` call site | exit 1, flagged as not a literal `"true"` |
| Same opt-out inside the exempt `terraform-unlock-manual.yml` | exit 0, allowed |
| All call sites removed | exit 1, "no `uses: ./.github/actions/tf-unlock` call sites found ... update check-tf-unlock-scope.mjs to match" |
| `only-current-runner` input renamed on the action | exit 1, fails closed |
| `action.yml` missing | exit 1, fails closed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
