### PR TITLE
security(web): clear and user-scope React Query data across account transitions

### DIFF
--- a/apps/api/src/features/fantasy/schemas.ts
+++ b/apps/api/src/features/fantasy/schemas.ts
@@ -430,7 +430,21 @@ export const myTeamResponseSchema = z.object({
       created_at: z.string(),
     })
     .nullable(),
-  players: z.array(z.record(z.string(), z.unknown())),
+  // Declared field by field rather than as a loose record: the generated
+  // client typed these rows as `{ [key: string]: unknown }`, which forced a
+  // hand-rolled interface and an `as unknown as` cast in the web app. Only
+  // the fields the squad builder renders are exposed - the join also carries
+  // internal row ids and gameweek bookkeeping that no client needs.
+  players: z.array(
+    z.object({
+      play_cricket_id: z.string(),
+      player_name: z.string(),
+      sandwich_cost: z.number(),
+      is_captain: z.boolean(),
+      slot_type: slotTypeSchema,
+      is_wicketkeeper: z.boolean(),
+    }),
+  ),
   gameweek: z.number(),
   transfersUsed: z.number(),
   maxTransfers: z.number().nullable(),

--- a/apps/api/src/features/fantasy/service.ts
+++ b/apps/api/src/features/fantasy/service.ts
@@ -116,6 +116,18 @@ export function getEligiblePlayers(db: Kysely<DB>) {
   };
 }
 
