### PR TITLE
cost(infra): API task memory 2048 -> 1024 MB (#721)

### DIFF
--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -160,7 +160,7 @@ module "ecs" {
   task_count               = 1
   max_task_count           = 4
   cpu                      = 256
-  memory                   = 2048
+  memory                   = 1024
   ecr_repository_url       = local.shared.ecr_repository_url
   acm_certificate_arn      = local.shared.acm_alb_certificate_arn
   vpc_id                   = module.vpc.vpc_id


### PR DESCRIPTION
## Summary

Reduces the production API task from 0.25 vCPU / 2048 MB to 0.25 vCPU / 1024 MB (~$3/mo saving). Sizing evidence from ECS/ContainerInsights `MemoryUtilized` for `production-api`, 2026-08-13 to 2026-08-26: daily averages 384-517 MB (~430 MB typical) and daily maxima 391-710 MB, so 1024 MB leaves ~30% headroom over the observed worst case. 256 CPU / 1024 MB is a valid Fargate combination.

One-line change: `memory = 2048` -> `1024` in the `module "ecs"` call in `infra/environments/production/main.tf`.

## Migrate task

The migrate task definition (`infra/modules/ecs-service/main.tf`, `aws_ecs_task_definition.migration`) uses the same `var.cpu` / `var.memory` as the API task, so it will also run at 1024 MB. Kysely migrations are light (single connection, sequential DDL) and are expected to be fine at 1024.

## Container-level memory settings

- The `api` container declares no container-level `memory` / `memoryReservation` in either task definition, so it inherits the task-level limit and needs no adjustment.
- The `newrelic-infra` sidecar has a hard-coded `memory = 128` (and `cpu = 64`), which is a fixed value independent of task memory and still fits comfortably within 1024.

## Merge order

Merge this BEFORE PR #725 (issue #718, Container Insights removal) so the sizing evidence stays checkable while the metrics still exist.

## Post-apply follow-ups (acceptance criteria)

- [ ] Deploy healthy after apply
- [ ] Migrate task completes on the next deploy
- [ ] No OOM kills (exit 137 / `OutOfMemory` stopped reason) over the following week

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Reduced the production service’s allocated memory from 2048 MiB to 1024 MiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->