### PR TITLE
feat(fantasy): alert in Slack when Play Cricket retires a player ID

### DIFF
--- a/apps/api/src/features/fantasy/integration.test.ts
+++ b/apps/api/src/features/fantasy/integration.test.ts
@@ -18,6 +18,7 @@ import { BUDGET, getCurrentSeason } from "./gameweek.ts";
 import type { PlayerInput } from "./schemas.ts";
 import { SLOT_COUNTS } from "./scoring.ts";
 import {
+  detectPlayerIdChanges,
   getEligiblePlayers,
   getMyTeam,
   getRecentTransfers,
@@ -743,6 +744,121 @@ describe("fantasy service (integration)", () => {
 
       const capped = await getRecentTransfers(ctx.db)(season, 2);
       expect(capped.entries.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("detectPlayerIdChanges", () => {
+    /**
+     * Detection scans the whole fantasy_player table, which this file shares
+     * across tests. Echo every existing row back as a current member so only
+     * the IDs a test deliberately omits look retired.
+     */
+    async function currentMembers(
+      omit: string[],
+      extra: Array<{ member_id: string; name: string }> = [],
+    ) {
+      const rows = await ctx.db
+        .selectFrom("fantasy_player")
+        .select(["play_cricket_id", "player_name"])
+        .execute();
+
+      return [
+        ...rows
+          .filter((r) => !omit.includes(r.play_cricket_id))
+          .map((r) => ({ member_id: r.play_cricket_id, name: r.player_name })),
+        ...extra,
+      ];
+    }
+
+    /** Put `playCricketId` in a real squad so it has a pick against it. */
+    async function seedPick(playCricketId: string) {
+      const { userId } = await seedTestUser(ctx.db, {
+        email: `idchange-${crypto.randomUUID()}@test.com`,
+      });
+      const team = await ctx.db
+        .insertInto("fantasy_team")
+        .values({ season: getCurrentSeason(), user_id: userId })
+        .returning("id")
+        .executeTakeFirstOrThrow();
+
+      await ctx.db
+        .insertInto("fantasy_team_player")
+        .values({
+          fantasy_team_id: team.id,
+          play_cricket_id: playCricketId,
+          gameweek_added: 1,
+          slot_type: "batting",
+        })
+        .execute();
+    }
+
+    it("pairs a retired ID with its replacement and counts the live picks", async () => {
+      // The 2026 incident in miniature: the member ID changes, the pick
+      // stays behind on the dead one.
+      const name = `Mashal ${crypto.randomUUID().slice(0, 8)}`;
+      const oldId = `old-${crypto.randomUUID()}`;
+      const newId = `new-${crypto.randomUUID()}`;
+      await seedFantasyPlayer({
+        playCricketId: oldId,
+        playerName: name,
+        eligible: true,
+      });
+      await seedPick(oldId);
+
+      const changes = await detectPlayerIdChanges(ctx.db)(
+        await currentMembers([oldId], [{ member_id: newId, name }]),
+      );
+
+      const found = changes.find((c) => c.oldPlayCricketId === oldId);
+      expect(found?.playerName).toBe(name);
+      // count(*) comes back as a bigint string; this is the conversion.
+      expect(found?.pickCount).toBe(1);
+      expect(found?.candidates).toEqual([
+        { playCricketId: newId, playerName: name },
+      ]);
+    });
+
+    it("ignores a retired ID that is neither eligible nor picked", async () => {
+      const goneId = `gone-${crypto.randomUUID()}`;
+      await seedFantasyPlayer({
+        playCricketId: goneId,
+        playerName: `Retired ${crypto.randomUUID().slice(0, 8)}`,
+        eligible: false,
+      });
+
+      const changes = await detectPlayerIdChanges(ctx.db)(
+        await currentMembers([goneId]),
+      );
+
+      expect(changes.map((c) => c.oldPlayCricketId)).not.toContain(goneId);
+    });
+
+    it("flags a retired ID with no name match and no candidates", async () => {
+      const goneId = `nomatch-${crypto.randomUUID()}`;
+      await seedFantasyPlayer({
+        playCricketId: goneId,
+        playerName: `Unmatched ${crypto.randomUUID().slice(0, 8)}`,
+        eligible: true,
+      });
+
+      const changes = await detectPlayerIdChanges(ctx.db)(
+        await currentMembers([goneId]),
+      );
+
+      const found = changes.find((c) => c.oldPlayCricketId === goneId);
+      expect(found).toBeDefined();
+      expect(found?.candidates).toEqual([]);
+      expect(found?.pickCount).toBe(0);
+    });
+
+    it("reports nothing when every known ID is still a member", async () => {
+      await seedFantasyPlayer({ eligible: true });
+
+      const changes = await detectPlayerIdChanges(ctx.db)(
+        await currentMembers([]),
+      );
+
+      expect(changes).toEqual([]);
     });
   });
 });

--- a/apps/api/src/features/fantasy/service.test.ts
+++ b/apps/api/src/features/fantasy/service.test.ts
@@ -70,6 +70,8 @@ import {
 } from "./gameweek.ts";
 import type { PlayerInput } from "./schemas.ts";
 import {
+  detectPlayerIdChanges,
+  formatPlayerIdChangeAlert,
   getEligiblePlayers,
   populatePlayers,
   saveTeam,
@@ -339,5 +341,237 @@ describe("fantasy service", () => {
       expect(result.total).toBe(3);
       expect(result.inserted).toBe(2);
     });
+  });
+
+  describe("detectPlayerIdChanges", () => {
+    // Two queries in order: every fantasy_player row, then pick counts per
+    // play_cricket_id. The second is skipped when nothing has vanished.
+    function mockDb(
+      players: Array<{
+        play_cricket_id: string;
+        player_name: string;
+        eligible: boolean;
+      }>,
+      picks: Array<{ play_cricket_id: string; pick_count: string }> = [],
+    ) {
+      mockExecute.mockResolvedValueOnce(players).mockResolvedValueOnce(picks);
+    }
+
+    it("flags a vanished ID and pairs it with the new exact-name match", async () => {
+      // The 2026 incident: Play Cricket reissued Mashal's member ID.
+      mockDb(
+        [
+          {
+            play_cricket_id: "6324643",
+            player_name: "Mashal Ahmed",
+            eligible: true,
+          },
+          {
+            play_cricket_id: "111",
+            player_name: "Alice Smith",
+            eligible: true,
+          },
+        ],
+        // Postgres count() arrives as a bigint string.
+        [{ play_cricket_id: "6324643", pick_count: "2" }],
+      );
+
+      const changes = await detectPlayerIdChanges(db)([
+        { member_id: 7161990, name: "Mashal Ahmed" },
+        { member_id: 111, name: "Alice Smith" },
+      ]);
+
+      expect(changes).toEqual([
+        {
+          oldPlayCricketId: "6324643",
+          playerName: "Mashal Ahmed",
+          eligible: true,
+          pickCount: 2,
+          candidates: [
+            { playCricketId: "7161990", playerName: "Mashal Ahmed" },
+          ],
+        },
+      ]);
+    });
+
+    it("matches names that differ only in case and whitespace", async () => {
+      mockDb([
+        {
+          play_cricket_id: "6324643",
+          player_name: "  Mashal   Ahmed ",
+          eligible: true,
+        },
+      ]);
+
+      const changes = await detectPlayerIdChanges(db)([
+        { member_id: 7161990, name: "mashal ahmed" },
+      ]);
+
+      expect(changes[0].candidates).toEqual([
+        { playCricketId: "7161990", playerName: "mashal ahmed" },
+      ]);
+    });
+
+    it("still flags a vanished ID with no name match, with no candidates", async () => {
+      mockDb(
+        [{ play_cricket_id: "555", player_name: "Bob Jones", eligible: true }],
+        [],
+      );
+
+      const changes = await detectPlayerIdChanges(db)([
+        { member_id: 999, name: "Someone Else" },
+      ]);
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0].oldPlayCricketId).toBe("555");
+      expect(changes[0].candidates).toEqual([]);
+    });
+
+    it("ignores a vanished ID that is neither eligible nor picked", async () => {
+      // Ordinary churn: opposition players and long-retired members the
+      // populate step inserted but nobody ever picked.
+      mockDb(
+        [
+          {
+            play_cricket_id: "555",
+            player_name: "Old Member",
+            eligible: false,
+          },
+        ],
+        [],
+      );
+
+      const changes = await detectPlayerIdChanges(db)([
+        { member_id: 999, name: "Someone Else" },
+      ]);
+
+      expect(changes).toEqual([]);
+    });
+
+    it("flags a vanished ineligible player who is still picked", async () => {
+      mockDb(
+        [
+          {
+            play_cricket_id: "555",
+            player_name: "Dropped Player",
+            eligible: false,
+          },
+        ],
+        [{ play_cricket_id: "555", pick_count: "1" }],
+      );
+
+      const changes = await detectPlayerIdChanges(db)([
+        { member_id: 999, name: "Someone Else" },
+      ]);
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0].pickCount).toBe(1);
+      expect(changes[0].eligible).toBe(false);
+    });
+
+    it("does not flag two distinct players who share a name when neither vanished", async () => {
+      mockDb([
+        { play_cricket_id: "111", player_name: "John Smith", eligible: true },
+        { play_cricket_id: "222", player_name: "John Smith", eligible: true },
+      ]);
+
+      const changes = await detectPlayerIdChanges(db)([
+        { member_id: 111, name: "John Smith" },
+        { member_id: 222, name: "John Smith" },
+      ]);
+
+      expect(changes).toEqual([]);
+    });
+
+    it("returns nothing when every known ID is still present", async () => {
+      mockDb([
+        { play_cricket_id: "111", player_name: "Alice Smith", eligible: true },
+      ]);
+
+      const changes = await detectPlayerIdChanges(db)([
+        { member_id: 111, name: "Alice Smith" },
+      ]);
+
+      expect(changes).toEqual([]);
+    });
+
+    it("returns nothing when the API sends an empty members list", async () => {
+      // An empty list is indistinguishable from Play Cricket dropping every
+      // member, so it must not flag the whole squad.
+      const changes = await detectPlayerIdChanges(db)([]);
+
+      expect(changes).toEqual([]);
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it("lists every same-name candidate and sorts by pick count", async () => {
+      mockDb(
+        [
+          {
+            play_cricket_id: "111",
+            player_name: "Alice Smith",
+            eligible: true,
+          },
+          { play_cricket_id: "222", player_name: "Bob Jones", eligible: true },
+        ],
+        [{ play_cricket_id: "222", pick_count: "3" }],
+      );
+
+      const changes = await detectPlayerIdChanges(db)([
+        { member_id: 900, name: "Alice Smith" },
+        { member_id: 901, name: "Alice Smith" },
+        { member_id: 902, name: "Bob Jones" },
+      ]);
+
+      expect(changes.map((c) => c.oldPlayCricketId)).toEqual(["222", "111"]);
+      expect(changes[1].candidates.map((c) => c.playCricketId)).toEqual([
+        "900",
+        "901",
+      ]);
+    });
+  });
+});
+
+describe("formatPlayerIdChangeAlert", () => {
+  const change = {
+    oldPlayCricketId: "6324643",
+    playerName: "Mashal Ahmed",
+    eligible: true,
+    pickCount: 2,
+    candidates: [{ playCricketId: "7161990", playerName: "Mashal Ahmed" }],
+  };
+
+  it("names the player, both IDs, and the pick count", () => {
+    const text = formatPlayerIdChangeAlert([change]);
+
+    expect(text).toContain("Mashal Ahmed");
+    expect(text).toContain("old ID 6324643");
+    expect(text).toContain("possible new ID 7161990");
+    expect(text).toContain("2 picks");
+    expect(text).toContain("issue #596");
+  });
+
+  it("says so when there is no candidate ID", () => {
+    const text = formatPlayerIdChangeAlert([
+      { ...change, candidates: [], pickCount: 1 },
+    ]);
+
+    expect(text).toContain("no new ID with a matching name");
+    expect(text).toContain("1 pick");
+    expect(text).not.toContain("1 picks");
+  });
+
+  it("truncates a run that flags more than ten players", () => {
+    const many = Array.from({ length: 14 }, (_, i) => ({
+      ...change,
+      oldPlayCricketId: String(i),
+      playerName: `Player ${i}`,
+    }));
+
+    const text = formatPlayerIdChangeAlert(many);
+
+    expect(text).toContain("... and 4 more");
+    expect(text).toContain("Player 9");
+    expect(text).not.toContain("Player 10");
   });
 });

