### PR TITLE
fix(prerender): skip sitemap write and invalidation when content unchanged (#717)

### DIFF
--- a/apps/web/server/prerender/lambda.ts
+++ b/apps/web/server/prerender/lambda.ts
@@ -27,6 +27,7 @@ import {
   navHash,
   nextState,
   planReconcile,
+  sitemapNeedsUpdate,
   type ManifestItem,
   type PrerenderState,
 } from "@/prerender/reconcile.js";
@@ -63,6 +64,7 @@ import {
 // build:ssr; if it fails, run `pnpm dedupe @smithy/signature-v4`.
 import "@smithy/signature-v4a";
 import { QueryClient } from "@tanstack/react-query";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -464,6 +466,10 @@ async function sync(force: boolean): Promise<SyncSummary> {
         nextState(
           manifest,
           currentNavHash,
+          // sitemap.xml is only rewritten at the end of the sync, so a
+          // mid-sync flush must carry the stored hash - flushing the new
+          // one would make a resumed sync skip the sitemap rewrite.
+          state?.sitemapHash,
           new Set([...failed, ...pendingUrls]),
         ),
       ),
@@ -513,25 +519,44 @@ async function sync(force: boolean): Promise<SyncSummary> {
     plan.toUnrender.map(snapshotKvsKey),
   );
 
-  await putObject(
-    "sitemap.xml",
-    buildSitemap(manifest, siteOrigin()),
-    "application/xml",
+  const sitemap = buildSitemap(manifest, siteOrigin());
+  const sitemapHash = createHash("sha256").update(sitemap).digest("hex");
+  const sitemapChanged = sitemapNeedsUpdate(
+    plan.mode,
+    state?.sitemapHash,
+    sitemapHash,
   );
-  await putObject(
-    STATE_KEY,
-    JSON.stringify(nextState(manifest, currentNavHash, failed)),
-    "application/json",
-  );
+  if (sitemapChanged) {
+    await putObject("sitemap.xml", sitemap, "application/xml");
+  }
+
+  // The 15-minute sweep mostly changes nothing; a clean diff sweep skips
+  // the state write too (it would be identical) so it costs zero S3
+  // writes and zero CloudFront invalidations. Write order matters: the
+  // sitemap lands before the state that records its hash, so a crash
+  // between the two rewrites the sitemap next sweep instead of
+  // stranding a stale one.
+  const noop =
+    plan.mode === "diff" &&
+    plan.toRender.length === 0 &&
+    plan.toUnrender.length === 0 &&
+    !sitemapChanged;
+  if (!noop) {
+    await putObject(
+      STATE_KEY,
+      JSON.stringify(nextState(manifest, currentNavHash, sitemapHash, failed)),
+      "application/json",
+    );
+  }
 
   // Earlier flushes already invalidated their batches; only the final
-  // batch, unrendered urls and the sitemap remain.
+  // batch, unrendered urls and the sitemap (when it changed) remain.
   const invalidationPaths =
     plan.mode === "diff"
       ? [
           ...finalBatch.map(snapshotInvalidationPath),
           ...plan.toUnrender.map(snapshotInvalidationPath),
-          "/sitemap.xml",
+          ...(sitemapChanged ? ["/sitemap.xml"] : []),
         ]
       : ["/_prerender/*", "/sitemap.xml"];
   await invalidate(invalidationPaths);

--- a/apps/web/src/prerender/reconcile.test.ts
+++ b/apps/web/src/prerender/reconcile.test.ts
@@ -3,6 +3,7 @@ import {
   navHash,
   nextState,
   planReconcile,
+  sitemapNeedsUpdate,
   type ManifestItem,
   type PrerenderState,
 } from "./reconcile.js";
@@ -167,7 +168,12 @@ describe("nextState", () => {
   it("records the manifest minus failures so retries happen next sync", () => {
     const ok = item("/club");
     const failed = item("/club/history");
-    const result = nextState([ok, failed], "abc", new Set(["/club/history"]));
+    const result = nextState(
+      [ok, failed],
+      "abc",
+      "map1",
+      new Set(["/club/history"]),
+    );
     expect(Object.keys(result.items)).toEqual(["/club"]);
     expect(result.navHash).toBe("abc");
     expect(result.v).toBe(1);
@@ -176,9 +182,36 @@ describe("nextState", () => {
   it("persists the content hash when an item carries one", () => {
     const game = item("/calendar/game/123", { kind: "game", hash: "abc123" });
     const page = item("/club");
-    const result = nextState([game, page], "nav");
+    const result = nextState([game, page], "nav", "map1");
     expect(result.items["/calendar/game/123"].hash).toBe("abc123");
     expect("hash" in result.items["/club"]).toBe(false);
+  });
+
+  it("persists the sitemap hash, omitting the key when there is none", () => {
+    expect(nextState([], "nav", "map1").sitemapHash).toBe("map1");
+    // A mid-sync flush before the rollout state exists carries undefined;
+    // the key is left out entirely rather than written as null.
+    expect("sitemapHash" in nextState([], "nav", undefined)).toBe(false);
+  });
+});
+
+describe("sitemapNeedsUpdate", () => {
+  it("skips a diff sweep whose sitemap is unchanged", () => {
+    expect(sitemapNeedsUpdate("diff", "map1", "map1")).toBe(false);
+  });
+
+  it("updates on a diff sweep when the sitemap content changed", () => {
+    expect(sitemapNeedsUpdate("diff", "map1", "map2")).toBe(true);
+  });
+
+  it("updates when the state file predates sitemap hashing", () => {
+    expect(sitemapNeedsUpdate("diff", undefined, "map1")).toBe(true);
+  });
+
+  it("always updates in full-render modes, even on a hash match", () => {
+    for (const mode of ["initial", "nav-changed", "forced"] as const) {
+      expect(sitemapNeedsUpdate(mode, "map1", "map1")).toBe(true);
+    }
   });
 });
 

--- a/apps/web/src/prerender/reconcile.ts
+++ b/apps/web/src/prerender/reconcile.ts
@@ -43,6 +43,12 @@ export interface PrerenderState {
   v: 1;
   navHash: string;
   items: Record<string, StateEntry>;
+  /**
+   * sha256 of the sitemap.xml the last sync left in the bucket, so a
+   * sweep that changes nothing can skip the rewrite and its CloudFront
+   * invalidation. Absent in pre-rollout state files.
+   */
+  sitemapHash?: string;
 }
 
 export interface ReconcilePlan {
@@ -112,10 +118,27 @@ export function planReconcile(options: {
   return { mode: "diff", toRender, toUnrender };
 }
 
+/**
+ * Whether this sync must rewrite sitemap.xml and invalidate its CDN
+ * path. Full-render modes always refresh it; a diff sweep skips it when
+ * the content hash matches the stored one. A state file without a
+ * stored hash (pre-rollout) reads as changed, which writes the hash in
+ * on the first sweep.
+ */
+export function sitemapNeedsUpdate(
+  mode: ReconcilePlan["mode"],
+  storedHash: string | undefined,
+  currentHash: string,
+): boolean {
+  return mode !== "diff" || storedHash !== currentHash;
+}
+
 /** The state file a completed sync should persist. */
 export function nextState(
   manifest: ManifestItem[],
   currentNavHash: string,
+  /** Hash of the sitemap the bucket holds; undefined only pre-rollout. */
+  sitemapHash: string | undefined,
   /** URLs that failed to render this sync - left out so the next reconcile retries them. */
   failedUrls: ReadonlySet<string> = new Set(),
 ): PrerenderState {
@@ -128,5 +151,10 @@ export function nextState(
       ...(item.hash !== undefined ? { hash: item.hash } : {}),
     };
   }
-  return { v: 1, navHash: currentNavHash, items };
+  return {
+    v: 1,
+    navHash: currentNavHash,
+    items,
+    ...(sitemapHash !== undefined ? { sitemapHash } : {}),
+  };
 }


### PR DESCRIPTION
## Summary

The prerender reconcile sweep runs every 15 minutes as a backstop for scheduled publishes. On every run - including the ~96/day where nothing changed - `sync()` rewrote `sitemap.xml` to S3 and issued a CloudFront invalidation for it. That is ~3,900 invalidation paths/month against CloudFront's 1,000 free, costing ~$12/mo for a no-op heartbeat.

## Changes

- `apps/web/src/prerender/reconcile.ts`: `PrerenderState` gains an optional `sitemapHash` field (sha256 of the sitemap the bucket holds); `nextState()` persists it; new pure helper `sitemapNeedsUpdate(mode, storedHash, currentHash)` decides whether the sitemap must be rewritten.
- `apps/web/server/prerender/lambda.ts` `sync()`: builds the sitemap once, hashes it, and skips the `sitemap.xml` put + the `/sitemap.xml` invalidation path when the hash matches the stored one in diff mode. A clean diff sweep (nothing rendered, nothing unrendered, sitemap unchanged) also skips the state-file write, so it performs zero S3 writes and zero CloudFront invalidations (`invalidate()` early-returns on the empty path list, and the final `kvsUpdate` with no ops makes no KVS calls either).
- Ordering and resume safety: the sitemap is written before the state that records its hash, so a crash between the two re-writes next sweep instead of stranding a stale sitemap; mid-sync progress flushes carry the previously stored hash for the same reason.

## Backwards compatibility

State files written before this change have no `sitemapHash`; `sitemapNeedsUpdate` treats a missing stored hash as changed, so the first sweep after deploy writes the sitemap once and stores the hash, then subsequent no-op sweeps go quiet.

## Unchanged behaviour

- Full-render modes (`initial`, `nav-changed`, `forced`/deploy) keep the unconditional sitemap write and `["/_prerender/*", "/sitemap.xml"]` invalidation.
- The 15-minute sweep cadence is untouched.
- Content edits still land in `toRender`, rewrite what changed, and refresh + invalidate the sitemap when its content differs.

## Testing

- Extended `apps/web/src/prerender/reconcile.test.ts`: `nextState` persists/omits `sitemapHash`; `sitemapNeedsUpdate` covers unchanged diff (skip), changed diff (write), pre-rollout state without hash (write), and full-render modes always writing. The `sync()` wiring in `lambda.ts` is AWS glue without an existing test harness and is verified by typecheck.
- `pnpm format`, `pnpm turbo lint typecheck --filter=web`, and `pnpm test` in `apps/web` (52 files, 703 tests) all pass.

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Sitemap updates are now skipped when its content has not changed.
  * CDN cache invalidation is limited to times when the sitemap is updated.
  * Prerender syncs avoid unnecessary state writes when no changes are detected.

* **Reliability**
  * Sitemap change tracking is preserved across syncs.
  * Initial syncs correctly establish sitemap tracking for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->