### PR TITLE
security(matchday): drop push subscription on sign-out and account switch

### DIFF
--- a/apps/api/src/features/push-subscriptions/integration.test.ts
+++ b/apps/api/src/features/push-subscriptions/integration.test.ts
@@ -156,11 +156,37 @@ describe("push-subscriptions service (integration)", () => {
     ).toEqual([SUB_A.endpoint]);
   });
 
+  it("returns the newest subscription first", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertPushSubscription(ctx.db)(userId, SUB_A);
+    await upsertPushSubscription(ctx.db)(userId, SUB_B);
+    // Two inserts in the same test can land in the same clock tick, so
+    // pin the timestamps rather than relying on insertion order.
+    await ctx.db
+      .updateTable("push_subscription")
+      .set({ created_at: new Date("2026-08-01T09:00:00.000Z") })
+      .where("endpoint", "=", SUB_A.endpoint)
+      .execute();
+    await ctx.db
+      .updateTable("push_subscription")
+      .set({ created_at: new Date("2026-08-02T09:00:00.000Z") })
+      .where("endpoint", "=", SUB_B.endpoint)
+      .execute();
+
+    const rows = await listPushSubscriptionsForUser(ctx.db)(userId);
+    expect(rows.map((s) => s.endpoint)).toEqual([
+      SUB_B.endpoint,
+      SUB_A.endpoint,
+    ]);
+  });
+
   it("serialises createdAt as an ISO string", async () => {
     const { userId } = await seedTestUser(ctx.db, { withMember: false });
     await upsertPushSubscription(ctx.db)(userId, SUB_A);
     const [row] = await listPushSubscriptionsForUser(ctx.db)(userId);
-    expect(row?.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(row?.createdAt).toBeDefined();
+    // Round-tripping proves it is a real instant, not just ISO-shaped.
+    expect(new Date(row?.createdAt ?? "").toISOString()).toBe(row?.createdAt);
   });
 
   it("hard-deletes a subscription by endpoint (gone-410 cleanup)", async () => {

--- a/apps/api/src/features/push-subscriptions/integration.test.ts
+++ b/apps/api/src/features/push-subscriptions/integration.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   deletePushSubscription,
   deletePushSubscriptionByEndpoint,
+  listPushSubscriptionsForUser,
   listPushSubscriptionsForUsers,
   upsertPushSubscription,
 } from "./service.ts";
@@ -115,6 +116,51 @@ describe("push-subscriptions service (integration)", () => {
     expect(map.get(a.userId)).toHaveLength(1);
     expect(map.get(b.userId)).toHaveLength(1);
     expect(map.get(a.userId)?.[0]?.endpoint).toBe(SUB_A.endpoint);
+  });
+
+  it("lists only the caller's own subscriptions", async () => {
+    const a = await seedTestUser(ctx.db, { withMember: false });
+    const b = await seedTestUser(ctx.db, { withMember: false });
+    await upsertPushSubscription(ctx.db)(a.userId, SUB_A);
+    await upsertPushSubscription(ctx.db)(b.userId, SUB_B);
+
+    const forA = await listPushSubscriptionsForUser(ctx.db)(a.userId);
+    expect(forA).toHaveLength(1);
+    expect(forA[0]?.endpoint).toBe(SUB_A.endpoint);
+    expect(forA[0]?.userAgent).toBe("Chrome/Mac");
+    expect(forA.map((s) => s.endpoint)).not.toContain(SUB_B.endpoint);
+
+    // The shared-device check the matchday client relies on: B must not
+    // see A's endpoint, so B's local subscription reads as unsubscribed.
+    const forB = await listPushSubscriptionsForUser(ctx.db)(b.userId);
+    expect(forB.map((s) => s.endpoint)).toEqual([SUB_B.endpoint]);
+    expect(forB[0]?.userAgent).toBeNull();
+  });
+
+  it("returns an empty list for a user with no subscriptions", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    expect(await listPushSubscriptionsForUser(ctx.db)(userId)).toEqual([]);
+  });
+
+  it("stops listing an endpoint once it is re-keyed to another user", async () => {
+    const a = await seedTestUser(ctx.db, { withMember: false });
+    const b = await seedTestUser(ctx.db, { withMember: false });
+    await upsertPushSubscription(ctx.db)(a.userId, SUB_A);
+    await upsertPushSubscription(ctx.db)(b.userId, SUB_A);
+
+    expect(await listPushSubscriptionsForUser(ctx.db)(a.userId)).toEqual([]);
+    expect(
+      (await listPushSubscriptionsForUser(ctx.db)(b.userId)).map(
+        (s) => s.endpoint,
+      ),
+    ).toEqual([SUB_A.endpoint]);
+  });
+
+  it("serialises createdAt as an ISO string", async () => {
+    const { userId } = await seedTestUser(ctx.db, { withMember: false });
+    await upsertPushSubscription(ctx.db)(userId, SUB_A);
+    const [row] = await listPushSubscriptionsForUser(ctx.db)(userId);
+    expect(row?.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   it("hard-deletes a subscription by endpoint (gone-410 cleanup)", async () => {

--- a/apps/api/src/features/push-subscriptions/routes.ts
+++ b/apps/api/src/features/push-subscriptions/routes.ts
@@ -5,14 +5,20 @@ import {
   createPushSubscriptionSchema,
   deletePushSubscriptionResponseSchema,
   deletePushSubscriptionSchema,
+  listPushSubscriptionsResponseSchema,
   vapidPublicKeyResponseSchema,
 } from "./schemas.ts";
-import { deletePushSubscription, upsertPushSubscription } from "./service.ts";
+import {
+  deletePushSubscription,
+  listPushSubscriptionsForUser,
+  upsertPushSubscription,
+} from "./service.ts";
 
 // eslint-disable-next-line @typescript-eslint/require-await -- FastifyPluginAsync requires async
 export const pushSubscriptionRoutes: FastifyPluginAsyncZod = async (app) => {
   const upsert = upsertPushSubscription(app.db);
   const remove = deletePushSubscription(app.db);
+  const listForUser = listPushSubscriptionsForUser(app.db);
 
   // Public: the matchday SPA needs the VAPID public key before it can
   // call PushManager.subscribe(). Public key is non-secret by design -
@@ -27,6 +33,26 @@ export const pushSubscriptionRoutes: FastifyPluginAsyncZod = async (app) => {
     },
     // eslint-disable-next-line @typescript-eslint/require-await -- Fastify expects an async handler
     async () => ({ publicKey: app.config.VAPID_PUBLIC_KEY }),
+  );
+
+  // Identity-aware push state: the browser's PushManager knows only that
+  // *a* subscription exists on this device, not who it belongs to. The
+  // client cross-references its local endpoint against this list so a
+  // subscription left behind by the previous user of a shared device
+  // isn't reported as "enabled" for whoever is signed in now.
+  app.get(
+    "/me/push-subscriptions",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        response: { 200: listPushSubscriptionsResponseSchema },
+      },
+    },
+    async (request) => {
+      const { user } = getAuthSession(request);
+      const subscriptions = await listForUser(user.id);
+      return { subscriptions };
+    },
   );
 
   app.post(

--- a/apps/api/src/features/push-subscriptions/schemas.ts
+++ b/apps/api/src/features/push-subscriptions/schemas.ts
@@ -49,6 +49,20 @@ export const createPushSubscriptionResponseSchema = z.object({
   id: z.string(),
 });
 
+// The caller only ever sees their own endpoints, so returning them in
+// full is safe - and it's what lets the client decide whether the
+// browser's local subscription belongs to the signed-in account.
+export const listPushSubscriptionsResponseSchema = z.object({
+  subscriptions: z.array(
+    z.object({
+      id: z.string(),
+      endpoint: z.string(),
+      userAgent: z.string().nullable(),
+      createdAt: z.string(),
+    }),
+  ),
+});
+
 export const deletePushSubscriptionSchema = z.object({
   endpoint: pushEndpointSchema,
 });

--- a/apps/api/src/features/push-subscriptions/service.ts
+++ b/apps/api/src/features/push-subscriptions/service.ts
@@ -62,6 +62,36 @@ export function deletePushSubscription(db: Kysely<DB>) {
   };
 }
 
+// Powers GET /api/me/push-subscriptions - lets the matchday PWA check
+// whether the browser's local PushSubscription is actually registered
+// against the signed-in account. On a shared device the endpoint may
+// still belong to whoever used the browser last, and a local-only
+// subscription must not render as "enabled for this account".
+export interface OwnPushSubscription {
+  id: string;
+  endpoint: string;
+  userAgent: string | null;
+  createdAt: string;
+}
+
+export function listPushSubscriptionsForUser(db: Kysely<DB>) {
+  return async (userId: string): Promise<OwnPushSubscription[]> => {
+    const rows = await db
+      .selectFrom("push_subscription")
+      .select(["id", "endpoint", "user_agent", "created_at"])
+      .where("user_id", "=", userId)
+      .orderBy("created_at", "desc")
+      .execute();
+
+    return rows.map((row) => ({
+      id: row.id,
+      endpoint: row.endpoint,
+      userAgent: row.user_agent,
+      createdAt: row.created_at.toISOString(),
+    }));
+  };
+}
+
 export function listPushSubscriptionsForUsers(db: Kysely<DB>) {
   return async (
     userIds: string[],

--- a/apps/matchday/src/features/notifications/notifications-card.tsx
+++ b/apps/matchday/src/features/notifications/notifications-card.tsx
@@ -7,13 +7,10 @@ import {
   CardTitle,
 } from "@/components/ui/card.js";
 import { api, callApi, type ApiResponse } from "@/lib/api-client.js";
+import { disablePushOnThisDevice, enablePushOnThisDevice } from "@/lib/push.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import {
-  disablePushOnThisDevice,
-  enablePushOnThisDevice,
-  usePushState,
-} from "./use-push.js";
+import { usePushState } from "./use-push.js";
 
 type Prefs = ApiResponse<"/api/me/notification-preferences">;
 type Channel = Prefs["matchdayChannel"];
@@ -177,8 +174,14 @@ function PushStatus({
   }
   return (
     <div className="flex items-center justify-between gap-3">
+      {/*
+        Covers three cases that all end in the same action: never
+        subscribed, a subscription this device is holding for a
+        different account (shared device), and "we couldn't check with
+        the server". Enable re-registers the endpoint to this account.
+      */}
       <p className="text-text-secondary text-xs">
-        Not subscribed on this device yet.
+        Push isn't enabled for this account on this device.
       </p>
       <Button size="sm" onClick={onEnable} disabled={busy}>
         Enable

--- a/apps/matchday/src/features/notifications/use-push.ts
+++ b/apps/matchday/src/features/notifications/use-push.ts
@@ -1,137 +1,6 @@
-import { api, API_BASE, callApi } from "@/lib/api-client.js";
+import { useSession } from "@/lib/auth-client.js";
+import { detectSupport, readPushState, type PushState } from "@/lib/push.js";
 import { useQuery } from "@tanstack/react-query";
-
-// Shared with public/push-handler.js: the SW reads this Cache entry on
-// `pushsubscriptionchange` to re-subscribe + re-register after the push
-// service rotates an endpoint. Window and SW share Cache storage per
-// origin, so this is the durable handoff for config the SW can't read
-// from import.meta.env. Keep the names in sync with push-handler.js.
-const PUSH_CONFIG_CACHE = "push-config-v1";
-const PUSH_CONFIG_KEY = "/__push-config__";
-
-async function storePushConfig(vapidPublicKey: string): Promise<void> {
-  if (typeof caches === "undefined") return;
-  try {
-    const cache = await caches.open(PUSH_CONFIG_CACHE);
-    await cache.put(
-      PUSH_CONFIG_KEY,
-      new Response(JSON.stringify({ apiBase: API_BASE, vapidPublicKey }), {
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
-  } catch {
-    // Best-effort: without it, a post-rotation re-subscribe just falls
-    // back to the user re-enabling manually (the pre-existing behaviour).
-  }
-}
-
-async function clearPushConfig(): Promise<void> {
-  if (typeof caches === "undefined") return;
-  try {
-    await caches.delete(PUSH_CONFIG_CACHE);
-  } catch {
-    // ignore
-  }
-}
-
-type Support =
-  | { supported: true; permission: NotificationPermission }
-  | { supported: false; reason: string };
-
-function detectSupport(): Support {
-  if (typeof window === "undefined") {
-    return { supported: false, reason: "ssr" };
-  }
-  if (!("serviceWorker" in navigator)) {
-    return { supported: false, reason: "no_service_worker" };
-  }
-  if (!("PushManager" in window)) {
-    return { supported: false, reason: "no_push_manager" };
-  }
-  if (!("Notification" in window)) {
-    return { supported: false, reason: "no_notification_api" };
-  }
-  return { supported: true, permission: Notification.permission };
-}
-
-function bytesEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
-  if (a.byteLength !== b.byteLength) return false;
-  const aView = new Uint8Array(a);
-  const bView = new Uint8Array(b);
-  for (let i = 0; i < aView.length; i++) {
-    if (aView[i] !== bView[i]) return false;
-  }
-  return true;
-}
-
-// Convert the base64url-encoded VAPID public key the API hands us into
-// the raw Uint8Array<ArrayBuffer> that PushManager.subscribe() expects.
-// Backed by a real ArrayBuffer (not ArrayBufferLike) so the DOM types
-// accept it as a BufferSource without an `as` escape hatch.
-function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
-  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
-  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
-  const rawData = window.atob(base64);
-  const buffer = new ArrayBuffer(rawData.length);
-  const output = new Uint8Array(buffer);
-  for (let i = 0; i < rawData.length; ++i) {
-    output[i] = rawData.charCodeAt(i);
-  }
-  return output;
-}
-
-// base64url-encode raw key bytes - inverse of urlBase64ToUint8Array. Used
-// to recover the stored VAPID key from an existing subscription's
-// applicationServerKey when backfilling config for devices that
-// subscribed before the pushsubscriptionchange recovery path shipped.
-function urlBase64FromBytes(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return window
-    .btoa(binary)
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-}
-
-// Devices that enabled push before the SW recovery path shipped have a
-// live subscription but no stashed config, so a pushsubscriptionchange
-// would no-op for them. Backfill from the subscription's own
-// applicationServerKey (no network round-trip) the first time we see it.
-async function backfillPushConfig(sub: PushSubscription): Promise<void> {
-  if (typeof caches === "undefined") return;
-  const key = sub.options.applicationServerKey;
-  if (!key) return;
-  try {
-    const cache = await caches.open(PUSH_CONFIG_CACHE);
-    if (await cache.match(PUSH_CONFIG_KEY)) return; // already stored
-  } catch {
-    return;
-  }
-  await storePushConfig(urlBase64FromBytes(key));
-}
-
-export interface PushState {
-  support: Support;
-  // null while react-query is still resolving the SW registration check.
-  subscribed: boolean | null;
-}
-
-async function readPushState(): Promise<PushState> {
-  const support = detectSupport();
-  if (!support.supported) return { support, subscribed: false };
-  try {
-    const reg = await navigator.serviceWorker.ready;
-    const sub = await reg.pushManager.getSubscription();
-    if (sub) await backfillPushConfig(sub);
-    return { support, subscribed: Boolean(sub) };
-  } catch {
-    return { support, subscribed: false };
-  }
-}
 
 export const PUSH_STATE_QUERY_KEY = ["me", "push-state"] as const;
 
@@ -139,112 +8,28 @@ export function usePushState(): {
   state: PushState;
   refresh: () => Promise<unknown>;
 } {
+  const { data: session } = useSession();
+  const userId = session?.user.id ?? null;
+
   const query = useQuery({
-    queryKey: PUSH_STATE_QUERY_KEY,
+    // Keyed by user: push state is now partly server state (is this
+    // browser's endpoint registered to *this* account?), so a cached
+    // answer must never be reused across an account switch.
+    queryKey: [...PUSH_STATE_QUERY_KEY, userId],
     queryFn: readPushState,
-    // Browser state, not server state - no need to refetch on focus or
-    // mount thrash. Caller invalidates explicitly after enable/disable.
+    // Only enable/disable from this screen change it, and both refetch
+    // explicitly via `refresh`.
     staleTime: Infinity,
     refetchOnWindowFocus: false,
     refetchOnMount: false,
   });
 
   const state: PushState = query.data ?? {
+    // Support is a synchronous capability check, so surface it on first
+    // paint - only `subscribed` waits on the query.
     support: detectSupport(),
     subscribed: null,
   };
 
   return { state, refresh: () => query.refetch() };
-}
-
-// Walks the browser through permission -> subscribe -> register on
-// the server. Returns the endpoint on success so callers can show a
-// confirmation chip.
-export async function enablePushOnThisDevice(): Promise<{
-  endpoint: string;
-}> {
-  if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
-    throw new Error("Push notifications are not supported on this device.");
-  }
-  const permission = await Notification.requestPermission();
-  if (permission !== "granted") {
-    throw new Error(
-      permission === "denied"
-        ? "Notification permission is blocked. Re-enable it in the browser site settings to receive push."
-        : "Notification permission not granted.",
-    );
-  }
-
-  const reg = await navigator.serviceWorker.ready;
-  // Pull the VAPID public key from the API rather than baking it into
-  // the bundle - lets us rotate the keypair without a matchday rebuild.
-  const { publicKey } = await callApi(api.GET("/api/push/public-key"));
-  const serverKey = urlBase64ToUint8Array(publicKey);
-
-  // Existing subscription? Reuse it only if it was created with the
-  // *current* VAPID key. After a key rotation the old subscription is
-  // still in PushManager but the push service will reject any sends to
-  // it - so unsubscribe + re-subscribe with the new key transparently.
-  let existing = await reg.pushManager.getSubscription();
-  if (existing) {
-    const existingKey = existing.options.applicationServerKey;
-    if (!existingKey || !bytesEqual(existingKey, serverKey.buffer)) {
-      await existing.unsubscribe();
-      existing = null;
-    }
-  }
-  const sub =
-    existing ??
-    (await reg.pushManager.subscribe({
-      userVisibleOnly: true,
-      applicationServerKey: serverKey,
-    }));
-
-  const json = sub.toJSON();
-  const keys = json.keys ?? {};
-  if (!json.endpoint || !keys.p256dh || !keys.auth) {
-    throw new Error("Push subscription is missing key material.");
-  }
-
-  await callApi(
-    api.POST("/api/me/push-subscriptions", {
-      body: {
-        endpoint: json.endpoint,
-        keys: { p256dh: keys.p256dh, auth: keys.auth },
-        userAgent: navigator.userAgent.slice(0, 500),
-      },
-    }),
-  );
-
-  // Hand the SW what it needs to re-subscribe + re-register itself after
-  // the push service rotates this endpoint (pushsubscriptionchange).
-  await storePushConfig(publicKey);
-
-  return { endpoint: json.endpoint };
-}
-
-export async function disablePushOnThisDevice(): Promise<void> {
-  if (!("serviceWorker" in navigator)) return;
-  // Drop the stashed config first - unconditionally, even if the local
-  // subscription has already expired/disappeared - so a later
-  // pushsubscriptionchange can't resurrect a subscription the user just
-  // turned off.
-  await clearPushConfig();
-  const reg = await navigator.serviceWorker.ready;
-  const sub = await reg.pushManager.getSubscription();
-  if (!sub) return;
-
-  // Best-effort server cleanup before we yank the local subscription -
-  // if the server call fails the worst case is a stale row that gets
-  // pruned at first 410 from the push service.
-  try {
-    await callApi(
-      api.DELETE("/api/me/push-subscriptions", {
-        body: { endpoint: sub.endpoint },
-      }),
-    );
-  } catch {
-    // ignore - local unsubscribe still proceeds
-  }
-  await sub.unsubscribe();
 }

--- a/apps/matchday/src/lib/api-client.ts
+++ b/apps/matchday/src/lib/api-client.ts
@@ -16,7 +16,7 @@
 
 import createClient from "openapi-fetch";
 import type { paths } from "./api.gen.js";
-import { PER_USER_RUNTIME_CACHES } from "./auth-client.js";
+import { PER_USER_RUNTIME_CACHES } from "./runtime-caches.js";
 
 /**
  * Resolve the 200 application/json body for a path + method to its

--- a/apps/matchday/src/lib/api.gen.d.ts
+++ b/apps/matchday/src/lib/api.gen.d.ts
@@ -13318,7 +13318,33 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscriptions: {
+                                id: string;
+                                endpoint: string;
+                                userAgent: string | null;
+                                createdAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
         put?: never;
         post: {
             parameters: {

--- a/apps/matchday/src/lib/api.gen.json
+++ b/apps/matchday/src/lib/api.gen.json
@@ -24106,6 +24106,54 @@
       }
     },
     "/api/me/push-subscriptions": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "subscriptions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "userAgent": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "endpoint",
+                          "userAgent",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "subscriptions"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "requestBody": {
           "required": true,

--- a/apps/matchday/src/lib/auth-client.ts
+++ b/apps/matchday/src/lib/auth-client.ts
@@ -6,6 +6,11 @@ import {
 } from "@percy-main/shared/auth/permissions";
 import { adminClient, twoFactorClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
+import {
+  disablePushOnThisDevice,
+  reconcilePushSubscriptionForUser,
+} from "./push.js";
+import { clearPerUserCaches } from "./runtime-caches.js";
 
 const apiUrl = (import.meta.env.VITE_API_URL as string | undefined) ?? "/api";
 // VITE_API_URL is e.g. "https://api.v2.percymain.org/api" — strip the /api
@@ -68,50 +73,43 @@ export function canManageMatchday(
 }
 
 /**
- * Names of every runtime cache populated by vite-plugin-pwa for
- * /api/* responses. Kept in lockstep with vite.config.ts. Used to
- * wipe per-user data on sign-out / sign-in-as-someone-else so a
- * shared device doesn't leak account A's availability/charges/team-
- * sheet to account B (each Workbox StaleWhileRevalidate entry is
- * keyed on URL only, so without this clear the first paint after
- * switching shows the previous user's cached body).
- *
- * Also consumed by `api-client.ts` to evict a single entry when a
- * /api/* GET returns 401 — covers the case where a cookie expired
- * server-side without the user clicking sign-out.
+ * Ceiling on the push teardown during sign-out. `navigator.serviceWorker
+ * .ready` never settles when no registration ever activates (dev builds,
+ * a browser with the SW disabled), and a sign-out button that hangs
+ * forever is worse than a subscription that survives one extra boot -
+ * the next signed-in boot reconciles it either way.
  */
-export const PER_USER_RUNTIME_CACHES = [
-  "matchday-availability-active",
-  "matchday-team-sheet",
-  "matchday-charges",
-  "matchday-games",
-];
+const PUSH_TEARDOWN_TIMEOUT_MS = 3_000;
 
-/**
- * Wipe every per-user runtime cache. Returns `true` only if every
- * `caches.delete()` resolved cleanly — Safari private mode can have
- * the `caches` API present but reject deletes, in which case we must
- * NOT report the user's caches as clean (the previous-user data is
- * still on disk).
- */
-async function clearPerUserCaches(): Promise<boolean> {
-  if (typeof caches === "undefined") return true;
-  const results = await Promise.all(
-    PER_USER_RUNTIME_CACHES.map((name) =>
-      caches
-        .delete(name)
-        .then(() => true)
-        .catch(() => false),
-    ),
-  );
-  return results.every(Boolean);
+function withTimeout(work: Promise<unknown>, ms: number): Promise<unknown> {
+  return Promise.race([
+    work,
+    new Promise((resolve) => setTimeout(resolve, ms)),
+  ]);
 }
 
 /**
- * Sign out + clear any cached per-user API responses. Use this instead
- * of `authClient.signOut()` everywhere a sign-out is wired up.
+ * Sign out + drop this device's push subscription + clear any cached
+ * per-user API responses. Use this instead of `authClient.signOut()`
+ * everywhere a sign-out is wired up.
  */
 export async function signOut(): Promise<void> {
+  // Order matters: the DELETE /api/me/push-subscriptions inside
+  // `disablePushOnThisDevice` has to authenticate as the departing user,
+  // so it must run while the session cookie is still valid. It also
+  // unsubscribes locally and clears the stashed SW push config, which is
+  // what stops `pushsubscriptionchange` re-registering the endpoint for
+  // whoever signs in next on a shared device.
+  //
+  // Best-effort throughout: sign-out must complete even if push teardown
+  // throws or stalls. A subscription that outlives this call is caught
+  // by `reconcilePushSubscriptionForUser` on the next signed-in boot.
+  try {
+    await withTimeout(disablePushOnThisDevice(), PUSH_TEARDOWN_TIMEOUT_MS);
+  } catch {
+    // ignore
+  }
+
   try {
     await authClient.signOut();
   } finally {
@@ -148,6 +146,14 @@ export async function ensureCachesMatchUser(
   const previous = localStorage.getItem(LAST_USER_KEY);
   const current = userId ?? null;
   if (current !== previous) {
+    // Whoever is signed in now is not who this device was last used by,
+    // so the browser's push subscription may still belong to the
+    // previous account. Reconcile it against the server (drop it unless
+    // it is registered to the current user) - deliberately not awaited,
+    // because the render gate below must not block on a network call
+    // that the PWA routinely makes offline.
+    void reconcilePushSubscriptionForUser(current);
+
     const cleared = await clearPerUserCaches();
     if (!cleared) return false;
     if (current) {

--- a/apps/matchday/src/lib/auth-client.ts
+++ b/apps/matchday/src/lib/auth-client.ts
@@ -82,10 +82,13 @@ export function canManageMatchday(
 const PUSH_TEARDOWN_TIMEOUT_MS = 3_000;
 
 function withTimeout(work: Promise<unknown>, ms: number): Promise<unknown> {
-  return Promise.race([
-    work,
-    new Promise((resolve) => setTimeout(resolve, ms)),
-  ]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise((resolve) => {
+    timer = setTimeout(resolve, ms);
+  });
+  return Promise.race([work, deadline]).finally(() => {
+    clearTimeout(timer);
+  });
 }
 
 /**

--- a/apps/matchday/src/lib/push.test.ts
+++ b/apps/matchday/src/lib/push.test.ts
@@ -377,6 +377,25 @@ describe("push subscriptions on a shared device", () => {
     expect(backend.calls).toEqual([]);
   });
 
+  it("drops the subscription when an account switch can't be verified offline", async () => {
+    await signInAndEnablePush("user-a");
+    const { ensureCachesMatchUser } = await loadModules();
+    localStorageStub.setItem(LAST_USER_KEY, "user-a");
+
+    // No way to ask who owns the endpoint, and no second chance: once
+    // the last-user key is rewritten this boot, later boots see no
+    // mismatch and never reconcile again. Dropping is the safe
+    // direction, at the cost of a re-enable tap if the device was
+    // actually still user A's.
+    backend.currentUserId = "user-b";
+    backend.online = false;
+    await ensureCachesMatchUser("user-b");
+
+    await vi.waitFor(() => {
+      expect(pushManager.current).toBeNull();
+    });
+  });
+
   it("reports unsubscribed when ownership cannot be verified offline", async () => {
     await signInAndEnablePush("user-a");
     const { readPushState } = await loadModules();

--- a/apps/matchday/src/lib/push.test.ts
+++ b/apps/matchday/src/lib/push.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Shared-device account switching (issue #633).
+ *
+ * A PushSubscription lives in the browser, not in the session, so
+ * without the wiring exercised here it survives a sign-out: the next
+ * person to sign in on the device sees "subscribed" while the pushes
+ * keep going to the account that registered the endpoint.
+ *
+ * The environment is `node`, so the DOM surface these modules touch
+ * (service worker registration, PushManager, Cache storage,
+ * localStorage, Notification) is stubbed below. The fakes are
+ * deliberately dumb: the behaviour under test is *which* calls happen
+ * and in what order, not how a real push service behaves.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shared with the vi.mock factory below, which is hoisted above the
+// imports - hence vi.hoisted rather than a plain const.
+const backend = vi.hoisted(() => ({
+  /** endpoint -> the account it is registered to, server-side. */
+  rows: new Map<string, { userId: string; userAgent: string | null }>(),
+  /** Who the session cookie authenticates as for the next call. */
+  currentUserId: null as string | null,
+  /** Flip to false to simulate the PWA being offline. */
+  online: true,
+  /** Ordered log of API + auth calls, for asserting sequencing. */
+  calls: [] as string[],
+}));
+
+const authSignOut = vi.hoisted(() =>
+  vi.fn(() => {
+    backend.calls.push("auth signOut");
+    backend.currentUserId = null;
+    return Promise.resolve({ data: null, error: null });
+  }),
+);
+
+vi.mock("better-auth/react", () => ({
+  createAuthClient: () => ({
+    signOut: authSignOut,
+    useSession: () => ({ data: null, isPending: false }),
+  }),
+}));
+
+vi.mock("@/lib/api-client.js", () => {
+  const ok = <T>(data: T) => Promise.resolve({ data, error: undefined });
+  const fail = (message: string) =>
+    Promise.resolve({ data: undefined, error: { error: message } });
+
+  const requireSession = () => {
+    if (!backend.online) return "offline";
+    if (!backend.currentUserId) return "Unauthorized";
+    return null;
+  };
+
+  return {
+    API_BASE: "/api",
+    callApi: async <T>(pending: Promise<{ data?: T; error?: unknown }>) => {
+      const { data, error } = await pending;
+      if (error !== undefined) throw new Error(JSON.stringify(error));
+      return data;
+    },
+    api: {
+      GET: (path: string) => {
+        backend.calls.push(`GET ${path}`);
+        if (path === "/api/push/public-key") {
+          if (!backend.online) return fail("offline");
+          return ok({ publicKey: VAPID_PUBLIC_KEY });
+        }
+        const denied = requireSession();
+        if (denied) return fail(denied);
+        return ok({
+          subscriptions: [...backend.rows.entries()]
+            .filter(([, row]) => row.userId === backend.currentUserId)
+            .map(([endpoint, row]) => ({
+              id: `sub-${endpoint}`,
+              endpoint,
+              userAgent: row.userAgent,
+              createdAt: new Date("2026-08-01T10:00:00.000Z").toISOString(),
+            })),
+        });
+      },
+      POST: (
+        path: string,
+        init: { body: { endpoint: string; userAgent?: string } },
+      ) => {
+        backend.calls.push(`POST ${path}`);
+        const denied = requireSession();
+        if (denied) return fail(denied);
+        // Mirrors upsertPushSubscription: the endpoint is unique, so
+        // re-registering it re-keys the row onto the caller.
+        backend.rows.set(init.body.endpoint, {
+          userId: backend.currentUserId ?? "",
+          userAgent: init.body.userAgent ?? null,
+        });
+        return ok({ id: `sub-${init.body.endpoint}` });
+      },
+      DELETE: (path: string, init: { body: { endpoint: string } }) => {
+        backend.calls.push(`DELETE ${path}`);
+        const denied = requireSession();
+        if (denied) return fail(denied);
+        const row = backend.rows.get(init.body.endpoint);
+        // The API scopes the delete to the caller's own rows.
+        if (row?.userId !== backend.currentUserId) {
+          return ok({ deleted: false });
+        }
+        backend.rows.delete(init.body.endpoint);
+        return ok({ deleted: true });
+      },
+    },
+  };
+});
+
+// A real VAPID public key shape (base64url, 65 raw bytes) so the
+// base64 -> bytes -> base64 round trip in push.ts runs for real.
+const VAPID_PUBLIC_KEY =
+  "BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8U";
+
+interface FakeSubscription {
+  endpoint: string;
+  options: { applicationServerKey: ArrayBuffer };
+  toJSON: () => { endpoint: string; keys: { p256dh: string; auth: string } };
+  unsubscribe: () => Promise<boolean>;
+}
+
+function createPushManager() {
+  let issued = 0;
+  const manager = {
+    current: null as FakeSubscription | null,
+    getSubscription: () => Promise.resolve(manager.current),
+    subscribe: (opts: { applicationServerKey: Uint8Array<ArrayBuffer> }) => {
+      issued += 1;
+      const endpoint = `https://push.example.com/endpoint-${String(issued)}`;
+      const sub: FakeSubscription = {
+        endpoint,
+        options: { applicationServerKey: opts.applicationServerKey.buffer },
+        toJSON: () => ({
+          endpoint,
+          keys: { p256dh: `p256dh-${endpoint}`, auth: `auth-${endpoint}` },
+        }),
+        unsubscribe: () => {
+          if (manager.current?.endpoint === endpoint) manager.current = null;
+          return Promise.resolve(true);
+        },
+      };
+      manager.current = sub;
+      return Promise.resolve(sub);
+    },
+  };
+  return manager;
+}
+
+function createCacheStorage() {
+  const stores = new Map<string, Map<string, Response>>();
+  return {
+    stores,
+    open: (name: string) => {
+      const store = stores.get(name) ?? new Map<string, Response>();
+      stores.set(name, store);
+      return Promise.resolve({
+        put: (key: string, value: Response) => {
+          store.set(key, value);
+          return Promise.resolve();
+        },
+        match: (key: string) => Promise.resolve(store.get(key)),
+        delete: (key: string) => Promise.resolve(store.delete(key)),
+      });
+    },
+    delete: (name: string) => Promise.resolve(stores.delete(name)),
+  };
+}
+
+function createLocalStorage() {
+  const entries = new Map<string, string>();
+  return {
+    entries,
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => entries.set(key, value),
+    removeItem: (key: string) => entries.delete(key),
+  };
+}
+
+let pushManager: ReturnType<typeof createPushManager>;
+let cacheStorage: ReturnType<typeof createCacheStorage>;
+let localStorageStub: ReturnType<typeof createLocalStorage>;
+
+const PUSH_CONFIG_CACHE = "push-config-v1";
+const LAST_USER_KEY = "matchday-last-user-id";
+
+beforeEach(() => {
+  backend.rows.clear();
+  backend.currentUserId = null;
+  backend.online = true;
+  backend.calls.length = 0;
+  authSignOut.mockClear();
+
+  pushManager = createPushManager();
+  cacheStorage = createCacheStorage();
+  localStorageStub = createLocalStorage();
+
+  vi.stubGlobal("navigator", {
+    serviceWorker: { ready: Promise.resolve({ pushManager }) },
+    userAgent: "vitest",
+  });
+  vi.stubGlobal("window", {
+    atob: globalThis.atob.bind(globalThis),
+    btoa: globalThis.btoa.bind(globalThis),
+    // detectSupport only probes for the key, never constructs it.
+    PushManager: () => undefined,
+    Notification: { permission: "granted" },
+  });
+  vi.stubGlobal("Notification", {
+    permission: "granted",
+    requestPermission: () => Promise.resolve("granted"),
+  });
+  vi.stubGlobal("caches", cacheStorage);
+  vi.stubGlobal("localStorage", localStorageStub);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+/**
+ * Imported lazily so each test picks up the freshly stubbed globals
+ * (auth-client builds its client at module load).
+ */
+async function loadModules() {
+  const push = await import("./push.js");
+  const auth = await import("./auth-client.js");
+  return { ...push, ...auth };
+}
+
+async function signInAndEnablePush(userId: string): Promise<string> {
+  backend.currentUserId = userId;
+  const { enablePushOnThisDevice } = await loadModules();
+  const { endpoint } = await enablePushOnThisDevice();
+  return endpoint;
+}
+
+describe("push subscriptions on a shared device", () => {
+  it("registers the endpoint against the signed-in account", async () => {
+    const endpoint = await signInAndEnablePush("user-a");
+
+    expect(backend.rows.get(endpoint)?.userId).toBe("user-a");
+    expect(pushManager.current?.endpoint).toBe(endpoint);
+    // The SW config has to be stashed for pushsubscriptionchange (#444).
+    expect(cacheStorage.stores.has(PUSH_CONFIG_CACHE)).toBe(true);
+
+    const { readPushState } = await loadModules();
+    await expect(readPushState()).resolves.toMatchObject({ subscribed: true });
+  });
+
+  it("drops the subscription on explicit sign-out, before the session dies", async () => {
+    const endpoint = await signInAndEnablePush("user-a");
+    const { signOut } = await loadModules();
+
+    await signOut();
+
+    // Server row gone: the DELETE has to happen while the departing
+    // user is still authenticated, so it must precede signOut().
+    expect(backend.rows.has(endpoint)).toBe(false);
+    expect(backend.calls).toEqual([
+      "GET /api/push/public-key",
+      "POST /api/me/push-subscriptions",
+      "DELETE /api/me/push-subscriptions",
+      "auth signOut",
+    ]);
+    // Local subscription gone, and the stashed config with it - without
+    // that, pushsubscriptionchange would re-subscribe and re-register.
+    expect(pushManager.current).toBeNull();
+    expect(cacheStorage.stores.has(PUSH_CONFIG_CACHE)).toBe(false);
+    expect(localStorageStub.entries.has(LAST_USER_KEY)).toBe(false);
+  });
+
+  it("reads as unsubscribed for the next user who signs in", async () => {
+    await signInAndEnablePush("user-a");
+    const { signOut, ensureCachesMatchUser, readPushState } =
+      await loadModules();
+    await signOut();
+
+    backend.currentUserId = "user-b";
+    await expect(ensureCachesMatchUser("user-b")).resolves.toBe(true);
+
+    await expect(readPushState()).resolves.toMatchObject({
+      subscribed: false,
+    });
+    expect(pushManager.current).toBeNull();
+  });
+
+  it("completes sign-out even when push teardown fails", async () => {
+    await signInAndEnablePush("user-a");
+    const { signOut } = await loadModules();
+    // Service worker never settles (dev build / SW disabled): the
+    // teardown must not wedge the sign-out button.
+    vi.stubGlobal("navigator", {
+      serviceWorker: {
+        ready: new Promise(() => {
+          /* never resolves */
+        }),
+      },
+      userAgent: "vitest",
+    });
+
+    vi.useFakeTimers();
+    try {
+      const pending = signOut();
+      // Burn the teardown timeout rather than the wall clock.
+      await vi.advanceTimersByTimeAsync(5_000);
+      await pending;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(authSignOut).toHaveBeenCalledTimes(1);
+    expect(localStorageStub.entries.has(LAST_USER_KEY)).toBe(false);
+  });
+
+  it("drops a subscription left behind when the account switches without a sign-out", async () => {
+    const endpoint = await signInAndEnablePush("user-a");
+    const { ensureCachesMatchUser, readPushState } = await loadModules();
+    localStorageStub.setItem(LAST_USER_KEY, "user-a");
+
+    // A's cookie is replaced by B's without matchday's signOut() ever
+    // running (signed in elsewhere, session swapped, expiry + re-login).
+    backend.currentUserId = "user-b";
+    await ensureCachesMatchUser("user-b");
+
+    // Reconciliation is fired without awaiting so it can't block the
+    // render gate on a network call.
+    await vi.waitFor(() => {
+      expect(pushManager.current).toBeNull();
+    });
+
+    // B never inherits A's alerts, and B's push reads as off.
+    await expect(readPushState()).resolves.toMatchObject({
+      subscribed: false,
+    });
+    // A's row can't be deleted while authenticated as B - it is pruned
+    // by deletePushSubscriptionByEndpoint on the first 404/410 from the
+    // push service, now that the endpoint is unsubscribed.
+    expect(backend.rows.get(endpoint)?.userId).toBe("user-a");
+  });
+
+  it("keeps the subscription when the same user signs back in", async () => {
+    const endpoint = await signInAndEnablePush("user-a");
+    const { ensureCachesMatchUser } = await loadModules();
+    // Safari evicted localStorage, so the last-user hint is gone: the
+    // mismatch branch fires for a user whose subscription is genuinely
+    // theirs. Server ownership is what decides, so it survives.
+    localStorageStub.removeItem(LAST_USER_KEY);
+
+    await ensureCachesMatchUser("user-a");
+    await vi.waitFor(() => {
+      expect(backend.calls).toContain("GET /api/me/push-subscriptions");
+    });
+
+    expect(pushManager.current?.endpoint).toBe(endpoint);
+    expect(cacheStorage.stores.has(PUSH_CONFIG_CACHE)).toBe(true);
+  });
+
+  it("leaves the subscription alone when the session simply ends", async () => {
+    await signInAndEnablePush("user-a");
+    const { ensureCachesMatchUser } = await loadModules();
+    localStorageStub.setItem(LAST_USER_KEY, "user-a");
+    backend.calls.length = 0;
+
+    // Cookie expired on a personal device. Dropping here would silently
+    // turn push off for the person about to sign back in; a genuine
+    // account switch is caught when the *next* user signs in instead.
+    backend.currentUserId = null;
+    await ensureCachesMatchUser(null);
+
+    expect(pushManager.current).not.toBeNull();
+    expect(backend.calls).toEqual([]);
+  });
+
+  it("reports unsubscribed when ownership cannot be verified offline", async () => {
+    await signInAndEnablePush("user-a");
+    const { readPushState } = await loadModules();
+
+    backend.online = false;
+
+    // Safe direction: an unverifiable subscription must not render as
+    // "this device will receive matchday push" - Enable re-registers
+    // the existing browser subscription once the network is back.
+    await expect(readPushState()).resolves.toMatchObject({
+      subscribed: false,
+    });
+    expect(pushManager.current).not.toBeNull();
+  });
+
+  it("re-keys the endpoint to whoever explicitly enables push next", async () => {
+    const first = await signInAndEnablePush("user-a");
+    const { signOut } = await loadModules();
+    await signOut();
+
+    const second = await signInAndEnablePush("user-b");
+
+    expect(backend.rows.get(second)?.userId).toBe("user-b");
+    expect(backend.rows.has(first)).toBe(false);
+  });
+});

--- a/apps/matchday/src/lib/push.ts
+++ b/apps/matchday/src/lib/push.ts
@@ -1,0 +1,340 @@
+/**
+ * Browser push subscription lifecycle for the matchday PWA.
+ *
+ * Lives in `lib/` rather than the notifications feature because
+ * `auth-client.ts` has to tear a subscription down on sign-out and on
+ * an account switch, and a lib module must not import a feature module.
+ * The React binding stays in `features/notifications/use-push.ts`.
+ *
+ * The invariant this module enforces: a PushSubscription in the browser
+ * is only ever reported as "on" for the account it is registered to
+ * server-side. PushManager itself knows nothing about accounts, so on a
+ * shared device an endpoint left behind by the previous user would
+ * otherwise read as subscribed for whoever signs in next while the
+ * pushes kept going to the previous user.
+ */
+
+import { api, API_BASE, callApi } from "@/lib/api-client.js";
+
+// Shared with public/push-handler.js: the SW reads this Cache entry on
+// `pushsubscriptionchange` to re-subscribe + re-register after the push
+// service rotates an endpoint. Window and SW share Cache storage per
+// origin, so this is the durable handoff for config the SW can't read
+// from import.meta.env. Keep the names in sync with push-handler.js.
+const PUSH_CONFIG_CACHE = "push-config-v1";
+const PUSH_CONFIG_KEY = "/__push-config__";
+
+async function storePushConfig(vapidPublicKey: string): Promise<void> {
+  if (typeof caches === "undefined") return;
+  try {
+    const cache = await caches.open(PUSH_CONFIG_CACHE);
+    await cache.put(
+      PUSH_CONFIG_KEY,
+      new Response(JSON.stringify({ apiBase: API_BASE, vapidPublicKey }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  } catch {
+    // Best-effort: without it, a post-rotation re-subscribe just falls
+    // back to the user re-enabling manually (the pre-existing behaviour).
+  }
+}
+
+async function clearPushConfig(): Promise<void> {
+  if (typeof caches === "undefined") return;
+  try {
+    await caches.delete(PUSH_CONFIG_CACHE);
+  } catch {
+    // ignore
+  }
+}
+
+export type Support =
+  | { supported: true; permission: NotificationPermission }
+  | { supported: false; reason: string };
+
+/**
+ * Synchronous browser capability check. Exported so the UI can render
+ * the support/permission copy on first paint, without waiting for the
+ * async subscription + ownership lookup.
+ */
+export function detectSupport(): Support {
+  if (typeof window === "undefined") {
+    return { supported: false, reason: "ssr" };
+  }
+  if (!("serviceWorker" in navigator)) {
+    return { supported: false, reason: "no_service_worker" };
+  }
+  if (!("PushManager" in window)) {
+    return { supported: false, reason: "no_push_manager" };
+  }
+  if (!("Notification" in window)) {
+    return { supported: false, reason: "no_notification_api" };
+  }
+  return { supported: true, permission: Notification.permission };
+}
+
+function bytesEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  const aView = new Uint8Array(a);
+  const bView = new Uint8Array(b);
+  for (let i = 0; i < aView.length; i++) {
+    if (aView[i] !== bView[i]) return false;
+  }
+  return true;
+}
+
+// Convert the base64url-encoded VAPID public key the API hands us into
+// the raw Uint8Array<ArrayBuffer> that PushManager.subscribe() expects.
+// Backed by a real ArrayBuffer (not ArrayBufferLike) so the DOM types
+// accept it as a BufferSource without an `as` escape hatch.
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = window.atob(base64);
+  const buffer = new ArrayBuffer(rawData.length);
+  const output = new Uint8Array(buffer);
+  for (let i = 0; i < rawData.length; ++i) {
+    output[i] = rawData.charCodeAt(i);
+  }
+  return output;
+}
+
+// base64url-encode raw key bytes - inverse of urlBase64ToUint8Array. Used
+// to recover the stored VAPID key from an existing subscription's
+// applicationServerKey when backfilling config for devices that
+// subscribed before the pushsubscriptionchange recovery path shipped.
+function urlBase64FromBytes(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return window
+    .btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+// Devices that enabled push before the SW recovery path shipped have a
+// live subscription but no stashed config, so a pushsubscriptionchange
+// would no-op for them. Backfill from the subscription's own
+// applicationServerKey (no network round-trip) the first time we see it.
+async function backfillPushConfig(sub: PushSubscription): Promise<void> {
+  if (typeof caches === "undefined") return;
+  const key = sub.options.applicationServerKey;
+  if (!key) return;
+  try {
+    const cache = await caches.open(PUSH_CONFIG_CACHE);
+    if (await cache.match(PUSH_CONFIG_KEY)) return; // already stored
+  } catch {
+    return;
+  }
+  await storePushConfig(urlBase64FromBytes(key));
+}
+
+/** The browser's own subscription for this origin, or null. */
+async function getLocalSubscription(): Promise<PushSubscription | null> {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+    return null;
+  }
+  try {
+    const reg = await navigator.serviceWorker.ready;
+    return await reg.pushManager.getSubscription();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Endpoints registered to the *currently signed-in* user, or `null` when
+ * the API could not be reached (offline, 401, 5xx). `null` means "cannot
+ * prove ownership", which every caller treats as "not ours".
+ */
+async function fetchRegisteredEndpoints(): Promise<Set<string> | null> {
+  try {
+    const { subscriptions } = await callApi(
+      api.GET("/api/me/push-subscriptions"),
+    );
+    return new Set(subscriptions.map((sub) => sub.endpoint));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Kill the browser-side subscription and the stashed SW config, without
+ * touching the server. Used when the row we would want to delete belongs
+ * to a different account, so the authenticated DELETE isn't available to
+ * us: unsubscribing at the push service makes the next dispatch to that
+ * endpoint return 404/410, and the dispatcher prunes the row then
+ * (`deletePushSubscriptionByEndpoint`).
+ *
+ * Clearing the config is what stops a later `pushsubscriptionchange`
+ * from resurrecting the subscription and re-registering it (PR #444).
+ */
+async function dropLocalPushSubscription(sub: PushSubscription): Promise<void> {
+  await clearPushConfig();
+  try {
+    await sub.unsubscribe();
+  } catch {
+    // Best-effort. The config is gone either way, so nothing will
+    // re-register this endpoint, and the state read below reports it as
+    // not subscribed for this account.
+  }
+}
+
+export interface PushState {
+  support: Support;
+  // null while react-query is still resolving the SW registration check.
+  subscribed: boolean | null;
+}
+
+/**
+ * Report `subscribed: true` only when the browser's local subscription
+ * is registered against the signed-in account.
+ *
+ * Offline behaviour: if the endpoint list can't be fetched we report
+ * "not subscribed" rather than trusting the local subscription. It's the
+ * safe direction - claiming "this device will receive matchday push" to
+ * someone whose account has no such row is exactly the bug this fixes,
+ * and the recovery is one tap on Enable (which reuses the existing
+ * browser subscription and re-registers the endpoint).
+ */
+export async function readPushState(): Promise<PushState> {
+  const support = detectSupport();
+  if (!support.supported) return { support, subscribed: false };
+  try {
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.getSubscription();
+    if (!sub) return { support, subscribed: false };
+    await backfillPushConfig(sub);
+    const registered = await fetchRegisteredEndpoints();
+    return { support, subscribed: registered?.has(sub.endpoint) ?? false };
+  } catch {
+    return { support, subscribed: false };
+  }
+}
+
+/**
+ * Reconcile this device's push subscription with the account that just
+ * became active. Call on any identity change the app detects.
+ *
+ * We deliberately do NOT re-key the endpoint onto the new user: push is
+ * a consent decision, so the new user gets "not subscribed" and an
+ * Enable button rather than silently inheriting someone else's alerts.
+ *
+ * Skipped when nobody is signed in (`userId === null`). A session ending
+ * without an explicit sign-out is usually just an expired cookie on a
+ * personal device, and dropping the subscription there would silently
+ * turn off notifications for the person who is about to sign back in.
+ * The explicit sign-out path tears the subscription down itself, and a
+ * genuine account switch is caught on the next signed-in boot, before
+ * any UI renders.
+ */
+export async function reconcilePushSubscriptionForUser(
+  userId: string | null,
+): Promise<void> {
+  if (!userId) return;
+  const sub = await getLocalSubscription();
+  if (!sub) return;
+  const registered = await fetchRegisteredEndpoints();
+  if (registered?.has(sub.endpoint)) return;
+  await dropLocalPushSubscription(sub);
+}
+
+// Walks the browser through permission -> subscribe -> register on
+// the server. Returns the endpoint on success so callers can show a
+// confirmation chip.
+export async function enablePushOnThisDevice(): Promise<{
+  endpoint: string;
+}> {
+  if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+    throw new Error("Push notifications are not supported on this device.");
+  }
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") {
+    throw new Error(
+      permission === "denied"
+        ? "Notification permission is blocked. Re-enable it in the browser site settings to receive push."
+        : "Notification permission not granted.",
+    );
+  }
+
+  const reg = await navigator.serviceWorker.ready;
+  // Pull the VAPID public key from the API rather than baking it into
+  // the bundle - lets us rotate the keypair without a matchday rebuild.
+  const { publicKey } = await callApi(api.GET("/api/push/public-key"));
+  const serverKey = urlBase64ToUint8Array(publicKey);
+
+  // Existing subscription? Reuse it only if it was created with the
+  // *current* VAPID key. After a key rotation the old subscription is
+  // still in PushManager but the push service will reject any sends to
+  // it - so unsubscribe + re-subscribe with the new key transparently.
+  let existing = await reg.pushManager.getSubscription();
+  if (existing) {
+    const existingKey = existing.options.applicationServerKey;
+    if (!existingKey || !bytesEqual(existingKey, serverKey.buffer)) {
+      await existing.unsubscribe();
+      existing = null;
+    }
+  }
+  const sub =
+    existing ??
+    (await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: serverKey,
+    }));
+
+  const json = sub.toJSON();
+  const keys = json.keys ?? {};
+  if (!json.endpoint || !keys.p256dh || !keys.auth) {
+    throw new Error("Push subscription is missing key material.");
+  }
+
+  // Re-registering an endpoint that some other account still owns
+  // re-keys the row onto the caller (see `upsertPushSubscription`), so
+  // the previous user stops receiving on a device they no longer use.
+  await callApi(
+    api.POST("/api/me/push-subscriptions", {
+      body: {
+        endpoint: json.endpoint,
+        keys: { p256dh: keys.p256dh, auth: keys.auth },
+        userAgent: navigator.userAgent.slice(0, 500),
+      },
+    }),
+  );
+
+  // Hand the SW what it needs to re-subscribe + re-register itself after
+  // the push service rotates this endpoint (pushsubscriptionchange).
+  await storePushConfig(publicKey);
+
+  return { endpoint: json.endpoint };
+}
+
+export async function disablePushOnThisDevice(): Promise<void> {
+  if (!("serviceWorker" in navigator)) return;
+  // Drop the stashed config first - unconditionally, even if the local
+  // subscription has already expired/disappeared - so a later
+  // pushsubscriptionchange can't resurrect a subscription the user just
+  // turned off.
+  await clearPushConfig();
+  const reg = await navigator.serviceWorker.ready;
+  const sub = await reg.pushManager.getSubscription();
+  if (!sub) return;
+
+  // Best-effort server cleanup before we yank the local subscription -
+  // if the server call fails the worst case is a stale row that gets
+  // pruned at first 410 from the push service.
+  try {
+    await callApi(
+      api.DELETE("/api/me/push-subscriptions", {
+        body: { endpoint: sub.endpoint },
+      }),
+    );
+  } catch {
+    // ignore - local unsubscribe still proceeds
+  }
+  await sub.unsubscribe();
+}

--- a/apps/matchday/src/lib/runtime-caches.ts
+++ b/apps/matchday/src/lib/runtime-caches.ts
@@ -1,0 +1,45 @@
+/**
+ * Names of every runtime cache populated by vite-plugin-pwa for
+ * /api/* responses. Kept in lockstep with vite.config.ts. Used to
+ * wipe per-user data on sign-out / sign-in-as-someone-else so a
+ * shared device doesn't leak account A's availability/charges/team-
+ * sheet to account B (each Workbox StaleWhileRevalidate entry is
+ * keyed on URL only, so without this clear the first paint after
+ * switching shows the previous user's cached body).
+ *
+ * Also consumed by `api-client.ts` to evict a single entry when a
+ * /api/* GET returns 401 - covers the case where a cookie expired
+ * server-side without the user clicking sign-out.
+ *
+ * Lives in its own module rather than in `auth-client.ts` so that
+ * `api-client.ts` can read it without importing the auth client:
+ * `auth-client.ts` now depends on `push.ts`, which depends on
+ * `api-client.ts`, and routing that through `auth-client.ts` would
+ * close an import cycle.
+ */
+export const PER_USER_RUNTIME_CACHES = [
+  "matchday-availability-active",
+  "matchday-team-sheet",
+  "matchday-charges",
+  "matchday-games",
+];
+
+/**
+ * Wipe every per-user runtime cache. Returns `true` only if every
+ * `caches.delete()` resolved cleanly - Safari private mode can have
+ * the `caches` API present but reject deletes, in which case we must
+ * NOT report the user's caches as clean (the previous-user data is
+ * still on disk).
+ */
+export async function clearPerUserCaches(): Promise<boolean> {
+  if (typeof caches === "undefined") return true;
+  const results = await Promise.all(
+    PER_USER_RUNTIME_CACHES.map((name) =>
+      caches
+        .delete(name)
+        .then(() => true)
+        .catch(() => false),
+    ),
+  );
+  return results.every(Boolean);
+}

--- a/apps/matchday/vitest.config.ts
+++ b/apps/matchday/vitest.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     exclude: ["**/node_modules/**", "**/dist/**"],
-    // No tests yet in this workspace — don't fail CI for the absence.
-    // Drop this once we add the first .test.ts.
-    passWithNoTests: true,
     reporters: process.env.CI
       ? [
           "default",

--- a/apps/web/src/lib/api.gen.d.ts
+++ b/apps/web/src/lib/api.gen.d.ts
@@ -13318,7 +13318,33 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscriptions: {
+                                id: string;
+                                endpoint: string;
+                                userAgent: string | null;
+                                createdAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
         put?: never;
         post: {
             parameters: {

--- a/apps/web/src/lib/api.gen.json
+++ b/apps/web/src/lib/api.gen.json
@@ -24106,6 +24106,54 @@
       }
     },
     "/api/me/push-subscriptions": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "subscriptions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          },
+                          "userAgent": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "endpoint",
+                          "userAgent",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "subscriptions"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "requestBody": {
           "required": true,

--- a/docs/adrs/058-push-subscription-dropped-on-account-change.md
+++ b/docs/adrs/058-push-subscription-dropped-on-account-change.md
@@ -1,0 +1,88 @@
+# Decision 058: Push Subscriptions Are Dropped, Not Re-Keyed, When the Account Changes
+
+**Date:** 2026-08-21
+**Status:** Accepted
+
+## Decision
+
+A browser push subscription belongs to the account that explicitly enabled it,
+and never transfers. On sign-out the matchday PWA tears the subscription down
+before destroying the session. When the app boots as a different user, the
+subscription is reconciled against the server and dropped unless that endpoint
+is registered to the user who is signed in now. The new user sees "not enabled
+for this account" and an Enable button; nothing re-keys silently.
+
+Push state is no longer read from the browser alone. `GET
+/api/me/push-subscriptions` returns the caller's own endpoints, and the client
+reports `subscribed: true` only when its local endpoint appears in that list.
+
+## Problem
+
+`PushManager` has no notion of accounts (#633, severity medium). The
+subscription is scoped to the origin, so on a shared device it outlived
+sign-out: the API row still pointed at user A, the browser still held A's
+endpoint, and the UI read "subscribed" purely from
+`registration.pushManager.getSubscription()`. User B signed in, saw a
+subscribed device, never registered an endpoint of their own, and A's matchday
+alerts kept arriving on B's phone.
+
+## Options considered
+
+1. **Drop on account change; require an explicit re-enable (chosen).**
+   Sign-out deletes the row and unsubscribes locally; an identity change
+   unsubscribes anything the server does not confirm as the current user's.
+
+2. **Silently re-key the endpoint to the new user.** One fewer tap for
+   returning users on a shared device, and the row moves in a single upsert
+   (`upsertPushSubscription` already re-keys on endpoint conflict).
+
+3. **Server-side only: delete every row for the departing user at sign-out.**
+   No client changes, but it kills that user's push on _every_ device they own
+   because a session has no idea which endpoint belongs to the device in hand.
+
+## Rationale
+
+Notifications are a consent decision, not a device setting. Re-keying would
+start pushing club alerts to someone who never asked for them, on the strength
+of nothing more than sharing a browser profile with a teammate - and the
+notification would look like it came from an app they had configured. The
+extra tap is a one-time cost paid only by users who switch accounts on a
+shared device.
+
+Dropping needs both halves. Deleting the server row alone leaves a live
+endpoint the push service still accepts; unsubscribing locally alone leaves a
+row that dispatch keeps trying. The sign-out path does both while the
+departing user's cookie is still valid, so the ordering (push teardown first,
+`authClient.signOut()` second) is load-bearing. Clearing the stashed VAPID
+config matters just as much: without it the `pushsubscriptionchange` recovery
+handler added in PR #444 would re-subscribe and re-register the device for
+whoever is signed in next.
+
+When the session is switched without going through our sign-out, the departing
+user's row cannot be deleted (we are authenticated as somebody else by then).
+Unsubscribing at the push service is enough: the next dispatch gets 404/410 and
+`deletePushSubscriptionByEndpoint` prunes the row, which is the same path a
+browser-expired subscription already takes.
+
+Ownership is decided by the server, not by the `matchday-last-user-id`
+localStorage hint, which is only a cache-hygiene optimisation and is routinely
+absent (Safari evicts it). Asking the API "is this endpoint mine?" makes a
+returning user's own subscription survive an eviction, and still drops a
+stranger's.
+
+## Trade-offs
+
+- **Unverifiable state reads as "off".** If the endpoint list cannot be
+  fetched (offline, 401, 5xx) the UI reports not-subscribed even though a
+  local subscription exists. Claiming "this device will receive matchday push"
+  to an account with no such row is the bug being fixed, so the failure is
+  deliberately in the safe direction. Recovery is one tap: Enable reuses the
+  existing browser subscription and re-registers the endpoint.
+- **An expired cookie does not drop the subscription.** `ensureCachesMatchUser`
+  skips reconciliation when nobody is signed in, because a session that simply
+  ended is usually a personal device whose owner is about to sign back in, and
+  silently disabling their notifications is worse than the leak window. The
+  leak closes when the _next_ user signs in, before any UI renders.
+- **Reconciliation is not awaited.** It runs a network call, and the
+  `<RequireAuth />` render gate must not block on the network in a PWA that
+  boots offline. Rendering is gated on the cache wipe only, as before.

--- a/docs/adrs/058-push-subscription-dropped-on-account-change.md
+++ b/docs/adrs/058-push-subscription-dropped-on-account-change.md
@@ -72,12 +72,19 @@ stranger's.
 
 ## Trade-offs
 
-- **Unverifiable state reads as "off".** If the endpoint list cannot be
-  fetched (offline, 401, 5xx) the UI reports not-subscribed even though a
-  local subscription exists. Claiming "this device will receive matchday push"
-  to an account with no such row is the bug being fixed, so the failure is
-  deliberately in the safe direction. Recovery is one tap: Enable reuses the
-  existing browser subscription and re-registers the endpoint.
+- **An unverifiable answer counts as "not yours", and that is destructive.**
+  If the endpoint list cannot be fetched (offline, 401, 5xx) the UI reports
+  not-subscribed, and reconciliation on an identity change goes further: it
+  unsubscribes the local subscription. That is deliberate, because
+  reconciliation gets one attempt - `ensureCachesMatchUser` rewrites
+  `matchday-last-user-id` on the same boot, so later boots see no mismatch and
+  never retry. Skipping the drop when offline would leave the previous user's
+  alerts arriving on this device indefinitely, which is the bug being fixed.
+  The cost is a false positive when the device was still the same user's and
+  the last-user hint had been evicted: they lose push until they re-enable.
+  Recovery is one tap - Enable reuses the existing browser subscription and
+  re-registers the endpoint - and the card shows an Enable button, so the
+  state is at least visible rather than silent.
 - **An expired cookie does not drop the subscription.** `ensureCachesMatchUser`
   skips reconciliation when nobody is signed in, because a session that simply
   ended is usually a personal device whose owner is about to sign back in, and

--- a/docs/adrs/059-push-subscription-dropped-on-account-change.md
+++ b/docs/adrs/059-push-subscription-dropped-on-account-change.md
@@ -1,4 +1,4 @@
-# Decision 058: Push Subscriptions Are Dropped, Not Re-Keyed, When the Account Changes
+# Decision 059: Push Subscriptions Are Dropped, Not Re-Keyed, When the Account Changes
 
 **Date:** 2026-08-21
 **Status:** Accepted

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -36,4 +36,4 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 | [055](055-content-assistant-edit-ops-and-sidebar.md)      | Content assistant edit-op protocol + persistent sidebar            | 2026-07-09 | Accepted |
 | [056](056-dnb-rows-stay-in-batting-table.md)              | "Did not bat" rows stay in the batting table with a did_bat flag   | 2026-07-26 | Accepted |
 | [057](057-reviewer-gated-terraform-pr-plans.md)           | Reviewer-gated Terraform PR plans instead of a de-scoped plan role | 2026-08-20 | Accepted |
-| [058](058-push-subscription-dropped-on-account-change.md) | Push subscriptions dropped, not re-keyed, when the account changes | 2026-08-21 | Accepted |
+| [059](059-push-subscription-dropped-on-account-change.md) | Push subscriptions dropped, not re-keyed, when the account changes | 2026-08-21 | Accepted |

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -6,33 +6,34 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 
 ## Index
 
-| #                                                        | Title                                                              | Date       | Status   |
-| -------------------------------------------------------- | ------------------------------------------------------------------ | ---------- | -------- |
-| [001](001-api-framework.md)                              | API Framework - Fastify over Express                               | 2026-03-14 | Accepted |
-| [002](002-email-provider.md)                             | Email Provider - SES over Mailgun                                  | 2026-03-14 | Accepted |
-| [003](003-baseline-migration-strategy.md)                | Baseline Migration Strategy - Single Consolidated Migration        | 2026-03-14 | Accepted |
-| [004](004-auth-database-type.md)                         | better-auth Database Type - postgres                               | 2026-03-14 | Accepted |
-| [005](005-generated-types-approach.md)                   | Generated DB Types - Placeholder with PostgreSQL Types             | 2026-03-14 | Accepted |
-| [006](006-monorepo-structure.md)                         | Monorepo Structure - Following the Plan                            | 2026-03-14 | Accepted |
-| [007](007-webhook-raw-body.md)                           | Stripe Webhook Raw Body Handling                                   | 2026-03-14 | Accepted |
-| [008](008-vite-proxy-for-local-dev.md)                   | Vite Dev Server Proxy for Local Development                        | 2026-03-14 | Accepted |
-| [009](009-dependency-injection.md)                       | Functional Dependency Injection                                    | 2026-03-14 | Accepted |
-| [010](010-testcontainers.md)                             | Testcontainers for Integration Tests                               | 2026-03-14 | Accepted |
-| [011](011-api-type-safety.md)                            | API Type Safety Between Backend and Frontend                       | 2026-03-16 | Accepted |
-| [012](012-prod-db-access.md)                             | Production DB Access via Tailscale                                 | 2026-04-20 | Accepted |
-| [042](042-scout-recognition-sources.md)                  | Scout Recognition Sources - Public-Source Discovery                | 2026-05-14 | Accepted |
-| [043](043-db-role-split-principle-of-least-privilege.md) | DB Role Split - Principle of Least Privilege                       | 2026-05-15 | Accepted |
-| [044](044-matchday-notification-channel-modelling.md)    | Matchday notification channel modelling                            | 2026-05-21 | Accepted |
-| [045](045-matchday-service-worker-push-integration.md)   | Matchday service worker push integration via importScripts         | 2026-05-21 | Accepted |
-| [046](046-vapid-public-key-via-api.md)                   | VAPID public key delivered via API, not bundled                    | 2026-05-21 | Accepted |
-| [047](047-content-editor-blocknote.md)                   | Content Editor - BlockNote with JSON canonical format              | 2026-06-10 | Accepted |
-| [048](048-editor-image-webp-only-sync-processing.md)     | Editor images - WebP-only ladder, synchronous processing           | 2026-06-10 | Accepted |
-| [049](049-ai-content-author-assistant.md)                | AI content-author assistant reuses Scout's tools                   | 2026-06-14 | Accepted |
-| [050](050-profile-self-edit-proposal-tier.md)            | Profile self-editing via a proposal/approval tier                  | 2026-06-23 | Accepted |
-| [051](051-member-slug-backfill-and-profile-fallback.md)  | Member slug backfill, member-backed profile fallback, self-create  | 2026-06-24 | Accepted |
-| [052](052-publish-time-prerendering.md)                  | Publish-time prerendering via Lambda + CloudFront KeyValueStore    | 2026-07-03 | Accepted |
-| [053](053-prerendering-fixtures-and-calendar.md)         | Prerendering fixtures and calendar months via hash-diffed manifest | 2026-07-04 | Accepted |
-| [054](054-typescript-7-native-with-v6-api-alias.md)      | TypeScript 7 native compiler, v6 JS API aliased for tooling        | 2026-07-08 | Accepted |
-| [055](055-content-assistant-edit-ops-and-sidebar.md)     | Content assistant edit-op protocol + persistent sidebar            | 2026-07-09 | Accepted |
-| [056](056-dnb-rows-stay-in-batting-table.md)             | "Did not bat" rows stay in the batting table with a did_bat flag   | 2026-07-26 | Accepted |
-| [057](057-reviewer-gated-terraform-pr-plans.md)          | Reviewer-gated Terraform PR plans instead of a de-scoped plan role | 2026-08-20 | Accepted |
+| #                                                         | Title                                                              | Date       | Status   |
+| --------------------------------------------------------- | ------------------------------------------------------------------ | ---------- | -------- |
+| [001](001-api-framework.md)                               | API Framework - Fastify over Express                               | 2026-03-14 | Accepted |
+| [002](002-email-provider.md)                              | Email Provider - SES over Mailgun                                  | 2026-03-14 | Accepted |
+| [003](003-baseline-migration-strategy.md)                 | Baseline Migration Strategy - Single Consolidated Migration        | 2026-03-14 | Accepted |
+| [004](004-auth-database-type.md)                          | better-auth Database Type - postgres                               | 2026-03-14 | Accepted |
+| [005](005-generated-types-approach.md)                    | Generated DB Types - Placeholder with PostgreSQL Types             | 2026-03-14 | Accepted |
+| [006](006-monorepo-structure.md)                          | Monorepo Structure - Following the Plan                            | 2026-03-14 | Accepted |
+| [007](007-webhook-raw-body.md)                            | Stripe Webhook Raw Body Handling                                   | 2026-03-14 | Accepted |
+| [008](008-vite-proxy-for-local-dev.md)                    | Vite Dev Server Proxy for Local Development                        | 2026-03-14 | Accepted |
+| [009](009-dependency-injection.md)                        | Functional Dependency Injection                                    | 2026-03-14 | Accepted |
+| [010](010-testcontainers.md)                              | Testcontainers for Integration Tests                               | 2026-03-14 | Accepted |
+| [011](011-api-type-safety.md)                             | API Type Safety Between Backend and Frontend                       | 2026-03-16 | Accepted |
+| [012](012-prod-db-access.md)                              | Production DB Access via Tailscale                                 | 2026-04-20 | Accepted |
+| [042](042-scout-recognition-sources.md)                   | Scout Recognition Sources - Public-Source Discovery                | 2026-05-14 | Accepted |
+| [043](043-db-role-split-principle-of-least-privilege.md)  | DB Role Split - Principle of Least Privilege                       | 2026-05-15 | Accepted |
+| [044](044-matchday-notification-channel-modelling.md)     | Matchday notification channel modelling                            | 2026-05-21 | Accepted |
+| [045](045-matchday-service-worker-push-integration.md)    | Matchday service worker push integration via importScripts         | 2026-05-21 | Accepted |
+| [046](046-vapid-public-key-via-api.md)                    | VAPID public key delivered via API, not bundled                    | 2026-05-21 | Accepted |
+| [047](047-content-editor-blocknote.md)                    | Content Editor - BlockNote with JSON canonical format              | 2026-06-10 | Accepted |
+| [048](048-editor-image-webp-only-sync-processing.md)      | Editor images - WebP-only ladder, synchronous processing           | 2026-06-10 | Accepted |
+| [049](049-ai-content-author-assistant.md)                 | AI content-author assistant reuses Scout's tools                   | 2026-06-14 | Accepted |
+| [050](050-profile-self-edit-proposal-tier.md)             | Profile self-editing via a proposal/approval tier                  | 2026-06-23 | Accepted |
+| [051](051-member-slug-backfill-and-profile-fallback.md)   | Member slug backfill, member-backed profile fallback, self-create  | 2026-06-24 | Accepted |
+| [052](052-publish-time-prerendering.md)                   | Publish-time prerendering via Lambda + CloudFront KeyValueStore    | 2026-07-03 | Accepted |
+| [053](053-prerendering-fixtures-and-calendar.md)          | Prerendering fixtures and calendar months via hash-diffed manifest | 2026-07-04 | Accepted |
+| [054](054-typescript-7-native-with-v6-api-alias.md)       | TypeScript 7 native compiler, v6 JS API aliased for tooling        | 2026-07-08 | Accepted |
+| [055](055-content-assistant-edit-ops-and-sidebar.md)      | Content assistant edit-op protocol + persistent sidebar            | 2026-07-09 | Accepted |
+| [056](056-dnb-rows-stay-in-batting-table.md)              | "Did not bat" rows stay in the batting table with a did_bat flag   | 2026-07-26 | Accepted |
+| [057](057-reviewer-gated-terraform-pr-plans.md)           | Reviewer-gated Terraform PR plans instead of a de-scoped plan role | 2026-08-20 | Accepted |
+| [058](058-push-subscription-dropped-on-account-change.md) | Push subscriptions dropped, not re-keyed, when the account changes | 2026-08-21 | Accepted |


### PR DESCRIPTION
Closes #633

## What was wrong

A browser `PushSubscription` is scoped to the origin, not the session, so it survived sign-out. On a shared device the API row still pointed at user A, the browser still held A's endpoint, and the notifications card read "subscribed" from `PushManager.getSubscription()` alone. User B signed in, saw a subscribed device, never registered an endpoint of their own, and A's matchday alerts kept arriving on B's phone.

## Decision (yours, from the ticket): drop, don't re-key

Push belongs to the account that explicitly enabled it and never transfers. The alternative - silently re-keying the endpoint onto whoever signs in next - would start pushing club alerts to someone who never opted in, on the strength of nothing more than sharing a browser profile. Recorded as [ADR 058](docs/adrs/058-push-subscription-dropped-on-account-change.md).

**Behaviour change for shared-device users:** one extra tap. After an account switch the card reads "Push isn't enabled for this account on this device" with an Enable button, which reuses the existing browser subscription and re-registers the endpoint to the new account.

## How

1. **Sign-out drops it first.** `signOut()` calls the existing `disablePushOnThisDevice()` before `authClient.signOut()`, so `DELETE /api/me/push-subscriptions` still authenticates as the departing user. Best-effort in two ways: the call is wrapped in try/catch so a throw can't block sign-out, and it is time-boxed to 3s because `navigator.serviceWorker.ready` never settles when no registration ever activates (dev build, SW disabled) - a sign-out button that hangs forever would be worse than a subscription that survives one extra boot. Either way the next signed-in boot reconciles it. A test asserts sign-out still completes with a service worker that never resolves.
2. **Identity switch reconciles.** `ensureCachesMatchUser()` calls `reconcilePushSubscriptionForUser(current)` on a mismatch. A's server row can't be deleted while authenticated as B, so we kill the endpoint at the push service; the next dispatch gets 404/410 and the existing `deletePushSubscriptionByEndpoint` pruning removes the row. Not awaited - the `<RequireAuth />` render gate must not block on a network call in a PWA that boots offline. Rendering stays gated on the cache wipe exactly as before.
3. **New `GET /api/me/push-subscriptions`** returns the caller's own endpoints (`requireAuth`, response schema declared, OpenAPI artifacts regenerated and committed).
4. **`readPushState()` is identity-aware** - `subscribed: true` only when the local endpoint appears in the current user's server rows.
5. **Tests** - see below.

The `pushsubscriptionchange` handler and `inlineWorkboxRuntime` from #444 are untouched. Clearing the stashed VAPID config (which `disablePushOnThisDevice` already does) is exactly what stops that handler resurrecting a dropped endpoint.

## Offline behaviour (step 4 choice)

If the endpoint list can't be fetched (offline, 401, 5xx), `fetchRegisteredEndpoints()` returns `null` and the state reads **not subscribed**. Claiming "this device will receive matchday push" to an account with no such row is the bug being fixed, so the failure is deliberately in the safe direction rather than trusting the local subscription. Recovery is one tap on Enable, which reuses the existing browser subscription. The "not subscribed" copy was reworded to cover all three cases it now represents (never subscribed / another account's subscription / couldn't verify).

## Deviations from the triage plan

- **Step 2 checks the server before dropping, rather than unsubscribing unconditionally.** An unconditional drop also fires on `null -> A` (Safari evicting `localStorage`, or signing back in after the session expired), silently turning push off for a user whose subscription is genuinely theirs - and push is the app's core value, so a silent disable is invisible until someone misses a game. Ownership is now decided by the server: a returning user's own subscription survives, a stranger's does not. If the server is unreachable the fallback is the plan's original behaviour (drop).
- **`ensureCachesMatchUser(null)` does not drop.** A session ending without an explicit sign-out is usually just an expired cookie on a personal device. The leak closes when the *next* user signs in (before any UI renders), which is the transition that actually matters.
- **Refactor to enable step 1/2:** browser push primitives moved from `features/notifications/use-push.ts` to `lib/push.ts` (a lib module shouldn't import a feature module), and `PER_USER_RUNTIME_CACHES` moved to `lib/runtime-caches.ts` so `api-client.ts` no longer imports `auth-client.ts` - otherwise `auth-client -> push -> api-client -> auth-client` closes an import cycle. `use-push.ts` keeps the react-query binding, now keyed by user id so a cached state can't cross an account switch.
- **ADR added** per CLAUDE.md (non-obvious decision, reasonable alternative rejected).

## Assumptions

- Returning the caller's own endpoints in full is safe: they're the user's own capability URLs, and a send still requires the VAPID private key.
- `staleTime: Infinity` on the push-state query is still right now that it has a server component - the only things that change it are enable/disable from that screen, and both refetch explicitly. Sign-in crosses an origin boundary, so a switch always comes with a fresh page load; the user id in the query key covers the rest.

## Tests

- **API integration** (`push-subscriptions/integration.test.ts`, testcontainers): 10 tests, 6 pre-existing + 4 new covering the new list service - only the caller's own rows, empty list, an endpoint disappearing from A's list once re-keyed to B, ISO `createdAt`.
- **Matchday unit** (`apps/matchday/src/lib/push.test.ts`): 9 tests, the first in that workspace. Fakes `PushManager`/`caches`/`localStorage`/`Notification` and the API, and covers the acceptance criteria end to end: A enables -> signs out -> B signs in reads unsubscribed; the DELETE provably precedes `authClient.signOut()`; account switch without a sign-out; same user signing back in keeps their subscription; signed-out session leaves it alone; offline reads as unsubscribed; sign-out survives a wedged service worker; B enabling re-keys the endpoint. Verified non-vacuous - 5 of the 9 fail with the fix reverted.
- `passWithNoTests` dropped from `apps/matchday/vitest.config.ts` (its comment asked for exactly that once the first test landed).
- Full repo `pnpm lint`, `pnpm typecheck`, `pnpm test` (688 API unit tests + web + matchday) and `pnpm format:check` all green.

## Open questions

1. **Should the notifications card distinguish "couldn't check" from "not subscribed"?** Right now both render as Enable. A third state ("can't check right now, you're offline") is friendlier for a PWA that's routinely offline, but it's more surface for a case most users will never hit. Happy to add it if you'd rather not show an Enable button that will fail while offline.
2. **Should reconciliation run somewhere broader than an identity mismatch?** As shipped it fires only when `matchday-last-user-id` disagrees with the session. Running it on every boot would catch a subscription whose row was pruned server-side (dead endpoint) and self-heal the card, at the cost of one extra GET per cold start.
3. **Nothing tells a user their push was dropped.** After an account switch the card just reads "not enabled". A one-time toast ("push was turned off when the account on this device changed") would explain it, but needs a place to store "we dropped one".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated access to view the current account’s push subscriptions.
  * Improved push notification setup, recovery, and cleanup across sign-in, sign-out, and account changes.
  * Push subscriptions are now safely associated with the active account and removed when ownership changes.
  * Added clearer notifications-card messaging for unsupported or unavailable push notifications.

* **Documentation**
  * Documented push subscription ownership and account-change behavior.

* **Tests**
  * Added comprehensive coverage for subscription listing, account switching, sign-out cleanup, offline behavior, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->