### PR TITLE
security(auth): enforce team scope on expenses, game reports and juniors

### DIFF
--- a/apps/api/src/features/admin/club-wide-gates-integration.test.ts
+++ b/apps/api/src/features/admin/club-wide-gates-integration.test.ts
@@ -152,6 +152,29 @@ describe("juniors endpoints are club-wide only (#627)", () => {
     expect(link.statusCode).toBe(403);
   });
 
+  it("403s a junior_manager on the junior-teams reference list", async () => {
+    // Shares the juniors admin surface's gate, but keeps its second branch:
+    // a standalone superadmin needs the list to assign scoped roles from the
+    // Access tab, which is where the only UI consumer lives.
+    const scoped = await sessionFor("junior_manager");
+    const refused = await app.inject({
+      method: "GET",
+      url: "/api/admin/junior-teams",
+      headers: { cookie: scoped },
+    });
+    expect(refused.statusCode).toBe(403);
+
+    for (const role of ["juniors_viewer", "superadmin"]) {
+      const cookie = await sessionFor(role);
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/admin/junior-teams",
+        headers: { cookie },
+      });
+      expect(res.statusCode).toBe(200);
+    }
+  });
+
   it("does not leak dependent PII in the refusal body", async () => {
     const cookie = await sessionFor("junior_manager");
     const res = await app.inject({

--- a/apps/api/src/features/admin/club-wide-gates-integration.test.ts
+++ b/apps/api/src/features/admin/club-wide-gates-integration.test.ts
@@ -1,0 +1,210 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildTestApp } from "../../test/app.ts";
+import {
+  startTestContainer,
+  stopTestContainer,
+  type TestContext,
+} from "../../test/containers.ts";
+
+/**
+ * HTTP-level checks for the club-wide-only gates added in #627.
+ *
+ * These run the real stack - better-auth sessions, requireAuth,
+ * requireClubWidePermission - rather than calling services, because the
+ * boundary under test IS the preHandler: both routes are reachable with the
+ * generic permission and are supposed to be refused anyway.
+ *
+ * Two rules are asserted:
+ *  - juniors: `junior_manager` is team-scoped, and there is no
+ *    dependent-to-junior-team association to scope the admin juniors tab by,
+ *    so it is club-wide-only. That tab lists every minor in the club plus
+ *    guardian contact details.
+ *  - reimbursement: paying a claim out is a whole-club treasurer action, so a
+ *    team-scoped `official` is refused even for their own team.
+ */
+
+let ctx: TestContext;
+let app: Awaited<ReturnType<typeof buildTestApp>>;
+
+const PASSWORD = "Sup3rSecure!password";
+
+/** Sign up + verify + set role + sign in; returns the session cookie header. */
+async function sessionFor(role: string): Promise<string> {
+  const email = `${crypto.randomUUID()}@example.com`;
+  const signUp = await app.inject({
+    method: "POST",
+    url: "/api/auth/sign-up/email",
+    payload: { email, password: PASSWORD, name: `Test ${role}` },
+  });
+  expect(signUp.statusCode).toBe(200);
+
+  await ctx.db
+    .updateTable("user")
+    .set({ role, emailVerified: true })
+    .where("email", "=", email)
+    .execute();
+
+  const signIn = await app.inject({
+    method: "POST",
+    url: "/api/auth/sign-in/email",
+    payload: { email, password: PASSWORD },
+  });
+  expect(signIn.statusCode).toBe(200);
+
+  const setCookie = signIn.headers["set-cookie"];
+  const raw = Array.isArray(setCookie)
+    ? setCookie
+    : typeof setCookie === "string"
+      ? [setCookie]
+      : [];
+  const cookie = raw
+    .map((entry) => entry.split(";")[0])
+    .filter(Boolean)
+    .join("; ");
+  expect(cookie).not.toBe("");
+  return cookie;
+}
+
+beforeAll(async () => {
+  ctx = await startTestContainer();
+  app = await buildTestApp(ctx.db, ctx.dialect);
+}, 120_000);
+
+afterAll(async () => {
+  await app.close();
+  await stopTestContainer(ctx);
+});
+
+describe("juniors endpoints are club-wide only (#627)", () => {
+  /**
+   * Every juniors route, with a payload where the method needs one. The
+   * link/unlink bodies point at ids that don't exist: a club-wide caller is
+   * expected to get past the gate and fail on the data, which is exactly what
+   * distinguishes "refused at the door" from "allowed in".
+   */
+  const routes = [
+    { method: "GET" as const, url: "/api/admin/juniors" },
+    {
+      method: "GET" as const,
+      // Schema validation runs before preHandler, so every request here has
+      // to be well-formed or a 400 would mask the gate under test.
+      url: `/api/admin/juniors/search-users?dependentId=dep-${crypto.randomUUID()}`,
+    },
+    {
+      method: "POST" as const,
+      url: "/api/admin/juniors/link",
+      payload: {
+        dependentId: `dep-${crypto.randomUUID()}`,
+        userId: `user-${crypto.randomUUID()}`,
+      },
+    },
+    {
+      method: "POST" as const,
+      url: "/api/admin/juniors/unlink",
+      payload: { dependentId: `dep-${crypto.randomUUID()}` },
+    },
+  ];
+
+  it.each(routes)(
+    "403s a team-scoped junior_manager on $method $url",
+    async ({ method, url, payload }) => {
+      const cookie = await sessionFor("junior_manager");
+      const res = await app.inject({
+        method,
+        url,
+        headers: { cookie },
+        ...(payload ? { payload } : {}),
+      });
+      expect(res.statusCode).toBe(403);
+    },
+  );
+
+  it("lets a club-wide juniors_admin through to the listing", async () => {
+    const cookie = await sessionFor("juniors_admin");
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/admin/juniors",
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("lets juniors_viewer read but not link", async () => {
+    const cookie = await sessionFor("juniors_viewer");
+
+    const read = await app.inject({
+      method: "GET",
+      url: "/api/admin/juniors",
+      headers: { cookie },
+    });
+    expect(read.statusCode).toBe(200);
+
+    // juniors_viewer is club-wide but has no manage action.
+    const link = await app.inject({
+      method: "POST",
+      url: "/api/admin/juniors/link",
+      headers: { cookie },
+      payload: {
+        dependentId: `dep-${crypto.randomUUID()}`,
+        userId: `user-${crypto.randomUUID()}`,
+      },
+    });
+    expect(link.statusCode).toBe(403);
+  });
+
+  it("does not leak dependent PII in the refusal body", async () => {
+    const cookie = await sessionFor("junior_manager");
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/admin/juniors",
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toEqual({ error: "Forbidden" });
+  });
+});
+
+describe("expense reimbursement is club-wide only (#627)", () => {
+  it("403s a team-scoped official", async () => {
+    const cookie = await sessionFor("official");
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/matchday/expenses/${crypto.randomUUID()}/reimburse`,
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("lets a club-wide matchday_admin past the gate", async () => {
+    const cookie = await sessionFor("matchday_admin");
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/matchday/expenses/${crypto.randomUUID()}/reimburse`,
+      headers: { cookie },
+    });
+    // Past the permission gate, so it fails on the missing expense instead.
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("still lets a team-scoped official approve and reject", async () => {
+    const cookie = await sessionFor("official");
+
+    // Not 403: the approve/reject gates stay on the generic permission and
+    // the team scope is enforced inside the service, which 404s an id the
+    // official can't reach.
+    const approve = await app.inject({
+      method: "POST",
+      url: `/api/matchday/expenses/${crypto.randomUUID()}/approve`,
+      headers: { cookie },
+    });
+    expect(approve.statusCode).toBe(404);
+
+    const reject = await app.inject({
+      method: "POST",
+      url: `/api/matchday/expenses/${crypto.randomUUID()}/reject`,
+      headers: { cookie },
+      payload: { reason: "No receipt" },
+    });
+    expect(reject.statusCode).toBe(404);
+  });
+});

--- a/apps/api/src/features/admin/game-reports-integration.test.ts
+++ b/apps/api/src/features/admin/game-reports-integration.test.ts
@@ -174,7 +174,7 @@ describe("game-reports-service (integration)", () => {
         opposition: "Team B",
       });
 
-      const result = await listGameReports(ctx.db)({
+      const result = await listGameReports(ctx.db)(defaultUserId, "admin", {
         limit: 50,
         offset: 0,
       });
@@ -194,7 +194,7 @@ describe("game-reports-service (integration)", () => {
       await seedMatchday(ctx.db, teamA, { opposition: "Opponent A" });
       await seedMatchday(ctx.db, teamB, { opposition: "Opponent B" });
 
-      const result = await listGameReports(ctx.db)({
+      const result = await listGameReports(ctx.db)(defaultUserId, "admin", {
         teamId: teamA,
         limit: 50,
         offset: 0,
@@ -209,7 +209,7 @@ describe("game-reports-service (integration)", () => {
       const teamId = await seedTeam(ctx.db, { name: "Percy Main 2nd XI" });
       await seedMatchday(ctx.db, teamId);
 
-      const result = await listGameReports(ctx.db)({
+      const result = await listGameReports(ctx.db)(defaultUserId, "admin", {
         teamId,
         limit: 50,
         offset: 0,
@@ -221,9 +221,9 @@ describe("game-reports-service (integration)", () => {
 
   describe("getMatchdayReport", () => {
     it("throws 404 for missing matchday", async () => {
-      await expect(getMatchdayReport(ctx.db)("nonexistent-id")).rejects.toThrow(
-        "Matchday not found",
-      );
+      await expect(
+        getMatchdayReport(ctx.db)(defaultUserId, "admin", "nonexistent-id"),
+      ).rejects.toThrow("Matchday not found");
     });
 
     it("returns financial summary with correct calculations", async () => {
@@ -255,7 +255,11 @@ describe("game-reports-service (integration)", () => {
         createdBy: user.userId,
       });
 
-      const report = await getMatchdayReport(ctx.db)(matchdayId);
+      const report = await getMatchdayReport(ctx.db)(
+        defaultUserId,
+        "admin",
+        matchdayId,
+      );
 
       expect(report.matchday.id).toBe(matchdayId);
       expect(report.team).not.toBeNull();
@@ -282,7 +286,11 @@ describe("game-reports-service (integration)", () => {
         chargeDeletedAt: "2026-06-16T00:00:00Z",
       });
 
-      const report = await getMatchdayReport(ctx.db)(matchdayId);
+      const report = await getMatchdayReport(ctx.db)(
+        defaultUserId,
+        "admin",
+        matchdayId,
+      );
 
       expect(report.summary.totalIncoming).toBe(0);
       expect(report.summary.totalPaid).toBe(0);
@@ -309,12 +317,98 @@ describe("game-reports-service (integration)", () => {
         })
         .execute();
 
-      const report = await getMatchdayReport(ctx.db)(matchdayId);
+      const report = await getMatchdayReport(ctx.db)(
+        defaultUserId,
+        "admin",
+        matchdayId,
+      );
 
       expect(report.sponsorship).not.toBeNull();
       expect(report.sponsorship?.sponsor_name).toBe("Local Pub");
       expect(report.summary.sponsorshipIncome).toBe(5000);
       expect(report.summary.profitLoss).toBe(5000);
+    });
+  });
+
+  // #627: `official` is a team-scoped role, so game reports - which carry
+  // per-player charge amounts and expense totals - must be filtered to the
+  // teams the caller is actually assigned to.
+  describe("team scoping", () => {
+    /** Two teams with a matchday each, and an official assigned to the first. */
+    async function seedTwoTeams() {
+      const { userId: officialId } = await seedTestUser(ctx.db, {
+        withMember: true,
+        role: "official",
+      });
+      const myTeam = await seedTeam(ctx.db, { name: "Scoped XI" });
+      const otherTeam = await seedTeam(ctx.db, { name: "Other XI" });
+      await ctx.db
+        .insertInto("team_official")
+        .values({ user_id: officialId, play_cricket_team_id: myTeam })
+        .execute();
+
+      const myMatchday = await seedMatchday(ctx.db, myTeam, {
+        opposition: "Mine CC",
+      });
+      const otherMatchday = await seedMatchday(ctx.db, otherTeam, {
+        opposition: "Theirs CC",
+      });
+
+      return { officialId, myTeam, otherTeam, myMatchday, otherMatchday };
+    }
+
+    it("listGameReports filters rows and the total to assigned teams", async () => {
+      const { officialId, myMatchday, otherMatchday } = await seedTwoTeams();
+
+      const scoped = await listGameReports(ctx.db)(officialId, "official", {
+        limit: 100,
+        offset: 0,
+      });
+      const ids = scoped.matchdays.map((m) => m.id);
+      expect(ids).toContain(myMatchday);
+      expect(ids).not.toContain(otherMatchday);
+      // The count is filtered too, so pagination can't hint at the size of
+      // the fixture list the official can't see.
+      expect(scoped.total).toBe(scoped.matchdays.length);
+
+      const clubWide = await listGameReports(ctx.db)(defaultUserId, "admin", {
+        limit: 100,
+        offset: 0,
+      });
+      const clubWideIds = clubWide.matchdays.map((m) => m.id);
+      expect(clubWideIds).toContain(myMatchday);
+      expect(clubWideIds).toContain(otherMatchday);
+    });
+
+    it("listGameReports returns nothing for an official with no assignments", async () => {
+      const { userId: strandedId } = await seedTestUser(ctx.db, {
+        withMember: true,
+        role: "official",
+      });
+      await seedTwoTeams();
+
+      const result = await listGameReports(ctx.db)(strandedId, "official", {
+        limit: 100,
+        offset: 0,
+      });
+      expect(result).toEqual({ matchdays: [], total: 0 });
+    });
+
+    it("getMatchdayReport 404s an official on another team's report", async () => {
+      const { officialId, myMatchday, otherMatchday } = await seedTwoTeams();
+      await seedExpense(ctx.db, otherMatchday, { amountPence: 9999 });
+
+      await expect(
+        getMatchdayReport(ctx.db)(officialId, "official", otherMatchday),
+      ).rejects.toThrow("Matchday not found");
+
+      // Their own team's report still resolves.
+      const own = await getMatchdayReport(ctx.db)(
+        officialId,
+        "official",
+        myMatchday,
+      );
+      expect(own.matchday.id).toBe(myMatchday);
     });
   });
 });

--- a/apps/api/src/features/admin/game-reports-service.test.ts
+++ b/apps/api/src/features/admin/game-reports-service.test.ts
@@ -9,6 +9,7 @@ const { mockExecuteTakeFirst, mockExecute, mockQueryBuilder } = vi.hoisted(
 
     const mockQueryBuilder: Record<string, unknown> = {
       selectFrom: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
       leftJoin: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
@@ -62,7 +63,7 @@ describe("game-reports-service", () => {
       // Second call: count query
       mockExecuteTakeFirst.mockResolvedValueOnce({ count: "1" });
 
-      const result = await listGameReports(db)({
+      const result = await listGameReports(db)("admin-1", "admin", {
         limit: 50,
         offset: 0,
       });
@@ -75,7 +76,7 @@ describe("game-reports-service", () => {
       mockExecute.mockResolvedValueOnce([]);
       mockExecuteTakeFirst.mockResolvedValueOnce({ count: "0" });
 
-      const result = await listGameReports(db)({
+      const result = await listGameReports(db)("admin-1", "admin", {
         teamId: "t1",
         limit: 50,
         offset: 0,
@@ -91,22 +92,92 @@ describe("game-reports-service", () => {
       mockExecute.mockResolvedValueOnce([]);
       mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
 
-      const result = await listGameReports(db)({
+      const result = await listGameReports(db)("admin-1", "admin", {
         limit: 50,
         offset: 0,
       });
 
       expect(result.total).toBe(0);
     });
+
+    it("filters list and count to the official's assigned teams", async () => {
+      // getAssignedTeamIds, then the listing query.
+      mockExecute
+        .mockResolvedValueOnce([{ play_cricket_team_id: "t1" }])
+        .mockResolvedValueOnce([]);
+      mockExecuteTakeFirst.mockResolvedValueOnce({ count: "0" });
+
+      await listGameReports(db)("official-1", "official", {
+        limit: 50,
+        offset: 0,
+      });
+
+      expect(mockQueryBuilder.selectFrom).toHaveBeenCalledWith("team_official");
+      // Listing query and count query both constrained, so the total can't
+      // leak the size of other teams' fixture lists.
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        "matchday.play_cricket_team_id",
+        "in",
+        ["t1"],
+      );
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        "play_cricket_team_id",
+        "in",
+        ["t1"],
+      );
+    });
+
+    it("returns nothing for an official with no team assignments", async () => {
+      mockExecute.mockResolvedValueOnce([]);
+
+      const result = await listGameReports(db)("official-1", "official", {
+        limit: 50,
+        offset: 0,
+      });
+
+      expect(result).toEqual({ matchdays: [], total: 0 });
+      expect(mockQueryBuilder.selectFrom).not.toHaveBeenCalledWith("matchday");
+    });
   });
 
   describe("getMatchdayReport", () => {
+    it("404s an official on another team's report before reading it", async () => {
+      // Access check misses.
+      mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
+
+      await expect(
+        getMatchdayReport(db)("official-1", "official", "m-other-team"),
+      ).rejects.toThrow("Matchday not found");
+
+      expect(mockQueryBuilder.innerJoin).toHaveBeenCalledWith(
+        "team_official",
+        "team_official.play_cricket_team_id",
+        "matchday.play_cricket_team_id",
+      );
+      // Charge amounts and expense rows are never fetched.
+      expect(mockQueryBuilder.selectAll).not.toHaveBeenCalled();
+    });
+
+    it("skips the access check for club-wide roles", async () => {
+      mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
+
+      await expect(
+        getMatchdayReport(db)("admin-1", "matchday_viewer", "m1"),
+      ).rejects.toThrow("Matchday not found");
+
+      expect(mockQueryBuilder.innerJoin).not.toHaveBeenCalledWith(
+        "team_official",
+        "team_official.play_cricket_team_id",
+        "matchday.play_cricket_team_id",
+      );
+    });
+
     it("throws 404 when matchday not found", async () => {
       mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
 
-      await expect(getMatchdayReport(db)("nonexistent")).rejects.toThrow(
-        "Matchday not found",
-      );
+      await expect(
+        getMatchdayReport(db)("admin-1", "admin", "nonexistent"),
+      ).rejects.toThrow("Matchday not found");
     });
 
     it("returns full report with financial summary", async () => {
@@ -171,7 +242,7 @@ describe("game-reports-service", () => {
         name: "1st XI",
       });
 
-      const result = await getMatchdayReport(db)("m1");
+      const result = await getMatchdayReport(db)("admin-1", "admin", "m1");
 
       expect(result.matchday.id).toBe("m1");
       expect(result.team?.name).toBe("1st XI");
@@ -220,7 +291,7 @@ describe("game-reports-service", () => {
         amount_pence: 5000,
       });
 
-      const result = await getMatchdayReport(db)("m1");
+      const result = await getMatchdayReport(db)("admin-1", "admin", "m1");
 
       expect(result.sponsorship).not.toBeNull();
       expect(result.summary.sponsorshipIncome).toBe(5000);
@@ -267,7 +338,7 @@ describe("game-reports-service", () => {
         name: "1st XI",
       });
 
-      const result = await getMatchdayReport(db)("m1");
+      const result = await getMatchdayReport(db)("admin-1", "admin", "m1");
 
       // Deleted charge should be excluded
       expect(result.summary.totalIncoming).toBe(0);
@@ -329,7 +400,7 @@ describe("game-reports-service", () => {
         name: "1st XI",
       });
 
-      const result = await getMatchdayReport(db)("m1");
+      const result = await getMatchdayReport(db)("admin-1", "admin", "m1");
 
       expect(result.players[0].charge_status).toBe("paid");
       expect(result.players[1].charge_status).toBe("relieved");

--- a/apps/api/src/features/admin/game-reports-service.ts
+++ b/apps/api/src/features/admin/game-reports-service.ts
@@ -1,6 +1,8 @@
 import type { DB } from "@percy-main/db";
+import { hasClubWideAccess } from "@percy-main/shared/auth/permissions";
 import type { Kysely } from "kysely";
 import { sql } from "kysely";
+import { getAssignedTeamIds } from "../../lib/team-access.ts";
 import type { ListGameReports } from "./schemas.ts";
 
 const ABANDONED_THRESHOLD_HOURS = 1;
@@ -34,8 +36,17 @@ function getChargeStatus(
 }
 
 export function listGameReports(db: Kysely<DB>) {
-  return async (params: ListGameReports) => {
+  return async (userId: string, role: string, params: ListGameReports) => {
     const { teamId, limit, offset } = params;
+
+    // Team-scoped officials only see reports for their assigned teams. No
+    // assignments means nothing to show - short-circuit rather than emit an
+    // empty IN list.
+    let assignedTeamIds: string[] | null = null;
+    if (!hasClubWideAccess(role, "matchday", "view")) {
+      assignedTeamIds = await getAssignedTeamIds(db, userId);
+      if (assignedTeamIds.length === 0) return { matchdays: [], total: 0 };
+    }
 
     let query = db
       .selectFrom("matchday")
@@ -55,6 +66,14 @@ export function listGameReports(db: Kysely<DB>) {
       ])
       .orderBy("matchday.match_date", "desc");
 
+    if (assignedTeamIds) {
+      query = query.where(
+        "matchday.play_cricket_team_id",
+        "in",
+        assignedTeamIds,
+      );
+    }
+
     if (teamId) {
       query = query.where("matchday.play_cricket_team_id", "=", teamId);
     }
@@ -62,6 +81,14 @@ export function listGameReports(db: Kysely<DB>) {
     let countQuery = db
       .selectFrom("matchday")
       .select(sql<string>`count(*)`.as("count"));
+
+    if (assignedTeamIds) {
+      countQuery = countQuery.where(
+        "play_cricket_team_id",
+        "in",
+        assignedTeamIds,
+      );
+    }
 
     if (teamId) {
       countQuery = countQuery.where("play_cricket_team_id", "=", teamId);
@@ -80,7 +107,31 @@ export function listGameReports(db: Kysely<DB>) {
 }
 
 export function getMatchdayReport(db: Kysely<DB>) {
-  return async (matchdayId: string) => {
+  return async (userId: string, role: string, matchdayId: string) => {
+    // Same 404-on-out-of-scope rule as matchday's getMatch: a scoped official
+    // can't tell another team's report from one that doesn't exist. The report
+    // carries per-player charge amounts and expense totals, so this is a
+    // financial boundary, not just a tidiness one.
+    if (!hasClubWideAccess(role, "matchday", "view")) {
+      const access = await db
+        .selectFrom("matchday")
+        .innerJoin(
+          "team_official",
+          "team_official.play_cricket_team_id",
+          "matchday.play_cricket_team_id",
+        )
+        .where("matchday.id", "=", matchdayId)
+        .where("team_official.user_id", "=", userId)
+        .select("matchday.id")
+        .executeTakeFirst();
+
+      if (!access) {
+        throw Object.assign(new Error("Matchday not found"), {
+          statusCode: 404,
+        });
+      }
+    }
+
     const matchday = await db
       .selectFrom("matchday")
       .where("id", "=", matchdayId)

--- a/apps/api/src/features/admin/routes.ts
+++ b/apps/api/src/features/admin/routes.ts
@@ -7,6 +7,7 @@ import React from "react";
 import {
   getAuthSession,
   requireAnyPermission,
+  requireClubWidePermission,
   requirePermission,
 } from "../auth/middleware.ts";
 import { createApiClient } from "../play-cricket/api-client.ts";
@@ -149,8 +150,13 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
   const financeView = requirePermission("finance", "view");
   const financeManage = requirePermission("finance", "manage");
   const matchdayView = requirePermission("matchday", "view");
-  const juniorsView = requirePermission("juniors", "view");
-  const juniorsManage = requirePermission("juniors", "manage");
+  // Club-wide, not just permission-holding (#627): the juniors tab lists every
+  // dependent in the club along with guardian contact details, and there is no
+  // dependent-to-junior-team association in the schema to scope it by. Until
+  // one exists, a team-scoped junior_manager can't have it - they keep the
+  // per-team /junior-manager area, which is scoped via junior_team_manager.
+  const juniorsView = requireClubWidePermission("juniors", "view");
+  const juniorsManage = requireClubWidePermission("juniors", "manage");
   const marketingView = requirePermission("marketing", "view");
   const list = listUsers(app.db);
   const update = updateUser(app.db);
@@ -860,7 +866,9 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await listReports(request.query);
+      const { user } = getAuthSession(request);
+      const role = (user as { role?: string | null }).role ?? "user";
+      return await listReports(user.id, role, request.query);
     },
   );
 
@@ -874,7 +882,9 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await getReport(request.params.matchdayId);
+      const { user } = getAuthSession(request);
+      const role = (user as { role?: string | null }).role ?? "user";
+      return await getReport(user.id, role, request.params.matchdayId);
     },
   );
 };

--- a/apps/api/src/features/admin/routes.ts
+++ b/apps/api/src/features/admin/routes.ts
@@ -385,7 +385,11 @@ export const adminRoutes: FastifyPluginAsyncZod = async (app) => {
     {
       preHandler: [
         requireAnyPermission(
-          { resource: "juniors", action: "view" },
+          // Club-wide, like the rest of the juniors admin surface this feeds
+          // (#627). The only UI consumer is the Access tab, which needs
+          // users.manage_roles anyway, so a scoped junior_manager loses
+          // nothing they were actually using.
+          { resource: "juniors", action: "view", clubWide: true },
           { resource: "users", action: "manage_roles" },
         ),
       ],

--- a/apps/api/src/features/auth/auth.test.ts
+++ b/apps/api/src/features/auth/auth.test.ts
@@ -46,6 +46,43 @@ describe("requireClubWidePermission", () => {
     await requireClubWidePermission("matchday", "view")(request, reply);
     expect(reply.sent).toBe(false);
   });
+
+  it("403s a team-scoped junior_manager on juniors (#627)", async () => {
+    const { request, reply, getStatus } = makeReqReply("junior_manager");
+    await requireClubWidePermission("juniors", "view")(request, reply);
+    expect(getStatus()).toBe(403);
+  });
+
+  it("allows juniors_admin, and juniors_viewer for view only", async () => {
+    const admin = makeReqReply("juniors_admin");
+    await requireClubWidePermission("juniors", "manage")(
+      admin.request,
+      admin.reply,
+    );
+    expect(admin.reply.sent).toBe(false);
+
+    const viewer = makeReqReply("juniors_viewer");
+    await requireClubWidePermission("juniors", "view")(
+      viewer.request,
+      viewer.reply,
+    );
+    expect(viewer.reply.sent).toBe(false);
+
+    const viewerManaging = makeReqReply("juniors_viewer");
+    await requireClubWidePermission("juniors", "manage")(
+      viewerManaging.request,
+      viewerManaging.reply,
+    );
+    expect(viewerManaging.getStatus()).toBe(403);
+  });
+
+  it("still 403s a junior_manager who also holds a scoped official role", async () => {
+    const { request, reply, getStatus } = makeReqReply(
+      "junior_manager,official",
+    );
+    await requireClubWidePermission("juniors", "view")(request, reply);
+    expect(getStatus()).toBe(403);
+  });
 });
 
 describe("Auth middleware", () => {

--- a/apps/api/src/features/auth/middleware.ts
+++ b/apps/api/src/features/auth/middleware.ts
@@ -108,7 +108,17 @@ export function requireClubWidePermission<R extends Resource>(
 }
 
 type PermissionCheck = {
-  [R in Resource]: { resource: R; action: Action<R> };
+  [R in Resource]: {
+    resource: R;
+    action: Action<R>;
+    /**
+     * Test this branch with {@link hasClubWideAccess} instead of
+     * checkPermission, so a team-scoped role holding the permission does not
+     * satisfy it. Set it when the branch exists to serve a surface that is
+     * itself club-wide gated.
+     */
+    clubWide?: boolean;
+  };
 }[Resource];
 
 /**
@@ -124,7 +134,9 @@ export function requireAnyPermission(...checks: PermissionCheck[]) {
     const userRole =
       (request.authSession?.user as { role?: string | null }).role ?? "user";
     const allowed = checks.some((c) =>
-      checkPermission(userRole, c.resource, c.action),
+      c.clubWide
+        ? hasClubWideAccess(userRole, c.resource, c.action)
+        : checkPermission(userRole, c.resource, c.action),
     );
     if (!allowed) {
       return reply.status(403).send({ error: "Forbidden" });

--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -1513,7 +1513,7 @@ describe("matchday service (integration)", () => {
       expect(expense?.submitted_at).toBeTruthy();
 
       // 2. Approve
-      await approveExpense(ctx.db)(adminId, expenseId);
+      await approveExpense(ctx.db)(adminId, "admin", expenseId);
 
       expense = await ctx.db
         .selectFrom("matchday_expense")
@@ -1564,7 +1564,7 @@ describe("matchday service (integration)", () => {
         },
       );
 
-      await rejectExpense(ctx.db)(adminId, expenseId, {
+      await rejectExpense(ctx.db)(adminId, "admin", expenseId, {
         reason: "No receipt attached",
       });
 
@@ -1596,9 +1596,9 @@ describe("matchday service (integration)", () => {
         amountPence: 2000,
       });
 
-      await expect(approveExpense(ctx.db)(adminId, expenseId)).rejects.toThrow(
-        "Only submitted expenses can be approved",
-      );
+      await expect(
+        approveExpense(ctx.db)(adminId, "admin", expenseId),
+      ).rejects.toThrow("Only submitted expenses can be approved");
     });
 
     it("cannot reimburse a non-approved expense", async () => {
@@ -1664,10 +1664,10 @@ describe("matchday service (integration)", () => {
       });
 
       // Approve the first one
-      await approveExpense(ctx.db)(adminId, exp1);
+      await approveExpense(ctx.db)(adminId, "admin", exp1);
 
       // List all pending (submitted + approved)
-      const result = await listPendingExpenses(ctx.db)({
+      const result = await listPendingExpenses(ctx.db)(adminId, "admin", {
         limit: 50,
         offset: 0,
       });
@@ -1677,7 +1677,7 @@ describe("matchday service (integration)", () => {
       expect(result.items.length).toBeGreaterThanOrEqual(2);
 
       // Filter by submitted only
-      const submitted = await listPendingExpenses(ctx.db)({
+      const submitted = await listPendingExpenses(ctx.db)(adminId, "admin", {
         status: "submitted",
         limit: 50,
         offset: 0,
@@ -1685,6 +1685,172 @@ describe("matchday service (integration)", () => {
       for (const item of submitted.items) {
         expect(item.status).toBe("submitted");
       }
+    });
+  });
+
+  // #627: `official` is a team-scoped role. Before this, holding it was
+  // enough to read and approve every team's claims.
+  describe("expense team scoping", () => {
+    /**
+     * Two teams, an official assigned to only the first, and one submitted
+     * expense on each. Returns the ids the assertions need.
+     */
+    async function seedTwoTeamExpenses(label: string) {
+      const { userId: officialId } = await seedTestUser(ctx.db, {
+        email: `off-${label}-${crypto.randomUUID()}@test.com`,
+        role: "official",
+      });
+      // `admin`, not `matchday_admin`: withdrawFromMatch emails every
+      // matchday_admin in the database, so seeding one here would inflate the
+      // recipient counts asserted by the withdrawal tests. Both roles are
+      // club-wide for this purpose - the matchday_admin path is covered by
+      // the unit tests.
+      const { userId: adminId } = await seedTestUser(ctx.db, {
+        email: `adm-${label}-${crypto.randomUUID()}@test.com`,
+        role: "admin",
+      });
+
+      const myTeam = await seedTeam();
+      const otherTeam = await seedTeam();
+      await seedTeamOfficial(officialId, myTeam);
+
+      const myMatch = await seedMatchday({
+        teamId: myTeam,
+        createdBy: officialId,
+        status: "confirmed",
+      });
+      const otherMatch = await seedMatchday({
+        teamId: otherTeam,
+        createdBy: adminId,
+        status: "confirmed",
+      });
+
+      const { expenseId: mine } = await submitExpenseClaim(ctx.db, s3)(
+        officialId,
+        "official",
+        { matchId: myMatch, type: "umpire_fee", amountPence: 5000 },
+      );
+      const { expenseId: theirs } = await submitExpenseClaim(ctx.db, s3)(
+        adminId,
+        "admin",
+        { matchId: otherMatch, type: "teas", amountPence: 3000 },
+      );
+
+      return { officialId, adminId, mine, theirs, myTeam, otherTeam };
+    }
+
+    it("listPendingExpenses shows an official only their own teams' claims", async () => {
+      const { officialId, adminId, mine, theirs } =
+        await seedTwoTeamExpenses("list");
+
+      const scoped = await listPendingExpenses(ctx.db)(officialId, "official", {
+        limit: 50,
+        offset: 0,
+      });
+      const scopedIds = scoped.items.map((e) => e.id);
+      expect(scopedIds).toContain(mine);
+      expect(scopedIds).not.toContain(theirs);
+
+      // The club-wide manager still sees both.
+      const clubWide = await listPendingExpenses(ctx.db)(adminId, "admin", {
+        limit: 50,
+        offset: 0,
+      });
+      const clubWideIds = clubWide.items.map((e) => e.id);
+      expect(clubWideIds).toContain(mine);
+      expect(clubWideIds).toContain(theirs);
+    });
+
+    it("listPendingExpenses returns nothing for an official with no assignments", async () => {
+      const { userId: strandedId } = await seedTestUser(ctx.db, {
+        email: `off-stranded-${crypto.randomUUID()}@test.com`,
+        role: "official",
+      });
+      await seedTwoTeamExpenses("stranded");
+
+      const result = await listPendingExpenses(ctx.db)(strandedId, "official", {
+        limit: 50,
+        offset: 0,
+      });
+      expect(result.items).toEqual([]);
+    });
+
+    it("approveExpense 404s an official on another team's claim and leaves it untouched", async () => {
+      const { officialId, mine, theirs } = await seedTwoTeamExpenses("approve");
+
+      await expect(
+        approveExpense(ctx.db)(officialId, "official", theirs),
+      ).rejects.toThrow("Expense not found");
+
+      const untouched = await ctx.db
+        .selectFrom("matchday_expense")
+        .where("id", "=", theirs)
+        .select(["status", "approved_by"])
+        .executeTakeFirst();
+      expect(untouched?.status).toBe("submitted");
+      expect(untouched?.approved_by).toBeNull();
+
+      // Their own team's claim still goes through.
+      await approveExpense(ctx.db)(officialId, "official", mine);
+      const approved = await ctx.db
+        .selectFrom("matchday_expense")
+        .where("id", "=", mine)
+        .select(["status", "approved_by"])
+        .executeTakeFirst();
+      expect(approved?.status).toBe("approved");
+      expect(approved?.approved_by).toBe(officialId);
+    });
+
+    it("rejectExpense 404s an official on another team's claim", async () => {
+      const { officialId, mine, theirs } = await seedTwoTeamExpenses("reject");
+
+      await expect(
+        rejectExpense(ctx.db)(officialId, "official", theirs, {
+          reason: "Not my problem",
+        }),
+      ).rejects.toThrow("Expense not found");
+
+      const untouched = await ctx.db
+        .selectFrom("matchday_expense")
+        .where("id", "=", theirs)
+        .select(["status", "rejected_reason"])
+        .executeTakeFirst();
+      expect(untouched?.status).toBe("submitted");
+      expect(untouched?.rejected_reason).toBeNull();
+
+      await rejectExpense(ctx.db)(officialId, "official", mine, {
+        reason: "No receipt",
+      });
+      const rejected = await ctx.db
+        .selectFrom("matchday_expense")
+        .where("id", "=", mine)
+        .select("status")
+        .executeTakeFirst();
+      expect(rejected?.status).toBe("rejected");
+    });
+
+    it("an out-of-scope expense id is indistinguishable from a nonexistent one", async () => {
+      const { officialId, theirs } = await seedTwoTeamExpenses("indistinct");
+
+      /** The failure an official sees, as message plus status code. */
+      const refusal = async (expenseId: string) => {
+        try {
+          await approveExpense(ctx.db)(officialId, "official", expenseId);
+          throw new Error("expected the approval to be refused");
+        } catch (e: unknown) {
+          const err = e as Error & { statusCode?: number };
+          return { message: err.message, statusCode: err.statusCode };
+        }
+      };
+
+      const outOfScope = await refusal(theirs);
+      const nonexistent = await refusal(`exp-${crypto.randomUUID()}`);
+
+      expect(outOfScope).toEqual({
+        message: "Expense not found",
+        statusCode: 404,
+      });
+      expect(outOfScope).toEqual(nonexistent);
     });
   });
 

--- a/apps/api/src/features/matchday/integration.test.ts
+++ b/apps/api/src/features/matchday/integration.test.ts
@@ -1751,9 +1751,12 @@ describe("matchday service (integration)", () => {
       expect(scopedIds).toContain(mine);
       expect(scopedIds).not.toContain(theirs);
 
-      // The club-wide manager still sees both.
+      // The club-wide manager still sees both. Uses the schema's maximum
+      // limit: the container is shared across this file, so every other
+      // suite's expenses compete for the page and a lower limit would
+      // eventually truncate these two out of the result.
       const clubWide = await listPendingExpenses(ctx.db)(adminId, "admin", {
-        limit: 50,
+        limit: 100,
         offset: 0,
       });
       const clubWideIds = clubWide.items.map((e) => e.id);

--- a/apps/api/src/features/matchday/routes.ts
+++ b/apps/api/src/features/matchday/routes.ts
@@ -3,6 +3,7 @@ import { createPrerenderTrigger } from "../../lib/prerender-trigger.ts";
 import {
   getAuthSession,
   requireAuth,
+  requireClubWidePermission,
   requirePermission,
 } from "../auth/middleware.ts";
 import { createApiClient } from "../play-cricket/api-client.ts";
@@ -85,6 +86,7 @@ import { generateTeamNewsImage } from "./team-news-image.ts";
 export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
   const officialRole = requirePermission("matchday", "view");
   const adminRole = requirePermission("matchday", "manage");
+  const clubWideAdminRole = requireClubWidePermission("matchday", "manage");
   // Manual results and cancellations surface on prerendered game pages
   // (outcome badge); fire a reconcile so they don't wait for the
   // 15-minute sweep.
@@ -376,7 +378,9 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
       },
     },
     async (request) => {
-      return await pending(request.query);
+      const { user } = getAuthSession(request);
+      const role = (user as { role?: string | null }).role ?? "user";
+      return await pending(user.id, role, request.query);
     },
   );
 
@@ -411,7 +415,8 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request) => {
       const { user } = getAuthSession(request);
-      return await approve(user.id, request.params.expenseId);
+      const role = (user as { role?: string | null }).role ?? "user";
+      return await approve(user.id, role, request.params.expenseId);
     },
   );
 
@@ -427,14 +432,23 @@ export const matchdayRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     async (request) => {
       const { user } = getAuthSession(request);
-      return await reject(user.id, request.params.expenseId, request.body);
+      const role = (user as { role?: string | null }).role ?? "user";
+      return await reject(
+        user.id,
+        role,
+        request.params.expenseId,
+        request.body,
+      );
     },
   );
 
+  // Paying a claim out is a whole-club treasurer action (#627), so this is
+  // the one expense route a team-scoped official can't reach even for their
+  // own team: club-wide matchday:manage only.
   app.post(
     "/matchday/expenses/:expenseId/reimburse",
     {
-      preHandler: [adminRole],
+      preHandler: [clubWideAdminRole],
       schema: {
         params: expenseIdParamSchema,
         response: { 200: successResponseSchema },

--- a/apps/api/src/features/matchday/service.test.ts
+++ b/apps/api/src/features/matchday/service.test.ts
@@ -45,6 +45,7 @@ import {
   deleteExpense,
   finishMatch,
   listMatches,
+  listPendingExpenses,
   listTeams,
   markExpenseReimbursed,
   recordExpense,
@@ -333,11 +334,60 @@ describe("expense approval workflow", () => {
       });
       mockExecute.mockResolvedValueOnce([]);
 
-      const result = await approveExpense(db)("admin-1", "exp-1");
+      const result = await approveExpense(db)("admin-1", "admin", "exp-1");
       expect(result).toEqual({ success: true });
       expect(mockQueryBuilder.set).toHaveBeenCalledWith(
         expect.objectContaining({ status: "approved" }),
       );
+    });
+
+    it("skips the team-scope check for club-wide managers", async () => {
+      mockExecuteTakeFirst.mockResolvedValueOnce({
+        id: "exp-1",
+        status: "submitted",
+      });
+      mockExecute.mockResolvedValueOnce([]);
+
+      await approveExpense(db)("admin-1", "matchday_admin", "exp-1");
+
+      expect(mockQueryBuilder.innerJoin).not.toHaveBeenCalledWith(
+        "team_official",
+        "team_official.play_cricket_team_id",
+        "matchday.play_cricket_team_id",
+      );
+    });
+
+    it("scopes the lookup to the official's teams", async () => {
+      // Access check hits, then the expense row itself.
+      mockExecuteTakeFirst
+        .mockResolvedValueOnce({ id: "exp-1" })
+        .mockResolvedValueOnce({ id: "exp-1", status: "submitted" });
+      mockExecute.mockResolvedValueOnce([]);
+
+      await approveExpense(db)("official-1", "official", "exp-1");
+
+      expect(mockQueryBuilder.innerJoin).toHaveBeenCalledWith(
+        "team_official",
+        "team_official.play_cricket_team_id",
+        "matchday.play_cricket_team_id",
+      );
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        "team_official.user_id",
+        "=",
+        "official-1",
+      );
+    });
+
+    it("404s an official on another team's expense without touching it", async () => {
+      // Access check misses.
+      mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
+
+      await expect(
+        approveExpense(db)("official-1", "official", "exp-other-team"),
+      ).rejects.toThrow("Expense not found");
+
+      // Same message as a nonexistent id, and no write attempted.
+      expect(mockQueryBuilder.updateTable).not.toHaveBeenCalled();
     });
 
     it("rejects approval of non-submitted expense", async () => {
@@ -346,9 +396,9 @@ describe("expense approval workflow", () => {
         status: "draft",
       });
 
-      await expect(approveExpense(db)("admin-1", "exp-1")).rejects.toThrow(
-        "Only submitted expenses can be approved",
-      );
+      await expect(
+        approveExpense(db)("admin-1", "admin", "exp-1"),
+      ).rejects.toThrow("Only submitted expenses can be approved");
     });
   });
 
@@ -360,7 +410,7 @@ describe("expense approval workflow", () => {
       });
       mockExecute.mockResolvedValueOnce([]);
 
-      const result = await rejectExpense(db)("admin-1", "exp-1", {
+      const result = await rejectExpense(db)("admin-1", "admin", "exp-1", {
         reason: "Missing details",
       });
       expect(result).toEqual({ success: true });
@@ -369,6 +419,76 @@ describe("expense approval workflow", () => {
           status: "rejected",
           rejected_reason: "Missing details",
         }),
+      );
+    });
+
+    it("404s an official on another team's expense", async () => {
+      mockExecuteTakeFirst.mockResolvedValueOnce(undefined);
+
+      await expect(
+        rejectExpense(db)("official-1", "official", "exp-other-team", {
+          reason: "Nope",
+        }),
+      ).rejects.toThrow("Expense not found");
+
+      expect(mockQueryBuilder.updateTable).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listPendingExpenses", () => {
+    it("does not filter by team for club-wide managers", async () => {
+      mockExecute.mockResolvedValueOnce([{ id: "exp-1" }]);
+
+      const result = await listPendingExpenses(db)(
+        "admin-1",
+        "matchday_admin",
+        { limit: 20, offset: 0 },
+      );
+
+      expect(result.items).toEqual([{ id: "exp-1" }]);
+      expect(mockQueryBuilder.selectFrom).not.toHaveBeenCalledWith(
+        "team_official",
+      );
+      expect(mockQueryBuilder.where).not.toHaveBeenCalledWith(
+        "matchday.play_cricket_team_id",
+        "in",
+        expect.anything(),
+      );
+    });
+
+    it("filters to the official's assigned teams", async () => {
+      // getAssignedTeamIds, then the listing itself.
+      mockExecute
+        .mockResolvedValueOnce([{ play_cricket_team_id: "t1" }])
+        .mockResolvedValueOnce([{ id: "exp-1" }]);
+
+      const result = await listPendingExpenses(db)("official-1", "official", {
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(result.items).toEqual([{ id: "exp-1" }]);
+      expect(mockQueryBuilder.selectFrom).toHaveBeenCalledWith("team_official");
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        "matchday.play_cricket_team_id",
+        "in",
+        ["t1"],
+      );
+    });
+
+    it("returns nothing for an official with no team assignments", async () => {
+      mockExecute.mockResolvedValueOnce([]);
+
+      const result = await listPendingExpenses(db)("official-1", "official", {
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(result.items).toEqual([]);
+      // Short-circuited before building the listing query - an empty IN
+      // list is invalid SQL, and there is nothing to return anyway.
+      expect(mockQueryBuilder.selectFrom).not.toHaveBeenCalledWith(
+        "matchday_expense",
       );
     });
   });

--- a/apps/api/src/features/matchday/service.ts
+++ b/apps/api/src/features/matchday/service.ts
@@ -14,7 +14,10 @@ import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 import type { SendPush } from "../../lib/push-sender.ts";
 import type { S3Uploader } from "../../lib/s3-upload.ts";
-import { getAccessibleTeamIds } from "../../lib/team-access.ts";
+import {
+  getAccessibleTeamIds,
+  getAssignedTeamIds,
+} from "../../lib/team-access.ts";
 import { applyReliefIfAny } from "../financial-relief/apply-relief.ts";
 import type { MatchdayChannel } from "../notification-preferences/schemas.ts";
 import {
@@ -2568,8 +2571,43 @@ export function submitExpenseClaim(db: Kysely<DB>, s3: S3Uploader) {
   };
 }
 
+/**
+ * Team-scope guard for expense mutations addressed by expense ID.
+ *
+ * Club-wide matchday managers pass straight through. A scoped official only
+ * passes if the expense hangs off a matchday for one of their assigned teams;
+ * otherwise this throws the same 404 the service raises for an expense that
+ * doesn't exist, so an out-of-scope ID is indistinguishable from a bad one
+ * (same rule as getMatch's "not found or access denied").
+ */
+async function assertExpenseInScope(
+  db: Kysely<DB>,
+  userId: string,
+  role: string,
+  expenseId: string,
+): Promise<void> {
+  if (hasClubWideAccess(role, "matchday", "manage")) return;
+
+  const access = await db
+    .selectFrom("matchday_expense")
+    .innerJoin("matchday", "matchday.id", "matchday_expense.matchday_id")
+    .innerJoin(
+      "team_official",
+      "team_official.play_cricket_team_id",
+      "matchday.play_cricket_team_id",
+    )
+    .where("matchday_expense.id", "=", expenseId)
+    .where("team_official.user_id", "=", userId)
+    .select("matchday_expense.id")
+    .executeTakeFirst();
+
+  if (!access) throwHttpError(404, "Expense not found");
+}
+
 export function approveExpense(db: Kysely<DB>) {
-  return async (adminUserId: string, expenseId: string) => {
+  return async (adminUserId: string, role: string, expenseId: string) => {
+    await assertExpenseInScope(db, adminUserId, role, expenseId);
+
     const expense = await db
       .selectFrom("matchday_expense")
       .where("id", "=", expenseId)
@@ -2602,9 +2640,12 @@ export function approveExpense(db: Kysely<DB>) {
 export function rejectExpense(db: Kysely<DB>) {
   return async (
     adminUserId: string,
+    role: string,
     expenseId: string,
     data: RejectExpense,
   ) => {
+    await assertExpenseInScope(db, adminUserId, role, expenseId);
+
     const expense = await db
       .selectFrom("matchday_expense")
       .where("id", "=", expenseId)
@@ -2633,6 +2674,12 @@ export function rejectExpense(db: Kysely<DB>) {
   };
 }
 
+/**
+ * Paying a claim out is a club-wide treasurer action, not a per-team one, so
+ * there is no team-scope branch here: the route gates it with
+ * requireClubWidePermission and team-scoped officials never reach this
+ * service.
+ */
 export function markExpenseReimbursed(db: Kysely<DB>) {
   return async (adminUserId: string, expenseId: string) => {
     const expense = await db
@@ -2665,7 +2712,16 @@ export function markExpenseReimbursed(db: Kysely<DB>) {
 }
 
 export function listPendingExpenses(db: Kysely<DB>) {
-  return async (params: ListPendingExpenses) => {
+  return async (userId: string, role: string, params: ListPendingExpenses) => {
+    // Team-scoped officials see only expenses raised on their own teams'
+    // matchdays. No assignments means no visible expenses - short-circuit
+    // rather than emit an empty IN list.
+    let assignedTeamIds: string[] | null = null;
+    if (!hasClubWideAccess(role, "matchday", "manage")) {
+      assignedTeamIds = await getAssignedTeamIds(db, userId);
+      if (assignedTeamIds.length === 0) return { items: [] };
+    }
+
     let query = db
       .selectFrom("matchday_expense")
       .innerJoin("matchday", "matchday.id", "matchday_expense.matchday_id")
@@ -2695,6 +2751,14 @@ export function listPendingExpenses(db: Kysely<DB>) {
         "submitted",
         "approved",
       ]);
+    }
+
+    if (assignedTeamIds) {
+      query = query.where(
+        "matchday.play_cricket_team_id",
+        "in",
+        assignedTeamIds,
+      );
     }
 
     if (params.teamId) {

--- a/apps/api/src/lib/team-access.ts
+++ b/apps/api/src/lib/team-access.ts
@@ -26,6 +26,22 @@ export async function getAccessibleTeamIds(
     return allTeams.map((t) => t.id).filter((id): id is string => id !== null);
   }
 
+  return getAssignedTeamIds(db, userId);
+}
+
+/**
+ * The play_cricket_team IDs a caller is assigned to via team_official, with
+ * no club-wide branch of its own.
+ *
+ * Use this (not getAccessibleTeamIds) when the caller has already tested
+ * `hasClubWideAccess` for the specific action it is gating: getAccessibleTeamIds
+ * always tests `matchday:view`, so a caller gating on `matchday:manage` would
+ * be silently handed every team by a role that is club-wide for view only.
+ */
+export async function getAssignedTeamIds(
+  db: Kysely<DB>,
+  userId: string,
+): Promise<string[]> {
   const assignments = await db
     .selectFrom("team_official")
     .where("user_id", "=", userId)

--- a/apps/matchday/src/pages/expenses-mine.tsx
+++ b/apps/matchday/src/pages/expenses-mine.tsx
@@ -39,7 +39,7 @@ export default function ExpensesMine() {
     <div className="mx-auto w-full max-w-2xl pb-6">
       <header className="px-4 pt-6 pb-2">
         <p className="text-text-secondary text-[11px] font-semibold tracking-[0.06em] uppercase">
-          My expenses
+          Team expenses
         </p>
         <h1 className="text-2xl font-semibold tracking-[-0.015em]">Recorded</h1>
       </header>
@@ -69,7 +69,7 @@ export default function ExpensesMine() {
         )}
       {!isLoading && items.length === 0 && (
         <p className="text-text-secondary px-6 py-12 text-center text-sm">
-          You haven't recorded any expenses yet. Add one from the captain's
+          No expenses recorded for your teams yet. Add one from the captain's
           match-day view.
         </p>
       )}

--- a/apps/matchday/src/pages/expenses-mine.tsx
+++ b/apps/matchday/src/pages/expenses-mine.tsx
@@ -8,11 +8,13 @@ type PendingExpense =
   ApiResponse<"/api/matchday/expenses/pending">["items"][number];
 
 /**
- * /expenses/mine — list of matchday expenses the current official has
- * recorded, grouped by status. Re-uses GET /api/matchday/expenses/pending
- * for submitted+approved+reimbursed (treasurer view filtered server-side
- * by caller). For a thorough "draft only" view we'd add a separate
- * endpoint; for v1 this is the most useful surface the captain has.
+ * /expenses/mine — matchday expenses for the current official's teams,
+ * grouped by status. Re-uses GET /api/matchday/expenses/pending for
+ * submitted+approved+reimbursed; since #627 that endpoint filters to the
+ * caller's assigned teams (team_official), so a scoped official sees their
+ * own teams' claims rather than the whole club's. For a true "only the ones
+ * I raised" view we'd add a separate endpoint; for v1 this is the most
+ * useful surface the captain has.
  */
 export default function ExpensesMine() {
   const { data, isLoading } = useQuery({

--- a/apps/web/src/hooks/use-has-permission.ts
+++ b/apps/web/src/hooks/use-has-permission.ts
@@ -2,6 +2,7 @@ import {
   checkPermission,
   hasAdminPanelAccess,
   hasAnyElevatedRole,
+  hasClubWideAccess,
   type Action,
   type Resource,
 } from "@percy-main/shared/auth/permissions";
@@ -22,6 +23,26 @@ export function useHasPermission<R extends Resource>(
   if (!session) return { isPending: false, allowed: false };
   const role = (session.user as { role?: string | null }).role ?? null;
   return { isPending: false, allowed: checkPermission(role, resource, action) };
+}
+
+/**
+ * Like {@link useHasPermission}, but ignores the team-scoped roles
+ * (`official`, `junior_manager`). Mirror of the backend's
+ * requireClubWidePermission preHandler - use it for actions the API gates
+ * club-wide so the UI never offers a control that 403s.
+ */
+export function useHasClubWidePermission<R extends Resource>(
+  resource: R,
+  action: Action<R>,
+): { isPending: boolean; allowed: boolean } {
+  const { data: session, isPending } = useSession();
+  if (isPending) return { isPending: true, allowed: false };
+  if (!session) return { isPending: false, allowed: false };
+  const role = (session.user as { role?: string | null }).role ?? null;
+  return {
+    isPending: false,
+    allowed: hasClubWideAccess(role, resource, action),
+  };
 }
 
 /**

--- a/apps/web/src/pages/admin/admin-panel.tsx
+++ b/apps/web/src/pages/admin/admin-panel.tsx
@@ -1,7 +1,10 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { useSession } from "@/lib/auth-client";
-import { checkPermission } from "@percy-main/shared/auth/permissions";
+import {
+  checkPermission,
+  hasClubWideAccess,
+} from "@percy-main/shared/auth/permissions";
 import { Link, useSearchParams } from "react-router";
 import { AccessTab } from "./access-tab";
 import { ChargesTab } from "./charges-tab";
@@ -62,9 +65,12 @@ const SECTIONS: readonly SectionDef[] = [
         render: () => <GroupsTab />,
       },
       {
+        // Club-wide only (#627): the tab lists every dependent in the club
+        // with guardian contact details, so a team-scoped junior_manager is
+        // 403'd by the API. Their per-team surface is /junior-manager.
         value: "juniors",
         label: "Juniors",
-        visible: (role) => checkPermission(role, "juniors", "view"),
+        visible: (role) => hasClubWideAccess(role, "juniors", "view"),
         render: () => <JuniorsTab />,
       },
       {

--- a/apps/web/src/pages/admin/treasurer-expenses-section.tsx
+++ b/apps/web/src/pages/admin/treasurer-expenses-section.tsx
@@ -16,6 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useHasClubWidePermission } from "@/hooks/use-has-permission";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -70,6 +71,10 @@ export function TreasurerExpensesSection({
   dateTo,
 }: TreasurerExpensesSectionProps) {
   const queryClient = useQueryClient();
+  // Paying out is a club-wide treasurer action (#627) - a team-scoped
+  // official holds matchday:manage but the API refuses the reimburse call,
+  // so don't offer the button.
+  const canReimburse = useHasClubWidePermission("matchday", "manage").allowed;
   const [selectedExpense, setSelectedExpense] = useState<Expense | null>(null);
   const [rejectingId, setRejectingId] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState("");
@@ -374,7 +379,7 @@ export function TreasurerExpensesSection({
                     )}
                   </>
                 )}
-                {selectedExpense.status === "approved" && (
+                {selectedExpense.status === "approved" && canReimburse && (
                   <Button
                     size="sm"
                     disabled={anyActionPending}

--- a/docs/adrs/058-team-scope-enforced-in-services.md
+++ b/docs/adrs/058-team-scope-enforced-in-services.md
@@ -1,0 +1,56 @@
+# Decision 058: Team scope enforced in services, juniors admin club-wide only
+
+**Date:** 2026-08-21
+**Status:** Accepted
+
+## Decision
+
+Roles documented as team-scoped are now enforced as team-scoped in the places that were only checking the generic permission:
+
+- **Matchday expenses and game reports** filter and 404 by the caller's `team_official` assignments, in the service layer, the same way `listMatches` / `getMatch` already did.
+- **Expense reimbursement** is club-wide only. A team-scoped `official` cannot pay a claim out, even one raised on their own team.
+- **The admin Juniors tab is club-wide only.** `junior_manager` loses it entirely rather than getting a scoped version of it, because there is nothing in the schema to scope it by. Their per-team `/junior-manager` area is unaffected.
+
+Route-level gates (`requireClubWidePermission`) express "this action has no per-team meaning". Service-level filters express "this action is per-team, show me mine". Nothing new was built for either: both mechanisms already existed and were simply not applied to these paths.
+
+## Problem
+
+`SCOPED_ROLES` (`official`, `junior_manager`) grant full `matchday` / `juniors` permissions, with the per-team restriction enforced separately by service-layer code against the `team_official` and `junior_team_manager` join tables. Several endpoints only ran `checkPermission` and then queried by ID with no scope filter at all, so the documented restriction did not exist there:
+
+- any `matchday:manage` holder could list, approve, reject and reimburse **every** team's expense claims;
+- game reports - which carry per-player charge amounts and expense totals - were unfiltered;
+- a `junior_manager` could list **every** dependent in the club with guardian contact details, and link or unlink arbitrary dependent IDs.
+
+The last one is the sharp end: a role handed out per junior team could enumerate every minor's PII in the club.
+
+## Options considered
+
+**A. Build the real juniors scoping model.** Add a dependent-to-junior-team association (migration, assignment UI, filtered queries), then scope the juniors endpoints by it the same way matchday is scoped by `team_official`.
+
+**B. Make the juniors admin endpoints club-wide only.** Gate them on `hasClubWideAccess` so only `juniors_viewer` / `juniors_admin` / `admin` reach them, and remove the tab from scoped junior managers.
+
+**C. Derive the association at query time** from `dependent.school_year` / `dependent.sex` against `junior_team.age_group` / `junior_team.sex`.
+
+For reimbursement, the parallel question was whether a scoped official should be able to reimburse their own team's claims (team-scope filter, like approve/reject) or not at all (club-wide gate).
+
+## Rationale
+
+Option B, plus a club-wide gate on reimbursement.
+
+There is no dependent-to-junior-team membership table today, so true scoping for juniors is not currently _expressible_ - option A is a feature, not a fix, and leaving the hole open while it is built is not acceptable for minors' PII. Option B closes it now with machinery that already exists, and costs a small number of `junior_manager` holders a tab they should arguably never have had. Their actual working surface, the per-team `/junior-manager` area backed by `junior_team_manager`, is untouched.
+
+Reimbursement is a treasurer action: it records that money left the club's account. That is a whole-club financial fact, not a per-team one, and it is the point in the workflow where a self-approving official would be cashing their own claim. Gating it club-wide keeps approve/reject usefully delegated to team officials while keeping the payout with the treasurer.
+
+Mutations by ID 404 rather than 403 on an out-of-scope target, matching `getMatch`'s existing "not found or access denied" behaviour, so an expense or report belonging to another team is indistinguishable from one that does not exist.
+
+## Rejected alternatives
+
+**A. Build the real juniors scoping model.** Rejected as the immediate fix only - it remains the right long-term answer. It becomes attractive as soon as junior managers actually need club-record access for their own teams (checking guardian contacts for their squad, say). Doing it needs a membership table, an assignment UI in the admin panel, and filtered queries; at that point the juniors endpoints move from `requireClubWidePermission` back to `requirePermission` plus a service-layer filter, exactly like matchday.
+
+**C. Derive juniors scope from age group and sex.** Rejected: it encodes a guess about squad membership as an authorisation boundary. Age groups and teams do not line up cleanly (a player can play up, a team can span years, mixed teams exist), so the derivation would be wrong in both directions - silently hiding a manager's own players, and silently exposing children they have nothing to do with. An authorisation rule should be a fact someone recorded, not an inference.
+
+**Team-scoping reimbursement instead of gating it.** Rejected per the above. If reimbursement is ever delegated to team budgets, the filter is the same one already applied to approve and reject.
+
+## Follow-ups
+
+`finance_admin` - the role a treasurer would most naturally hold - still cannot reimburse, because these routes gate on `matchday:manage` and always have. In practice today's treasurers hold the legacy kitchen-sink `admin` role, so nothing regressed, but if the reimburse gate should follow the finance resource rather than matchday, that is a deliberate change to make on its own.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -36,3 +36,4 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 | [055](055-content-assistant-edit-ops-and-sidebar.md)     | Content assistant edit-op protocol + persistent sidebar            | 2026-07-09 | Accepted |
 | [056](056-dnb-rows-stay-in-batting-table.md)             | "Did not bat" rows stay in the batting table with a did_bat flag   | 2026-07-26 | Accepted |
 | [057](057-reviewer-gated-terraform-pr-plans.md)          | Reviewer-gated Terraform PR plans instead of a de-scoped plan role | 2026-08-20 | Accepted |
+| [058](058-team-scope-enforced-in-services.md)            | Team scope enforced in services, juniors admin club-wide only      | 2026-08-21 | Accepted |

--- a/packages/shared/src/auth/permissions.test.ts
+++ b/packages/shared/src/auth/permissions.test.ts
@@ -4,8 +4,11 @@ import {
   ASSIGNABLE_ROLES,
   checkPermission,
   hasAdminPanelAccess,
+  hasAnyElevatedRole,
+  hasClubWideAccess,
   ROLE_LABELS,
   roles,
+  SCOPED_ROLES,
   type Action,
   type Resource,
 } from "./permissions.js";
@@ -120,5 +123,47 @@ describe("content roles", () => {
       expect(ROLE_LABELS[role]).toBeTruthy();
       expect(roles[role]).toBeDefined();
     }
+  });
+});
+
+describe("club-wide vs team-scoped access (#627)", () => {
+  it("hasClubWideAccess ignores the scoped roles", () => {
+    for (const role of SCOPED_ROLES) {
+      expect(hasAnyElevatedRole(role)).toBe(true);
+    }
+
+    // junior_manager and official hold the permission, but only per-team.
+    expect(checkPermission("junior_manager", "juniors", "view")).toBe(true);
+    expect(hasClubWideAccess("junior_manager", "juniors", "view")).toBe(false);
+    expect(checkPermission("official", "matchday", "manage")).toBe(true);
+    expect(hasClubWideAccess("official", "matchday", "manage")).toBe(false);
+
+    // Club-wide equivalents are unaffected.
+    expect(hasClubWideAccess("juniors_admin", "juniors", "manage")).toBe(true);
+    expect(hasClubWideAccess("matchday_admin", "matchday", "manage")).toBe(
+      true,
+    );
+    expect(hasClubWideAccess("admin", "juniors", "view")).toBe(true);
+  });
+
+  it("a scoped role does not mask a club-wide one held alongside it", () => {
+    expect(hasClubWideAccess("official,juniors_admin", "juniors", "view")).toBe(
+      true,
+    );
+    expect(
+      hasClubWideAccess("junior_manager,official", "juniors", "view"),
+    ).toBe(false);
+  });
+
+  it("junior_manager alone no longer counts as admin-panel access", () => {
+    // The Juniors sub-tab is its only surface and that is now club-wide
+    // only, so counting it would land them on an empty /admin.
+    expect(hasAdminPanelAccess("junior_manager")).toBe(false);
+    expect(hasAdminPanelAccess("juniors_viewer")).toBe(true);
+    expect(hasAdminPanelAccess("juniors_admin")).toBe(true);
+
+    // `official` keeps its (team-filtered) Game Reports sub-tab.
+    expect(hasAdminPanelAccess("official")).toBe(true);
+    expect(hasAdminPanelAccess("junior_manager,official")).toBe(true);
   });
 });

--- a/packages/shared/src/auth/permissions.ts
+++ b/packages/shared/src/auth/permissions.ts
@@ -255,7 +255,10 @@ export function hasAdminPanelAccess(
     checkPermission(rawRole, "users", "view") ||
     checkPermission(rawRole, "users", "manage") ||
     checkPermission(rawRole, "users", "manage_roles") ||
-    checkPermission(rawRole, "juniors", "view") ||
+    // Club-wide, matching the Juniors sub-tab's own gate (#627): a scoped
+    // junior_manager has juniors:view but no admin-panel surface, so counting
+    // it here would leave them on an empty /admin.
+    hasClubWideAccess(rawRole, "juniors", "view") ||
     checkPermission(rawRole, "marketing", "view") ||
     checkPermission(rawRole, "finance", "view") ||
     checkPermission(rawRole, "finance", "manage") ||


### PR DESCRIPTION
Closes #627

## Summary

Roles documented as team-scoped (`official`, `junior_manager`) were authorised by the generic permission only, so on several endpoints the per-team restriction did not exist at all. A team-scoped official could read and act on every team's expense claims and game reports; a `junior_manager` could list every dependent in the club with guardian contact details and link or unlink arbitrary dependent IDs.

The scoping machinery already existed (`SCOPED_ROLES` + `hasClubWideAccess`, the `team_official` join in `listMatches` / `getMatch`, and the `requireClubWidePermission` preHandler). This applies it to the paths that never adopted it. Nothing new was invented.

### Team-scoped in the service layer

| Endpoint | Gate |
| --- | --- |
| `GET /matchday/expenses/pending` | filtered to the caller's `team_official` assignments |
| `POST /matchday/expenses/:id/approve` | verify then 404 |
| `POST /matchday/expenses/:id/reject` | verify then 404 |
| `GET /admin/game-reports` | filtered, list **and** count query |
| `GET /admin/game-reports/:matchdayId` | verify then 404 |

Mutations by ID throw the same 404 and message as a nonexistent expense or matchday, matching `getMatch`'s existing "not found or access denied" rule, so an out-of-scope ID is indistinguishable from a bad one. The count query on game reports is filtered too, so pagination totals can't hint at the size of the fixture list an official can't see.

### Club-wide only, at the route

| Endpoint | Gate |
| --- | --- |
| `POST /matchday/expenses/:id/reimburse` | `requireClubWidePermission("matchday", "manage")` |
| `GET /admin/juniors` | `requireClubWidePermission("juniors", "view")` |
| `GET /admin/juniors/search-users` | `requireClubWidePermission("juniors", "view")` |
| `POST /admin/juniors/link` | `requireClubWidePermission("juniors", "manage")` |
| `POST /admin/juniors/unlink` | `requireClubWidePermission("juniors", "manage")` |
| `GET /admin/junior-teams` | club-wide `juniors:view`, **or** `users:manage_roles` |

## The two decisions applied

**Juniors are club-wide only (Q1).** No dependent-to-junior-team scoping model was built. There is no such association in the schema, so true scoping isn't currently expressible - and leaving the hole open while it gets built isn't acceptable for minors' PII. `junior_manager` loses the admin Juniors tab entirely and keeps its per-team `/junior-manager` area, which is backed by `junior_team_manager` and untouched here.

**Reimbursement is treasurer-only (Q2).** `mark-reimbursed` is gated club-wide rather than team-scoped: it records that money left the club's account, and it's the point where a self-approving official would be cashing their own claim. Approve and reject stay delegated to team officials, team-scoped.

`/admin/junior-teams` is the reference list of junior team names. It keeps its second branch - a standalone superadmin needs it to assign scoped roles from the Access tab, which is its only UI consumer - so `requireAnyPermission` gained a per-check `clubWide` flag rather than being split into a separate helper.

Recorded as [ADR 058](docs/adrs/058-team-scope-enforced-in-services.md), including why the alternatives (build the membership model now; derive scope from age group and sex) were rejected and what would make the first one attractive later.

## User-visible behaviour changes

- **Junior managers lose the Juniors tab.** The admin panel sub-tab is hidden and the API 403s. A user whose *only* role is `junior_manager` also stops seeing the "Admin Panel" link - `hasAdminPanelAccess` no longer counts scoped juniors access, because that tab was their only surface and they would otherwise land on an empty `/admin`. Their `/junior-manager` area is unchanged.
- **Team-scoped officials lose "Mark Reimbursed".** The button is hidden (it lives in the Treasurer tab, so in practice only an `official` who also holds `finance_admin` ever saw it) and the API 403s.
- **Officials see less, correctly.** Game reports and the Matchday PWA expenses page now show their assigned teams only rather than the whole club. That page's comment already claimed this filtering happened server-side; now it does, and its copy ("My expenses" / "You haven't recorded any expenses yet") was corrected to describe team claims, which is what it has always actually listed.
- Club-wide roles (`matchday_admin`, `matchday_viewer`, `juniors_admin`, `juniors_viewer`, legacy `admin`) are unaffected throughout.

## Assumptions

- `hasClubWideAccess` is checked against the action the route itself gates - `matchday:manage` for expenses, `matchday:view` for game reports - rather than reusing `getAccessibleTeamIds`, which always tests `matchday:view`. A new `getAssignedTeamIds` sits alongside it with no club-wide branch, so the club-wide test and the filter can't drift apart (otherwise a `matchday_viewer,official` would pass a `manage` gate via the scoped role and then be handed every team by the view-based helper).
- No response schemas changed, so no OpenAPI regeneration; `pnpm run openapi:generate` produces no diff.

## Tests

Authorisation logic guarding minors' PII and money, so it's covered at all three levels. **761 unit tests and 88 integration tests pass**; lint, typecheck and `format:check` are clean.

- **New HTTP integration suite** (`apps/api/src/features/admin/club-wide-gates-integration.test.ts`, 10 tests) drives the real stack - better-auth sessions, `requireAuth`, `requireClubWidePermission`. `junior_manager` 403s on all four juniors routes (table-driven, with well-formed payloads since schema validation runs before `preHandler`); `juniors_admin` passes; `juniors_viewer` reads but can't link; the refusal body leaks nothing. `official` 403s on reimburse while `matchday_admin` gets through to a 404, and `official` still reaches approve/reject (404, not 403 - proving the gate moved to the service, not the door).
- **Service integration tests** against real PostgreSQL: two teams, an official assigned to one. Cross-team expense list filtering, cross-team approve/reject 404 with the row verifiably untouched, out-of-scope vs nonexistent IDs returning byte-identical refusals, the no-assignments case, and the same set for game reports including the filtered count.
- **Unit tests** for the query shapes (join vs no join, `in` filter present or absent), the `hasClubWideAccess` / `hasAdminPanelAccess` wiring in `packages/shared`, and the `requireClubWidePermission` preHandler for the juniors resource including multi-role strings.

One unrelated fix was needed: seeding a `matchday_admin` in the matchday integration file inflates the recipient counts asserted by the `withdrawFromMatch` notification tests (that service emails every club-wide matchday admin). The new fixtures use the legacy `admin` role, which that path deliberately excludes; the comment explains why so nobody "tidies" it back.

## Open questions

1. **Should reimburse follow `finance` rather than `matchday`?** "Treasurer-only" is implemented as club-wide `matchday:manage`, because that's what the route has always required. A pure `finance_admin` - the role an actual treasurer would most naturally hold - still can't reimburse, and couldn't before this PR either. Nothing regressed (today's treasurers hold the kitchen-sink `admin` role), but if the gate should be "club-wide `matchday:manage` **or** `finance:manage`" that's a deliberate widening, so I left it alone. Noted in the ADR's follow-ups.
2. **`junior_manager` is left with no admin-panel surface at all.** If any current holder actually uses the juniors tab day to day, they need `juniors_viewer` adding alongside their scoped role - that grants club-wide read, which is the whole point of the decision, so it's a judgement call per person rather than something to automate.
3. **`submitExpenseClaim`, `updateExpense` and `deleteExpense` still scope via `getAccessibleTeamIds`**, i.e. against `matchday:view`. That's pre-existing and out of scope here, but it means a `matchday_viewer,official` combination is treated as club-wide for those three. Worth a follow-up if that combination is ever assigned in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access Control**
  - Enforced team-based access for game reports and expense management.
  - Restricted reimbursement and Juniors administration to club-wide roles.
  - Prevented unauthorized users from viewing or modifying out-of-scope records.

- **User Interface**
  - Juniors administration and reimbursement controls now appear only for eligible roles.
  - Clarified that officials see expenses for their assigned teams.

- **Bug Fixes**
  - Improved handling of inaccessible records with consistent not-found responses.
  - Prevented unauthorized data and financial details from being exposed.

- **Documentation**
  - Documented team-scoped access rules and related authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