+const SLOT_TYPES = ["batting", "bowling", "allrounder"] as const;
+
+/**
+ * `fantasy_team_player.slot_type` is a plain text column. Only saveTeam
+ * writes it and its input is enum-validated, so an out-of-range value means
+ * hand-edited data; treat it as a batting slot rather than failing the
+ * whole squad response.
+ */
+function toSlotType(value: string): (typeof SLOT_TYPES)[number] {
+  return SLOT_TYPES.find((slot) => slot === value) ?? "batting";
+}
+
 export function getMyTeam(db: Kysely<DB>) {
   return async (userId: string, season?: string) => {
     const s = season ?? getCurrentSeason();
@@ -204,7 +216,18 @@ export function getMyTeam(db: Kysely<DB>) {
 
     return {
       team,
-      players,
+      // Projected to the six fields the squad builder renders. The join also
+      // carries row ids and gameweek bookkeeping, which no client needs and
+      // which used to reach the browser through this endpoint's untyped
+      // `players` array.
+      players: players.map((p) => ({
+        play_cricket_id: p.play_cricket_id,
+        player_name: p.player_name,
+        sandwich_cost: p.sandwich_cost,
+        is_captain: p.is_captain,
+        slot_type: toSlotType(p.slot_type),
+        is_wicketkeeper: p.is_wicketkeeper,
+      })),
       gameweek,
       transfersUsed,
       maxTransfers: unlimitedTransfers ? null : MAX_TRANSFERS_PER_GAMEWEEK,

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -1818,7 +1818,13 @@ export interface paths {
                                 created_at: string;
                             } | null;
                             players: {
-                                [key: string]: unknown;
+                                play_cricket_id: string;
+                                player_name: string;
+                                sandwich_cost: number;
+                                is_captain: boolean;
+                                /** @enum {string} */
+                                slot_type: "batting" | "bowling" | "allrounder";
+                                is_wicketkeeper: boolean;
                             }[];
                             gameweek: number;
                             transfersUsed: number;

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -3171,7 +3171,40 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "additionalProperties": {}
+                        "properties": {
+                          "play_cricket_id": {
+                            "type": "string"
+                          },
+                          "player_name": {
+                            "type": "string"
+                          },
+                          "sandwich_cost": {
+                            "type": "number"
+                          },
+                          "is_captain": {
+                            "type": "boolean"
+                          },
+                          "slot_type": {
+                            "type": "string",
+                            "enum": [
+                              "batting",
+                              "bowling",
+                              "allrounder"
+                            ]
+                          },
+                          "is_wicketkeeper": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "play_cricket_id",
+                          "player_name",
+                          "sandwich_cost",
+                          "is_captain",
+                          "slot_type",
+                          "is_wicketkeeper"
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "gameweek": {

--- a/apps/web/src/components/members/change-password.tsx
+++ b/apps/web/src/components/members/change-password.tsx
@@ -1,7 +1,8 @@
 import { SimpleInput } from "@/components/form/simple-input";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useReducer } from "react";
 
 const MIN_PASSWORD_LENGTH = 8;
@@ -53,6 +54,7 @@ function formReducer(state: FormState, action: FormAction): FormState {
 
 export function ChangePassword() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [form, dispatch] = useReducer(formReducer, initialState);
   const {
     currentPassword,
@@ -62,7 +64,7 @@ export function ChangePassword() {
     success,
   } = form;
 
-  const { data: accounts, isLoading: accountsLoading } = useQuery({
+  const { data: accounts, isLoading: accountsLoading } = useAuthedQuery({
     queryKey: ["accounts"],
     queryFn: async () => {
       const result = await authClient.listAccounts();
@@ -90,7 +92,7 @@ export function ChangePassword() {
     },
     onSuccess: () => {
       dispatch({ type: "submitSucceeded" });
-      void queryClient.invalidateQueries({ queryKey: ["accounts"] });
+      void queryClient.invalidateQueries({ queryKey: authedKey(["accounts"]) });
     },
   });
 

--- a/apps/web/src/components/members/charges.tsx
+++ b/apps/web/src/components/members/charges.tsx
@@ -19,7 +19,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { formatDate } from "date-fns";
 import { useMemo, useState } from "react";
 
@@ -35,7 +36,7 @@ type ChargeRow = NonNullable<
 >["charges"][number];
 
 function useChargesQuery() {
-  return useQuery({
+  return useAuthedQuery({
     queryKey: ["myCharges"],
     queryFn: () => callApi(api.GET("/api/charges")),
   });
@@ -43,6 +44,7 @@ function useChargesQuery() {
 
 export function Charges() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [paymentError, setPaymentError] = useState<string | null>(null);
   const [paymentData, setPaymentData] = useState<{
     clientSecret: string;
@@ -100,7 +102,9 @@ export function Charges() {
           paymentIntentId: piId,
         });
       }
-      void queryClient.invalidateQueries({ queryKey: ["myCharges"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["myCharges"]),
+      });
     },
     onError: () => {
       setPaymentError("Failed to create payment. Please try again.");
@@ -137,7 +141,9 @@ export function Charges() {
             })
             .finally(() => {
               setPaymentData(null);
-              void queryClient.invalidateQueries({ queryKey: ["myCharges"] });
+              void queryClient.invalidateQueries({
+                queryKey: authedKey(["myCharges"]),
+              });
             });
         }}
         onCancel={() => setPaymentData(null)}

--- a/apps/web/src/components/members/documents.tsx
+++ b/apps/web/src/components/members/documents.tsx
@@ -9,7 +9,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { useNavigate } from "react-router";
 
 function formatDate(iso: string) {
@@ -23,7 +23,7 @@ function formatDate(iso: string) {
 export function Documents() {
   const navigate = useNavigate();
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["myDocuments"],
     queryFn: () => callApi(api.GET("/api/documents")),
   });

--- a/apps/web/src/components/members/financial-relief-status.tsx
+++ b/apps/web/src/components/members/financial-relief-status.tsx
@@ -1,8 +1,8 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { REQUEST_STATUS_LABELS } from "@percy-main/shared";
-import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 
 /**
@@ -15,7 +15,7 @@ import { Link } from "react-router";
  * make another one" appearing for members mid-review.
  */
 export function FinancialReliefStatus() {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["financial-relief", "me"],
     queryFn: () => callApi(api.GET("/api/financial-relief/me")),
   });

--- a/apps/web/src/components/members/member-details.tsx
+++ b/apps/web/src/components/members/member-details.tsx
@@ -2,11 +2,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 export function useMemberDetails() {
-  return useQuery({
+  return useAuthedQuery({
     queryKey: ["memberDetails"],
     queryFn: () => callApi(api.GET("/api/members/me")),
   });
@@ -78,6 +79,7 @@ function EditView({
   onSaved: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const initial = member ?? { ...emptyMember, name: defaultName ?? null };
   const [form, setForm] = useState<NonNullable<MemberData>>(initial);
 
@@ -104,7 +106,9 @@ function EditView({
       );
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["memberDetails"] });
+      await queryClient.invalidateQueries({
+        queryKey: authedKey(["memberDetails"]),
+      });
       onSaved();
     },
   });

--- a/apps/web/src/components/members/membership.tsx
+++ b/apps/web/src/components/members/membership.tsx
@@ -1,5 +1,5 @@
 import { api, callApi } from "@/lib/api-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { formatDate, isPast, parseISO } from "date-fns";
 import { Link } from "react-router";
 import { match } from "ts-pattern";
@@ -9,12 +9,12 @@ export function Membership() {
     data: membershipData,
     isLoading,
     isError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["membership"],
     queryFn: () => callApi(api.GET("/api/members/me/membership")),
   });
 
-  const { data: dependentsData } = useQuery({
+  const { data: dependentsData } = useAuthedQuery({
     queryKey: ["dependents"],
     queryFn: () => callApi(api.GET("/api/junior/dependents")),
   });

--- a/apps/web/src/components/members/passkeys.tsx
+++ b/apps/web/src/components/members/passkeys.tsx
@@ -1,7 +1,8 @@
 import { SimpleInput } from "@/components/form/simple-input";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { formatDate } from "date-fns";
 import { useState } from "react";
 import { IoTrashBinOutline } from "react-icons/io5";
@@ -9,8 +10,9 @@ import { IoTrashBinOutline } from "react-icons/io5";
 export function Passkeys() {
   const [newPasskeyName, setNewPasskeyName] = useState("");
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
-  const { data: passkeys } = useQuery({
+  const { data: passkeys } = useAuthedQuery({
     queryKey: ["passkeys"],
     queryFn: async () => {
       const result = await authClient.passkey.listUserPasskeys();
@@ -28,7 +30,7 @@ export function Passkeys() {
       return result.data;
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
+      void queryClient.invalidateQueries({ queryKey: authedKey(["passkeys"]) });
     },
   });
 
@@ -40,7 +42,7 @@ export function Passkeys() {
       return result.data;
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
+      void queryClient.invalidateQueries({ queryKey: authedKey(["passkeys"]) });
       setNewPasskeyName("");
     },
   });

--- a/apps/web/src/components/members/subscriptions.tsx
+++ b/apps/web/src/components/members/subscriptions.tsx
@@ -1,9 +1,9 @@
 import { api, callApi } from "@/lib/api-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { formatDate } from "date-fns";
 
 export function Subscriptions() {
-  const { data } = useQuery({
+  const { data } = useAuthedQuery({
     queryKey: ["subscriptions"],
     queryFn: () => callApi(api.GET("/api/members/me/subscriptions")),
   });

--- a/apps/web/src/components/require-auth.tsx
+++ b/apps/web/src/components/require-auth.tsx
@@ -15,5 +15,10 @@ export function RequireAuth() {
     return <Navigate to={`/auth/login?returnTo=${returnTo}`} replace />;
   }
 
-  return <Outlet />;
+  // Keying the whole authenticated subtree on the user id forces a remount
+  // when the signed-in account changes, so component-local state cannot
+  // straddle two identities (#628). Clearing the query cache is not enough
+  // on its own: state seeded from query data on mount (TeamBuilder's squad,
+  // for one) keeps the previous user's values until the component unmounts.
+  return <Outlet key={session.user.id} />;
 }

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -1818,7 +1818,13 @@ export interface paths {
                                 created_at: string;
                             } | null;
                             players: {
-                                [key: string]: unknown;
+                                play_cricket_id: string;
+                                player_name: string;
+                                sandwich_cost: number;
+                                is_captain: boolean;
+                                /** @enum {string} */
+                                slot_type: "batting" | "bowling" | "allrounder";
+                                is_wicketkeeper: boolean;
                             }[];
                             gameweek: number;
                             transfersUsed: number;

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -3171,7 +3171,40 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "additionalProperties": {}
+                        "properties": {
+                          "play_cricket_id": {
+                            "type": "string"
+                          },
+                          "player_name": {
+                            "type": "string"
+                          },
+                          "sandwich_cost": {
+                            "type": "number"
+                          },
+                          "is_captain": {
+                            "type": "boolean"
+                          },
+                          "slot_type": {
+                            "type": "string",
+                            "enum": [
+                              "batting",
+                              "bowling",
+                              "allrounder"
+                            ]
+                          },
+                          "is_wicketkeeper": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "play_cricket_id",
+                          "player_name",
+                          "sandwich_cost",
+                          "is_captain",
+                          "slot_type",
+                          "is_wicketkeeper"
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "gameweek": {

--- a/apps/web/src/lib/authed-query.test.tsx
+++ b/apps/web/src/lib/authed-query.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The real auth client builds a better-auth instance at import time; the
+// hooks under test only need a session shape.
+const session: { current: { user: { id: string } } | null } = { current: null };
+vi.mock("@/lib/auth-client.js", () => ({
+  useSession: () => ({ data: session.current, isPending: false }),
+}));
+
+import {
+  ANONYMOUS_USER_KEY,
+  AUTHED_KEY_NAMESPACE,
+  authedQueryKey,
+  useAuthedQuery,
+  useAuthedQueryKey,
+} from "./authed-query.js";
+
+function render(node: React.ReactNode, client: QueryClient) {
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>{node}</QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  session.current = null;
+});
+
+describe("authedQueryKey", () => {
+  it("fronts the logical key with the namespace and the owning user", () => {
+    expect(authedQueryKey("user-a", ["fantasy", "my-team"])).toEqual([
+      AUTHED_KEY_NAMESPACE,
+      "user-a",
+      "fantasy",
+      "my-team",
+    ]);
+  });
+
+  it("gives two accounts different keys for the same logical query", () => {
+    expect(authedQueryKey("user-a", ["fantasy", "my-team"])).not.toEqual(
+      authedQueryKey("user-b", ["fantasy", "my-team"]),
+    );
+  });
+});
+
+describe("useAuthedQueryKey", () => {
+  // Rendered as a slash-joined string: renderToStaticMarkup escapes the
+  // quotes JSON.stringify would produce.
+  function Probe() {
+    const authedKey = useAuthedQueryKey();
+    return <span>{(authedKey(["myCharges"]) as string[]).join("/")}</span>;
+  }
+
+  it("builds keys for the signed-in user", () => {
+    session.current = { user: { id: "user-b" } };
+
+    const html = render(<Probe />, new QueryClient());
+
+    expect(html).toContain(`${AUTHED_KEY_NAMESPACE}/user-b/myCharges`);
+  });
+
+  it("falls back to the anonymous bucket with no session", () => {
+    const html = render(<Probe />, new QueryClient());
+
+    expect(html).toContain(
+      `${AUTHED_KEY_NAMESPACE}/${ANONYMOUS_USER_KEY}/myCharges`,
+    );
+  });
+});
+
+describe("useAuthedQuery", () => {
+  function Squad() {
+    const { data } = useAuthedQuery({
+      queryKey: ["fantasy", "my-team"],
+      queryFn: () => Promise.resolve({ captain: "unfetched" }),
+    });
+    return <span>{data?.captain ?? "no data"}</span>;
+  }
+
+  it("registers the query under the user-prefixed key", () => {
+    session.current = { user: { id: "user-a" } };
+    const client = new QueryClient();
+
+    render(<Squad />, client);
+
+    expect(
+      client
+        .getQueryCache()
+        .getAll()
+        .map((q) => q.queryKey),
+    ).toEqual([[AUTHED_KEY_NAMESPACE, "user-a", "fantasy", "my-team"]]);
+  });
+
+  it("does not read another account's entry for the same logical key", () => {
+    // The leak in #628: one page-lifetime cache holding both accounts.
+    const client = new QueryClient();
+    client.setQueryData(authedQueryKey("user-a", ["fantasy", "my-team"]), {
+      captain: "Alice Alpha",
+    });
+    client.setQueryData(authedQueryKey("user-b", ["fantasy", "my-team"]), {
+      captain: "Bob Beta",
+    });
+
+    session.current = { user: { id: "user-b" } };
+    const html = render(<Squad />, client);
+
+    expect(html).toContain("Bob Beta");
+    expect(html).not.toContain("Alice Alpha");
+  });
+});

--- a/apps/web/src/lib/authed-query.test.tsx
+++ b/apps/web/src/lib/authed-query.test.tsx
@@ -13,6 +13,8 @@ import {
   ANONYMOUS_USER_KEY,
   AUTHED_KEY_NAMESPACE,
   authedQueryKey,
+  formatKeyForTelemetry,
+  REDACTED_USER_KEY,
   useAuthedQuery,
   useAuthedQueryKey,
 } from "./authed-query.js";
@@ -41,6 +43,29 @@ describe("authedQueryKey", () => {
     expect(authedQueryKey("user-a", ["fantasy", "my-team"])).not.toEqual(
       authedQueryKey("user-b", ["fantasy", "my-team"]),
     );
+  });
+});
+
+describe("formatKeyForTelemetry", () => {
+  it("drops the account id from a user-scoped key", () => {
+    const formatted = formatKeyForTelemetry(
+      authedQueryKey("user-a", ["fantasy", "my-team"]),
+    );
+
+    expect(formatted).toBe(
+      `${AUTHED_KEY_NAMESPACE}:${REDACTED_USER_KEY}:fantasy:my-team`,
+    );
+    expect(formatted).not.toContain("user-a");
+  });
+
+  it("leaves a public key untouched", () => {
+    expect(formatKeyForTelemetry(["content", "page", "/club/history"])).toBe(
+      "content:page:/club/history",
+    );
+  });
+
+  it("keeps skipping non-string segments", () => {
+    expect(formatKeyForTelemetry(["games", 2026, null])).toBe("games");
   });
 });
 

--- a/apps/web/src/lib/authed-query.ts
+++ b/apps/web/src/lib/authed-query.ts
@@ -1,0 +1,100 @@
+import { useSession } from "@/lib/auth-client.js";
+import {
+  useQuery,
+  type QueryKey,
+  type UseQueryOptions,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+
+/**
+ * User-scoped query caching (#628).
+ *
+ * Two accounts share one page-lifetime QueryClient, so any key that
+ * addresses "the signed-in user's data" has to carry the user's identity.
+ * Without it, `["fantasy", "my-team"]` means user A's squad before a logout
+ * and user B's squad after, and react-query cannot tell the difference:
+ * B renders A's cached squad and can save it as their own.
+ *
+ * `resetAuthCaches` (lib/query-client.ts) wipes the cache at each account
+ * transition, and this module is the second line of defence: even if a new
+ * login path forgets to reset, a key built here can never resolve to
+ * another account's entry.
+ *
+ * PUBLIC content stays unprefixed. `["content", ...]`, `["games", ...]` and
+ * friends are seeded from the prerendered document's dehydrated state
+ * (ADR 052), which is generated with no session at all - prefixing those
+ * keys would orphan the seed and reintroduce the hydration flash.
+ */
+
+/**
+ * Namespace fronting every user-scoped key. Makes the convention greppable
+ * and keeps prefixed keys from colliding with a public key that happens to
+ * start with a user id.
+ */
+export const AUTHED_KEY_NAMESPACE = "user-scoped";
+
+/**
+ * Stand-in identity for a user-scoped query rendered without a resolved
+ * session. Everything behind `RequireAuth` has a session before it mounts,
+ * but a public page can hold a user-scoped query gated on `enabled`
+ * (`["availability", "active"]` on the public availability page). Keying
+ * those under a reserved id keeps signed-out reads in their own bucket
+ * rather than sharing a slot with the next account to sign in.
+ */
+export const ANONYMOUS_USER_KEY = "anonymous";
+
+/**
+ * Prefix a user-scoped key with the owning account. Exported so that
+ * invalidation call sites build the key exactly the way `useAuthedQuery`
+ * does - if the two ever drift, invalidation silently stops matching.
+ */
+export function authedQueryKey(
+  userId: string,
+  queryKey: readonly unknown[],
+): QueryKey {
+  return [AUTHED_KEY_NAMESPACE, userId, ...queryKey];
+}
+
+/** The signed-in user's id, or `ANONYMOUS_USER_KEY` when there is no session. */
+export function useAuthedUserId(): string {
+  const { data } = useSession();
+  return data?.user.id ?? ANONYMOUS_USER_KEY;
+}
+
+/**
+ * Builds user-scoped keys for the current session. Use at every call site
+ * that invalidates (or otherwise addresses) a key owned by
+ * `useAuthedQuery`:
+ *
+ * ```ts
+ * const authedKey = useAuthedQueryKey();
+ * void queryClient.invalidateQueries({ queryKey: authedKey(["fantasy"]) });
+ * ```
+ */
+export function useAuthedQueryKey(): (
+  queryKey: readonly unknown[],
+) => QueryKey {
+  const userId = useAuthedUserId();
+  return (queryKey: readonly unknown[]) => authedQueryKey(userId, queryKey);
+}
+
+/**
+ * `useQuery` for data owned by the signed-in account. Pass the logical key
+ * (`["fantasy", "my-team"]`); the hook prefixes it with the session user id
+ * before handing it to react-query.
+ */
+export function useAuthedQuery<
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+>(
+  options: Omit<UseQueryOptions<TQueryFnData, TError, TData>, "queryKey"> & {
+    queryKey: readonly unknown[];
+  },
+): UseQueryResult<TData, TError> {
+  const userId = useAuthedUserId();
+  return useQuery<TQueryFnData, TError, TData>({
+    ...options,
+    queryKey: authedQueryKey(userId, options.queryKey),
+  });
+}

--- a/apps/web/src/lib/authed-query.ts
+++ b/apps/web/src/lib/authed-query.ts
@@ -43,6 +43,9 @@ export const AUTHED_KEY_NAMESPACE = "user-scoped";
  */
 export const ANONYMOUS_USER_KEY = "anonymous";
 
+/** Stands in for the account id when a key is rendered for observability. */
+export const REDACTED_USER_KEY = "<user>";
+
 /**
  * Prefix a user-scoped key with the owning account. Exported so that
  * invalidation call sites build the key exactly the way `useAuthedQuery`
@@ -53,6 +56,23 @@ export function authedQueryKey(
   queryKey: readonly unknown[],
 ): QueryKey {
   return [AUTHED_KEY_NAMESPACE, userId, ...queryKey];
+}
+
+/**
+ * Render a query key as a telemetry string with the account id removed.
+ *
+ * Cache identity keeps the full key; only what leaves the browser is
+ * redacted, so a New Relic error attribute (or the console fallback)
+ * never carries a user id.
+ */
+export function formatKeyForTelemetry(queryKey: readonly unknown[]): string {
+  const parts =
+    queryKey[0] === AUTHED_KEY_NAMESPACE
+      ? [AUTHED_KEY_NAMESPACE, REDACTED_USER_KEY, ...queryKey.slice(2)]
+      : queryKey;
+  return parts
+    .flatMap((part) => (typeof part === "string" ? [part] : []))
+    .join(":");
 }
 
 /** The signed-in user's id, or `ANONYMOUS_USER_KEY` when there is no session. */

--- a/apps/web/src/lib/query-client.test.ts
+++ b/apps/web/src/lib/query-client.test.ts
@@ -1,6 +1,38 @@
 import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
-import { resetAuthCaches } from "./query-client.js";
+import {
+  AUTHED_KEY_NAMESPACE,
+  authedQueryKey,
+  REDACTED_USER_KEY,
+} from "./authed-query.js";
+import { createAppQueryClient, resetAuthCaches } from "./query-client.js";
+
+describe("createAppQueryClient", () => {
+  it("keeps the account id out of query-error telemetry", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const client = createAppQueryClient();
+
+    await client
+      .fetchQuery({
+        queryKey: authedQueryKey("user-a", ["fantasy", "my-team"]),
+        queryFn: () => Promise.reject(new Error("boom")),
+        retry: false,
+      })
+      .catch(() => undefined);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "react-query (NR not loaded):",
+      "boom",
+      {
+        kind: "query",
+        queryKey: `${AUTHED_KEY_NAMESPACE}:${REDACTED_USER_KEY}:fantasy:my-team`,
+      },
+    );
+    consoleError.mockRestore();
+  });
+});
 
 describe("resetAuthCaches", () => {
   it("cancels before clearing", async () => {

--- a/apps/web/src/lib/query-client.test.ts
+++ b/apps/web/src/lib/query-client.test.ts
@@ -1,0 +1,55 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { resetAuthCaches } from "./query-client.js";
+
+describe("resetAuthCaches", () => {
+  it("cancels before clearing", async () => {
+    const client = new QueryClient();
+    const order: string[] = [];
+    vi.spyOn(client, "cancelQueries").mockImplementation(() => {
+      order.push("cancel");
+      return Promise.resolve();
+    });
+    vi.spyOn(client, "clear").mockImplementation(() => {
+      order.push("clear");
+    });
+
+    await resetAuthCaches(client);
+
+    // Order is the whole point: clearing first would leave an in-flight
+    // fetch free to write the old account's response into the fresh cache.
+    expect(order).toEqual(["cancel", "clear"]);
+  });
+
+  it("empties the cache", async () => {
+    const client = new QueryClient();
+    client.setQueryData(["user-scoped", "user-a", "fantasy", "my-team"], {
+      players: ["Alice"],
+    });
+    client.setQueryData(["content", "news-list"], { items: [] });
+
+    await resetAuthCaches(client);
+
+    expect(client.getQueryCache().getAll()).toHaveLength(0);
+  });
+
+  it("does not let a fetch issued under the old identity land afterwards", async () => {
+    const client = new QueryClient();
+    const key = ["user-scoped", "user-a", "fantasy", "my-team"];
+    let release: (value: { players: string[] }) => void = () => undefined;
+    const inFlight = new Promise<{ players: string[] }>((resolve) => {
+      release = resolve;
+    });
+    // Started under user A and still unresolved when the account changes.
+    const fetching = client
+      .fetchQuery({ queryKey: key, queryFn: () => inFlight })
+      .catch(() => undefined);
+
+    await resetAuthCaches(client);
+    release({ players: ["Alice"] });
+    await fetching;
+
+    expect(client.getQueryData(key)).toBeUndefined();
+    expect(client.getQueryCache().getAll()).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,3 +1,4 @@
+import { formatKeyForTelemetry } from "@/lib/authed-query.js";
 import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 
 /**
@@ -49,19 +50,18 @@ export function createAppQueryClient(): QueryClient {
       onError: (err, query) =>
         noticeQueryError(err, {
           kind: "query",
-          queryKey: query.queryKey
-            .flatMap((part) => (typeof part === "string" ? [part] : []))
-            .join(":"),
+          // User-scoped keys carry the account id (#628); the telemetry
+          // string drops it while the cache keeps addressing the full key.
+          queryKey: formatKeyForTelemetry(query.queryKey),
         }),
     }),
     mutationCache: new MutationCache({
       onError: (err, _vars, _ctx, mutation) =>
         noticeQueryError(err, {
           kind: "mutation",
-          mutationKey:
-            mutation.options.mutationKey
-              ?.flatMap((part) => (typeof part === "string" ? [part] : []))
-              .join(":") ?? "unknown",
+          mutationKey: mutation.options.mutationKey
+            ? formatKeyForTelemetry(mutation.options.mutationKey)
+            : "unknown",
         }),
     }),
   });

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -25,6 +25,24 @@ function noticeQueryError(
  * React mounts or the first commit wipes the prerendered DOM with
  * spinners.
  */
+/**
+ * Drop every cached query and mutation at an account transition (sign in,
+ * sign out, 2FA/recovery completion).
+ *
+ * `invalidateQueries()` is not enough: it only marks entries stale, so
+ * inactive queries keep the previous account's data and active ones keep
+ * rendering it while the refetch is in flight. That is the leak in #628 -
+ * user B could see (and re-save) user A's fantasy squad.
+ *
+ * Cancellation comes first on purpose. A fetch issued under the old
+ * identity that is still in flight would otherwise resolve after `clear()`
+ * and write the old account's response into the fresh cache.
+ */
+export async function resetAuthCaches(queryClient: QueryClient): Promise<void> {
+  await queryClient.cancelQueries();
+  queryClient.clear();
+}
+
 export function createAppQueryClient(): QueryClient {
   return new QueryClient({
     queryCache: new QueryCache({

--- a/apps/web/src/pages/admin/access-tab.tsx
+++ b/apps/web/src/pages/admin/access-tab.tsx
@@ -16,8 +16,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import { parseRoles, type RoleName } from "@percy-main/shared/auth/permissions";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { getRoleLabels } from "./member-detail-modal.lib";
 import { StatusPill } from "./status-pill";
@@ -30,7 +31,7 @@ interface Item {
 }
 
 export function AccessTab() {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error } = useAuthedQuery({
     queryKey: ["admin", "access", "list"],
     queryFn: () => callApi(api.GET("/api/admin/access/users")),
   });
@@ -211,7 +212,7 @@ function EditRolesDialog({
   user: Item;
   onClose: () => void;
 }) {
-  const { data: detail, isLoading: detailLoading } = useQuery({
+  const { data: detail, isLoading: detailLoading } = useAuthedQuery({
     queryKey: ["admin", "userDetail", user.id],
     queryFn: () =>
       callApi(
@@ -220,11 +221,12 @@ function EditRolesDialog({
         }),
       ),
   });
-  const { data: juniorTeamsData, isLoading: juniorTeamsLoading } = useQuery({
-    queryKey: ["admin", "juniorTeams"],
-    queryFn: () => callApi(api.GET("/api/admin/junior-teams")),
-  });
-  const { data: pcTeamsData, isLoading: pcTeamsLoading } = useQuery({
+  const { data: juniorTeamsData, isLoading: juniorTeamsLoading } =
+    useAuthedQuery({
+      queryKey: ["admin", "juniorTeams"],
+      queryFn: () => callApi(api.GET("/api/admin/junior-teams")),
+    });
+  const { data: pcTeamsData, isLoading: pcTeamsLoading } = useAuthedQuery({
     queryKey: ["admin", "playCricketTeams"],
     queryFn: () => callApi(api.GET("/api/admin/play-cricket-teams")),
   });
@@ -272,6 +274,7 @@ function EditRolesBody({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [selectedRoles, setSelectedRoles] = useState<Set<RoleName>>(
     () => new Set(parseRoles(user.role)),
   );
@@ -335,11 +338,13 @@ function EditRolesBody({
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "access", "list"],
+        queryKey: authedKey(["admin", "access", "list"]),
       });
-      void queryClient.invalidateQueries({ queryKey: ["admin", "listUsers"] });
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "userDetail", user.id],
+        queryKey: authedKey(["admin", "listUsers"]),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "userDetail", user.id]),
       });
       onClose();
     },
@@ -684,7 +689,7 @@ function AddUserDialog({
     };
   }, [search]);
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["admin", "access", "search", debounced],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/admin/charges-tab.tsx
+++ b/apps/web/src/pages/admin/charges-tab.tsx
@@ -35,7 +35,8 @@ import {
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { API_BASE, api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useReducer, useRef, useState } from "react";
 import {
   type ChargeStatus,
@@ -66,6 +67,7 @@ const statusBadgeMap: Record<
 // eslint-disable-next-line react-doctor/no-giant-component -- admin charges tab: filter bar + paginated table + row actions (refund, void, edit) all share the filters reducer + table query; splitting would mean lifting the reducer and queryClient through props for marginal benefit.
 export function ChargesTab() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [filters, dispatch] = useReducer(
     chargesFilterReducer,
     initialChargesFilterState,
@@ -142,7 +144,7 @@ export function ChargesTab() {
     data: result,
     isLoading: chargesLoading,
     isError: chargesError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: [
       "admin",
       "charges",
@@ -172,7 +174,7 @@ export function ChargesTab() {
       ),
   });
 
-  const { data: aggregates } = useQuery({
+  const { data: aggregates } = useAuthedQuery({
     queryKey: ["admin", "chargeAggregates", dateFrom, dateTo],
     queryFn: () =>
       callApi(
@@ -196,7 +198,9 @@ export function ChargesTab() {
       ),
     onSuccess: () => {
       setConfirmAction(null);
-      void queryClient.invalidateQueries({ queryKey: ["admin", "charges"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "charges"]),
+      });
     },
   });
 
@@ -210,9 +214,11 @@ export function ChargesTab() {
       ),
     onSuccess: () => {
       setConfirmAction(null);
-      void queryClient.invalidateQueries({ queryKey: ["admin", "charges"] });
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "chargeAggregates"],
+        queryKey: authedKey(["admin", "charges"]),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "chargeAggregates"]),
       });
     },
   });
@@ -227,9 +233,11 @@ export function ChargesTab() {
       ),
     onSuccess: () => {
       setConfirmAction(null);
-      void queryClient.invalidateQueries({ queryKey: ["admin", "charges"] });
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "chargeAggregates"],
+        queryKey: authedKey(["admin", "charges"]),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "chargeAggregates"]),
       });
     },
   });
@@ -251,9 +259,11 @@ export function ChargesTab() {
       ),
     onSuccess: () => {
       setConfirmAction(null);
-      void queryClient.invalidateQueries({ queryKey: ["admin", "charges"] });
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "chargeAggregates"],
+        queryKey: authedKey(["admin", "charges"]),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "chargeAggregates"]),
       });
     },
   });

--- a/apps/web/src/pages/admin/contacts-tab.tsx
+++ b/apps/web/src/pages/admin/contacts-tab.tsx
@@ -9,7 +9,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { useEffect, useRef, useState } from "react";
 import { formatDate } from "./status-pill";
 
@@ -42,7 +42,7 @@ export function ContactsTab() {
     };
   }, [search]);
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError } = useAuthedQuery({
     queryKey: ["admin", "contactSubmissions", page, PAGE_SIZE, debouncedSearch],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -3873,13 +3873,11 @@ function LoadedEditor({
   const canSave = canManage && (item?.status !== "published" || canPublish);
   const metadataIssue = metadataProblem(kind, form);
 
-  // Suggestions come from list pages already in the query cache; computed
-  // once per mount, which is as fresh as the list the author came from.
-  const tagSuggestions = useMemo(
-    () =>
-      kind === "news" ? cachedTagSuggestions(queryClient, kind, userId) : [],
-    [kind, queryClient, userId],
-  );
+  // Suggestions come from list pages already in the query cache, which is
+  // as fresh as the list the author came from. Left to the compiler to
+  // cache rather than a manual useMemo.
+  const tagSuggestions =
+    kind === "news" ? cachedTagSuggestions(queryClient, kind, userId) : [];
 
   const { uploadError, fileInputRef, startImageUpload, onFileChosen } =
     useSlashImageUpload(editor, consentConfirmed);

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -1,3 +1,4 @@
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import {
   BlockNoteSchema,
   defaultBlockSpecs,
@@ -1491,7 +1492,7 @@ export default function ContentEditor({
     data: item,
     isLoading,
     error,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["admin", "content", "detail", contentId],
     queryFn: () =>
       callApi(
@@ -2152,7 +2153,7 @@ function PageMetadataFields({
 }) {
   // Same key as the Pages tab's tree query, so opening the editor from
   // the tree hits the cache and the picker renders instantly.
-  const { data } = useQuery({
+  const { data } = useAuthedQuery({
     queryKey: ["admin", "content", "page-tree"],
     queryFn: () => callApi(api.GET("/api/admin/content/page-tree")),
   });
@@ -2950,6 +2951,7 @@ function PublishingCard({
   beforePublish: () => Promise<unknown>;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [mode, setMode] = useState<"now" | "schedule">("now");
   // UK wall-clock datetime-local value (same convention as event times).
@@ -3013,7 +3015,9 @@ function PublishingCard({
     },
     onSuccess: (_result, input) => {
       if (input.action === "publish") setDialogOpen(false);
-      void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "content"]),
+      });
       // Public pages cache content under ["content", ...] with a 5 minute
       // staleTime; drop those too so a publish/unpublish shows up on the
       // live site without waiting out the cache.
@@ -3277,7 +3281,7 @@ function RevisionDialog({
     data: revision,
     isLoading,
     error,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["admin", "content", "revision", item.id, revisionId],
     queryFn: () =>
       callApi(
@@ -3387,7 +3391,7 @@ function HistoryCard({
   canRestore: boolean;
   onRestore: (revision: RevisionDetail) => boolean;
 }) {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error } = useAuthedQuery({
     queryKey: ["admin", "content", "revisions", item.id],
     queryFn: () =>
       callApi(
@@ -3734,6 +3738,7 @@ function LoadedEditor({
   onCreated: (id: string) => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const { allowed: canManage } = useHasPermission(
     CONTENT_KIND_RESOURCES[kind],
     "manage",
@@ -3834,7 +3839,9 @@ function LoadedEditor({
       dirtyRef.current = false;
       clearRestoreNotice();
       setLastSavedAt(new Date().toISOString());
-      void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "content"]),
+      });
       // Saving a published item changes the live page immediately; drop
       // the public ["content", ...] cache so the SPA reflects it.
       void queryClient.invalidateQueries({ queryKey: ["content"] });

--- a/apps/web/src/pages/admin/content-editor.tsx
+++ b/apps/web/src/pages/admin/content-editor.tsx
@@ -1,4 +1,9 @@
-import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import {
+  authedQueryKey,
+  useAuthedQuery,
+  useAuthedQueryKey,
+  useAuthedUserId,
+} from "@/lib/authed-query.js";
 import {
   BlockNoteSchema,
   defaultBlockSpecs,
@@ -1989,10 +1994,13 @@ function buildMetadata(
 function cachedTagSuggestions(
   queryClient: QueryClient,
   kind: ContentKind,
+  userId: string,
 ): string[] {
   const tags = new Set<string>();
+  // The list pages register under the user-scoped prefix (#628), so the
+  // lookup has to be built the same way the query was.
   for (const [, data] of queryClient.getQueriesData({
-    queryKey: ["admin", "content", kind],
+    queryKey: authedQueryKey(userId, ["admin", "content", kind]),
   })) {
     const items = (data as { items?: unknown } | undefined)?.items;
     if (!Array.isArray(items)) continue;
@@ -3739,6 +3747,7 @@ function LoadedEditor({
 }) {
   const queryClient = useQueryClient();
   const authedKey = useAuthedQueryKey();
+  const userId = useAuthedUserId();
   const { allowed: canManage } = useHasPermission(
     CONTENT_KIND_RESOURCES[kind],
     "manage",
@@ -3867,8 +3876,9 @@ function LoadedEditor({
   // Suggestions come from list pages already in the query cache; computed
   // once per mount, which is as fresh as the list the author came from.
   const tagSuggestions = useMemo(
-    () => (kind === "news" ? cachedTagSuggestions(queryClient, kind) : []),
-    [kind, queryClient],
+    () =>
+      kind === "news" ? cachedTagSuggestions(queryClient, kind, userId) : [],
+    [kind, queryClient, userId],
   );
 
   const { uploadError, fileInputRef, startImageUpload, onFileChosen } =

--- a/apps/web/src/pages/admin/content-tab.tsx
+++ b/apps/web/src/pages/admin/content-tab.tsx
@@ -18,13 +18,13 @@ import {
 } from "@/components/ui/table";
 import { useHasPermission } from "@/hooks/use-has-permission";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import {
   CONTENT_KIND_RESOURCES,
   CONTENT_STATUSES,
   type ContentKind,
   type ContentStatus,
 } from "@percy-main/shared/content";
-import { useQuery } from "@tanstack/react-query";
 import { formatInTimeZone } from "date-fns-tz";
 import { lazy, Suspense } from "react";
 import { IoOpenOutline } from "react-icons/io5";
@@ -116,7 +116,7 @@ export function ContentTab({ kind }: { kind: ContentKind }) {
     setSearchParams(params, { replace: options.replace ?? false });
   };
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error } = useAuthedQuery({
     queryKey: ["admin", "content", kind, status, search, page],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/admin/documents-tab.tsx
+++ b/apps/web/src/pages/admin/documents-tab.tsx
@@ -17,8 +17,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import { noticedFetch } from "@/lib/newrelic";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 function formatDate(iso: string) {
@@ -47,6 +48,7 @@ function CreateDocumentDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [title, setTitle] = useState("");
   const [file, setFile] = useState<File | null>(null);
 
@@ -77,7 +79,7 @@ function CreateDocumentDialog({
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "documents"],
+        queryKey: authedKey(["admin", "documents"]),
       });
       setTitle("");
       setFile(null);
@@ -163,6 +165,7 @@ function EditDocumentDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   // Seeded from `currentTitle` on mount; the parent passes a `key` tied to
   // (title, version) so a new doc opening remounts this dialog with fresh state.
   const [title, setTitle] = useState(() => currentTitle);
@@ -204,10 +207,10 @@ function EditDocumentDialog({
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "documents"],
+        queryKey: authedKey(["admin", "documents"]),
       });
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "documentDetail", documentId],
+        queryKey: authedKey(["admin", "documentDetail", documentId]),
       });
       setFile(null);
       onOpenChange(false);
@@ -288,11 +291,12 @@ function AssignUsersDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [search, setSearch] = useState("");
   const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
   const [resultMessage, setResultMessage] = useState<string | null>(null);
 
-  const { data: usersData } = useQuery({
+  const { data: usersData } = useAuthedQuery({
     queryKey: ["admin", "listUsers", search],
     queryFn: () =>
       callApi(
@@ -315,10 +319,10 @@ function AssignUsersDialog({
       ),
     onSuccess: (data) => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "documents"],
+        queryKey: authedKey(["admin", "documents"]),
       });
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "documentDetail", documentId],
+        queryKey: authedKey(["admin", "documentDetail", documentId]),
       });
       setResultMessage(
         `Assigned to ${data.assigned} new member${data.assigned === 1 ? "" : "s"}.`,
@@ -452,10 +456,11 @@ function DocumentDetailModal({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [editOpen, setEditOpen] = useState(false);
   const [assignOpen, setAssignOpen] = useState(false);
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["admin", "documentDetail", documentId],
     queryFn: () =>
       callApi(
@@ -474,7 +479,7 @@ function DocumentDetailModal({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "documents"],
+        queryKey: authedKey(["admin", "documents"]),
       });
       onClose();
     },
@@ -489,10 +494,10 @@ function DocumentDetailModal({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "documentDetail", documentId],
+        queryKey: authedKey(["admin", "documentDetail", documentId]),
       });
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "documents"],
+        queryKey: authedKey(["admin", "documents"]),
       });
     },
   });
@@ -659,7 +664,7 @@ export function DocumentsTab() {
   const [createOpen, setCreateOpen] = useState(false);
   const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["admin", "documents"],
     queryFn: () => callApi(api.GET("/api/admin/documents")),
   });

--- a/apps/web/src/pages/admin/duplicates-tab.tsx
+++ b/apps/web/src/pages/admin/duplicates-tab.tsx
@@ -16,7 +16,8 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { StatusPill } from "./status-pill";
 
@@ -30,12 +31,13 @@ type MemberRecord = MergePreviewResponse["keep"]["member"];
 
 export function DuplicatesTab() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [previewGroup, setPreviewGroup] = useState<{
     keepId: string;
     removeId: string;
   } | null>(null);
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError } = useAuthedQuery({
     queryKey: ["admin", "duplicateMembers"],
     queryFn: () => callApi(api.GET("/api/admin/duplicates")),
   });
@@ -83,10 +85,10 @@ export function DuplicatesTab() {
           onMerged={() => {
             setPreviewGroup(null);
             void queryClient.invalidateQueries({
-              queryKey: ["admin", "duplicateMembers"],
+              queryKey: authedKey(["admin", "duplicateMembers"]),
             });
             void queryClient.invalidateQueries({
-              queryKey: ["admin", "listUsers"],
+              queryKey: authedKey(["admin", "listUsers"]),
             });
           }}
         />
@@ -196,9 +198,10 @@ function MergePreviewModal({
   onMerged: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [confirmText, setConfirmText] = useState("");
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError } = useAuthedQuery({
     queryKey: ["admin", "mergePreview", keepMemberId, removeMemberId],
     queryFn: () =>
       callApi(
@@ -219,9 +222,11 @@ function MergePreviewModal({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "duplicateMembers"],
+        queryKey: authedKey(["admin", "duplicateMembers"]),
       });
-      void queryClient.invalidateQueries({ queryKey: ["admin", "listUsers"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "listUsers"]),
+      });
       onMerged();
     },
   });

--- a/apps/web/src/pages/admin/expense-history-tab.tsx
+++ b/apps/web/src/pages/admin/expense-history-tab.tsx
@@ -24,8 +24,8 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { noticedFetch } from "@/lib/newrelic";
-import { useQuery } from "@tanstack/react-query";
 import { useEffect, useReducer, useRef, useState } from "react";
 import {
   expenseFiltersReducer,
@@ -117,7 +117,7 @@ export function ExpenseHistoryTab() {
     pageSize: PAGE_SIZE,
   };
 
-  const { data: expensesData, isLoading: expensesLoading } = useQuery({
+  const { data: expensesData, isLoading: expensesLoading } = useAuthedQuery({
     queryKey: ["treasurer", "expense-history", queryParams],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/admin/fantasy-tab.tsx
+++ b/apps/web/src/pages/admin/fantasy-tab.tsx
@@ -18,7 +18,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useReducer, useState } from "react";
 import {
   chaosWeekFormReducer,
@@ -45,6 +46,7 @@ const RULE_TYPE_LABELS: Record<string, string> = {
 
 function PlayCricketSyncSection() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -57,7 +59,7 @@ function PlayCricketSyncSection() {
       setError(null);
       // Sync runs in the background; invalidate broadly so any fantasy data
       // refetches once it completes.
-      void queryClient.invalidateQueries({ queryKey: ["admin"] });
+      void queryClient.invalidateQueries({ queryKey: authedKey(["admin"]) });
     },
     onError: (err) => {
       setResult(null);
@@ -95,6 +97,7 @@ function PlayCricketSyncSection() {
 
 function PlayerManagementSection() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [populateResult, setPopulateResult] = useState<string | null>(null);
@@ -107,7 +110,7 @@ function PlayerManagementSection() {
     return () => clearTimeout(timeout);
   }, [searchInput]);
 
-  const { data } = useQuery({
+  const { data } = useAuthedQuery({
     queryKey: ["admin", "fantasyPlayers", debouncedSearch],
     queryFn: () =>
       callApi(
@@ -128,7 +131,7 @@ function PlayerManagementSection() {
         `Found ${result.total} players, ${result.inserted} updated.`,
       );
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "fantasyPlayers"],
+        queryKey: authedKey(["admin", "fantasyPlayers"]),
       });
     },
   });
@@ -145,7 +148,7 @@ function PlayerManagementSection() {
         `Sandwich costs calculated from ${result.previousSeason} season data. ${result.updated} players updated for ${result.season} season.`,
       );
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "fantasyPlayers"],
+        queryKey: authedKey(["admin", "fantasyPlayers"]),
       });
     },
   });
@@ -165,7 +168,7 @@ function PlayerManagementSection() {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "fantasyPlayers"],
+        queryKey: authedKey(["admin", "fantasyPlayers"]),
       });
     },
   });
@@ -293,6 +296,7 @@ function PlayerManagementSection() {
 
 function ChaosWeeksSection() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [form, dispatch] = useReducer(
     chaosWeekFormReducer,
     initialChaosWeekFormState,
@@ -301,7 +305,7 @@ function ChaosWeeksSection() {
     form;
 
   const season = getCurrentSeason();
-  const { data } = useQuery({
+  const { data } = useAuthedQuery({
     queryKey: ["admin", "chaosWeeks", season],
     queryFn: () =>
       callApi(
@@ -325,7 +329,9 @@ function ChaosWeeksSection() {
       ruleConfig?: string;
     }) => callApi(api.POST("/api/fantasy/admin/chaos-weeks", { body })),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["admin", "chaosWeeks"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "chaosWeeks"]),
+      });
       dispatch({ type: "reset" });
     },
   });
@@ -334,7 +340,9 @@ function ChaosWeeksSection() {
     mutationFn: (id: number) =>
       callApi(api.DELETE("/api/fantasy/admin/chaos-weeks", { body: { id } })),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["admin", "chaosWeeks"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "chaosWeeks"]),
+      });
     },
   });
 
@@ -344,7 +352,9 @@ function ChaosWeeksSection() {
     mutationFn: (_id: number) =>
       Promise.reject(new Error("send-email endpoint not yet implemented")),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["admin", "chaosWeeks"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "chaosWeeks"]),
+      });
     },
   });
 

--- a/apps/web/src/pages/admin/financial-relief-tab.tsx
+++ b/apps/web/src/pages/admin/financial-relief-tab.tsx
@@ -28,6 +28,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import {
   CONTACT_PREFERENCE_LABELS,
   CONTRIBUTION_ABILITY_LABELS,
@@ -69,7 +70,7 @@ export function FinancialReliefTab() {
     );
   };
 
-  const { data: listData, isLoading: listLoading } = useQuery({
+  const { data: listData, isLoading: listLoading } = useAuthedQuery({
     queryKey: [
       "admin-relief",
       "list",
@@ -295,7 +296,8 @@ function RequestDetailDialog({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
-  const { data: detail, isLoading: detailLoading } = useQuery({
+  const authedKey = useAuthedQueryKey();
+  const { data: detail, isLoading: detailLoading } = useAuthedQuery({
     queryKey: ["admin-relief", "detail", requestId],
     queryFn: () =>
       callApi(
@@ -319,9 +321,11 @@ function RequestDetailDialog({
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["admin-relief", "detail", requestId],
+          queryKey: authedKey(["admin-relief", "detail", requestId]),
         }),
-        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+        queryClient.invalidateQueries({
+          queryKey: authedKey(["admin-relief", "list"]),
+        }),
       ]),
   });
 
@@ -585,6 +589,7 @@ function DeclineDialog({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [memberFacingNote, setMemberFacingNote] = useState("");
   const [adminNote, setAdminNote] = useState("");
 
@@ -602,9 +607,11 @@ function DeclineDialog({
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["admin-relief", "detail", requestId],
+          queryKey: authedKey(["admin-relief", "detail", requestId]),
         }),
-        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+        queryClient.invalidateQueries({
+          queryKey: authedKey(["admin-relief", "list"]),
+        }),
       ]).then(onClose),
   });
 
@@ -884,6 +891,7 @@ function DecideDialog({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const requestedMembership =
     request.requestedMembershipFull || request.requestedMembershipPartial;
   const [form, update] = useState<DecideFormState>(() => ({
@@ -944,9 +952,11 @@ function DecideDialog({
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["admin-relief", "detail", requestId],
+          queryKey: authedKey(["admin-relief", "detail", requestId]),
         }),
-        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+        queryClient.invalidateQueries({
+          queryKey: authedKey(["admin-relief", "list"]),
+        }),
       ]).then(onClose),
   });
 
@@ -1151,6 +1161,7 @@ function CloseGrantButton({
   requestId: string;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [confirming, setConfirming] = useState(false);
   const [reason, setReason] = useState("");
 
@@ -1165,9 +1176,11 @@ function CloseGrantButton({
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["admin-relief", "detail", requestId],
+          queryKey: authedKey(["admin-relief", "detail", requestId]),
         }),
-        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+        queryClient.invalidateQueries({
+          queryKey: authedKey(["admin-relief", "list"]),
+        }),
       ]).then(() => setConfirming(false)),
   });
 
@@ -1223,6 +1236,7 @@ function ApplyMembershipReliefButton({
   requestId: string;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [open, setOpen] = useState(false);
   const [form, update] = useReducer(
     (
@@ -1275,9 +1289,11 @@ function ApplyMembershipReliefButton({
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["admin-relief", "detail", requestId],
+          queryKey: authedKey(["admin-relief", "detail", requestId]),
         }),
-        queryClient.invalidateQueries({ queryKey: ["admin-relief", "list"] }),
+        queryClient.invalidateQueries({
+          queryKey: authedKey(["admin-relief", "list"]),
+        }),
       ]).then(() => setOpen(false)),
   });
 
@@ -1411,7 +1427,7 @@ function ReliefReportPanel() {
     }),
   );
 
-  const { data: reportData, isLoading: reportLoading } = useQuery({
+  const { data: reportData, isLoading: reportLoading } = useAuthedQuery({
     queryKey: ["admin-relief", "report", report.dateFrom, report.dateTo],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/admin/game-reports-tab.tsx
+++ b/apps/web/src/pages/admin/game-reports-tab.tsx
@@ -16,7 +16,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { useState } from "react";
 import { formatDate, formatPence } from "./status-pill";
 
@@ -48,12 +48,12 @@ export function GameReportsTab() {
     null,
   );
 
-  const { data: teamsData } = useQuery({
+  const { data: teamsData } = useAuthedQuery({
     queryKey: ["admin", "playCricketTeams"],
     queryFn: () => callApi(api.GET("/api/admin/play-cricket-teams")),
   });
 
-  const { data: matchdaysData, isLoading: matchdaysLoading } = useQuery({
+  const { data: matchdaysData, isLoading: matchdaysLoading } = useAuthedQuery({
     queryKey: ["admin", "gameReports", teamFilter],
     queryFn: () =>
       callApi(
@@ -220,7 +220,7 @@ function MatchdayReport({
     data,
     isLoading: reportLoading,
     isError: reportError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["admin", "matchdayReport", matchdayId],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/admin/groups-tab.tsx
+++ b/apps/web/src/pages/admin/groups-tab.tsx
@@ -15,7 +15,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router";
 import { AddMemberModal } from "./groups-tab/add-member-modal";
@@ -34,7 +35,7 @@ export function GroupsTab() {
     setSearchParams(next, { replace: true });
   };
 
-  const { data: groupsData, isLoading: groupsLoading } = useQuery({
+  const { data: groupsData, isLoading: groupsLoading } = useAuthedQuery({
     queryKey: ["admin", "user-groups"],
     queryFn: () => callApi(api.GET("/api/admin/user-groups")),
   });
@@ -138,7 +139,8 @@ function GroupMembers({
   onAddMember: () => void;
 }) {
   const qc = useQueryClient();
-  const { data: detailData, isLoading: detailLoading } = useQuery({
+  const authedKey = useAuthedQueryKey();
+  const { data: detailData, isLoading: detailLoading } = useAuthedQuery({
     queryKey: ["admin", "user-groups", "detail", groupId],
     queryFn: () =>
       callApi(
@@ -156,7 +158,9 @@ function GroupMembers({
         }),
       ),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["admin", "user-groups"] });
+      void qc.invalidateQueries({
+        queryKey: authedKey(["admin", "user-groups"]),
+      });
     },
   });
 

--- a/apps/web/src/pages/admin/groups-tab/add-member-modal.tsx
+++ b/apps/web/src/pages/admin/groups-tab/add-member-modal.tsx
@@ -8,7 +8,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useId, useMemo, useState } from "react";
 
 interface Props {
@@ -21,9 +22,10 @@ export function AddMemberModal({ groupId, open, onOpenChange }: Props) {
   const [filter, setFilter] = useState("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const qc = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const selectAllId = useId();
 
-  const { data: availableData, isLoading: availableLoading } = useQuery({
+  const { data: availableData, isLoading: availableLoading } = useAuthedQuery({
     queryKey: ["admin", "user-groups", "available", groupId],
     queryFn: () =>
       callApi(
@@ -79,7 +81,9 @@ export function AddMemberModal({ groupId, open, onOpenChange }: Props) {
         }),
       ),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["admin", "user-groups"] });
+      void qc.invalidateQueries({
+        queryKey: authedKey(["admin", "user-groups"]),
+      });
       onOpenChange(false);
     },
   });

--- a/apps/web/src/pages/admin/groups-tab/new-group-modal.tsx
+++ b/apps/web/src/pages/admin/groups-tab/new-group-modal.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQueryKey } from "@/lib/authed-query.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
@@ -24,6 +25,7 @@ export function NewGroupModal({ open, onOpenChange, onCreated }: Props) {
   const [description, setDescription] = useState("");
   const [error, setError] = useState<string | null>(null);
   const qc = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
   const reset = () => {
     setName("");
@@ -42,7 +44,9 @@ export function NewGroupModal({ open, onOpenChange, onCreated }: Props) {
         }),
       ),
     onSuccess: (data) => {
-      void qc.invalidateQueries({ queryKey: ["admin", "user-groups"] });
+      void qc.invalidateQueries({
+        queryKey: authedKey(["admin", "user-groups"]),
+      });
       onCreated?.(data.id);
       reset();
       onOpenChange(false);

--- a/apps/web/src/pages/admin/incidents-tab.tsx
+++ b/apps/web/src/pages/admin/incidents-tab.tsx
@@ -26,7 +26,8 @@ import {
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useReducer, useState } from "react";
 import { formatDate } from "./status-pill";
 
@@ -134,7 +135,7 @@ export function IncidentsTab() {
     data: reportsData,
     isLoading: reportsLoading,
     isError: reportsError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["admin", "incidentReports", page, PAGE_SIZE, statusFilter],
     queryFn: () =>
       callApi(
@@ -329,7 +330,7 @@ function IncidentDetailBody({
     data: detailData,
     isLoading: detailLoading,
     isError: detailError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["admin", "incidentReport", id],
     queryFn: () => loadIncidentDetail(id),
   });
@@ -354,6 +355,7 @@ function IncidentEditForm({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
   // All state seeded from `initial` on mount. The parent passes
   // `key={id}` so opening a different incident remounts this form
@@ -433,10 +435,10 @@ function IncidentEditForm({
       ),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["admin", "incidentReports"],
+        queryKey: authedKey(["admin", "incidentReports"]),
       });
       await queryClient.invalidateQueries({
-        queryKey: ["admin", "incidentReport", id],
+        queryKey: authedKey(["admin", "incidentReport", id]),
       });
       onClose();
     },

--- a/apps/web/src/pages/admin/juniors-tab.tsx
+++ b/apps/web/src/pages/admin/juniors-tab.tsx
@@ -25,8 +25,9 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import { AGE_GROUPS } from "@percy-main/shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useReducer, useRef, useState } from "react";
 import {
   initialJuniorsFilterState,
@@ -53,6 +54,7 @@ const PAGE_SIZE = 100;
 
 export function JuniorsTab() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [filters, dispatch] = useReducer(
     juniorsFilterReducer,
     initialJuniorsFilterState,
@@ -82,7 +84,7 @@ export function JuniorsTab() {
     };
   }, [search]);
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error } = useAuthedQuery({
     queryKey: [
       "admin",
       "listJuniors",
@@ -284,7 +286,7 @@ export function JuniorsTab() {
           onClose={() => setSelectedJunior(null)}
           onLinked={() => {
             void queryClient.invalidateQueries({
-              queryKey: ["admin", "listJuniors"],
+              queryKey: authedKey(["admin", "listJuniors"]),
             });
           }}
         />
@@ -400,6 +402,7 @@ function LinkingDialog({
   onLinked: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [userSearch, setUserSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -418,7 +421,7 @@ function LinkingDialog({
     data: suggestedUsersData,
     isLoading: suggestedUsersLoading,
     error: suggestedUsersError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["admin", "searchUsersForLinking", junior.id, debouncedSearch],
     queryFn: () =>
       callApi(
@@ -442,7 +445,7 @@ function LinkingDialog({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "listJuniors"],
+        queryKey: authedKey(["admin", "listJuniors"]),
       });
       onLinked();
       onClose();
@@ -458,7 +461,7 @@ function LinkingDialog({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "listJuniors"],
+        queryKey: authedKey(["admin", "listJuniors"]),
       });
       onLinked();
       onClose();

--- a/apps/web/src/pages/admin/leads-tab.tsx
+++ b/apps/web/src/pages/admin/leads-tab.tsx
@@ -9,8 +9,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import { campaigns } from "@percy-main/shared/marketing";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Fragment, useEffect, useReducer, useRef, useState } from "react";
 import {
   initialLeadsFilterState,
@@ -51,6 +52,7 @@ export function LeadsTab() {
   const [memberLinkLeadId, setMemberLinkLeadId] = useState<string | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
   useEffect(() => {
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
@@ -66,7 +68,7 @@ export function LeadsTab() {
     ? (campaigns[campaignId as keyof typeof campaigns]?.segments ?? [])
     : [];
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError } = useAuthedQuery({
     queryKey: [
       "admin",
       "leads",
@@ -111,9 +113,11 @@ export function LeadsTab() {
         }),
       ),
     onSuccess: (_data, vars) => {
-      void queryClient.invalidateQueries({ queryKey: ["admin", "leads"] });
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "lead-events", vars.leadId],
+        queryKey: authedKey(["admin", "leads"]),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "lead-events", vars.leadId]),
       });
     },
   });
@@ -365,7 +369,7 @@ export function LeadsTab() {
 }
 
 function LeadEventTimeline({ leadId }: { leadId: string }) {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["admin", "lead-events", leadId],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/admin/marketing-outbox-tab.tsx
+++ b/apps/web/src/pages/admin/marketing-outbox-tab.tsx
@@ -8,7 +8,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { formatDate } from "./status-pill";
 
@@ -26,8 +27,9 @@ export function MarketingOutboxTab() {
   const [page, setPage] = useState(1);
   const [status, setStatus] = useState<string>("");
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["admin", "marketing-outbox", page, status] as const,
     queryFn: () =>
       callApi(
@@ -52,7 +54,7 @@ export function MarketingOutboxTab() {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "marketing-outbox"],
+        queryKey: authedKey(["admin", "marketing-outbox"]),
       });
     },
   });

--- a/apps/web/src/pages/admin/match-fees-tab.tsx
+++ b/apps/web/src/pages/admin/match-fees-tab.tsx
@@ -17,7 +17,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useReducer, useState } from "react";
 import {
   buildAddRatePayload,
@@ -32,17 +33,18 @@ const COMPETITION_TYPES = ["League", "Cup", "Friendly"] as const;
 
 export function MatchFeesTab() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [newRate, dispatchNewRate] = useReducer(
     newRateFormReducer,
     initialNewRateFormState,
   );
 
-  const { data: ratesData, isLoading: ratesLoading } = useQuery({
+  const { data: ratesData, isLoading: ratesLoading } = useAuthedQuery({
     queryKey: ["admin", "matchFeeRates"],
     queryFn: () => callApi(api.GET("/api/admin/match-fee-rates")),
   });
 
-  const { data: teamsData } = useQuery({
+  const { data: teamsData } = useAuthedQuery({
     queryKey: ["admin", "playCricketTeams"],
     queryFn: () => callApi(api.GET("/api/admin/play-cricket-teams")),
   });
@@ -57,7 +59,7 @@ export function MatchFeesTab() {
     onSuccess: () => {
       dispatchNewRate({ type: "reset" });
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "matchFeeRates"],
+        queryKey: authedKey(["admin", "matchFeeRates"]),
       });
     },
   });
@@ -75,7 +77,7 @@ export function MatchFeesTab() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "matchFeeRates"],
+        queryKey: authedKey(["admin", "matchFeeRates"]),
       });
     },
     onSettled: (_data, _error, rateId) => {

--- a/apps/web/src/pages/admin/member-detail-modal.tsx
+++ b/apps/web/src/pages/admin/member-detail-modal.tsx
@@ -24,7 +24,8 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 import {
@@ -63,7 +64,7 @@ const CATEGORY_OPTIONS = [
 ] as const;
 
 export function MemberDetailModal({ userId, onClose }: MemberDetailModalProps) {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["admin", "userDetail", userId],
     queryFn: () =>
       callApi(
@@ -287,6 +288,7 @@ function MemberCategorySection({
   userId: string;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const currentCategory = member?.member_category ?? null;
   const categoryDisplay = getMemberCategoryDisplay(currentCategory);
 
@@ -300,9 +302,11 @@ function MemberCategorySection({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "userDetail", userId],
+        queryKey: authedKey(["admin", "userDetail", userId]),
       });
-      void queryClient.invalidateQueries({ queryKey: ["admin", "listUsers"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "listUsers"]),
+      });
     },
   });
 
@@ -528,6 +532,7 @@ function PaymentsSection({
   charges: UserDetail["charges"];
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [showForm, setShowForm] = useState(false);
   const [description, setDescription] = useState("");
   const [amount, setAmount] = useState("");
@@ -549,9 +554,11 @@ function PaymentsSection({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "userDetail", userId],
+        queryKey: authedKey(["admin", "userDetail", userId]),
       });
-      void queryClient.invalidateQueries({ queryKey: ["admin", "listUsers"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "listUsers"]),
+      });
       setDescription("");
       setAmount("");
       setChargeDate(new Date().toISOString().split("T")[0]);
@@ -675,6 +682,7 @@ function ChargeRow({
   userId: string;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [showDelete, setShowDelete] = useState(false);
   const [deleteReason, setDeleteReason] = useState("");
 
@@ -688,9 +696,11 @@ function ChargeRow({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "userDetail", userId],
+        queryKey: authedKey(["admin", "userDetail", userId]),
       });
-      void queryClient.invalidateQueries({ queryKey: ["admin", "listUsers"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "listUsers"]),
+      });
       setShowDelete(false);
     },
   });
@@ -764,6 +774,7 @@ function LinkedParentsSection({
   linkedParents: UserDetail["linkedParents"];
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [pickerOpen, setPickerOpen] = useState(false);
 
   const unlinkMutation = useMutation({
@@ -775,7 +786,7 @@ function LinkedParentsSection({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "userDetail", userId],
+        queryKey: authedKey(["admin", "userDetail", userId]),
       });
     },
   });
@@ -842,6 +853,7 @@ function ParentLinkDialog({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [search, setSearch] = useState("");
   const [debounced, setDebounced] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -860,7 +872,7 @@ function ParentLinkDialog({
     data: candidatesData,
     isLoading: candidatesLoading,
     error: candidatesError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["admin", "parentSearch", memberId, debounced],
     queryFn: () =>
       callApi(
@@ -884,7 +896,7 @@ function ParentLinkDialog({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "userDetail", userId],
+        queryKey: authedKey(["admin", "userDetail", userId]),
       });
       onClose();
     },
@@ -981,6 +993,7 @@ function ArchiveSection({
   member: UserDetail["member"];
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const isArchived = isMemberArchived(member);
   const [showArchiveForm, setShowArchiveForm] = useState(false);
   const [archiveReason, setArchiveReason] = useState("");
@@ -995,9 +1008,11 @@ function ArchiveSection({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "userDetail", userId],
+        queryKey: authedKey(["admin", "userDetail", userId]),
       });
-      void queryClient.invalidateQueries({ queryKey: ["admin", "listUsers"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "listUsers"]),
+      });
       setShowArchiveForm(false);
       setArchiveReason("");
     },
@@ -1012,9 +1027,11 @@ function ArchiveSection({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "userDetail", userId],
+        queryKey: authedKey(["admin", "userDetail", userId]),
       });
-      void queryClient.invalidateQueries({ queryKey: ["admin", "listUsers"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "listUsers"]),
+      });
     },
   });
 

--- a/apps/web/src/pages/admin/members-tab.tsx
+++ b/apps/web/src/pages/admin/members-tab.tsx
@@ -16,7 +16,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { useEffect, useReducer, useState } from "react";
 import { MemberDetailModal } from "./member-detail-modal";
 import { getRoleLabels } from "./member-detail-modal.lib";
@@ -59,7 +59,7 @@ export function MembersTab() {
     return () => clearTimeout(timeout);
   }, [searchInput]);
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: [
       "admin",
       "listUsers",

--- a/apps/web/src/pages/admin/pages-tab.tsx
+++ b/apps/web/src/pages/admin/pages-tab.tsx
@@ -8,7 +8,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useHasPermission } from "@/hooks/use-has-permission";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { formatInTimeZone } from "date-fns-tz";
 import { lazy, Suspense } from "react";
 import {
@@ -57,6 +58,7 @@ function siblingGroups(roots: PageTreeNode[]): Map<string, PageTreeItem[]> {
 export function PagesTab() {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const { allowed: canManage } = useHasPermission("content", "manage");
 
   const itemParam = searchParams.get("item");
@@ -88,7 +90,7 @@ export function PagesTab() {
     setSearchParams(params, { replace: options.replace ?? false });
   };
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error } = useAuthedQuery({
     // Rooted under ["admin", "content"] so the editor's existing save/
     // publish invalidations cover the tree without knowing about it.
     queryKey: ["admin", "content", "page-tree"],
@@ -122,7 +124,9 @@ export function PagesTab() {
       );
     },
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: ["admin", "content"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["admin", "content"]),
+      });
       // menuOrder drives the public nav ordering; drop ["content", ...]
       // (which includes ["content", "nav"]) so the live menu reorders too.
       void queryClient.invalidateQueries({ queryKey: ["content"] });

--- a/apps/web/src/pages/admin/profile-requests-tab.tsx
+++ b/apps/web/src/pages/admin/profile-requests-tab.tsx
@@ -21,7 +21,8 @@ import {
 import { Textarea } from "@/components/ui/textarea.js";
 import { api, callApi } from "@/lib/api-client.js";
 import type { paths } from "@/lib/api.gen.js";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useSearchParams } from "react-router";
 
@@ -50,7 +51,7 @@ export function ProfileRequestsTab() {
     data: listData,
     isPending: listPending,
     isError: listError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: listQueryKey,
     queryFn: () => callApi(api.GET("/api/admin/profile-proposals")),
   });
@@ -116,6 +117,7 @@ function ReviewPanel({
   onBack: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [rejectOpen, setRejectOpen] = useState(false);
   const [note, setNote] = useState("");
 
@@ -123,7 +125,7 @@ function ReviewPanel({
     data: detail,
     isPending: detailPending,
     isError: detailError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["admin", "profile-proposals", proposalId],
     queryFn: () =>
       callApi(
@@ -143,7 +145,7 @@ function ReviewPanel({
     onSuccess: () => {
       // The queue and (because approve applies the edit) the live public
       // profile both change.
-      void queryClient.invalidateQueries({ queryKey: listQueryKey });
+      void queryClient.invalidateQueries({ queryKey: authedKey(listQueryKey) });
       void queryClient.invalidateQueries({ queryKey: ["content"] });
       onBack();
     },
@@ -159,7 +161,7 @@ function ReviewPanel({
       ),
     onSuccess: () => {
       setRejectOpen(false);
-      void queryClient.invalidateQueries({ queryKey: listQueryKey });
+      void queryClient.invalidateQueries({ queryKey: authedKey(listQueryKey) });
       onBack();
     },
   });

--- a/apps/web/src/pages/admin/record-linking-tab.tsx
+++ b/apps/web/src/pages/admin/record-linking-tab.tsx
@@ -22,7 +22,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useReducer, useState } from "react";
 import {
   buildPlayerNameMap,
@@ -64,6 +65,7 @@ const initialRecordLinkingState: RecordLinkingState = {
 // eslint-disable-next-line react-doctor/no-giant-component -- admin record-linking tool: search + filter bar + people table + DetailModal that shares 4 mutations + linked PC players state. The DetailModal is already extracted; the remaining surface is the linker UI itself.
 export function RecordLinkingTab() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [state, update] = useReducer(
     (
       s: RecordLinkingState,
@@ -91,7 +93,7 @@ export function RecordLinkingTab() {
     return () => clearTimeout(timeout);
   }, [search]);
 
-  const { data: linkingData, isLoading } = useQuery({
+  const { data: linkingData, isLoading } = useAuthedQuery({
     queryKey: ["admin", "recordLinking"],
     queryFn: () => callApi(api.GET("/api/admin/record-linking")),
   });
@@ -119,7 +121,7 @@ export function RecordLinkingTab() {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "recordLinking"],
+        queryKey: authedKey(["admin", "recordLinking"]),
       });
       update((s) => ({
         detailModal: s.detailModal
@@ -139,7 +141,7 @@ export function RecordLinkingTab() {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "recordLinking"],
+        queryKey: authedKey(["admin", "recordLinking"]),
       });
     },
   });
@@ -151,7 +153,7 @@ export function RecordLinkingTab() {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "recordLinking"],
+        queryKey: authedKey(["admin", "recordLinking"]),
       });
     },
   });
@@ -163,7 +165,7 @@ export function RecordLinkingTab() {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "recordLinking"],
+        queryKey: authedKey(["admin", "recordLinking"]),
       });
     },
   });

--- a/apps/web/src/pages/admin/sponsorships-tab.tsx
+++ b/apps/web/src/pages/admin/sponsorships-tab.tsx
@@ -24,9 +24,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import { resizeLogo } from "@/lib/logo-resize";
 import { usePeopleList } from "@/lib/use-people";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useReducer, useRef, useState } from "react";
 import {
   buildGameSponsorshipPayload,
@@ -407,6 +408,7 @@ function CreateGameSponsorshipDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [form, dispatch] = useReducer(
     gameSponsorshipFormReducer,
     initialGameSponsorshipFormState,
@@ -421,7 +423,7 @@ function CreateGameSponsorshipDialog({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "gameSponsorships"],
+        queryKey: authedKey(["admin", "gameSponsorships"]),
       });
       dispatch({ type: "reset" });
       onOpenChange(false);
@@ -653,17 +655,19 @@ function CreatePlayerSponsorshipDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [form, dispatch] = useReducer(
     playerSponsorshipFormReducer,
     initialPlayerSponsorshipFormState,
   );
 
-  const { data: takenSlugsData, isLoading: isTakenSlugsLoading } = useQuery({
-    queryKey: ["admin", "playerSponsorships", "takenSlugs"],
-    queryFn: () =>
-      callApi(api.GET("/api/sponsorship/admin/player/taken-slugs", {})),
-    enabled: open,
-  });
+  const { data: takenSlugsData, isLoading: isTakenSlugsLoading } =
+    useAuthedQuery({
+      queryKey: ["admin", "playerSponsorships", "takenSlugs"],
+      queryFn: () =>
+        callApi(api.GET("/api/sponsorship/admin/player/taken-slugs", {})),
+      enabled: open,
+    });
 
   const takenSlugs = new Set(takenSlugsData?.slugs ?? []);
 
@@ -676,7 +680,7 @@ function CreatePlayerSponsorshipDialog({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "playerSponsorships"],
+        queryKey: authedKey(["admin", "playerSponsorships"]),
       });
       dispatch({ type: "reset" });
       onOpenChange(false);
@@ -919,8 +923,9 @@ function CreatePlayerSponsorshipDialog({
 function GameSponsorshipsTable({ filter }: { filter: FilterValue }) {
   const [page, setPage] = useState(1);
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["admin", "gameSponsorships", page, filter],
     queryFn: () =>
       callApi(
@@ -945,7 +950,7 @@ function GameSponsorshipsTable({ filter }: { filter: FilterValue }) {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "gameSponsorships"],
+        queryKey: authedKey(["admin", "gameSponsorships"]),
       });
     },
   });
@@ -959,7 +964,7 @@ function GameSponsorshipsTable({ filter }: { filter: FilterValue }) {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "gameSponsorships"],
+        queryKey: authedKey(["admin", "gameSponsorships"]),
       });
     },
   });
@@ -984,7 +989,7 @@ function GameSponsorshipsTable({ filter }: { filter: FilterValue }) {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "gameSponsorships"],
+        queryKey: authedKey(["admin", "gameSponsorships"]),
       });
     },
   });
@@ -1162,8 +1167,9 @@ function GameSponsorshipsTable({ filter }: { filter: FilterValue }) {
 function PlayerSponsorshipsTable({ filter }: { filter: FilterValue }) {
   const [page, setPage] = useState(1);
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading } = useAuthedQuery({
     queryKey: ["admin", "playerSponsorships", page, filter],
     queryFn: () =>
       callApi(
@@ -1188,7 +1194,7 @@ function PlayerSponsorshipsTable({ filter }: { filter: FilterValue }) {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "playerSponsorships"],
+        queryKey: authedKey(["admin", "playerSponsorships"]),
       });
     },
   });
@@ -1202,7 +1208,7 @@ function PlayerSponsorshipsTable({ filter }: { filter: FilterValue }) {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "playerSponsorships"],
+        queryKey: authedKey(["admin", "playerSponsorships"]),
       });
     },
   });
