### PR TITLE
cost(infra): drop Container Insights and CloudFront additional metrics (#718)

### DIFF
--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -454,52 +454,6 @@ resource "aws_cloudwatch_metric_alarm" "cdn_5xx_rate" {
   ok_actions    = compact([local.reliability_alarms_topic_arn_us_east_1])
 }
 
-resource "aws_cloudwatch_metric_alarm" "cdn_origin_latency" {
-  provider = aws.us_east_1
-
-  alarm_name          = "percy-main-production-cdn-origin-latency"
-  alarm_description   = "CloudFront OriginLatency p99 >2s - slow origin (ALB → API) responses, may indicate API saturation"
-  namespace           = "AWS/CloudFront"
-  metric_name         = "OriginLatency"
-  extended_statistic  = "p99"
-  period              = 300
-  evaluation_periods  = 3
-  threshold           = 2000
-  comparison_operator = "GreaterThanThreshold"
-  treat_missing_data  = "notBreaching"
-
-  dimensions = {
-    DistributionId = module.cdn.distribution_id
-    Region         = "Global"
-  }
-
-  alarm_actions = compact([local.reliability_alarms_topic_arn_us_east_1])
-  ok_actions    = compact([local.reliability_alarms_topic_arn_us_east_1])
-}
-
-resource "aws_cloudwatch_metric_alarm" "cdn_cache_hit_rate" {
-  provider = aws.us_east_1
-
-  alarm_name          = "percy-main-production-cdn-cache-hit-rate"
-  alarm_description   = "CloudFront cache hit rate <80% - regression in cache config or sudden uncached traffic pattern. CacheHitRate requires additional metrics to be enabled on the distribution."
-  namespace           = "AWS/CloudFront"
-  metric_name         = "CacheHitRate"
-  statistic           = "Average"
-  period              = 3600
-  evaluation_periods  = 2
-  threshold           = 80
-  comparison_operator = "LessThanThreshold"
-  treat_missing_data  = "notBreaching"
-
-  dimensions = {
-    DistributionId = module.cdn.distribution_id
-    Region         = "Global"
-  }
-
-  alarm_actions = compact([local.reliability_alarms_topic_arn_us_east_1])
-  ok_actions    = compact([local.reliability_alarms_topic_arn_us_east_1])
-}
-
 # ── matchday distribution alarms ──
 
 resource "aws_cloudwatch_metric_alarm" "cdn_matchday_5xx_rate" {

--- a/infra/modules/cdn/main.tf
+++ b/infra/modules/cdn/main.tf
@@ -455,22 +455,6 @@ resource "aws_cloudfront_distribution" "main" {
 }
 
 # -----------------------------------------------------------------------------
-# Additional metrics — required for OriginLatency and CacheHitRate alarms
-# (see production env). Without this subscription, those metrics are not
-# published and the corresponding alarms stay perpetually OK.
-# -----------------------------------------------------------------------------
-
-resource "aws_cloudfront_monitoring_subscription" "main" {
-  distribution_id = aws_cloudfront_distribution.main.id
-
-  monitoring_subscription {
-    realtime_metrics_subscription_config {
-      realtime_metrics_subscription_status = "Enabled"
-    }
-  }
-}
-
-# -----------------------------------------------------------------------------
 # Outputs
 # -----------------------------------------------------------------------------
 

--- a/infra/modules/ecs-service/main.tf
+++ b/infra/modules/ecs-service/main.tf
@@ -208,14 +208,14 @@ resource "aws_cloudwatch_log_group" "api" {
 resource "aws_ecs_cluster" "main" {
   name = "${local.name_prefix}-cluster"
 
-  # Enabled so the monitoring module's task-count-drop alarm (#205) has
-  # ECS/ContainerInsights DesiredTaskCount + RunningTaskCount metrics
-  # to alarm against. Without this, those metrics are not published
-  # and the alarm sits in INSUFFICIENT_DATA forever. The cost is the
-  # extra CW Logs ingest for ContainerInsights - small at our scale.
+  # Disabled (#718): the ~28 custom ECS/ContainerInsights metrics cost
+  # more than they tell us - task health is already covered by the ALB
+  # unhealthy-host alarm, the deployment-failed EventBridge rule, and
+  # the in-process OTel/New Relic agent. Re-enable only if an alarm
+  # needs ECS/ContainerInsights metrics again.
   setting {
     name  = "containerInsights"
-    value = "enabled"
+    value = "disabled"
   }
 
   tags = local.tags

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -134,57 +134,6 @@ resource "aws_cloudwatch_metric_alarm" "ecs_memory_high" {
   tags = local.default_tags
 }
 
-# Running below desired — pages on task crash-loop / cold-stop / 0
-# tasks running. Uses metric math so it works for any desired count.
-resource "aws_cloudwatch_metric_alarm" "ecs_running_below_desired" {
-  alarm_name          = "${local.prefix}-ecs-running-below-desired"
-  alarm_description   = "ECS service has fewer running tasks than desired — crash loop, capacity exhaustion, or stuck deployment"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 2
-  threshold           = 0
-  treat_missing_data  = "notBreaching"
-
-  metric_query {
-    id          = "missing"
-    expression  = "desired - running"
-    label       = "Desired - Running"
-    return_data = true
-  }
-
-  metric_query {
-    id = "desired"
-    metric {
-      metric_name = "DesiredTaskCount"
-      namespace   = "ECS/ContainerInsights"
-      period      = 60
-      stat        = "Average"
-      dimensions = {
-        ClusterName = var.cluster_name
-        ServiceName = var.service_name
-      }
-    }
-  }
-
-  metric_query {
-    id = "running"
-    metric {
-      metric_name = "RunningTaskCount"
-      namespace   = "ECS/ContainerInsights"
-      period      = 60
-      stat        = "Average"
-      dimensions = {
-        ClusterName = var.cluster_name
-        ServiceName = var.service_name
-      }
-    }
-  }
-
-  alarm_actions = [aws_sns_topic.alarms.arn]
-  ok_actions    = [aws_sns_topic.alarms.arn]
-
-  tags = local.default_tags
-}
-
 # Deployment failed (circuit-breaker rollback or other deployment-state
 # failure) — routed to SNS via EventBridge.
 resource "aws_cloudwatch_event_rule" "ecs_deployment_failed" {

--- a/infra/modules/spa-cdn/main.tf
+++ b/infra/modules/spa-cdn/main.tf
@@ -387,16 +387,6 @@ resource "aws_cloudfront_distribution" "main" {
   }
 }
 
-resource "aws_cloudfront_monitoring_subscription" "main" {
-  distribution_id = aws_cloudfront_distribution.main.id
-
-  monitoring_subscription {
-    realtime_metrics_subscription_config {
-      realtime_metrics_subscription_status = "Enabled"
-    }
-  }
-}
-
 # -----------------------------------------------------------------------------
 # Outputs
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes ~$11/mo of duplicate CloudWatch metric layers. The API task was watched three ways: the in-process OTel/New Relic agent, ECS Container Insights (~28 custom CloudWatch metrics), and CloudFront "additional metrics" subscriptions on both distributions. The paid CloudWatch layers duplicate coverage we get elsewhere.

- Set Container Insights to `disabled` on the ECS cluster (`infra/modules/ecs-service/main.tf`) and deleted its only consumer, the `ecs-running-below-desired` metric-math alarm (`infra/modules/monitoring/main.tf`).
- Deleted both `aws_cloudfront_monitoring_subscription` resources (`infra/modules/cdn/main.tf`, `infra/modules/spa-cdn/main.tf`) and the two alarms they fed, `cdn-origin-latency` (OriginLatency) and `cdn-cache-hit-rate` (CacheHitRate), in `infra/environments/production/main.tf`.

Detection coverage is unaffected: the ALB unhealthy-host alarm (plus target-5xx, rejected-connections, and connection-error alarms), the ECS deployment-failed EventBridge rule, and the external Route 53 health check remain, alongside the 5xx-rate CloudFront alarms (which use free default metrics), RDS storage/CPU/memory/latency alarms, SES alarms, and cert expiry monitoring.

No dangling wiring: the subscriptions and alarms had no `enable_*` flags, module variables, or outputs of their own; the monitoring module's `cluster_name`/`service_name` variables are still used by the CPU/memory alarms and the dashboard.

## Post-apply (out of band)

The Container Insights log groups (`/aws/ecs/containerinsights/...`) are created by the ECS agent, not Terraform, so they must be deleted manually in AWS after this applies.

## Merge order

**Do not merge this before the PR for #721 (API memory 2048 -> 1024)** - that sizing change cites Container Insights memory data and should land while the metrics still exist.

## Verification

- `terraform fmt -recursive` - clean
- `terraform init -backend=false` + `terraform validate` in `infra/environments/production` - Success! The configuration is valid.
- `pnpm format` - no changes
- Note: `infra/environments/staging` fails `terraform validate` on an unrelated pre-existing error (`alb_dns_name` not expected by the cdn module, same on main); staging is not in the CI validate matrix.

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Monitoring**
  - Removed CloudFront origin-latency and cache-hit-rate alerts.
  - Removed the ECS alert for services running below their desired task count.
  - Existing CloudFront 5xx, ECS, load balancer, database, deployment-failure alerts, and dashboards remain available.

- **Infrastructure**
  - Disabled real-time CloudFront metrics and ECS Container Insights for production services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->