### PR TITLE
infra: make Tailscale router on-demand with 30-minute auto-stop (#720)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,15 @@ All AWS CLI commands must use the `percy-main` profile:
 aws --profile percy-main ...
 ```
 
-Infrastructure is in [`infra/`](infra/). Production DB access for operators is via Tailscale — see [ADR 012](docs/adrs/012-prod-db-access.md).
+Infrastructure is in [`infra/`](infra/). Production DB access for operators is via Tailscale - see [ADR 012](docs/adrs/012-prod-db-access.md).
+
+The Tailscale subnet router is on-demand (stopped by default) to save cost. Open an access window with:
+
+```sh
+pnpm run db:tunnel
+```
+
+This starts the router (reachable in ~1-2 minutes) and it stops itself 30 minutes after boot. For a longer session, wait for the stop and run it again.
 
 ## Contributing
 

--- a/docs/adrs/012-prod-db-access.md
+++ b/docs/adrs/012-prod-db-access.md
@@ -1,7 +1,7 @@
 # Decision 012: Production DB Access via Tailscale
 
 **Date:** 2026-04-20
-**Status:** Accepted
+**Status:** Accepted (amended 2026-08-27 - on-demand router, see below)
 
 ## Decision
 
@@ -186,6 +186,29 @@ Label TablePlus connections distinctly — e.g. green for `admin_ro`, red for
   `var.tailscale_db_admins` in `infra/environments/production/variables.tf`
   and apply. They sign in to Tailscale with that account; nothing else to
   configure. DB passwords are in Secrets Manager (separate IAM).
+
+## Amendment (2026-08-27): on-demand router (issue #720)
+
+The router is no longer always-on. It is stopped by default and started per
+access window with `pnpm run db:tunnel` (looks the instance up by its Name
+tag, starts it, waits for running). A systemd oneshot enabled at
+multi-user.target runs `shutdown -h +30` on every boot, so the instance
+stops itself ~30 minutes after being started; the auto-assigned public IPv4
+is released (and unbilled) while stopped. For a longer session, wait for the
+stop and start again. Saves ~$12.50/mo (compute + public IPv4 + alarms).
+
+Consequences:
+
+- `enable_alarms` is now `false` in production - the StatusCheck alarms
+  treat missing data as breaching and cannot coexist with a deliberately
+  stopped instance. `scripts/bastion-sql.sh` remains the break-glass if the
+  router is broken.
+- The OAuth client secret is now used as
+  `--authkey="$AUTH_KEY?ephemeral=false&preauthorized=true"`. OAuth-secret
+  registrations are EPHEMERAL by default, and Tailscale garbage-collects
+  ephemeral nodes while they are offline - which would have made the node
+  vanish between access windows. Persistent registration keeps the node
+  entry (shown offline) across stops.
 
 ## Follow-ups
 

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -575,6 +575,8 @@ module "monitoring" {
 # ---------------------------------------------------------------------------
 # Tailscale Subnet Router - admin DB access
 # Advertises the VPC CIDR to the tailnet. See docs/adrs/ for bootstrap steps.
+# On-demand since issue #720: stopped by default, started with
+# `pnpm run db:tunnel`, self-stops 30 minutes after boot.
 # ---------------------------------------------------------------------------
 
 module "tailscale_router" {
@@ -583,7 +585,9 @@ module "tailscale_router" {
   vpc_id           = module.vpc.vpc_id
   public_subnet_id = module.vpc.public_subnet_ids[0]
   advertise_cidr   = "10.0.0.0/16"
-  enable_alarms    = true
+  # Off: the router is stopped by default; StatusCheck alarms treat missing
+  # data as breaching and would page constantly on a stopped instance.
+  enable_alarms = false
 }
 
 # Allow admins on the tailnet (via the router) to reach RDS

--- a/infra/modules/tailscale-router/main.tf
+++ b/infra/modules/tailscale-router/main.tf
@@ -11,6 +11,11 @@
 #     arrives via NAT-traversed UDP.
 #   - No SSH. If debugging is ever needed, `aws ssm start-session` via the
 #     SSM agent installed by user_data.
+#   - On-demand (issue #720): a systemd oneshot schedules `shutdown -h +30`
+#     on every boot, so the instance stops itself ~30 minutes after being
+#     started. The instance is EBS-backed with the default stop-on-shutdown
+#     behaviour, so `shutdown -h` stops rather than terminates it. Start it
+#     with `pnpm run db:tunnel` (scripts/db-tunnel.sh).
 #   - OAuth client secret (a `tskey-client-...` reusable auth key) lives in
 #     Secrets Manager at the ARN exposed by `auth_secret_arn`. The module
 #     owns the container; the environment is expected to own the value
@@ -213,8 +218,12 @@ locals {
       echo "Tailscale auth secret is empty — populate it manually." >&2
       exit 1
     fi
+    # OAuth client secrets used as auth keys register EPHEMERAL nodes by
+    # default; ephemeral nodes are removed by Tailscale while the instance
+    # is stopped, which breaks the on-demand stop/start pattern. Force a
+    # persistent, preauthorized registration instead.
     tailscale up \
-      --authkey="$AUTH_KEY" \
+      --authkey="$${AUTH_KEY}?ephemeral=false&preauthorized=true" \
       --advertise-routes="${var.advertise_cidr}" \
       --accept-dns=false \
       --hostname="${local.name_prefix}-router" \
@@ -241,6 +250,25 @@ locals {
     UNIT
     systemctl daemon-reload
     systemctl enable --now tailscale-authenticate.service
+
+    # On-demand auto-stop: schedule a halt 30 minutes after EVERY boot.
+    # Delivered as an enabled systemd unit (not a bare user-data command)
+    # because cloud-init user data only runs once per instance, while this
+    # must re-arm each time the instance is started.
+    cat > /etc/systemd/system/auto-stop.service <<'AUTOSTOP'
+    [Unit]
+    Description=Stop this on-demand instance 30 minutes after boot
+
+    [Service]
+    Type=oneshot
+    ExecStart=/usr/sbin/shutdown -h +30 "Auto-stop: on-demand Tailscale router halts 30 minutes after boot"
+    RemainAfterExit=yes
+
+    [Install]
+    WantedBy=multi-user.target
+    AUTOSTOP
+    systemctl daemon-reload
+    systemctl enable --now auto-stop.service
   EOT
 }
 
@@ -307,9 +335,10 @@ output "auth_secret_name" {
 
 # -----------------------------------------------------------------------------
 # CloudWatch alarms — StatusCheck (instance + system) and sustained high CPU.
-# The router gates admin DB access; if it goes down the only recovery path
-# is a Terraform redeploy, so failures need to page rather than be discovered
-# next time someone tries to reach RDS.
+# Only sensible for an ALWAYS-ON router. With the on-demand pattern (stopped
+# by default, issue #720) these must stay disabled: the StatusCheck alarms
+# treat missing data as breaching, so a deliberately stopped instance would
+# page constantly. The flag is kept for any future always-on deployment.
 #
 # A dedicated SNS topic (not the monitoring module's alarms topic) avoids
 # the encrypted-topic problem: the monitoring module's topic uses

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "db:migration": "pnpm --filter @percy-main/db db:migration",
     "db:reset": "pnpm --filter @percy-main/db db:reset",
     "db:lift": "pnpm --filter @percy-main/db db:lift",
+    "db:tunnel": "bash scripts/db-tunnel.sh",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",
     "openapi:generate": "turbo run openapi --filter=api"

--- a/scripts/db-tunnel.sh
+++ b/scripts/db-tunnel.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# db-tunnel.sh - Start the on-demand Tailscale subnet router for prod DB
+# access. The router self-stops 30 minutes after boot (issue #720); for a
+# longer session, wait for the stop and run this again.
+#
+# Usage:
+#   pnpm run db:tunnel
+#
+# Prerequisites:
+#   - AWS CLI v2 configured (profile: percy-main)
+#   - Tailscale up on your laptop (see docs/adrs/012-prod-db-access.md)
+
+set -euo pipefail
+
+PROFILE="percy-main"
+REGION="eu-west-2"
+ROUTER_NAME_TAG="percy-main-production-tailscale-router"
+
+# Look up by Name tag rather than a hardcoded instance id - the instance is
+# replaced whenever its user_data or AMI changes.
+read -r INSTANCE_ID STATE < <(aws --profile "$PROFILE" --region "$REGION" \
+  ec2 describe-instances \
+  --filters "Name=tag:Name,Values=${ROUTER_NAME_TAG}" \
+  "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query 'Reservations[0].Instances[0].[InstanceId,State.Name]' \
+  --output text)
+
+if [[ -z "${INSTANCE_ID:-}" || "$INSTANCE_ID" == "None" ]]; then
+  echo "ERROR: no instance found with tag Name=${ROUTER_NAME_TAG}" >&2
+  exit 1
+fi
+
+echo "Router instance: ${INSTANCE_ID} (${STATE})"
+
+case "$STATE" in
+running)
+  echo "Router already up - it self-stops 30 minutes after it last booted."
+  exit 0
+  ;;
+pending)
+  echo "Router already starting..."
+  ;;
+stopping)
+  echo "Router is stopping - waiting for it to finish before restarting..."
+  aws --profile "$PROFILE" --region "$REGION" ec2 wait instance-stopped \
+    --instance-ids "$INSTANCE_ID"
+  aws --profile "$PROFILE" --region "$REGION" ec2 start-instances \
+    --instance-ids "$INSTANCE_ID" --output text > /dev/null
+  ;;
+stopped)
+  echo "Starting router..."
+  aws --profile "$PROFILE" --region "$REGION" ec2 start-instances \
+    --instance-ids "$INSTANCE_ID" --output text > /dev/null
+  ;;
+esac
+
+aws --profile "$PROFILE" --region "$REGION" ec2 wait instance-running \
+  --instance-ids "$INSTANCE_ID"
+
+echo ""
+echo "Router up - it self-stops in 30 minutes."
+echo "Give Tailscale ~1 minute to connect, then use psql/TablePlus against RDS"
+echo "as usual (connection details: docs/adrs/012-prod-db-access.md)."


### PR DESCRIPTION
## Summary

The Tailscale subnet router exists solely for occasional admin psql access to RDS but ran 24/7. This makes it on-demand: stopped by default, started with one command, self-stopping 30 minutes after boot. Saves ~$12.50/mo (~$8.77 compute + ~$3.72 public IPv4, released while stopped + 3 CloudWatch alarms).

## How the auto-stop works

The module's user data now writes and enables `/etc/systemd/system/auto-stop.service`, a `Type=oneshot` unit at `multi-user.target` that runs `shutdown -h +30`. Because it is an enabled systemd unit (not a bare cloud-init command, which only runs once per instance), it re-arms on EVERY boot. The instance is EBS-backed with the default stop-on-shutdown behaviour, so `shutdown -h` stops it rather than terminating it.

`user_data_replace_on_change = true` means this change REPLACES the instance and re-bootstraps Tailscale. That is expected; see the auth-key section below.

## Usage

```sh
pnpm run db:tunnel
```

`scripts/db-tunnel.sh` looks the instance up by its `Name` tag (`percy-main-production-tailscale-router`, never a hardcoded id - the instance is replaced on user_data/AMI changes), starts it, waits for `instance-running`, and prints the 30-minute window. If the router is mid-stop it waits for the stop and restarts it. Documented in the README's prod DB access section and as an amendment to ADR 012.

**Accepted trade-off:** the window is fixed at 30 minutes per boot. A longer session means waiting for the stop and running `pnpm run db:tunnel` again.

## Alarms

`enable_alarms = false` at the production call site. The module already gates the dedicated SNS topic and all three alarms (StatusCheck instance/system, CPU) on that one flag via `count`, so nothing alarm-related remains. The StatusCheck alarms treat missing data as breaching and would page constantly on a deliberately stopped instance.

## Before apply: auth key and re-registration

What is stored: `percy-main-production/tailscale/auth-key` holds a `tskey-client-...` OAuth client secret minted BY TERRAFORM (`tailscale_oauth_client.subnet_router`, scope `auth_keys`, tag `tag:subnet-router`) and written into Secrets Manager by `aws_secretsmanager_secret_version.tailscale_auth`. It is NOT a manually minted auth key.

- OAuth client secrets are reusable and do NOT have the 90-day auth-key expiry; they live until the client is revoked. Secret metadata confirms it is the original from bootstrap (last changed 2026-04-20) and still being read (last accessed 2026-08-27). **No fresh key needs minting before merge.**
- Re-registration is unattended: the boot-time `tailscale-authenticate.service` runs `tailscale up --authkey` with this secret on every boot, `autoApprovers` re-approves the 10.0.0.0/16 route, and `preauthorized=true` (added here) skips device approval.
- One real bug found and fixed in this PR: OAuth-client-secret registrations are **ephemeral by default** per Tailscale docs. That was invisible while the router ran 24/7, but Tailscale garbage-collects ephemeral nodes while they are offline, so the node entry would have vanished between access windows. The auth line now appends `?ephemeral=false&preauthorized=true`.
- After apply, the OLD node entry from the replaced instance may linger in the Tailscale admin console (Machines). If it does, delete it there - cosmetic only. If the old registration was ephemeral, Tailscale removes it by itself once the old instance is gone.

## Post-apply (out-of-band, one time)

The replacement instance boots RUNNING (and will now self-stop ~30 minutes later regardless). To reach the default-stopped state immediately, stop it once by hand after verifying the tailnet registration:

```sh
aws --profile percy-main --region eu-west-2 ec2 describe-instances \
  --filters "Name=tag:Name,Values=percy-main-production-tailscale-router" \
  "Name=instance-state-name,Values=running" \
  --query 'Reservations[0].Instances[0].InstanceId' --output text
aws --profile percy-main --region eu-west-2 ec2 stop-instances --instance-ids <id-from-above>
```

From then on it only runs when started via `pnpm run db:tunnel`. Terraform plan stays clean with the instance stopped (`aws_instance` does not manage run state).

## Verification

- `terraform fmt -recursive` (no changes) and `terraform validate` on the production environment: Success
- Rendered the user_data heredoc with dummy values: valid bash, nested heredocs and `$${AUTH_KEY}` escaping render correctly
- `shellcheck` on `scripts/db-tunnel.sh` (via container): clean
- `pnpm run db:tunnel` against the live (currently running) instance: resolves `i-0789791c1b41c1dc7` by tag and takes the already-up path
- `pnpm format`: no diffs

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)