### PR TITLE
ci(terraform): run all CI terraform commands with -input=false

### DIFF
--- a/.github/workflows/deploy-terraform-manual.yml
+++ b/.github/workflows/deploy-terraform-manual.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: infra/environments/shared
-        run: terraform init
+        run: terraform init -input=false
 
       - name: Verify remote backend is configured
         working-directory: infra/environments/shared
@@ -101,7 +101,7 @@ jobs:
         working-directory: infra/environments/shared
         # See ADR 035 — apply-time plan recorded for audit.
         run: |
-          terraform plan -no-color -out=tfplan 2>&1 | tee plan.txt
+          terraform plan -input=false -no-color -out=tfplan 2>&1 | tee plan.txt
           exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if plan didn't release its own
@@ -239,14 +239,14 @@ jobs:
 
       - name: Terraform Init
         working-directory: infra/environments/production
-        run: terraform init
+        run: terraform init -input=false
 
       - name: Terraform Plan
         id: plan
         timeout-minutes: 10
         working-directory: infra/environments/production
         run: |
-          terraform plan -no-color -out=tfplan 2>&1 | tee plan.txt
+          terraform plan -input=false -no-color -out=tfplan 2>&1 | tee plan.txt
           exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if plan didn't release its own

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: infra/environments/shared
-        run: terraform init
+        run: terraform init -input=false
 
       - name: Verify remote backend is configured
         working-directory: infra/environments/shared
@@ -140,7 +140,7 @@ jobs:
         # -lock-timeout: queue briefly behind a concurrent in-flight
         # PR plan rather than failing instantly on lock contention.
         run: |
-          terraform plan -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
+          terraform plan -input=false -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
           exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if plan didn't release its own
@@ -266,14 +266,14 @@ jobs:
 
       - name: Terraform Init
         working-directory: infra/environments/production
-        run: terraform init
+        run: terraform init -input=false
 
       - name: Terraform Plan
         id: plan
         timeout-minutes: 10
         working-directory: infra/environments/production
         run: |
-          terraform plan -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
+          terraform plan -input=false -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
           exit "${PIPESTATUS[0]}"
 
       - name: Release stale state lock if plan didn't release its own

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: infra/environments/${{ matrix.environment }}
-        run: terraform init -backend=true
+        run: terraform init -backend=true -input=false
 
       - name: Terraform Plan (detailed exit code)
         id: plan
@@ -77,7 +77,7 @@ jobs:
         # We capture the code so the next step can branch.
         run: |
           set +e
-          terraform plan -detailed-exitcode -no-color -out=drift.tfplan 2>&1 | tee plan.txt
+          terraform plan -input=false -detailed-exitcode -no-color -out=drift.tfplan 2>&1 | tee plan.txt
           code=${PIPESTATUS[0]}
           set -e
           echo "exitcode=${code}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Terraform Init (no backend)
         working-directory: infra/environments/${{ matrix.environment }}
-        run: terraform init -backend=false
+        run: terraform init -backend=false -input=false
 
       - name: Terraform Validate
         working-directory: infra/environments/${{ matrix.environment }}
@@ -126,6 +126,10 @@ jobs:
       # NR provider - newrelic_cloud_aws_link_account in shared (#201).
       # Job-scoped rather than workflow-level so the uncredentialed
       # jobs above never see the secret.
+      # NOTE: dependabot-triggered runs resolve secrets from the
+      # separate Dependabot secret store, so this key must be defined
+      # in BOTH stores (Settings > Secrets and variables > Actions AND
+      # > Dependabot) or dependabot plans of shared fail.
       NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
       TF_VAR_newrelic_account_id: ${{ vars.NEW_RELIC_ACCOUNT_ID }}
     # Bound execution well under the 1h OIDC credential lifetime. The
@@ -162,7 +166,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: infra/environments/${{ matrix.environment }}
-        run: terraform init
+        run: terraform init -input=false
 
       - name: Terraform Plan
         id: plan
@@ -175,8 +179,14 @@ jobs:
         # `pipefail`, so we have to check explicitly.)
         # -lock-timeout: queue briefly behind a concurrent in-flight plan
         # rather than failing immediately on lock contention.
+        # -input=false: a missing provider credential must error, not
+        # prompt on stdin. Dependabot-triggered runs read the Dependabot
+        # secret store, so if NEW_RELIC_API_KEY is absent there terraform
+        # would otherwise prompt for provider.newrelic.api_key and hang
+        # plan (shared) to the step timeout (see the 2026-06-15 stale
+        # lock note above).
         run: |
-          terraform plan -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
+          terraform plan -input=false -no-color -lock-timeout=2m -out=tfplan 2>&1 | tee plan.txt
           exit "${PIPESTATUS[0]}"
         continue-on-error: true
 


### PR DESCRIPTION
## Why

Dependabot-triggered runs of the PR plan workflow resolve secrets from the **Dependabot** secret store, where `NEW_RELIC_API_KEY` is not defined. With an empty key, `terraform plan` for `shared` prompts interactively for `provider.newrelic.api_key` and hangs to the 10-minute step timeout ([example](https://github.com/percy-main/website-v2/actions/runs/32694827027/job/97334881393)):

```
05:22:12  provider.newrelic.api_key
05:32:20  ##[error]The action 'Terraform Plan' has timed out after 10 minutes.
```

While hung it holds the DynamoDB state lock; tonight that blocked the main deploy for #711 (`terraform-shared` failed on lock contention after its 2m `-lock-timeout`). Same failure mode as the 2026-06-15 stale-lock incident noted in the workflow.

## What

- Add `-input=false` to every `terraform init`/`plan` invocation across CI workflows (`terraform.yml`, `terraform-drift.yml`, `deploy.yml`, `deploy-terraform-manual.yml`) so a missing credential or variable errors immediately instead of prompting on stdin and hanging the runner.
- Document at the `NEW_RELIC_API_KEY` env wiring that the secret must exist in both the Actions and Dependabot secret stores.

## Note

This makes dependabot plans fail *fast*; making them *pass* additionally requires adding `NEW_RELIC_API_KEY` to the Dependabot secret store (Settings > Secrets and variables > Dependabot), which is being done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Automated infrastructure deployments and drift checks no longer pause for interactive input during initialization or planning.
  - Terraform plan output is more consistent across shared and production environments.
  - Added guidance for configuring the required monitoring service credentials for automated plan runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->