--- a/apps/api/src/features/fantasy/service.ts
+++ b/apps/api/src/features/fantasy/service.ts
@@ -624,6 +624,165 @@ export function populatePlayers(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Play Cricket ID-change detection (#596)
+// ---------------------------------------------------------------------------
+
+/** A member ID Play Cricket has started returning that fantasy has never seen. */
+export interface PlayerIdChangeCandidate {
+  playCricketId: string;
+  playerName: string;
+}
+
+export interface SuspectedPlayerIdChange {
+  /** The fantasy_player row Play Cricket has stopped returning. */
+  oldPlayCricketId: string;
+  playerName: string;
+  eligible: boolean;
+  /** fantasy_team_player rows still pointing at the vanished ID. */
+  pickCount: number;
+  /**
+   * New member IDs whose normalised name matches this player's exactly.
+   * Empty means the ID vanished with no obvious replacement, which is still
+   * worth flagging - it just needs more digging than a rename.
+   */
+  candidates: PlayerIdChangeCandidate[];
+}
+
+/** Trim, case-fold, collapse internal runs of whitespace. */
+function normaliseName(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/**
+ * Spot Play Cricket reassigning a player's member ID mid-season.
+ *
+ * Play Cricket occasionally issues a member a fresh ID and drops the old
+ * one. The player sync happily inserts the new ID as a second
+ * fantasy_player row while every existing pick keeps pointing at the dead
+ * one, which then scores nothing for the rest of the season. In 2026 that
+ * went unnoticed for weeks and cost two teams a player each.
+ *
+ * Matching is exact-on-normalised-name only. Fuzzy matching would turn a
+ * rare, high-signal alert into a recurring stream of near-miss noise, and a
+ * human reconciles these by hand anyway.
+ */
+export function detectPlayerIdChanges(db: Kysely<DB>) {
+  return async (
+    // `member_id` is typed number by the players endpoint, but Play Cricket
+    // returns IDs as strings elsewhere (see GetTeamsResponse), so accept both
+    // and compare as strings - the column is text.
+    apiPlayers: Array<{ member_id: number | string; name: string }>,
+  ): Promise<SuspectedPlayerIdChange[]> => {
+    // An empty members list is indistinguishable from Play Cricket dropping
+    // every member at once, and would flag the entire squad. No data means
+    // no conclusions.
+    if (apiPlayers.length === 0) return [];
+
+    const apiIds = new Set(apiPlayers.map((p) => String(p.member_id)));
+
+    const knownPlayers = await db
+      .selectFrom("fantasy_player")
+      .select(["play_cricket_id", "player_name", "eligible"])
+      .execute();
+
+    const vanished = knownPlayers.filter((p) => !apiIds.has(p.play_cricket_id));
+    if (vanished.length === 0) return [];
+
+    const pickRows = await db
+      .selectFrom("fantasy_team_player")
+      .select(["play_cricket_id", sql<string>`count(*)`.as("pick_count")])
+      .groupBy("play_cricket_id")
+      .execute();
+    const pickCounts = new Map(
+      pickRows.map((r) => [r.play_cricket_id, Number(r.pick_count)]),
+    );
+
+    // Group the IDs new to fantasy_player by name: the pool a reassigned ID
+    // could have moved to.
+    const knownIds = new Set(knownPlayers.map((p) => p.play_cricket_id));
+    const newIdsByName = new Map<string, PlayerIdChangeCandidate[]>();
+    for (const p of apiPlayers) {
+      const id = String(p.member_id);
+      if (knownIds.has(id)) continue;
+      const key = normaliseName(p.name);
+      const existing = newIdsByName.get(key);
+      const candidate = { playCricketId: id, playerName: p.name };
+      if (existing) {
+        existing.push(candidate);
+      } else {
+        newIdsByName.set(key, [candidate]);
+      }
+    }
+
+    const changes: SuspectedPlayerIdChange[] = [];
+    for (const player of vanished) {
+      const pickCount = pickCounts.get(player.play_cricket_id) ?? 0;
+      // Only players who can still cost somebody points are worth an alert.
+      // Everyone else is ordinary churn: opposition players, retired members,
+      // and the long tail the populate step inserts but nobody ever picks.
+      if (!player.eligible && pickCount === 0) continue;
+
+      changes.push({
+        oldPlayCricketId: player.play_cricket_id,
+        playerName: player.player_name,
+        eligible: player.eligible,
+        pickCount,
+        candidates: newIdsByName.get(normaliseName(player.player_name)) ?? [],
+      });
+    }
+
+    // Most-affected first, then stable by ID so repeat runs read identically.
+    return changes.sort(
+      (a, b) =>
+        b.pickCount - a.pickCount ||
+        a.oldPlayCricketId.localeCompare(b.oldPlayCricketId),
+    );
+  };
+}
+
+/** Cap the alert body; a run that flags dozens is a bug, not a rename. */
+const MAX_ALERT_LINES = 10;
+
+/**
+ * Club-readable Slack text for a set of suspected ID changes. Slack mrkdwn,
+ * so `*bold*` rather than markdown headings.
+ */
+export function formatPlayerIdChangeAlert(
+  changes: SuspectedPlayerIdChange[],
+): string {
+  const lines = changes.slice(0, MAX_ALERT_LINES).map((change) => {
+    const ids = change.candidates.map((c) => c.playCricketId);
+    const candidateText =
+      ids.length === 0
+        ? "no new ID with a matching name"
+        : ids.length === 1
+          ? `possible new ID ${ids[0]}`
+          : `possible new IDs ${ids.join(", ")}`;
+    const picks =
+      change.pickCount === 1 ? "1 pick" : `${change.pickCount} picks`;
+    const eligible = change.eligible ? ", eligible" : "";
+    return `- ${change.playerName} (old ID ${change.oldPlayCricketId}) - ${picks}${eligible} - ${candidateText}`;
+  });
+
+  const overflow = changes.length - lines.length;
+  if (overflow > 0) {
+    lines.push(`- ... and ${overflow} more`);
+  }
+
+  const subject =
+    changes.length === 1
+      ? "1 player ID it still relies on"
+      : `${changes.length} player IDs it still relies on`;
+
+  return [
+    "*Fantasy: possible Play Cricket player ID change*",
+    `Play Cricket has stopped returning ${subject}. Any pick left on a retired ID scores zero for the rest of the season, and nothing else will say so.`,
+    ...lines,
+    "Reconcile by hand: point the affected rows at the new ID, then recalculate the season's scores. Background and steps are on issue #596.",
+  ].join("\n");
+}
+
 export function calculateSandwichCosts(db: Kysely<DB>) {
   return async (season?: string) => {
     const s = season ?? getCurrentSeason();

--- a/apps/api/src/features/play-cricket/sync.test.ts
+++ b/apps/api/src/features/play-cricket/sync.test.ts
@@ -1,7 +1,21 @@
 import type { DB } from "@percy-main/db";
 import type { Kysely } from "kysely";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SlackNotifier } from "../../lib/slack.ts";
 import { createNoopLogger } from "../../lib/worker-logger.ts";
+
+// Detection itself is covered in fantasy/service.test.ts; stubbing it here
+// keeps these tests about the wiring - that the sync runs it, alerts on a
+// hit, and shrugs off failures.
+const { mockDetectPlayerIdChanges } = vi.hoisted(() => ({
+  mockDetectPlayerIdChanges: vi.fn(),
+}));
+
+vi.mock("../fantasy/service.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../fantasy/service.ts")>()),
+  detectPlayerIdChanges: () => mockDetectPlayerIdChanges,
+}));
+
 import type { PlayCricketApiClient } from "./api-client.ts";
 import {
   didBat,
@@ -239,6 +253,7 @@ describe("runSync", () => {
     vi.clearAllMocks();
     mockDb = createMockDb();
     mockApi = createMockApi();
+    mockDetectPlayerIdChanges.mockResolvedValue([]);
   });
 
   it("returns zero matches when no matches exist", async () => {
@@ -375,5 +390,93 @@ describe("runSync", () => {
 
     // Should have called insertInto for the sync log
     expect(mockDb.insertInto).toHaveBeenCalledWith("play_cricket_sync_log");
+  });
+
+  // --- Play Cricket ID-change alerting (#596) ---
+
+  const suspectedChange = {
+    oldPlayCricketId: "6324643",
+    playerName: "Mashal Ahmed",
+    eligible: true,
+    pickCount: 2,
+    candidates: [{ playCricketId: "7161990", playerName: "Mashal Ahmed" }],
+  };
+
+  it("runs ID-change detection against the current members list", async () => {
+    mockApi = createMockApi({
+      getPlayers: vi
+        .fn()
+        .mockResolvedValue({ players: [{ member_id: 111, name: "Alice" }] }),
+    });
+
+    const sync = runSync(mockDb, mockApi, null, log);
+    await sync({ siteId: "134" });
+
+    expect(mockApi.getPlayers).toHaveBeenCalled();
+    expect(mockDetectPlayerIdChanges).toHaveBeenCalledWith([
+      { member_id: 111, name: "Alice" },
+    ]);
+  });
+
+  it("sends a Slack alert naming both IDs when a change is suspected", async () => {
+    mockDetectPlayerIdChanges.mockResolvedValue([suspectedChange]);
+    const notifySlack = vi.fn<SlackNotifier>().mockResolvedValue(true);
+
+    const sync = runSync(mockDb, mockApi, null, log, notifySlack);
+    const result = await sync({ siteId: "134" });
+
+    expect(notifySlack).toHaveBeenCalledTimes(1);
+    const text: string = notifySlack.mock.calls[0][0];
+    expect(text).toContain("Mashal Ahmed");
+    expect(text).toContain("6324643");
+    expect(text).toContain("7161990");
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("stays quiet when nothing is suspected", async () => {
+    const notifySlack = vi.fn<SlackNotifier>().mockResolvedValue(true);
+
+    const sync = runSync(mockDb, mockApi, null, log, notifySlack);
+    await sync({ siteId: "134" });
+
+    expect(notifySlack).not.toHaveBeenCalled();
+  });
+
+  it("completes the sync when Slack delivery fails", async () => {
+    mockDetectPlayerIdChanges.mockResolvedValue([suspectedChange]);
+    const notifySlack = vi
+      .fn<SlackNotifier>()
+      .mockRejectedValue(new Error("slack is down"));
+
+    const sync = runSync(mockDb, mockApi, null, log, notifySlack);
+    const result = await sync({ siteId: "134" });
+
+    // Alerting is best-effort: nothing lands in errors, so the runner still
+    // exits 0 and the data half of the sync is not reported as failed.
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("completes the sync when detection itself fails", async () => {
+    mockDetectPlayerIdChanges.mockRejectedValue(new Error("db is down"));
+    const notifySlack = vi.fn<SlackNotifier>().mockResolvedValue(true);
+
+    const sync = runSync(mockDb, mockApi, null, log, notifySlack);
+    const result = await sync({ siteId: "134" });
+
+    expect(result.errors).toHaveLength(0);
+    expect(notifySlack).not.toHaveBeenCalled();
+  });
+
+  it("completes the sync when the members fetch fails", async () => {
+    mockApi = createMockApi({
+      getPlayers: vi.fn().mockRejectedValue(new Error("Unauthorized")),
+    });
+    const notifySlack = vi.fn<SlackNotifier>().mockResolvedValue(true);
+
+    const sync = runSync(mockDb, mockApi, null, log, notifySlack);
+    const result = await sync({ siteId: "134" });
+
+    expect(result.errors).toHaveLength(0);
+    expect(notifySlack).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/features/play-cricket/sync.ts
+++ b/apps/api/src/features/play-cricket/sync.ts
@@ -3,7 +3,12 @@ import type { FastifyBaseLogger } from "fastify";
 import type { Kysely } from "kysely";
 
 import type { z } from "zod";
+import { createSlackNotifier, type SlackNotifier } from "../../lib/slack.ts";
 import { calculateFantasyScores } from "../fantasy/calculate-scores.ts";
+import {
+  detectPlayerIdChanges,
+  formatPlayerIdChangeAlert,
+} from "../fantasy/service.ts";
 import {
   GetMatchDetailResponse,
   MatchDetailBat,
@@ -725,6 +730,44 @@ async function syncMatches(
   return { matchesProcessed, errors };
 }
 
+/**
+ * Check whether Play Cricket has retired a member ID that fantasy still
+ * depends on, and shout about it in Slack (#596).
+ *
+ * Deliberately swallows everything. Nothing here lands in `result.errors`:
+ * that list decides the sync-runner's exit code, and a missing webhook or a
+ * Slack outage must not turn a good data sync into a failed ECS task. The
+ * hit is logged before the Slack attempt so a detection still reaches New
+ * Relic when the webhook is unset or down.
+ */
+async function alertOnPlayerIdChanges(
+  db: Kysely<DB>,
+  api: PlayCricketApiClient,
+  log: FastifyBaseLogger,
+  notifySlack: SlackNotifier,
+): Promise<void> {
+  try {
+    const { players } = await api.getPlayers();
+    const changes = await detectPlayerIdChanges(db)(players);
+    if (changes.length === 0) return;
+
+    log.warn(
+      { count: changes.length, changes },
+      "fantasy_player_id_change_suspected",
+    );
+
+    const delivered = await notifySlack(formatPlayerIdChangeAlert(changes));
+    if (!delivered) {
+      log.warn(
+        { count: changes.length },
+        "fantasy_player_id_change_slack_unconfigured",
+      );
+    }
+  } catch (err) {
+    log.error({ err }, "fantasy_player_id_change_detection_failed");
+  }
+}
+
 // --- Public API ---
 
 /**
@@ -738,6 +781,7 @@ export function runSync(
   api: PlayCricketApiClient,
   rv: RvClient | null = null,
   log: FastifyBaseLogger,
+  notifySlack: SlackNotifier = createSlackNotifier(),
 ) {
   return async (config: SyncConfig): Promise<SyncResult> => {
     const logId = crypto.randomUUID();
@@ -783,6 +827,8 @@ export function runSync(
           }`,
         );
       }
+
+      await alertOnPlayerIdChanges(db, api, log, notifySlack);
 
       return result;
     } catch (err) {

--- a/apps/api/src/lib/slack.test.ts
+++ b/apps/api/src/lib/slack.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSlackNotifier, SlackWebhookError } from "./slack.ts";
+
+describe("createSlackNotifier", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetch(response: Response) {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("posts the text as a JSON webhook payload", async () => {
+    const fetchMock = stubFetch(new Response("ok", { status: 200 }));
+
+    const sent = await createSlackNotifier("https://hooks.slack.test/XYZ")(
+      "hello",
+    );
+
+    expect(sent).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://hooks.slack.test/XYZ");
+    expect(init?.method).toBe("POST");
+    const body = init?.body;
+    if (typeof body !== "string") throw new Error("expected a string body");
+    const parsed: unknown = JSON.parse(body);
+    expect(parsed).toEqual({ text: "hello" });
+  });
+
+  it("reports false without calling fetch when no webhook is configured", async () => {
+    const fetchMock = stubFetch(new Response("ok", { status: 200 }));
+
+    const sent = await createSlackNotifier()("hello");
+
+    expect(sent).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws on a rejected webhook rather than reporting success", async () => {
+    // A revoked webhook or deleted channel answers 404, which fetch resolves
+    // happily. Silently accepting that would defeat the point of alerting.
+    stubFetch(new Response("no_service", { status: 404 }));
+
+    await expect(
+      createSlackNotifier("https://hooks.slack.test/XYZ")("hello"),
+    ).rejects.toThrow(SlackWebhookError);
+  });
+
+  it("carries the status and body on the thrown error", async () => {
+    stubFetch(new Response("channel_not_found", { status: 400 }));
+
+    const err = await createSlackNotifier("https://hooks.slack.test/XYZ")(
+      "hello",
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SlackWebhookError);
+    expect((err as SlackWebhookError).status).toBe(400);
+    expect((err as SlackWebhookError).bodyPreview).toBe("channel_not_found");
+  });
+});

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -1,0 +1,57 @@
+/**
+ * Minimal Slack incoming-webhook sender for background workers.
+ *
+ * The request-scoped notifiers (contact, incident-report, marketing) each
+ * build a message and post it from inside a route handler. This one exists
+ * for code with no request to hang off - the scheduled Play Cricket sync -
+ * so it takes plain text and nothing else.
+ *
+ * Unlike those three it checks the response status. A webhook that has been
+ * revoked or pointed at a deleted channel answers 404/410 rather than
+ * failing the fetch, and an alerting path that silently accepts that is
+ * worse than no alerting at all.
+ */
+
+const TIMEOUT_MS = 10_000;
+
+/**
+ * Static-message error so New Relic groups every webhook failure together;
+ * status and body live as properties.
+ */
+export class SlackWebhookError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly bodyPreview: string,
+  ) {
+    super("slack_webhook_error");
+    this.name = "SlackWebhookError";
+  }
+}
+
+/**
+ * Returns a sender that resolves `true` when Slack accepted the message and
+ * `false` when no webhook is configured, so callers can tell "delivered"
+ * from "nowhere to deliver to" and log accordingly. Delivery failures throw.
+ */
+export function createSlackNotifier(webhookUrl?: string) {
+  return async (text: string): Promise<boolean> => {
+    if (!webhookUrl) return false;
+
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+      // A hung webhook must not eat into the sync's 10-minute deadline.
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new SlackWebhookError(res.status, body.slice(0, 200));
+    }
+
+    return true;
+  };
+}
+
+export type SlackNotifier = ReturnType<typeof createSlackNotifier>;

--- a/apps/api/src/sync-runner.ts
+++ b/apps/api/src/sync-runner.ts
@@ -12,6 +12,7 @@ import { createApiClient } from "./features/play-cricket/api-client.ts";
 import { createRvClient } from "./features/play-cricket/rv-client.ts";
 import { runSync } from "./features/play-cricket/sync.ts";
 import { invokePrerenderReconcile } from "./lib/prerender-trigger.ts";
+import { createSlackNotifier } from "./lib/slack.ts";
 import { withSpan } from "./lib/tracing.ts";
 import { createWorkerLogger } from "./lib/worker-logger.ts";
 
@@ -25,6 +26,10 @@ const PLAY_CRICKET_SITE_ID = process.env.PLAY_CRICKET_SITE_ID;
 // sync still runs end-to-end. See BALL_BY_BALL_FETCHING.md (gitignored)
 // for how to obtain / rotate this.
 const RV_SHARED_SECRET = process.env.RV_SHARED_SECRET;
+// Shared with the contact / incident / lead notifiers. Optional: when unset
+// the sync still runs and a suspected player ID change (#596) is logged
+// rather than posted.
+const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
 
 if (!DATABASE_URL) throw new Error("Missing required env var: DATABASE_URL");
 if (!PLAY_CRICKET_API_TOKEN)
@@ -66,9 +71,18 @@ const rv = RV_SHARED_SECRET
   : null;
 
 try {
-  logger.info({ withRv: Boolean(rv) }, "play_cricket_sync_started");
+  logger.info(
+    { withRv: Boolean(rv), withSlack: Boolean(SLACK_WEBHOOK_URL) },
+    "play_cricket_sync_started",
+  );
 
-  const sync = runSync(client, api, rv, logger);
+  const sync = runSync(
+    client,
+    api,
+    rv,
+    logger,
+    createSlackNotifier(SLACK_WEBHOOK_URL),
+  );
   // Throw out of withSpan if the sync returned a non-empty errors
   // list — withSpan only marks ERROR on a thrown error, so a
   // completed-with-errors run would otherwise look successful in

--- a/docs/adrs/060-fantasy-player-id-change-alerting.md
+++ b/docs/adrs/060-fantasy-player-id-change-alerting.md
@@ -1,0 +1,88 @@
+# Decision 060: Alert on Play Cricket player ID changes, reconcile them by hand
+
+**Date:** 2026-08-21
+**Status:** Accepted
+
+## Decision
+
+The scheduled Play Cricket sync compares the club's current Play Cricket
+members list against `fantasy_player` and posts a Slack alert when an ID that
+fantasy still depends on stops being returned. It does nothing else: no admin
+UI, no merge endpoint, no automatic repointing of rows. Repairing a confirmed
+ID change stays a manual database job.
+
+A player is only worth alerting about when they are `eligible` or already
+referenced by `fantasy_team_player`. Candidate replacements are found by exact
+match on a normalised name (trim, case-fold, collapse whitespace) against
+member IDs that `fantasy_player` has never seen.
+
+## Problem
+
+In July 2026 Play Cricket reassigned a player's member ID mid-season. The
+player sync upserts every member ID the API returns, so the new ID arrived as
+a second `fantasy_player` row while every existing pick stayed on the old one.
+Scores are joined on `play_cricket_id`, so two fantasy teams silently earned
+zero points from that player for the rest of the season. Nothing surfaced it -
+no error, no empty result, no failed sync - and it was only noticed weeks
+later when a manager queried their total. The repair was a handful of UPDATE
+statements and a score recalculation.
+
+## Options considered
+
+1. **Detect and alert only (chosen).** Run the comparison inside the scheduled
+   sync and post the suspected pairs to Slack. A human confirms against Play
+   Cricket and repoints the rows.
+
+2. **Detect, alert, and ship an admin merge tool.** The original proposal on
+   #596: a "possible ID changes" panel in the fantasy admin tab plus a
+   `mergeFantasyPlayers` transaction repointing `fantasy_team_player`,
+   `fantasy_player_score`, the three `match_performance_*` tables,
+   `member.play_cricket_id`, `dependent.play_cricket_id`, and
+   `rv_player_mapping.pc_player_id`.
+
+3. **Merge automatically on a confident name match.** No human in the loop at
+   all.
+
+## Rationale
+
+The expensive half of this incident was the silence, not the repair. Detection
+is a comparison over two small tables and one API response the sync already
+has a client for; the repair is a rare, ten-minute manual job. Building the
+merge tool means a transaction across seven tables with a conflict path on
+`fantasy_player_score`'s unique key, a confirmation UI, and its own integration
+tests - a substantial surface to own and keep correct for something that has
+happened once. Alerting closes the whole gap that actually cost anyone points,
+and if the frequency ever justifies automation the detection service is the
+input that tool would need anyway.
+
+Name matching is exact-on-normalised only. Fuzzy matching would convert a rare,
+high-signal alert into a recurring trickle of near-misses, and the alert's
+whole value is that receiving one means something is genuinely wrong. The
+incident case matched exactly.
+
+Alerting is deliberately best-effort: a detection or Slack failure is logged
+but never added to the sync's error list, because that list drives the ECS
+task's exit code. A missing webhook must not turn a successful data sync into
+a failed scheduled task. A hit is logged before the Slack call is attempted,
+so the finding still reaches New Relic when the webhook is unset or down.
+
+## Rejected alternatives
+
+- **Admin merge tool (option 2):** rejected as disproportionate for a
+  once-a-season event, per the reduced scope agreed on #596. Worth revisiting
+  if this fires more than once or twice a season, or if a repair is ever
+  needed by someone without database access.
+- **Automatic merge (option 3):** rejected outright. Two genuinely distinct
+  members can share a name at a club this size, and an incorrect merge
+  silently rewrites historical scorecards across the `match_performance_*`
+  tables - strictly worse than the bug it fixes, and much harder to undo.
+
+## Limitations
+
+Detection cannot distinguish an ID change from an ordinary departure, so a
+player who is eligible or picked and simply leaves the club will be flagged,
+with no candidate, on every sync run until someone marks them ineligible or
+the season's picks age out. There is no alert-state table, so nothing
+de-duplicates repeat alerts between runs. An empty members list from the API
+is treated as no data rather than as every member vanishing, which is what
+keeps a Play Cricket outage from flagging the entire squad.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -36,3 +36,4 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 | [055](055-content-assistant-edit-ops-and-sidebar.md)     | Content assistant edit-op protocol + persistent sidebar            | 2026-07-09 | Accepted |
 | [056](056-dnb-rows-stay-in-batting-table.md)             | "Did not bat" rows stay in the batting table with a did_bat flag   | 2026-07-26 | Accepted |
 | [057](057-reviewer-gated-terraform-pr-plans.md)          | Reviewer-gated Terraform PR plans instead of a de-scoped plan role | 2026-08-20 | Accepted |
+| [060](060-fantasy-player-id-change-alerting.md)          | Alert on Play Cricket player ID changes, reconcile by hand         | 2026-08-21 | Accepted |


### PR DESCRIPTION
Closes #596

## Summary

Play Cricket occasionally reassigns a member's ID mid-season. The player sync upserts every member ID the API returns, so the new ID arrives as a second `fantasy_player` row while every existing pick stays on the old one. Scores join on `play_cricket_id`, so those picks silently score zero for the rest of the season. In July 2026 that went unnoticed for weeks and cost two fantasy teams a player each.

The scheduled Play Cricket sync now compares the club's current members list against `fantasy_player` and posts a Slack alert when an ID that fantasy still depends on stops being returned.

Example alert:

> **Fantasy: possible Play Cricket player ID change**
> Play Cricket has stopped returning 1 player ID it still relies on. Any pick left on a retired ID scores zero for the rest of the season, and nothing else will say so.
> - Mashal Ahmed (old ID 6324643) - 2 picks, eligible - possible new ID 7161990
> Reconcile by hand: point the affected rows at the new ID, then recalculate the season's scores. Background and steps are on issue #596.

## Scope: alert only, per Alex's decision on the ticket

> "let's just do the alerting layer - PC sync only, send slack message if issue. it's rare enough that manual reconcile is fine"

So this is detection plus a Slack alert, wired into the **scheduled sync only**. Explicitly **not** built: the admin merge tool, any admin UI or endpoint, and any automatic repointing of rows. Repair stays a manual database job. Recorded as [ADR 060](docs/adrs/060-fantasy-player-id-change-alerting.md) (058 and 059 are taken by open PRs #703 and #706).

## What changed

- **`detectPlayerIdChanges(db)`** in `apps/api/src/features/fantasy/service.ts` - reports `fantasy_player` rows absent from the members list that are `eligible` **or** referenced by `fantasy_team_player`, each paired with any member ID new to `fantasy_player` whose normalised name (trim, case-fold, collapse whitespace) matches **exactly**. No fuzzy matching, per the triage recommendation. Returns old ID, name, eligibility, pick count, and candidate IDs, sorted most-affected first.
- **`formatPlayerIdChangeAlert`** - club-readable Slack mrkdwn, capped at 10 players with an "and N more" line.
- **`apps/api/src/lib/slack.ts`** - a small `createSlackNotifier(url)` for code with no request to hang off. Unlike the three existing request-scoped notifiers it **checks the response status**: a revoked webhook or deleted channel answers 404 rather than failing the fetch, and an alerting path that silently accepts that is worse than no alerting. Also carries a 10s timeout so a hung webhook cannot eat the sync's deadline. The existing three notifiers are left alone.
- **Wiring** in `runSync` (`play-cricket/sync.ts`), after the sync log write and the fantasy score recompute. `sync-runner.ts` passes the notifier built from `SLACK_WEBHOOK_URL`.

## Failure semantics

Alerting is best-effort and **cannot fail the sync**. A detection failure, a members-fetch failure, or a Slack failure is logged and swallowed, and nothing is added to `result.errors` - that list drives the sync-runner's exit code, and a missing webhook must not turn a good data sync into a failed ECS task. A detection hit is logged (`fantasy_player_id_change_suspected`, with the full change list) **before** the Slack call is attempted, so a hit still reaches New Relic when the webhook is unset or down. A separate `fantasy_player_id_change_slack_unconfigured` warning fires when there is a hit but no webhook.

## No config or infra change needed

This is the one place the plan shrank on contact with the code. `SLACK_WEBHOOK_URL` **already exists** in the API's Zod config and is **already wired** through Terraform (`infra/environments/{production,staging}/main.tf`), because the contact, incident-report, and marketing-lead notifiers all use it today. The scheduled sync runs on the **API's own task definition** with only a command override (`infra/modules/scheduling/main.tf`), so it already receives that secret.

So: no new env var, no fixture changes, no Terraform. **No manual pre-merge or pre-deploy step** - no webhook to create, no secret to set. Worth an explicit review sanity-check, since the task I was given anticipated all of the above.

The house rule that new API env vars must be required does not apply here: `SLACK_WEBHOOK_URL` is pre-existing and optional, with three existing consumers that no-op when it is unset. Changing it to required would be an unrelated breaking change.

## Assumptions

- **Reuses the existing webhook**, so these alerts land in whatever channel already receives contact-form, incident-report, and lead notifications. See open questions.
- **An empty members list is treated as no data**, not as every member vanishing - otherwise a Play Cricket outage or auth failure would flag the entire squad.
- **`member_id` accepts string or number.** The players endpoint types it as a number, but Play Cricket returns IDs as strings elsewhere (`GetTeamsResponse` uses `z.union([z.string(), z.number()])`), so detection normalises to string before comparing against the text column.
- **The eligible-or-picked filter** keeps ordinary churn out: opposition players and long-retired members that the populate step inserted but nobody ever picked.

## Tests

All green. `pnpm lint`, `pnpm typecheck`, `pnpm format:check` clean.

- **API unit suite: 710 passed** (up from 700), of which **22 are new**:
  - 12 in `fantasy/service.test.ts` covering every case asked for: vanished ID with an exact-name match (flagged with the candidate), vanished ID with no match (flagged, empty candidates), two distinct players sharing a name where neither vanished (not flagged), ineligible-and-unpicked vanished ID (not flagged), no changes (empty), plus the empty-API guard, case/whitespace normalisation, the ineligible-but-still-picked case, multi-candidate listing, sort order, and the alert formatter (including singular/plural and truncation).
  - 6 in `play-cricket/sync.test.ts` for the wiring: detection runs against the members list, Slack fires on a hit with both IDs in the text, stays quiet on no hits, and the sync completes with **zero errors** when Slack fails, when detection throws, and when the members fetch fails.
  - 4 in `lib/slack.test.ts`: payload shape, no-op when unconfigured, throws on a non-2xx webhook, and status/body carried on the error.
- **Integration (testcontainers, real Postgres): 23 passed in `fantasy/integration.test.ts`, 4 new.** These matter because the unit tests mock the DB entirely - the integration tests exercise the real queries, including the `count(*)` bigint-string conversion for pick counts. `play-cricket/integration.test.ts` (25) still passes with the extra `getPlayers()` call in the sync path.

## Open questions

1. **Which channel should these go to?** This reuses the single `SLACK_WEBHOOK_URL`, so an ops alert lands next to contact-form and lead notifications. If you would rather it went somewhere quieter, that needs a second webhook (new env var, new secret key, Terraform wiring) - say the word and I will do it as a follow-up.
2. **Repeat alerts.** There is no alert-state table, so anything flagged stays flagged on every run (3x/week) until it is resolved. For a true ID change that is fine - you will fix it that week. The nagging case is a player who is eligible or picked and simply **leaves the club**: they will be flagged with no candidate every run until they are marked ineligible or the season's picks age out. Options if that gets annoying: de-duplicate via a small `fantasy_player_id_alert` table, or only alert when there is at least one candidate. I did neither, since both add scope beyond the agreed alert-only layer.
3. **Pick counts span all seasons.** `fantasy_team_player` is not season-scoped in the count, so a player picked in 2025 but not 2026 still counts as "picked". That is deliberately conservative (it errs toward alerting), but if you would rather it only counted the current season's teams that is a one-line join.
4. **Worth flagging on the manual populate path too?** Alex's instruction was PC sync only, so `populatePlayers` (the admin action) is untouched and will still happily insert the duplicate row. The alert catches it within days either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)