@@ -1227,7 +1233,7 @@ function PlayerSponsorshipsTable({ filter }: { filter: FilterValue }) {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["admin", "playerSponsorships"],
+        queryKey: authedKey(["admin", "playerSponsorships"]),
       });
     },
   });

--- a/apps/web/src/pages/admin/treasurer-expenses-section.tsx
+++ b/apps/web/src/pages/admin/treasurer-expenses-section.tsx
@@ -18,7 +18,8 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { formatDate, formatPence } from "./status-pill";
 
@@ -70,12 +71,13 @@ export function TreasurerExpensesSection({
   dateTo,
 }: TreasurerExpensesSectionProps) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [selectedExpense, setSelectedExpense] = useState<Expense | null>(null);
   const [rejectingId, setRejectingId] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState("");
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
 
-  const { data: expensesSummary } = useQuery({
+  const { data: expensesSummary } = useAuthedQuery({
     queryKey: ["treasurer", "matchday-expenses-summary", dateFrom, dateTo],
     queryFn: () =>
       callApi(
@@ -85,8 +87,8 @@ export function TreasurerExpensesSection({
       ),
   });
 
-  const { data: expensesDetail, isLoading: isExpensesDetailLoading } = useQuery(
-    {
+  const { data: expensesDetail, isLoading: isExpensesDetailLoading } =
+    useAuthedQuery({
       queryKey: ["treasurer", "expenses-with-receipts", dateFrom, dateTo],
       queryFn: () =>
         callApi(
@@ -94,15 +96,14 @@ export function TreasurerExpensesSection({
             params: { query: { dateFrom, dateTo } },
           }),
         ),
-    },
-  );
+    });
 
   const invalidateExpenses = () => {
     void queryClient.invalidateQueries({
-      queryKey: ["treasurer", "expenses-with-receipts"],
+      queryKey: authedKey(["treasurer", "expenses-with-receipts"]),
     });
     void queryClient.invalidateQueries({
-      queryKey: ["treasurer", "matchday-expenses-summary"],
+      queryKey: authedKey(["treasurer", "matchday-expenses-summary"]),
     });
   };
 

--- a/apps/web/src/pages/admin/treasurer-outstanding-section.tsx
+++ b/apps/web/src/pages/admin/treasurer-outstanding-section.tsx
@@ -16,7 +16,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { formatPence } from "./status-pill";
 import { daysOverdue } from "./treasurer-tab.lib";
@@ -32,23 +33,26 @@ const PAGE_SIZE = 20;
  */
 export function TreasurerOutstandingSection() {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [page, setPage] = useState(1);
   const [chasingId, setChasingId] = useState<string | null>(null);
 
-  const { data: outstanding, isLoading: isOutstandingLoading } = useQuery({
-    queryKey: ["treasurer", "outstanding-payments", page],
-    queryFn: () =>
-      callApi(
-        api.GET("/api/treasurer/outstanding-payments", {
-          params: {
-            query: {
-              page,
-              pageSize: PAGE_SIZE,
+  const { data: outstanding, isLoading: isOutstandingLoading } = useAuthedQuery(
+    {
+      queryKey: ["treasurer", "outstanding-payments", page],
+      queryFn: () =>
+        callApi(
+          api.GET("/api/treasurer/outstanding-payments", {
+            params: {
+              query: {
+                page,
+                pageSize: PAGE_SIZE,
+              },
             },
-          },
-        }),
-      ),
-  });
+          }),
+        ),
+    },
+  );
 
   const chaseMutation = useMutation({
     mutationFn: (chargeId: string) =>
@@ -60,7 +64,7 @@ export function TreasurerOutstandingSection() {
     onSuccess: () => {
       setChasingId(null);
       void queryClient.invalidateQueries({
-        queryKey: ["treasurer", "outstanding-payments"],
+        queryKey: authedKey(["treasurer", "outstanding-payments"]),
       });
     },
   });

--- a/apps/web/src/pages/admin/treasurer-tab.tsx
+++ b/apps/web/src/pages/admin/treasurer-tab.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/table";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { Suspense, lazy, useState } from "react";
 import { formatPence } from "./status-pill";
 import { TreasurerExpensesSection } from "./treasurer-expenses-section";
@@ -58,7 +58,7 @@ export function TreasurerTab() {
 
   // --- Queries ---
 
-  const { data: income } = useQuery({
+  const { data: income } = useAuthedQuery({
     queryKey: ["treasurer", "income-by-month", dateFrom, dateTo],
     queryFn: () =>
       callApi(
@@ -68,7 +68,7 @@ export function TreasurerTab() {
       ),
   });
 
-  const { data: membership, isLoading: isMembershipLoading } = useQuery({
+  const { data: membership, isLoading: isMembershipLoading } = useAuthedQuery({
     queryKey: ["treasurer", "membership-summary"],
     queryFn: () => callApi(api.GET("/api/treasurer/membership-summary")),
   });
@@ -76,7 +76,7 @@ export function TreasurerTab() {
   // Page 1 fetched here purely so the summary card can show the count;
   // TreasurerOutstandingSection runs the same query with its own page
   // state (TanStack dedupes the page-1 hit).
-  const { data: outstanding } = useQuery({
+  const { data: outstanding } = useAuthedQuery({
     queryKey: ["treasurer", "outstanding-payments", 1],
     queryFn: () =>
       callApi(
@@ -91,17 +91,19 @@ export function TreasurerTab() {
       ),
   });
 
-  const { data: sponsorship, isLoading: isSponsorshipLoading } = useQuery({
-    queryKey: ["treasurer", "sponsorship-summary", dateFrom, dateTo],
-    queryFn: () =>
-      callApi(
-        api.GET("/api/treasurer/sponsorship-summary", {
-          params: { query: { dateFrom, dateTo } },
-        }),
-      ),
-  });
+  const { data: sponsorship, isLoading: isSponsorshipLoading } = useAuthedQuery(
+    {
+      queryKey: ["treasurer", "sponsorship-summary", dateFrom, dateTo],
+      queryFn: () =>
+        callApi(
+          api.GET("/api/treasurer/sponsorship-summary", {
+            params: { query: { dateFrom, dateTo } },
+          }),
+        ),
+    },
+  );
 
-  const { data: expensesSummary } = useQuery({
+  const { data: expensesSummary } = useAuthedQuery({
     queryKey: ["treasurer", "matchday-expenses-summary", dateFrom, dateTo],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/auth/login/email-password.tsx
+++ b/apps/web/src/pages/auth/login/email-password.tsx
@@ -1,6 +1,7 @@
 import { SimpleInput } from "@/components/form/simple-input.js";
 import { Button } from "@/components/ui/button.js";
 import { authClient, useSession } from "@/lib/auth-client.js";
+import { resetAuthCaches } from "@/lib/query-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState, type FC } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
@@ -121,6 +122,12 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
         {
           async onSuccess() {
             if (cancelled) return;
+            // Account transition - drop every cached query before the new
+            // session lands so nothing from the previous identity survives
+            // (#628). Passkey autofill signs a user in without ever
+            // submitting the form, so it needs the same reset as the
+            // password path.
+            await resetAuthCaches(queryClient);
             // The post-await `cancelled` check guards against unmount
             // during the session refetch — it's not a redundant
             // pre-await guard, so the rule's "move await past it" advice
@@ -159,10 +166,11 @@ export const EmailPassword: FC<Props> = ({ setPhase }) => {
         setPhase("2fa");
         return;
       }
+      // Session changed - drop all cached queries so the new user cannot see
+      // the previous user's (or anonymous) cached responses. Invalidation
+      // alone left the old data readable until each refetch landed (#628).
+      await resetAuthCaches(queryClient);
       await refetchSession();
-      // Session changed — drop all cached queries so the new user sees fresh
-      // data rather than the previous user's (or anonymous) cached responses.
-      void queryClient.invalidateQueries();
       navigateBack("/members");
     },
   });

--- a/apps/web/src/pages/auth/login/recovery.tsx
+++ b/apps/web/src/pages/auth/login/recovery.tsx
@@ -1,6 +1,7 @@
 import { SimpleInput } from "@/components/form/simple-input.js";
 import { Button } from "@/components/ui/button.js";
 import { authClient, useSession } from "@/lib/auth-client.js";
+import { resetAuthCaches } from "@/lib/query-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState, type FC } from "react";
 import { useNavigate, useSearchParams } from "react-router";
@@ -24,15 +25,16 @@ export const Recovery: FC<Props> = ({ setPhase }) => {
         { code: recoveryCode },
         {
           async onSuccess() {
+            // Session changed - drop all cached data before the new session
+            // lands, so nothing from the previous account is readable in the
+            // members area (#628). See TwoFA for why this sits here rather
+            // than in the mutation's own onSuccess.
+            await resetAuthCaches(queryClient);
             await refetchSession();
             void navigate(returnTo ?? "/members");
           },
         },
       ),
-    onSuccess: () => {
-      // Session changed — drop all cached data so member-scoped queries refetch.
-      void queryClient.invalidateQueries();
-    },
   });
 
   const handleSubmit = (event: React.SyntheticEvent) => {

--- a/apps/web/src/pages/auth/login/two-fa.tsx
+++ b/apps/web/src/pages/auth/login/two-fa.tsx
@@ -6,6 +6,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp.js";
 import { authClient, useSession } from "@/lib/auth-client.js";
+import { resetAuthCaches } from "@/lib/query-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState, type FC } from "react";
 import { useNavigate, useSearchParams } from "react-router";
@@ -29,6 +30,12 @@ export const TwoFA: FC<Props> = ({ setPhase }) => {
         { code: otp },
         {
           async onSuccess() {
+            // Session changed - drop all cached data before the new session
+            // lands. Invalidation alone kept the previous account's data
+            // readable until each refetch returned (#628). This runs here
+            // rather than in the mutation's own onSuccess so the cache is
+            // empty before we navigate into the members area.
+            await resetAuthCaches(queryClient);
             // See EmailPassword: refetch so the session atom is populated
             // before the new route's RequireAuth reads it.
             await refetchSession();
@@ -36,10 +43,6 @@ export const TwoFA: FC<Props> = ({ setPhase }) => {
           },
         },
       ),
-    onSuccess: () => {
-      // Session changed — drop all cached data so member-scoped queries refetch.
-      void queryClient.invalidateQueries();
-    },
   });
 
   const handleSubmit = (event: React.SyntheticEvent) => {

--- a/apps/web/src/pages/auth/logout.tsx
+++ b/apps/web/src/pages/auth/logout.tsx
@@ -1,20 +1,27 @@
 import { authClient } from "@/lib/auth-client.js";
+import { resetAuthCaches } from "@/lib/query-client.js";
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useNavigate } from "react-router";
 
 export function Component() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     void authClient
       .signOut()
       .catch(() => {
-        // Sign out failed (network error, etc.) — navigate home regardless
+        // Sign out failed (network error, etc.) - navigate home regardless
       })
-      .then(() => {
+      .then(async () => {
+        // Wipe every cached query before leaving this page, on the failure
+        // path too: the user asked to log out, so none of their data should
+        // survive in memory for whoever signs in next (#628).
+        await resetAuthCaches(queryClient);
         void navigate("/");
       });
-  }, [navigate]);
+  }, [navigate, queryClient]);
 
   return (
     <div className="w-full rounded-lg bg-white shadow-sm sm:max-w-md">

--- a/apps/web/src/pages/auth/register.tsx
+++ b/apps/web/src/pages/auth/register.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { authClient } from "@/lib/auth-client.js";
 import { trackEvent } from "@/lib/marketing/gtag.js";
+import { resetAuthCaches } from "@/lib/query-client.js";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useReducer, type FC } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
@@ -66,11 +67,13 @@ export function Component() {
         callbackURL: emailConfirmedUrl,
       });
     },
-    onSuccess(result) {
+    async onSuccess(result) {
       if (!result.error) {
         trackEvent("sign_up", { method: "email" });
-        // Session changed — drop cached anonymous queries.
-        void queryClient.invalidateQueries();
+        // Session changed - drop every cached query rather than marking it
+        // stale, so no data cached under the previous identity (anonymous or
+        // a signed-out account) is readable by the new one (#628).
+        await resetAuthCaches(queryClient);
         const registeredUrl = returnTo
           ? `/auth/registered?returnTo=${encodeURIComponent(returnTo)}`
           : "/auth/registered";

--- a/apps/web/src/pages/availability/public-availability.tsx
+++ b/apps/web/src/pages/availability/public-availability.tsx
@@ -5,6 +5,7 @@ import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen.js";
 import { useSession } from "@/lib/auth-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { useState } from "react";
@@ -63,8 +64,11 @@ export function Component() {
     enabled: !!requestId,
   });
 
-  // Check for existing member record (only if signed in)
-  const { data: memberData, isPending: memberPending } = useQuery({
+  // Check for existing member record (only if signed in). User-scoped, so it
+  // rides useAuthedQuery even though the surrounding page is public - the
+  // request data above stays on an unprefixed key because it is addressed by
+  // the shared request link, not by the viewer (#628).
+  const { data: memberData, isPending: memberPending } = useAuthedQuery({
     queryKey: ["availability", "active"],
     queryFn: () => callApi(api.GET("/api/availability/active")),
     enabled: !!session,
@@ -141,6 +145,7 @@ export function Component() {
   };
 
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
   const submitMutation = useMutation({
     mutationFn: () =>
@@ -160,7 +165,11 @@ export function Component() {
       if (requestId) clearDraft(requestId);
       setSubmitted(true);
       void queryClient.invalidateQueries({
-        queryKey: ["availability"],
+        queryKey: authedKey(["availability"]),
+      });
+      // The request itself is keyed publicly, so it needs its own pass.
+      void queryClient.invalidateQueries({
+        queryKey: ["availability", "public"],
       });
     },
   });

--- a/apps/web/src/pages/junior-manager/junior-manager.tsx
+++ b/apps/web/src/pages/junior-manager/junior-manager.tsx
@@ -19,7 +19,7 @@ import { useHasAdminPanelAccess } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen";
 import { useSession } from "@/lib/auth-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { format } from "date-fns";
 import { useState } from "react";
 import { Link } from "react-router";
@@ -31,14 +31,14 @@ type PlayerDetail =
   paths["/api/junior/players/{dependentId}"]["get"]["responses"]["200"]["content"]["application/json"];
 
 function useTeams() {
-  return useQuery({
+  return useAuthedQuery({
     queryKey: ["juniorManager", "myTeams"],
     queryFn: () => callApi(api.GET("/api/junior/teams")),
   });
 }
 
 function usePlayers(teamId: string, enabled: boolean) {
-  return useQuery({
+  return useAuthedQuery({
     queryKey: ["juniorManager", "players", teamId],
     queryFn: () =>
       callApi(
@@ -182,7 +182,7 @@ function PlayersTable({ players }: { players: Player[] }) {
 }
 
 function usePlayerDetail(dependentId: string) {
-  return useQuery({
+  return useAuthedQuery({
     queryKey: ["juniorManager", "playerDetail", dependentId],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/members/document-viewer.tsx
+++ b/apps/web/src/pages/members/document-viewer.tsx
@@ -3,7 +3,8 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Link, useParams } from "react-router";
 
@@ -11,9 +12,10 @@ export function Component() {
   useDocumentMeta("Review Document");
   const { documentId = "" } = useParams<{ documentId: string }>();
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [agreed, setAgreed] = useState(false);
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error } = useAuthedQuery({
     queryKey: ["document", documentId],
     queryFn: () =>
       callApi(
@@ -33,9 +35,11 @@ export function Component() {
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["document", documentId],
+        queryKey: authedKey(["document", documentId]),
       });
-      void queryClient.invalidateQueries({ queryKey: ["myDocuments"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["myDocuments"]),
+      });
     },
   });
 

--- a/apps/web/src/pages/members/financial-relief.tsx
+++ b/apps/web/src/pages/members/financial-relief.tsx
@@ -21,6 +21,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import {
   CONTACT_PREFERENCES,
   CONTACT_PREFERENCE_LABELS,
@@ -39,7 +40,7 @@ import {
   type ReasonCategory,
   type VolunteerOption,
 } from "@percy-main/shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useReducer, type ReactNode } from "react";
 import { Link } from "react-router";
 
@@ -97,13 +98,14 @@ export function Component() {
   );
 
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
-  const { data: eligibleData, isLoading: eligibleLoading } = useQuery({
+  const { data: eligibleData, isLoading: eligibleLoading } = useAuthedQuery({
     queryKey: ["financial-relief", "eligible-members"],
     queryFn: () => callApi(api.GET("/api/financial-relief/eligible-members")),
   });
 
-  const { data: myStatusData } = useQuery({
+  const { data: myStatusData } = useAuthedQuery({
     queryKey: ["financial-relief", "me"],
     queryFn: () => callApi(api.GET("/api/financial-relief/me")),
   });
@@ -151,7 +153,9 @@ export function Component() {
         }),
       ),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["financial-relief"] });
+      await queryClient.invalidateQueries({
+        queryKey: authedKey(["financial-relief"]),
+      });
     },
   });
 

--- a/apps/web/src/pages/members/members-availability.tsx
+++ b/apps/web/src/pages/members/members-availability.tsx
@@ -4,7 +4,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen.js";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { useState } from "react";
 import { Link } from "react-router";
@@ -13,7 +14,7 @@ import { Link } from "react-router";
 
 export function Component() {
   useDocumentMeta("Availability");
-  const { isPending, isError, data } = useQuery({
+  const { isPending, isError, data } = useAuthedQuery({
     queryKey: ["availability", "active"],
     queryFn: () => callApi(api.GET("/api/availability/active")),
   });
@@ -110,6 +111,7 @@ function DateCard({
   existing: MyResponse | undefined;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [status, setStatus] = useState(existing?.status ?? "");
   const [note, setNote] = useState(existing?.note ?? "");
 
@@ -131,7 +133,7 @@ function DateCard({
       ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["availability", "active"],
+        queryKey: authedKey(["availability", "active"]),
       });
     },
   });

--- a/apps/web/src/pages/members/members-dashboard.tsx
+++ b/apps/web/src/pages/members/members-dashboard.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/hooks/use-has-permission.js";
 import { api, callApi } from "@/lib/api-client";
 import { useSession } from "@/lib/auth-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { useState } from "react";
 import { Link, useSearchParams } from "react-router";
 
@@ -62,7 +62,7 @@ export function Component() {
 
   // Only members whose account is slug-linked to a player profile have
   // something to edit; the link is hidden otherwise.
-  const { data: profileEditState } = useQuery({
+  const { data: profileEditState } = useAuthedQuery({
     queryKey: ["profile", "edit"],
     queryFn: () => callApi(api.GET("/api/profile/edit")),
   });
@@ -243,7 +243,7 @@ function IncompleteDetailsBanner({ hidden }: { hidden: boolean }) {
 }
 
 function AvailabilityBanner() {
-  const { data } = useQuery({
+  const { data } = useAuthedQuery({
     queryKey: ["availability", "active"],
     queryFn: () => callApi(api.GET("/api/availability/active")),
   });
@@ -283,7 +283,7 @@ function AvailabilityBanner() {
  * API's requireScoutAccess preHandler).
  */
 function ScoutLink() {
-  const { data: access } = useQuery({
+  const { data: access } = useAuthedQuery({
     queryKey: ["scout", "access"],
     queryFn: () => callApi(api.GET("/api/scout/access")),
     staleTime: 5 * 60 * 1000,

--- a/apps/web/src/pages/members/members-fantasy.account-switch.test.tsx
+++ b/apps/web/src/pages/members/members-fantasy.account-switch.test.tsx
@@ -1,0 +1,157 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression cover for #628: user A opens their fantasy squad, logs out,
+ * user B logs in on the same page-lifetime QueryClient. B must never see
+ * (nor be able to save) A's squad.
+ */
+
+const session: { current: { user: { id: string } } | null } = { current: null };
+vi.mock("@/lib/auth-client.js", () => ({
+  useSession: () => ({ data: session.current, isPending: false }),
+  authClient: {},
+}));
+
+import { authedQueryKey } from "@/lib/authed-query.js";
+import { resetAuthCaches } from "@/lib/query-client.js";
+import { Component as MembersFantasy } from "./members-fantasy.js";
+
+// The free-agent pool is deliberately disjoint from either squad, so a
+// squad name appearing in the markup can only have come from that user's
+// own cached team.
+const ELIGIBLE_PLAYERS = {
+  players: [
+    {
+      play_cricket_id: "free-1",
+      player_name: "Charlie Carr",
+      sandwich_cost: 1,
+      previousSeasonPoints: 10,
+      ownershipPercent: 5,
+    },
+  ],
+};
+
+/** Prime the cache exactly as a completed page load for `userId` would. */
+function seedFantasyCache(
+  client: QueryClient,
+  userId: string,
+  captain: { id: string; name: string },
+) {
+  client.setQueryData(
+    authedQueryKey(userId, ["fantasy", "eligible-players"]),
+    ELIGIBLE_PLAYERS,
+  );
+  client.setQueryData(authedQueryKey(userId, ["fantasy", "my-team"]), {
+    team: { id: 1, user_id: userId, season: "2026", created_at: "" },
+    players: [
+      {
+        play_cricket_id: captain.id,
+        player_name: captain.name,
+        sandwich_cost: 1,
+        is_captain: true,
+        slot_type: "batting",
+        is_wicketkeeper: true,
+      },
+    ],
+    gameweek: 1,
+    transfersUsed: 0,
+    maxTransfers: null,
+    chaosWeek: null,
+  });
+  client.setQueryData(authedQueryKey(userId, ["fantasy", "chip-status"]), {
+    chips: [],
+    gameweek: 1,
+  });
+}
+
+const ALICE = { id: "a1", name: "Alice Alpha" };
+const BOB = { id: "b1", name: "Bob Beta" };
+
+function renderFantasyPage(client: QueryClient) {
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <MembersFantasy />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  session.current = null;
+});
+
+describe("members fantasy across an account switch", () => {
+  it("renders the signed-in user's own squad", () => {
+    const client = new QueryClient();
+    seedFantasyCache(client, "user-a", ALICE);
+    session.current = { user: { id: "user-a" } };
+
+    const html = renderFantasyPage(client);
+
+    expect(html).toContain("Alice Alpha");
+  });
+
+  it("shows user B a loading page, not user A's squad, after logout", async () => {
+    const client = new QueryClient();
+    seedFantasyCache(client, "user-a", ALICE);
+    session.current = { user: { id: "user-a" } };
+    expect(renderFantasyPage(client)).toContain("Alice Alpha");
+
+    // Logout: the page calls resetAuthCaches once signOut settles.
+    await resetAuthCaches(client);
+    expect(client.getQueryCache().getAll()).toHaveLength(0);
+
+    // Login as B.
+    session.current = { user: { id: "user-b" } };
+    const html = renderFantasyPage(client);
+
+    expect(html).not.toContain("Alice Alpha");
+    // Nothing cached for B yet, so the page sits in its loading state while
+    // the three queries refetch - under B's key, with A's entries gone.
+    expect(html).toContain("animate-pulse");
+    expect(
+      client
+        .getQueryCache()
+        .getAll()
+        .map((q) => q.queryKey),
+    ).toEqual([
+      authedQueryKey("user-b", ["fantasy", "eligible-players"]),
+      authedQueryKey("user-b", ["fantasy", "my-team"]),
+      authedQueryKey("user-b", ["fantasy", "chip-status"]),
+    ]);
+  });
+
+  it("keeps the accounts apart even if a login path skips the reset", () => {
+    // Belt and braces: the user-scoped key alone has to close the leak, so a
+    // future login path that forgets resetAuthCaches cannot reopen it. A's
+    // squad is still in the cache and B has fetched nothing.
+    const client = new QueryClient();
+    seedFantasyCache(client, "user-a", ALICE);
+
+    session.current = { user: { id: "user-b" } };
+    const html = renderFantasyPage(client);
+
+    expect(html).not.toContain("Alice Alpha");
+    expect(html).toContain("animate-pulse");
+  });
+
+  it("serves each account its own squad from the shared cache", () => {
+    const client = new QueryClient();
+    seedFantasyCache(client, "user-a", ALICE);
+    seedFantasyCache(client, "user-b", BOB);
+
+    session.current = { user: { id: "user-b" } };
+    const asBob = renderFantasyPage(client);
+    session.current = { user: { id: "user-a" } };
+    const asAlice = renderFantasyPage(client);
+
+    expect(asBob).toContain("Bob Beta");
+    expect(asBob).not.toContain("Alice Alpha");
+    expect(asAlice).toContain("Alice Alpha");
+    expect(asAlice).not.toContain("Bob Beta");
+  });
+});

--- a/apps/web/src/pages/members/members-fantasy.tsx
+++ b/apps/web/src/pages/members/members-fantasy.tsx
@@ -14,6 +14,7 @@ import {
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen.js";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import {
   closestCenter,
   DndContext,
@@ -33,7 +34,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useReducer, useState } from "react";
 import { Link } from "react-router";
 import {
@@ -69,8 +70,11 @@ function SandwichCost({ cost }: { cost: number }) {
 // Hooks
 // ---------------------------------------------------------------------------
 
+// All three ride useAuthedQuery: "my team" and "chip status" are the
+// signed-in member's own records, and the eligible-player list stays in the
+// same bucket so one invalidation covers the page (#628).
 function useEligiblePlayers() {
-  return useQuery({
+  return useAuthedQuery({
     queryKey: ["fantasy", "eligible-players"],
     queryFn: () => callApi(api.GET("/api/fantasy/players")),
     staleTime: 5 * 60_000,
@@ -78,18 +82,15 @@ function useEligiblePlayers() {
 }
 
 function useMyTeam() {
-  return useQuery({
+  return useAuthedQuery({
     queryKey: ["fantasy", "my-team"],
-    queryFn: async () => {
-      const data = await callApi(api.GET("/api/fantasy/team"));
-      return data as unknown as MyTeamResponse;
-    },
+    queryFn: () => callApi(api.GET("/api/fantasy/team")),
     staleTime: 30_000,
   });
 }
 
 function useChipStatus() {
-  return useQuery({
+  return useAuthedQuery({
     queryKey: ["fantasy", "chip-status"],
     queryFn: () => callApi(api.GET("/api/fantasy/chip")),
     staleTime: 30_000,
@@ -100,29 +101,8 @@ type EligiblePlayer =
   paths["/api/fantasy/players"]["get"]["responses"][200]["content"]["application/json"]["players"][number];
 type ChipStatus =
   paths["/api/fantasy/chip"]["get"]["responses"][200]["content"]["application/json"];
-
-// The generated spec types `/api/fantasy/team` players as `{ [key: string]: unknown }[]`
-// because Fastify serialises the response without a strict schema for the array items.
-// We define the shape explicitly here until the OpenAPI spec is tightened.
-interface MyTeamResponse {
-  team: { id: number; season: string } | null;
-  players: Array<{
-    play_cricket_id: string;
-    player_name: string;
-    sandwich_cost: number;
-    is_captain: boolean;
-    slot_type: string;
-    is_wicketkeeper: boolean;
-  }>;
-  gameweek: number;
-  transfersUsed: number;
-  maxTransfers: number | null;
-  chaosWeek: {
-    name: string;
-    description: string;
-    rule_type: string;
-  } | null;
-}
+type MyTeamResponse =
+  paths["/api/fantasy/team"]["get"]["responses"][200]["content"]["application/json"];
 
 // ---------------------------------------------------------------------------
 // Container — fetches data, handles loading/error, renders TeamBuilder
@@ -166,7 +146,7 @@ export function Component() {
           playerName: p.player_name,
           sandwichCost: p.sandwich_cost,
           isCaptain: p.is_captain,
-          slotType: p.slot_type as SlotType,
+          slotType: p.slot_type,
           isWicketkeeper: p.is_wicketkeeper,
         }))
       : [];
@@ -198,9 +178,11 @@ function TeamBuilder({
   chipData: ChipStatus | null;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
-  // Seeded from initialSquad on mount; parent never re-renders TeamBuilder
-  // with a different team for the same user, so a key isn't needed.
+  // Seeded from initialSquad on mount. RequireAuth keys the authenticated
+  // subtree on the session user id, so a change of account remounts this
+  // component and the seed can never carry another user's squad (#628).
   const [squad, setSquad] = useState<SelectedPlayer[]>(() => initialSquad);
   // UI state grouped via a shallow-merge reducer to keep search / save
   // status / drag-active state consolidated.
@@ -234,6 +216,9 @@ function TeamBuilder({
       updateUi({ saveError: null });
       updateUi({ saveSuccess: true });
       setTimeout(() => updateUi({ saveSuccess: false }), 3000);
+      void queryClient.invalidateQueries({ queryKey: authedKey(["fantasy"]) });
+      // The public fantasy pages read ownership percentages and leaderboards
+      // from unprefixed keys, so they need invalidating separately.
       void queryClient.invalidateQueries({ queryKey: ["fantasy"] });
     },
     onError: (err: Error) => {
@@ -257,7 +242,7 @@ function TeamBuilder({
           ),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["fantasy", "chip-status"],
+        queryKey: authedKey(["fantasy", "chip-status"]),
       });
     },
   });

--- a/apps/web/src/pages/members/profile-edit.tsx
+++ b/apps/web/src/pages/members/profile-edit.tsx
@@ -18,8 +18,9 @@ import { Label } from "@/components/ui/label.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client.js";
 import type { paths } from "@/lib/api.gen.js";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import { uploadProfilePhoto } from "@/lib/profile-photo.js";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { Link } from "react-router";
 
@@ -34,7 +35,7 @@ const profileEditQueryKey = ["profile", "edit"] as const;
 export function Component() {
   useDocumentMeta("Edit my profile");
 
-  const { data, isPending, isError } = useQuery({
+  const { data, isPending, isError } = useAuthedQuery({
     queryKey: profileEditQueryKey,
     queryFn: () => callApi(api.GET("/api/profile/edit")),
   });
@@ -137,6 +138,7 @@ function PendingNotice({
 
 function EditForm({ profile }: { profile: NonNullable<EditState["profile"]> }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const editable = bioIsEditable(profile.body);
   // The latest bio to submit: the edited document when the bio is editable,
   // otherwise the unchanged original (a photo-only change still re-submits
@@ -157,7 +159,9 @@ function EditForm({ profile }: { profile: NonNullable<EditState["profile"]> }) {
         api.POST("/api/profile/edit/proposals", { body: { body, photo } }),
       ),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: profileEditQueryKey });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(profileEditQueryKey),
+      });
     },
   });
 

--- a/apps/web/src/pages/membership/membership-junior.tsx
+++ b/apps/web/src/pages/membership/membership-junior.tsx
@@ -15,7 +15,8 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useDocumentMeta } from "@/hooks/use-document-meta";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { useReducer } from "react";
 import { Link } from "react-router";
@@ -183,7 +184,7 @@ function TextInput({
 }
 
 function SocialMembershipUpsell() {
-  const { data: membershipData } = useQuery({
+  const { data: membershipData } = useAuthedQuery({
     queryKey: ["membership"],
     queryFn: () => callApi(api.GET("/api/members/me/membership")),
   });
@@ -213,8 +214,9 @@ function JuniorRegistrationInner() {
   const { step, dependents, errors, paymentData, paymentError } = wizard;
   const setStep = (next: Step) => dispatch({ type: "goToStep", step: next });
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
-  const { data: existingDepsData } = useQuery({
+  const { data: existingDepsData } = useAuthedQuery({
     queryKey: ["dependents"],
     queryFn: () => callApi(api.GET("/api/junior/dependents")),
   });
@@ -246,8 +248,12 @@ function JuniorRegistrationInner() {
         }),
       ),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["dependents"] });
-      void queryClient.invalidateQueries({ queryKey: ["myCharges"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["dependents"]),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["myCharges"]),
+      });
     },
   });
 
@@ -271,7 +277,9 @@ function JuniorRegistrationInner() {
         },
       });
       dispatch({ type: "setPaymentError", message: null });
-      void queryClient.invalidateQueries({ queryKey: ["myCharges"] });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(["myCharges"]),
+      });
     },
     onError: () => {
       dispatch({

--- a/apps/web/src/pages/scout/attachments/message-attachments.tsx
+++ b/apps/web/src/pages/scout/attachments/message-attachments.tsx
@@ -1,5 +1,5 @@
 import { api, callApi } from "@/lib/api-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 
 interface MessageAttachmentsProps {
   threadId: string;
@@ -37,7 +37,7 @@ function AttachmentChip({
   threadId: string;
   attachmentId: string;
 }) {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error } = useAuthedQuery({
     queryKey: ["scout", "attachment", threadId, attachmentId],
     queryFn: () =>
       callApi(

--- a/apps/web/src/pages/scout/debrief-launcher.tsx
+++ b/apps/web/src/pages/scout/debrief-launcher.tsx
@@ -1,7 +1,7 @@
 import { ImbuzaiMascot } from "@/components/imbuzai-mascot.js";
 import { Button } from "@/components/ui/button";
 import { api, callApi } from "@/lib/api-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { format, parseISO } from "date-fns";
 import { useState } from "react";
 
@@ -28,7 +28,7 @@ export function DebriefLauncher({ onLaunch }: DebriefLauncherProps) {
     data: recent,
     isLoading: recentLoading,
     error: recentError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["scout", "debrief", "recent-matches"],
     queryFn: () => callApi(api.GET("/api/scout/debrief/recent-matches")),
   });

--- a/apps/web/src/pages/scout/facts-admin.tsx
+++ b/apps/web/src/pages/scout/facts-admin.tsx
@@ -9,7 +9,8 @@ import {
 } from "@/components/ui/dialog";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen.js";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useReducer } from "react";
 
 /**
@@ -62,7 +63,7 @@ export function FactsAdminView() {
     data: factsData,
     isLoading: factsLoading,
     error: factsError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["scout", "facts", { scope, q, tag }],
     queryFn: () =>
       callApi(
@@ -247,6 +248,7 @@ function FactEditDialog({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   // Single shallow-merge reducer keeps the field setters as data-flow
   // through one `update({ ... })` call. The form mounts fresh per-fact via
   // `key={fact.id}` on the parent, so the initial values pin to mount.
@@ -289,7 +291,7 @@ function FactEditDialog({
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["scout", "facts"],
+        queryKey: authedKey(["scout", "facts"]),
       });
       onClose();
     },
@@ -416,6 +418,7 @@ function FactDeleteDialog({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const mutation = useMutation({
     mutationFn: () => {
       if (!fact) throw new Error("no fact");
@@ -427,7 +430,7 @@ function FactDeleteDialog({
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["scout", "facts"],
+        queryKey: authedKey(["scout", "facts"]),
       });
       onClose();
     },

--- a/apps/web/src/pages/scout/knowledge-admin.tsx
+++ b/apps/web/src/pages/scout/knowledge-admin.tsx
@@ -9,8 +9,9 @@ import {
 } from "@/components/ui/dialog";
 import { api, callApi } from "@/lib/api-client";
 import type { paths } from "@/lib/api.gen.js";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import { noticedFetch } from "@/lib/newrelic";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useReducer, useState } from "react";
 import {
   initialUploadFormState,
@@ -60,12 +61,13 @@ export function KnowledgeAdminView() {
   const [search, setSearch] = useState("");
   const [pendingDelete, setPendingDelete] = useState<KbDocument | null>(null);
   const qc = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
   const {
     data: docsData,
     isLoading: docsLoading,
     error: docsError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["scout", "knowledge", { search }],
     queryFn: () =>
       callApi(
@@ -91,7 +93,8 @@ export function KnowledgeAdminView() {
           params: { path: { id } },
         }),
       ),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["scout", "knowledge"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: authedKey(["scout", "knowledge"]) }),
   });
 
   const remove = useMutation({
@@ -103,7 +106,9 @@ export function KnowledgeAdminView() {
       ),
     onSuccess: () => {
       setPendingDelete(null);
-      void qc.invalidateQueries({ queryKey: ["scout", "knowledge"] });
+      void qc.invalidateQueries({
+        queryKey: authedKey(["scout", "knowledge"]),
+      });
     },
   });
 
@@ -123,7 +128,9 @@ export function KnowledgeAdminView() {
       <div className="border-b border-stone-200 px-4 py-3">
         <UploadForm
           onUploaded={() => {
-            void qc.invalidateQueries({ queryKey: ["scout", "knowledge"] });
+            void qc.invalidateQueries({
+              queryKey: authedKey(["scout", "knowledge"]),
+            });
           }}
         />
       </div>

--- a/apps/web/src/pages/scout/reports-view.tsx
+++ b/apps/web/src/pages/scout/reports-view.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import type { ReportData } from "@percy-main/shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { ReportCard } from "./report-card.tsx";
 
@@ -25,7 +26,7 @@ export function ReportsView() {
     data: reportsData,
     isLoading,
     error,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: REPORTS_QUERY_KEY,
     queryFn: () => callApi(api.GET("/api/scout/reports")),
     // Listing-level poll catches new reports queued from other tabs and
@@ -129,6 +130,7 @@ function ReportFooter({ report }: { report: ReportRow }) {
 
 function DeleteReportButton({ reportId }: { reportId: string }) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const deleteMutation = useMutation({
     mutationFn: () =>
       callApi(
@@ -137,7 +139,9 @@ function DeleteReportButton({ reportId }: { reportId: string }) {
         }),
       ),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: REPORTS_QUERY_KEY });
+      void queryClient.invalidateQueries({
+        queryKey: authedKey(REPORTS_QUERY_KEY),
+      });
     },
   });
   return (

--- a/apps/web/src/pages/scout/scout-launcher.tsx
+++ b/apps/web/src/pages/scout/scout-launcher.tsx
@@ -1,7 +1,7 @@
 import { ImbuzaiMascot } from "@/components/imbuzai-mascot.js";
 import { Button } from "@/components/ui/button";
 import { api, callApi } from "@/lib/api-client";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/lib/authed-query.js";
 import { format, parseISO } from "date-fns";
 import { useState } from "react";
 
@@ -27,7 +27,7 @@ export function ScoutLauncher({ onLaunch }: ScoutLauncherProps) {
     data: upcoming,
     isLoading: upcomingLoading,
     error: upcomingError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["scout", "scout", "upcoming-matches"],
     queryFn: () => callApi(api.GET("/api/scout/upcoming-matches")),
   });

--- a/apps/web/src/pages/scout/scout.tsx
+++ b/apps/web/src/pages/scout/scout.tsx
@@ -2,10 +2,11 @@ import { ImbuzaiMascot } from "@/components/imbuzai-mascot.js";
 import { useDocumentMeta } from "@/hooks/use-document-meta.js";
 import { api, callApi } from "@/lib/api-client";
 import { useSession } from "@/lib/auth-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import type { UIMessage } from "@ai-sdk/react";
 import type { ReportData } from "@percy-main/shared";
 import { checkPermission } from "@percy-main/shared/auth/permissions";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import { MessageAttachments } from "./attachments/message-attachments.js";
@@ -283,7 +284,7 @@ function ActiveThread({ threadId }: { threadId: string }) {
     data: loaded,
     isLoading,
     error,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["scout", "thread", threadId],
     queryFn: () =>
       callApi(
@@ -633,6 +634,7 @@ function ReadOnlyBanner({
 }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
 
   // Forks the shared thread into a fresh thread owned by the current user.
   // Recipients lose nothing — the original stays read-only — but get an
@@ -648,7 +650,9 @@ function ReadOnlyBanner({
         }),
       ),
     onSuccess: async (newThread) => {
-      await queryClient.invalidateQueries({ queryKey: ["scout", "threads"] });
+      await queryClient.invalidateQueries({
+        queryKey: authedKey(["scout", "threads"]),
+      });
       void navigate(`/scout/${newThread.id}`);
     },
   });

--- a/apps/web/src/pages/scout/share-thread-modal.tsx
+++ b/apps/web/src/pages/scout/share-thread-modal.tsx
@@ -10,7 +10,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { api, callApi } from "@/lib/api-client";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 interface ShareActor {
@@ -33,6 +34,7 @@ export function ShareThreadModal({
   onOpenChange,
 }: Props) {
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [filter, setFilter] = useState("");
   // Multi-select staging: officials ticked but not yet committed. The
   // commit lands on "Share" — keeps the modal feel transactional rather
@@ -43,7 +45,7 @@ export function ShareThreadModal({
   // Officials picker. Only enabled while the modal is open so we don't
   // hit the API every page render. Stale-time short — list rarely changes
   // mid-session but a new official COULD appear via the admin UI.
-  const { data: officials, isLoading: officialsLoading } = useQuery({
+  const { data: officials, isLoading: officialsLoading } = useAuthedQuery({
     queryKey: ["scout", "officials"],
     queryFn: () => callApi(api.GET("/api/scout/officials")),
     enabled: open,
@@ -53,7 +55,7 @@ export function ShareThreadModal({
   // Current sharees for this thread. Owner-only endpoint; we surface a
   // friendly empty state (rather than a generic error) when it 403s,
   // since the modal is owner-only by construction anyway.
-  const { data: sharees } = useQuery({
+  const { data: sharees } = useAuthedQuery({
     queryKey: ["scout", "thread-shares", threadId],
     queryFn: () =>
       callApi(
@@ -90,9 +92,11 @@ export function ShareThreadModal({
       setSelectedToAdd(new Set());
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["scout", "thread-shares", threadId],
+          queryKey: authedKey(["scout", "thread-shares", threadId]),
         }),
-        queryClient.invalidateQueries({ queryKey: ["scout", "threads"] }),
+        queryClient.invalidateQueries({
+          queryKey: authedKey(["scout", "threads"]),
+        }),
       ]);
     },
   });
@@ -107,9 +111,11 @@ export function ShareThreadModal({
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ["scout", "thread-shares", threadId],
+          queryKey: authedKey(["scout", "thread-shares", threadId]),
         }),
-        queryClient.invalidateQueries({ queryKey: ["scout", "threads"] }),
+        queryClient.invalidateQueries({
+          queryKey: authedKey(["scout", "threads"]),
+        }),
       ]);
     },
   });

--- a/apps/web/src/pages/scout/thread-list.tsx
+++ b/apps/web/src/pages/scout/thread-list.tsx
@@ -15,8 +15,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import { checkPermission } from "@percy-main/shared/auth/permissions";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 
@@ -94,6 +95,7 @@ export function ThreadList({
   const activeThreadId = params.threadId;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   const [pendingDelete, setPendingDelete] = useState<ThreadSummary | null>(
     null,
   );
@@ -102,7 +104,7 @@ export function ThreadList({
     data: threadsData,
     isLoading: threadsLoading,
     error: threadsError,
-  } = useQuery({
+  } = useAuthedQuery({
     queryKey: ["scout", "threads"],
     queryFn: () => callApi(api.GET("/api/scout/threads")),
   });
@@ -116,7 +118,7 @@ export function ThreadList({
       ),
     onSuccess: async (_, threadId) => {
       await queryClient.invalidateQueries({
-        queryKey: ["scout", "threads"],
+        queryKey: authedKey(["scout", "threads"]),
       });
       setPendingDelete(null);
       if (threadId === activeThreadId) void navigate("/scout");
@@ -310,6 +312,7 @@ export function NewThreadButton({
 }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   // Filter the dropdown to modes the user can actually use. If the user
   // somehow lacks every mode permission, render nothing — the empty button
   // would be a dead-end.
@@ -331,7 +334,7 @@ export function NewThreadButton({
       ),
     onSuccess: async (thread) => {
       await queryClient.invalidateQueries({
-        queryKey: ["scout", "threads"],
+        queryKey: authedKey(["scout", "threads"]),
       });
       void navigate(`/scout/${thread.id}`);
       onCreated?.();

--- a/apps/web/src/pages/scout/use-report-detail.ts
+++ b/apps/web/src/pages/scout/use-report-detail.ts
@@ -1,6 +1,7 @@
 import { api, callApi } from "@/lib/api-client";
+import { useAuthedQuery, useAuthedQueryKey } from "@/lib/authed-query.js";
 import type { ReportData } from "@percy-main/shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 const POLL_INTERVAL_MS = 5_000;
 
@@ -17,7 +18,7 @@ const reportDetailKey = (reportId: string) =>
  * a fresh chat turn.
  */
 export function useReportDetail(reportId: string) {
-  return useQuery({
+  return useAuthedQuery({
     queryKey: reportDetailKey(reportId),
     queryFn: () =>
       callApi(
@@ -39,6 +40,7 @@ export function useReportDetail(reportId: string) {
 
 export function useCancelReport(reportId: string) {
   const qc = useQueryClient();
+  const authedKey = useAuthedQueryKey();
   return useMutation({
     mutationFn: () =>
       callApi(
@@ -50,7 +52,9 @@ export function useCancelReport(reportId: string) {
       // The next poll (≤5s) will see status='failed' once the worker's
       // flush picks up the cancel flag. Trigger a refetch immediately so
       // the FE doesn't sit on stale "generating" state for up to 5s.
-      void qc.invalidateQueries({ queryKey: reportDetailKey(reportId) });
+      void qc.invalidateQueries({
+        queryKey: authedKey(reportDetailKey(reportId)),
+      });
     },
   });
 }


### PR DESCRIPTION
Closes #628

## The leak

The SPA creates one `QueryClient` for the lifetime of the page. Logout dropped nothing, and every login path called bare `invalidateQueries()`, which marks entries stale without evicting them - inactive queries keep their data and active ones render the previous account's data while the refetch is in flight. On top of that, user-scoped keys like `["fantasy", "my-team"]` carried no user identity, so both accounts addressed the same cache slot.

Reproduction from the ticket: user A opens Members Fantasy, logs out, user B logs in, and B sees A's squad - and can save it as their own.

## The fix

Three layers, because each one alone leaves a gap.

**1. `resetAuthCaches(queryClient)`** (`apps/web/src/lib/query-client.ts`) cancels in-flight queries, then clears the cache. Cancelling first is load-bearing: a fetch issued under the old identity would otherwise resolve after the clear and write the old account's response into the fresh cache.

Called at both transition edges:

| Path | File | Before |
| --- | --- | --- |
| Logout (success and catch) | `pages/auth/logout.tsx` | nothing |
| Email + password | `pages/auth/login/email-password.tsx` | `invalidateQueries()` |
| Passkey autofill | `pages/auth/login/email-password.tsx` | **nothing** |
| 2FA TOTP | `pages/auth/login/two-fa.tsx` | `invalidateQueries()` |
| 2FA recovery code | `pages/auth/login/recovery.tsx` | `invalidateQueries()` |
| Register | `pages/auth/register.tsx` | `invalidateQueries()` |

The passkey-autofill path is new to the list - triage did not flag it, but it signs a user in without the form ever being submitted and reset nothing at all.

On the 2FA and recovery paths the reset moved from the mutation's `onSuccess` into better-auth's inner `onSuccess`, because the inner callback navigates into the members area and used to run *before* the outer invalidation.

Google OAuth is not in the table: it leaves the page and the browser reloads on return, so there is no in-page cache to carry across.

**2. `useAuthedQuery`** (`apps/web/src/lib/authed-query.ts`) is the enforcement wrapper (your call on the open question - wrapper fn, not lint, not review-only). It prefixes every key with `["user-scoped", <session user id>, ...]`. A companion `useAuthedQueryKey()` builder is exported from the same module so invalidation call sites construct the key exactly the way the query does; they cannot drift apart. 94 queries and 109 invalidation sites moved across.

**3. `RequireAuth` keys the authenticated subtree on the user id.** Clearing the cache does nothing for state seeded from query data *on mount* - `TeamBuilder` seeds `squad` from `initialSquad` once and its comment explicitly assumed "same user". Keying at `RequireAuth` covers every authenticated page at once rather than just this one component, so no future mount-seeded state can straddle two identities either.

## What got the wrapper, and what stayed public

**Wrapped (94 queries).** Everything that addresses the signed-in account's own data or data it can only see by virtue of its role:

- `components/members` (9): `accounts`, `myCharges`, `myDocuments`, `memberDetails`, `membership`, `dependents`, `passkeys`, `subscriptions`, `financial-relief/me`
- `pages/members` (11): the fantasy trio (`eligible-players`, `my-team`, `chip-status`), `profile/edit`, `availability/active`, `scout/access`, `document/:id`, `financial-relief` x2
- `pages/admin` (57): every `["admin", ...]`, `["treasurer", ...]` and `["admin-relief", ...]` key across all tabs
- `pages/scout` (11): every `["scout", ...]` key
- `pages/junior-manager` (3), `pages/membership` (2), `pages/availability` (1)

**Left unprefixed (41 queries).** Public content and reference data. The prerender-dehydrated seed is generated with no session at all (ADR 052), so prefixing these would orphan the seed and bring back the hydration flash:

`["content", ...]`, `["games", ...]`, `["game", ...]`, `["records"]`, `["records-honours"]`, `["getLeagueTable", ...]`, `["getMatchDetail", ...]`, `["season-leaders", ...]`, `["play-cricket-teams"]`, `["batting-leaderboard"/"bowling-leaderboard", ...]`, `["leaderboard", ...]`, `["player-career-stats", ...]`, `["wagon-wheel", ...]`, `["player-sponsors", ...]`, `["player-sponsor"/"player-sponsor-pending", ...]`, `["game-sponsor-pending", ...]`, the sponsorship/membership price keys, `["price", ...]`, the public fantasy leaderboards in `pages/fantasy/fantasy.tsx`, and `["availability", "public", requestId]` (addressed by the shared request link, not by the viewer).

A few places now invalidate both buckets deliberately, each with a comment: saving a fantasy team refreshes the member's own squad *and* the public ownership percentages; publishing content in the admin editor refreshes `["admin", "content"]` *and* the public `["content"]` cache.

## Tests

12 new tests, all of which I verified fail against the pre-fix behaviour:

- `lib/query-client.test.ts` (3) - `resetAuthCaches` cancels before it clears, empties the cache, and drops a fetch that was already in flight when the account changed.
- `lib/authed-query.test.tsx` (6) - key shape, two accounts get different keys, hook resolves the session id, anonymous fallback, the query registers under the prefixed key, and one account never reads another's entry.
- `pages/members/members-fantasy.account-switch.test.tsx` (4) - the reported repro end to end. A's squad renders for A; after logout + login as B the page shows its loading state with A's entries gone and the three queries re-registered under B's key; and with the reset skipped entirely, B still cannot see A's squad.

Sanity-checked by reverting each fix in turn: without `resetAuthCaches` the logout test fails, and without the key prefix B renders "Alice Alpha" - the exact bug.

Full suite green: 694 web tests, 52 fantasy API unit tests, 19 fantasy integration tests. `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, plus the web client and SSR/prerender builds.

## Adjacent: `/api/fantasy/team` response schema (separate commit)

Taken because it was quick and clean. The endpoint declared `players` as `z.array(z.record(z.string(), z.unknown()))`, which typed each row as `{ [key: string]: unknown }` in the generated client and forced the banned `as unknown as MyTeamResponse` cast plus a hand-rolled interface. Now declared field by field, with the service projecting to match, so `MyTeamResponse` comes from the spec and both casts are gone. The join was also shipping row ids and gameweek bookkeeping to the browser; those stay server-side now.

## Assumptions

- Admin/treasurer keys are wrapped even though they are role-scoped rather than strictly user-scoped. They hold privileged data that must not survive an account switch, and wrapping them keeps one rule for everything behind `RequireAuth`.
- Signed-out user-scoped reads bucket under a reserved `"anonymous"` id rather than sharing a slot with whoever signs in next.
- `resetAuthCaches` clears public content too. After logout we navigate to `/` client-side, so the home page refetches its games queries. No prerendered DOM is involved on a client-side navigation, so there is nothing to flash - correctness over the extra fetch.

## Open questions

- **`components/marketing/lead-form.tsx` is the one deliberate exception.** It invalidates `["admin", "leads"]` from the public marketing form, so it needs `useAuthedQueryKey()` to keep matching the now-prefixed admin key. Adding that one line pushed `LeadForm` past the 300-line `react-doctor/no-giant-component` threshold, and splitting an unrelated marketing component inside a security PR felt wrong - as did a disable comment with a fabricated justification. I left it unprefixed, so an admin who submits the public lead form in the same tab will not see their leads list auto-refresh. Marginal, but it is a real (tiny) behaviour change. Want me to split `LeadForm` in a follow-up, or is dropping that invalidation entirely fine?
- The web app has no DOM test infrastructure (no jsdom, no testing-library - all 14 existing `.test.tsx` files use `renderToStaticMarkup`). I followed that convention rather than adding three dev dependencies in a security PR, which means the regression test drives the transition by calling `resetAuthCaches` directly and re-rendering, rather than clicking through logout and login. It still fails against the old behaviour, but it does not exercise the actual logout component. Worth adding jsdom + testing-library separately?
- `toSlotType` in the fantasy service falls back to `"batting"` for an out-of-enum `slot_type`. Only the enum-validated save endpoint writes that column, so this should be unreachable - but silently defaulting rather than throwing is a judgement call I made for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Account Handling**
  * Improved separation of account-specific data when switching accounts.
  * Sign-in, registration, and sign-out transitions now clear previous account data more reliably.
  * Reduced the risk of stale information appearing after authentication changes.

* **Fantasy**
  * Fantasy team data now consistently includes player details, costs, roles, and captain or wicketkeeper status.
  * Invalid lineup slot values are handled safely.

* **Bug Fixes**
  * Improved data refreshes after updates across member, admin, and Scout areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->