### PR TITLE
infra: stand up API Gateway HTTP API alongside the ALB (stand-up only, no cutover) (#722)

### DIFF
--- a/docs/adrs/061-alb-to-api-gateway-http-api.md
+++ b/docs/adrs/061-alb-to-api-gateway-http-api.md
@@ -1,0 +1,190 @@
+# Decision 061: Replace the ALB with an API Gateway HTTP API (staged)
+
+**Date:** 2026-08-27
+**Status:** Accepted
+
+## Decision
+
+The public entry point for the API moves from the Application Load Balancer
+to an API Gateway HTTP API: custom domain -> VPC Link -> Cloud Map service
+discovery, with the ECS api tasks registered via `service_registries` (SRV
+records, so ECS publishes the port attribute `DiscoverInstances` needs).
+The change is staged across separate PRs: (1) stand the gateway up alongside
+the ALB serving only a test hostname (`api-gw-test.percymain.org`), with the
+regional ACM cert already covering `api.v2.percymain.org` as well; (2) after
+verification on the test hostname and after the route remediations below,
+flip the `api.v2` alias records to the gateway; (3) after a rollback window,
+remove the ALB, its listeners, target group, access-logs bucket and the two
+public IPv4s. Issue #722 tracks the sequence and stays open until step 3.
+
+## Problem
+
+After the winter cost work (#717-#723) the ALB is the largest remaining
+fixed cost: ~$19.83/mo hourly plus ~$7.45/mo for its two public IPv4
+addresses, ~$27/mo total, serving near-zero winter traffic. An HTTP API has
+no hourly fee and costs ~$1.11 per million requests in eu-west-2, which at
+our volume rounds to pennies. But the ALB fronts the exact path Stripe
+webhooks and auth ride on, and the two technologies are not equivalent: the
+ALB allows 120s idle (raised deliberately for slow image processing, ADR 048) and passes streamed responses through; HTTP APIs have a hard ~30s
+integration timeout, buffer responses (no SSE), and cap payloads at 10 MB.
+So the swap cannot be a blind cutover - it needs a route audit, a staged
+rollout, and remediation of the routes that violate the new constraints.
+
+## Options considered
+
+1. **API Gateway HTTP API via VPC Link + Cloud Map (chosen).** No fixed
+   hourly cost, pay-per-request, TLS termination with a regional ACM cert,
+   custom domains, CloudWatch access logging and metrics. Constraints: 30s
+   hard integration timeout, buffered responses, 10 MB payloads, no WAF
+   support.
+
+2. **Keep the ALB.** Zero risk, zero work, keeps 120s timeouts, streaming,
+   S3 access logs and the WAF attach point. Keeps paying ~$27/mo for a
+   near-idle load balancer, which is the single biggest line on the winter
+   bill after the other reductions.
+
+3. **Swap to an NLB.** Cheaper hourly than the ALB but still an hourly fee
+   plus LCU charges plus public IPv4s - it removes little of the fixed cost
+   and gives up L7 features (no TLS-terminating HTTP routing semantics we
+   use today without extra work). Worst of both.
+
+4. **API Gateway REST API.** Supports WAF and (by quota increase) longer
+   integration timeouts, but costs ~3x per request, still buffers responses
+   (no SSE), needs an NLB or VPC-link-v2 arrangement for private
+   integrations, and carries a much larger configuration surface for no
+   feature we need.
+
+## Rationale
+
+The fleet is tiny and the traffic is tiny; paying a fixed ~$27/mo for L7
+features we barely use is the wrong trade. The HTTP API's per-request
+pricing matches the load profile, and its real limitations turned out to be
+tractable: the route audit below found exactly two routes that structurally
+cannot cross the gateway (the streaming AI chat endpoints) and a small set
+of slow inline handlers, all of which have known async remediations - and
+several of which are latent bugs behind the ALB anyway (unbounded external
+fetches, an 80s default Stripe SDK timeout inside row-locking
+transactions). The staged rollout keeps risk near zero: the stand-up PR
+moves no traffic, verification happens on a test hostname against the real
+backend, the flip is a two-record DNS change with a tested one-commit
+rollback, and the ALB is only removed after a clean window.
+
+Cloud Map (rather than pointing the VPC Link at an ALB/NLB listener) is
+what removes the load balancer entirely: the gateway discovers task
+ENI IP:port pairs directly via `DiscoverInstances`. The Cloud Map service
+uses SRV records because ECS only registers the port attribute for SRV
+(A-record registration would leave the gateway with IPs and no port). The
+Cloud Map namespace and service live in the `ecs-service` module (they
+describe how the api tasks are discovered, and the registration is a block
+on the ECS service itself); everything gateway-side lives in a new
+`api-gateway` module. The gateway module owns its 5xx alarm
+(`alarms_sns_topic_arn` input, like `prerender` and `scheduling`), keeping
+the module graph acyclic: `monitoring` consumes `ecs-service` outputs, so
+the alarm could not live in `monitoring` without `ecs-service ->
+api-gateway -> monitoring -> ecs-service` becoming a module-level cycle.
+
+The regional ACM cert is issued from the api-gateway module with both
+`api.v2.percymain.org` and the test hostname as subject names, so the flip
+PR needs no new cert. ACM issues byte-identical validation CNAMEs for the
+same domain in the same account, so the api.v2 validation record duplicates
+the one the shared environment manages for the ALB cert; `allow_overwrite`
+on both sides makes the doubled management an idempotent UPSERT.
+
+Verified before writing the plan: the aws provider (6.61) applies
+`service_registries` changes through `UpdateService` (no `ForceNew` on the
+attribute), so registering the live service in Cloud Map is an in-place
+update that rolls tasks rather than replacing the service.
+
+## Route-duration audit
+
+Every route was audited against the gateway's constraints (29-30s total
+response budget, buffered responses, 10 MB payloads). Verdicts: **blocker**
+(structurally cannot cross an HTTP API), **needs async** (plausibly exceeds
+~29s inline; must move to a 202 + poll or background pattern before the
+flip), **needs hardening** (fine typically, but an unbounded tail can cross
+29s; cheap timeout fixes), **fine**.
+
+| Route                                                                      | Worst case / pattern                                                                                                                        | Verdict                                                                                          |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `POST /api/scout/threads/:threadId/messages`                               | Streamed AI chat turn (UIMessageStream over chunked HTTP, up to 20 agent steps + tool calls), 2-15 min                                      | **Blocker** - HTTP APIs buffer responses; needs an async-job + polling transport before the flip |
+| `POST /api/content-author/messages`                                        | Same streaming shape and step budget                                                                                                        | **Blocker** - same remediation                                                                   |
+| `POST /api/admin/content-images`                                           | Inline sharp ladder on 0.25 vCPU (up to 10 MB source, 6 encodes, 6 sequential S3 puts); 20-60s; produced ALB 504s before ADR 048 trimmed it | **Needs async**                                                                                  |
+| `POST /api/profile/edit/photo`                                             | Same `confirmUpload` path                                                                                                                   | **Needs async**                                                                                  |
+| `POST /api/scout/threads/:id/attachments/:id/commit`                       | Inline `generateText` (Haiku) over up to 10 MB PDF, no abort signal; 30-120s plausible                                                      | **Needs async**                                                                                  |
+| `POST /api/fantasy/admin/calculate-scores`                                 | Sequential per-row upserts (players, then teams x gameweeks); 10-30s+ and grows with league size                                            | **Needs async** (or batched writes)                                                              |
+| `POST /api/fantasy/admin/populate-players`                                 | Play Cricket fetch + per-player SELECT/INSERT N+1; 10-60s                                                                                   | **Needs async** (or batched writes)                                                              |
+| `POST /api/availability/requests` (auto-notify) and `POST .../notify/send` | Sequential awaited SES + web-push per recipient; club-wide blast 15-60s                                                                     | **Needs async**                                                                                  |
+| `POST /api/matchday/:matchId/notify-charges`                               | Same sequential email + push loop                                                                                                           | **Needs async**                                                                                  |
+| `POST /api/admin/charge-notification`                                      | Sequential render + SES per unpaid charge; 5-30s                                                                                            | **Needs async** (or batch)                                                                       |
+| `POST /api/charges/pay-outstanding`                                        | Sequential Stripe retrieves inside a `forUpdate` transaction; Stripe SDK left on its 80s default timeout; typical <10s                      | **Needs hardening** (Stripe client timeout)                                                      |
+| `POST /api/admin/financial-relief/requests/:id/decide`                     | Same Stripe-retrieve loop in a transaction                                                                                                  | **Needs hardening**                                                                              |
+| `GET /api/og/game/:matchId`                                                | Play Cricket calls and a sponsor-logo `fetch` with no timeout, then sharp; public + crawler-hit; typical <5s, unbounded tail                | **Needs hardening** (fetch timeouts)                                                             |
+| `GET /api/matchday/:matchId/team-news-image`                               | Same pattern, heavier compositing                                                                                                           | **Needs hardening**                                                                              |
+| `GET /api/play-cricket/league-table`; `GET /api/games*` cold cache         | Bare `fetch` to Play Cricket, no timeout (TTL cache mitigates)                                                                              | **Needs hardening**                                                                              |
+| `GET /api/admin/charges/unpaid-pdf`                                        | `@react-pdf` `renderToBuffer` inline on the event loop; scales with unpaid charges                                                          | **Needs hardening** (worker offload, like scout reports)                                         |
+| `POST /api/scout/knowledge/documents/:id/commit`                           | Inline S3 read up to 25 MB + hash (in-VPC, seconds); the ingest itself is already an ECS one-shot task                                      | Fine                                                                                             |
+| `POST /api/play-cricket/admin/sync`                                        | 202 + ECS RunTask, launch capped at 10s                                                                                                     | Fine                                                                                             |
+| Scout report generation, KB ingest                                         | Offloaded to one-shot ECS tasks; frontend polls                                                                                             | Fine                                                                                             |
+| `POST /api/stripe/webhook`                                                 | Signature verify + handler, bounded inline SES; 2-5s                                                                                        | Fine                                                                                             |
+| `/api/auth/*` (better-auth)                                                | Hashing + occasional inline SES; 1-3s                                                                                                       | Fine                                                                                             |
+| Stripe read routes (payments, membership, members)                         | 1-4 bounded Stripe calls                                                                                                                    | Fine                                                                                             |
+| Everything else                                                            | DB-only, sub-second                                                                                                                         | Fine                                                                                             |
+| Payloads                                                                   | Fastify `bodyLimit` is the 1 MiB default; responses are buffered JSON/images far below 10 MB; large objects move via presigned S3 URLs      | Fine (10 MB cap not a factor)                                                                    |
+| WebSockets / SSE consumers / long-lived idle connections                   | None anywhere beyond the two chat routes above                                                                                              | Fine                                                                                             |
+
+The two blockers gate the flip. The needs-async set would 504 at the
+gateway while the work completes server-side (the ADR 048 failure mode);
+all are admin/captain surfaces, not member-facing checkout or auth. The
+needs-hardening set is tail risk only and each fix is a timeout or an
+offload, not an architectural change.
+
+## Staged cutover plan
+
+The full runbook (verification commands, flip PR contents, rollback drill,
+removal PR contents) is in the stand-up PR body, linked from #722. In
+brief:
+
+1. **Stand-up (this ADR's PR):** gateway + VPC Link + Cloud Map + cert +
+   test hostname + access logs + 5xx alarm. `api.v2` DNS, the ALB and the
+   Route 53 health check untouched; zero traffic moves.
+2. **Verify on `api-gw-test.percymain.org`:** health endpoints, login + 2FA
+   cookie flow, a Stripe webhook replay signed with the production signing
+   secret (proves the gateway does not alter raw bytes), matchday PWA
+   calls, client-IP passthrough, access logs and alarm.
+3. **Remediate** the blocker and needs-async routes; land the hardening
+   fixes.
+4. **Flip PR:** add the `api.v2` custom domain + mapping (cert already
+   covers it) and repoint the two alias records from the ALB to the
+   gateway. Everything else - webhook URL, auth baseURL, SPA config, the
+   health check - keys off the unchanged hostname.
+5. **Rollback drill** during the overlap window: revert the alias records
+   to the ALB once, verify, re-flip. Alias changes propagate in ~a minute.
+6. **Removal PR** after a clean window: ALB + listeners + target group +
+   logs bucket + ALB security group + ALB alarms/widgets + shared ALB cert
+   (production apply restores the shared validation CNAME the teardown
+   deletes). This is where the ~$27/mo lands.
+
+## Losses accepted
+
+- **ALB S3 access logs** (90-day retention) -> API GW access logs to
+  CloudWatch, 14-day retention. Verification and triage, not archival.
+- **The WAF attach point.** Unused today, and HTTP APIs cannot attach WAF
+  at all. If WAF ever becomes necessary the options are CloudFront in
+  front or a REST API.
+- **Target-group health-check alarms** (unhealthy hosts, rejected
+  connections, connection errors, p99 latency) -> the gateway 5xx alarm
+  plus the existing ECS task-level alarms. `IntegrationLatency` alarms can
+  be added later if missed.
+- **120s idle timeout and streaming.** The hard constraint driving the
+  remediation list above; accepted deliberately as the price of removing
+  the fixed cost.
+
+## Rejected alternatives
+
+- **Keep the ALB:** becomes attractive again only if sustained traffic or
+  streaming-heavy features make per-request pricing or the 30s cap the
+  wrong trade; the stand-up is reversible by deleting the gateway module.
+- **NLB:** would only make sense as a private-integration target for a
+  REST API, which is itself rejected.
+- **REST API:** revisit if WAF or a >30s integration timeout ever becomes
+  a hard requirement that the async patterns cannot absorb.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -38,3 +38,4 @@ To add a new ADR, use the [`add-adr` skill](../../.claude/skills/add-adr/SKILL.m
 | [057](057-reviewer-gated-terraform-pr-plans.md)           | Reviewer-gated Terraform PR plans instead of a de-scoped plan role | 2026-08-20 | Accepted |
 | [059](059-push-subscription-dropped-on-account-change.md) | Push subscriptions dropped, not re-keyed, when the account changes | 2026-08-21 | Accepted |
 | [060](060-fantasy-player-id-change-alerting.md)           | Alert on Play Cricket player ID changes, reconcile by hand         | 2026-08-21 | Accepted |
+| [061](061-alb-to-api-gateway-http-api.md)                 | Replace the ALB with an API Gateway HTTP API, staged cutover       | 2026-08-27 | Accepted |

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -573,6 +573,27 @@ module "monitoring" {
 }
 
 # ---------------------------------------------------------------------------
+# API Gateway HTTP API (#722) - stood up ALONGSIDE the ALB, zero traffic
+# moved. api.v2.percymain.org still points at the ALB (records above); the
+# gateway serves only the test hostname until verification on it passes.
+# The DNS flip and the ALB removal are separate follow-up PRs (see ADR 061
+# for the staged plan and the route-duration audit that gates the flip).
+# ---------------------------------------------------------------------------
+
+module "api_gateway" {
+  source                        = "../../modules/api-gateway"
+  environment                   = "production"
+  vpc_id                        = module.vpc.vpc_id
+  subnet_ids                    = module.vpc.public_subnet_ids
+  ecs_security_group_id         = module.vpc.ecs_security_group_id
+  service_discovery_service_arn = module.ecs.service_discovery_service_arn
+  zone_id                       = local.shared.zone_id
+  api_domain_name               = "api.v2.percymain.org"
+  test_domain_name              = "api-gw-test.percymain.org"
+  alarms_sns_topic_arn          = module.monitoring.sns_topic_arn
+}
+
+# ---------------------------------------------------------------------------
 # Tailscale Subnet Router - admin DB access
 # Advertises the VPC CIDR to the tailnet. See docs/adrs/ for bootstrap steps.
 # ---------------------------------------------------------------------------

--- a/infra/environments/production/outputs.tf
+++ b/infra/environments/production/outputs.tf
@@ -10,6 +10,11 @@ output "alb_dns_name" {
   value = module.ecs.alb_dns_name
 }
 
+output "api_gateway_test_url" {
+  value       = module.api_gateway.test_url
+  description = "Pre-cutover API Gateway verification hostname (#722)"
+}
+
 output "cloudfront_distribution_id" {
   value = module.cdn.distribution_id
 }

--- a/infra/modules/api-gateway/main.tf
+++ b/infra/modules/api-gateway/main.tf
@@ -1,0 +1,371 @@
+# API Gateway HTTP API Module (#722)
+# Stands up an HTTP API in front of the ECS api service via a VPC Link and
+# Cloud Map service discovery, as the eventual replacement for the ALB.
+# In the stand-up phase it serves a test hostname only: api.v2 DNS, the ALB
+# and the Route 53 health check are untouched. Constraints accepted with
+# this path (recorded in ADR 061): hard ~30s integration timeout, buffered
+# responses (no SSE/streaming), 10 MB payload cap, no WAF attach point.
+
+# ------------------------------------------------------------------------------
+# Variables
+# ------------------------------------------------------------------------------
+
+variable "environment" {
+  type        = string
+  description = "Environment name"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC to place the VPC Link in"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnets for the VPC Link ENIs (same subnets the api tasks run in)"
+}
+
+variable "ecs_security_group_id" {
+  type        = string
+  description = "Security group of the ECS api tasks (given ingress from the VPC Link)"
+}
+
+variable "service_discovery_service_arn" {
+  type        = string
+  description = "Cloud Map service ARN the integration discovers api tasks through"
+}
+
+variable "zone_id" {
+  type        = string
+  description = "Route 53 hosted zone for the cert validation and test hostname records"
+}
+
+variable "api_domain_name" {
+  type        = string
+  description = "Production API hostname (cert primary name only in the stand-up phase; gets a custom domain at cutover)"
+}
+
+variable "test_domain_name" {
+  type        = string
+  description = "Pre-cutover verification hostname served by the gateway"
+}
+
+variable "alarms_sns_topic_arn" {
+  type        = string
+  description = "SNS topic ARN for the 5xx alarm"
+}
+
+variable "log_retention_days" {
+  type        = number
+  default     = 14
+  description = "Retention for the access-log CloudWatch log group"
+}
+
+# ------------------------------------------------------------------------------
+# Locals
+# ------------------------------------------------------------------------------
+
+locals {
+  name_prefix = "percy-main-${var.environment}"
+
+  tags = {
+    Environment = var.environment
+    Project     = "percy-main"
+    ManagedBy   = "terraform"
+    Module      = "api-gateway"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# VPC Link networking
+# Mirrors the ALB -> task path: the link ENIs only ever open connections
+# TO the tasks on the application port, so the link SG is egress-only and
+# the task SG gets a matching ingress rule (the counterpart of
+# ecs_ingress_from_alb in the vpc module - attached from here so the vpc
+# module doesn't need to know about API Gateway, same pattern as
+# rds_ingress_from_tailscale in environments/production).
+# ------------------------------------------------------------------------------
+
+resource "aws_security_group" "vpc_link" {
+  name        = "${local.name_prefix}-vpc-link"
+  description = "API Gateway VPC Link ENIs"
+  vpc_id      = var.vpc_id
+
+  tags = local.tags
+}
+
+resource "aws_security_group_rule" "vpc_link_egress_to_ecs" {
+  type                     = "egress"
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "tcp"
+  source_security_group_id = var.ecs_security_group_id
+  security_group_id        = aws_security_group.vpc_link.id
+  description              = "To ECS tasks on the application port"
+}
+
+resource "aws_security_group_rule" "ecs_ingress_from_vpc_link" {
+  type                     = "ingress"
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.vpc_link.id
+  security_group_id        = var.ecs_security_group_id
+  description              = "Inbound from API Gateway VPC Link on application port"
+}
+
+resource "aws_apigatewayv2_vpc_link" "main" {
+  name               = "${local.name_prefix}-api"
+  security_group_ids = [aws_security_group.vpc_link.id]
+  subnet_ids         = var.subnet_ids
+
+  tags = local.tags
+}
+
+# ------------------------------------------------------------------------------
+# HTTP API
+# ------------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_api" "main" {
+  name          = "${local.name_prefix}-api"
+  protocol_type = "HTTP"
+
+  # Custom domains only - the default execute-api URL would be a second,
+  # unmonitored public hostname for the same backend.
+  disable_execute_api_endpoint = true
+
+  # Deliberately no cors_configuration: CORS stays in the Fastify app
+  # (@fastify/cors), exactly as behind the ALB. Configuring it here would
+  # have the gateway answer preflights itself with a second, drifting
+  # origin list.
+
+  tags = local.tags
+}
+
+# HTTP_PROXY via the VPC Link straight to the Cloud Map service: the
+# gateway resolves healthy task IP:port pairs with DiscoverInstances at
+# request time. payload_format_version 1.0 is the only valid value for
+# HTTP_PROXY - plain proxying, no Lambda-style event shaping. The
+# integration timeout is the HTTP API hard maximum (30s) by default;
+# deliberately not set lower.
+resource "aws_apigatewayv2_integration" "api" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "HTTP_PROXY"
+  integration_method     = "ANY"
+  integration_uri        = var.service_discovery_service_arn
+  connection_type        = "VPC_LINK"
+  connection_id          = aws_apigatewayv2_vpc_link.main.id
+  payload_format_version = "1.0"
+}
+
+resource "aws_apigatewayv2_route" "default" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.api.id}"
+}
+
+# ------------------------------------------------------------------------------
+# Access logging
+# Replaces the ALB's S3 access logs on this path. 14-day retention: these
+# are for cutover verification and incident triage, not archival.
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "access_logs" {
+  name              = "/aws/apigateway/${local.name_prefix}-api"
+  retention_in_days = var.log_retention_days
+
+  tags = local.tags
+}
+
+# The $default stage serves requests at the domain root, so backend paths
+# pass through unmodified (no stage prefix).
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId               = "$context.requestId"
+      ip                      = "$context.identity.sourceIp"
+      requestTime             = "$context.requestTime"
+      httpMethod              = "$context.httpMethod"
+      path                    = "$context.path"
+      protocol                = "$context.protocol"
+      status                  = "$context.status"
+      responseLength          = "$context.responseLength"
+      integrationLatency      = "$context.integrationLatency"
+      integrationStatus       = "$context.integrationStatus"
+      integrationErrorMessage = "$context.integrationErrorMessage"
+      userAgent               = "$context.identity.userAgent"
+    })
+  }
+
+  tags = local.tags
+}
+
+# ------------------------------------------------------------------------------
+# Regional ACM certificate
+# Covers the production hostname AND the test hostname now, so the later
+# DNS flip needs no new cert - just a second custom domain + mapping.
+# ------------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "api" {
+  domain_name               = var.api_domain_name
+  subject_alternative_names = [var.test_domain_name]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.tags
+}
+
+resource "aws_route53_record" "api_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.api.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = var.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+
+  # ACM issues the identical validation CNAME for the same domain in the
+  # same account, so the api.v2 record here is byte-for-byte the one the
+  # shared environment already manages for the ALB cert - allow_overwrite
+  # makes the doubled-up management an idempotent UPSERT (same setting as
+  # the shared validation records). If the shared ALB cert is ever torn
+  # down first, a production apply restores the record from here.
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "api" {
+  certificate_arn         = aws_acm_certificate.api.arn
+  validation_record_fqdns = [for record in aws_route53_record.api_cert_validation : record.fqdn]
+}
+
+# ------------------------------------------------------------------------------
+# Custom domain - test hostname only in the stand-up phase.
+# The cutover PR adds a second aws_apigatewayv2_domain_name + mapping for
+# the production hostname and repoints its alias records here.
+# ------------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_domain_name" "test" {
+  domain_name = var.test_domain_name
+
+  domain_name_configuration {
+    certificate_arn = aws_acm_certificate.api.arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+    # The ALB records the flip replaces are dualstack (A + AAAA) - keep
+    # IPv6 parity from the start.
+    ip_address_type = "dualstack"
+  }
+
+  depends_on = [aws_acm_certificate_validation.api]
+
+  tags = local.tags
+}
+
+resource "aws_apigatewayv2_api_mapping" "test" {
+  api_id      = aws_apigatewayv2_api.main.id
+  domain_name = aws_apigatewayv2_domain_name.test.id
+  stage       = aws_apigatewayv2_stage.default.id
+}
+
+resource "aws_route53_record" "test_a" {
+  zone_id = var.zone_id
+  name    = var.test_domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.test.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.test.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "test_aaaa" {
+  zone_id = var.zone_id
+  name    = var.test_domain_name
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.test.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.test.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Alarms
+# The API GW analogue of the two ALB 5xx alarms in the monitoring module.
+# HTTP API metrics don't split gateway-generated from upstream 5xx the way
+# the ALB's ELB/Target metric pair does, so one alarm covers both; the
+# threshold mirrors the stricter target-side alarm (>5 in 5 minutes) since
+# upstream 500s are what it exists to catch.
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "api_5xx_errors" {
+  alarm_name          = "${local.name_prefix}-api-gateway-5xx-errors"
+  alarm_description   = "API Gateway 5xx count >5 in 5min - gateway or upstream API errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "5xx"
+  namespace           = "AWS/ApiGateway"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 5
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ApiId = aws_apigatewayv2_api.main.id
+  }
+
+  alarm_actions = [var.alarms_sns_topic_arn]
+  ok_actions    = [var.alarms_sns_topic_arn]
+
+  tags = local.tags
+}
+
+# ------------------------------------------------------------------------------
+# Outputs
+# ------------------------------------------------------------------------------
+
+output "api_id" {
+  description = "HTTP API id (CloudWatch ApiId dimension)"
+  value       = aws_apigatewayv2_api.main.id
+}
+
+output "vpc_link_id" {
+  description = "VPC Link id"
+  value       = aws_apigatewayv2_vpc_link.main.id
+}
+
+output "vpc_link_security_group_id" {
+  description = "Security group on the VPC Link ENIs"
+  value       = aws_security_group.vpc_link.id
+}
+
+output "certificate_arn" {
+  description = "Regional ACM cert covering the production and test hostnames"
+  value       = aws_acm_certificate.api.arn
+}
+
+output "test_url" {
+  description = "Base URL of the pre-cutover verification hostname"
+  value       = "https://${var.test_domain_name}"
+}
+
+output "access_log_group_name" {
+  description = "CloudWatch log group receiving gateway access logs"
+  value       = aws_cloudwatch_log_group.access_logs.name
+}

--- a/infra/modules/ecs-service/main.tf
+++ b/infra/modules/ecs-service/main.tf
@@ -915,6 +915,49 @@ resource "aws_lb_listener" "https" {
 }
 
 # ------------------------------------------------------------------------------
+# Cloud Map Service Discovery (#722)
+# Gives API Gateway's VPC Link a stable target for the api tasks: the
+# gateway resolves task ENI IPs via DiscoverInstances at request time.
+# Runs alongside the ALB registration - the two are independent data
+# paths, so this is safe to stand up with zero traffic on it.
+# ------------------------------------------------------------------------------
+
+resource "aws_service_discovery_private_dns_namespace" "main" {
+  name        = "${var.environment}.percymain.internal"
+  description = "Service discovery namespace for the ${var.environment} ECS services"
+  vpc         = var.vpc_id
+
+  tags = local.tags
+}
+
+resource "aws_service_discovery_service" "api" {
+  name = "api"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.main.id
+
+    # SRV, not A: API Gateway private integrations discover targets via
+    # DiscoverInstances and need both an IP and a port attribute on each
+    # instance. ECS only registers AWS_INSTANCE_PORT when the service
+    # discovery config uses SRV records (see the ECS note in the API GW
+    # private-integration docs). Task IPs churn on every deployment, so
+    # keep the TTL low.
+    dns_records {
+      type = "SRV"
+      ttl  = 10
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  # ECS manages registration/deregistration through the task lifecycle;
+  # no Route 53 health check is involved.
+  health_check_custom_config {}
+
+  tags = local.tags
+}
+
+# ------------------------------------------------------------------------------
 # ECS Service
 # ------------------------------------------------------------------------------
 
@@ -942,6 +985,16 @@ resource "aws_ecs_service" "api" {
     target_group_arn = aws_lb_target_group.api.arn
     container_name   = "api"
     container_port   = 3000
+  }
+
+  # Cloud Map registration for the API Gateway path (#722). `port` (not
+  # container_name/container_port) is the correct field for awsvpc tasks
+  # with SRV records. The aws provider applies service_registries changes
+  # via UpdateService - an in-place update that rolls the tasks, not a
+  # service replacement.
+  service_registries {
+    registry_arn = aws_service_discovery_service.api.arn
+    port         = 3000
   }
 
   lifecycle {
@@ -987,6 +1040,11 @@ resource "aws_appautoscaling_policy" "ecs_cpu" {
 output "alb_dns_name" {
   description = "DNS name of the Application Load Balancer"
   value       = aws_lb.main.dns_name
+}
+
+output "service_discovery_service_arn" {
+  description = "Cloud Map service ARN for the api tasks (API Gateway private-integration target)"
+  value       = aws_service_discovery_service.api.arn
 }
 
 output "cluster_name" {


### PR DESCRIPTION
Stand-up only, per the staged plan in #722: builds the API Gateway HTTP API **alongside** the ALB and points a **test hostname** at it. **Zero traffic moves. The ALB, its listeners/target group/logs bucket, the `api.v2.percymain.org` records and the Route 53 health check are untouched.** The DNS flip and the ALB removal are separate later PRs, gated on the verification checklist and the route remediations below. Full decision record: ADR 061.

## What this creates

- **Cloud Map** private DNS namespace `production.percymain.internal` + service `api` (in `modules/ecs-service`), registered on the ECS service via `service_registries`. SRV records deliberately: API GW private integrations resolve targets with `DiscoverInstances` and need an IP **and port** attribute, and ECS only registers the port for SRV. Verified against the aws provider source at the pinned version (6.61): `service_registries` has no `ForceNew` and feeds `UpdateService`, so this is an **in-place update** that rolls tasks (normal rolling deployment), not a service replacement. The live service was confirmed to be on the `ECS` rolling controller with empty registries.
- **New `modules/api-gateway`**: VPC Link in the task subnets with an egress-only SG (plus the matching ingress rule on the task SG, mirroring `ecs_ingress_from_alb`); HTTP API with `$default` route -> `HTTP_PROXY` integration (payload format 1.0) via the VPC Link to the Cloud Map service; execute-api endpoint disabled (custom domains only); **no gateway CORS** (CORS stays in Fastify, as behind the ALB).
- **Regional ACM cert** (eu-west-2, DNS-validated in the shared zone) covering **both** `api.v2.percymain.org` and `api-gw-test.percymain.org`, so the flip needs no new cert. The api.v2 validation CNAME is byte-identical to the one the shared env manages for the ALB cert (ACM reuses validation tokens per domain per account); `allow_overwrite` on both sides makes the doubled management an idempotent UPSERT.
- **Custom domain for the test hostname only** (`api-gw-test.percymain.org`, dualstack for IPv6 parity with the ALB records) + A/AAAA alias records.
- **Access logs** to CloudWatch (`/aws/apigateway/percy-main-production-api`, 14-day retention) and a **5xx alarm** (>5 in 5 min, mirroring the stricter ALB target-5xx alarm since HTTP API metrics do not split gateway vs upstream 5xx) wired to the production alarms SNS topic.

Module graph stays acyclic: `api-gateway` consumes `vpc`, `ecs` (Cloud Map ARN) and `monitoring` (SNS topic); nothing consumes `api-gateway`. The alarm lives in the gateway module (the `prerender`/`scheduling` pattern) because putting it in `monitoring` would create a module-level cycle with `ecs-service`. No conditional `count`/`for_each` on new module outputs anywhere.

## Route-duration audit

Constraints audited against: hard ~30s integration timeout, buffered responses (no SSE/streaming), 10 MB payload cap, no WebSockets. Verdicts: **blocker** (structurally cannot cross an HTTP API), **needs async** (plausibly >29s inline; must become 202 + poll before the flip), **needs hardening** (typical case fine, unbounded tail; cheap timeout fixes), **fine**.

| Route | Worst case / pattern | Verdict |
| --- | --- | --- |
| `POST /api/scout/threads/:threadId/messages` | Streamed AI chat turn (UIMessageStream over chunked HTTP, up to 20 agent steps + tool calls), 2-15 min | **Blocker** - HTTP APIs buffer responses; needs async-job + polling transport before the flip |
| `POST /api/content-author/messages` | Same streaming shape and step budget | **Blocker** - same remediation |
| `POST /api/admin/content-images` | Inline sharp ladder on 0.25 vCPU (10 MB source, 6 encodes, 6 sequential S3 puts); 20-60s; produced ALB 504s before ADR 048 | **Needs async** |
| `POST /api/profile/edit/photo` | Same `confirmUpload` path | **Needs async** |
| `POST /api/scout/threads/:id/attachments/:id/commit` | Inline `generateText` (Haiku) over up to 10 MB PDF, no abort signal; 30-120s plausible | **Needs async** |
| `POST /api/fantasy/admin/calculate-scores` | Sequential per-row upserts (players, then teams x gameweeks); 10-30s+, grows with league size | **Needs async** (or batched writes) |
| `POST /api/fantasy/admin/populate-players` | Play Cricket fetch + per-player SELECT/INSERT N+1; 10-60s | **Needs async** (or batched writes) |
| `POST /api/availability/requests` (auto-notify) and `POST .../notify/send` | Sequential awaited SES + web-push per recipient; club-wide blast 15-60s | **Needs async** |
| `POST /api/matchday/:matchId/notify-charges` | Same sequential email + push loop | **Needs async** |
| `POST /api/admin/charge-notification` | Sequential render + SES per unpaid charge; 5-30s | **Needs async** (or batch) |
| `POST /api/charges/pay-outstanding` | Sequential Stripe retrieves inside a `forUpdate` transaction; Stripe SDK on its 80s default timeout; typical <10s | **Needs hardening** (Stripe client timeout) |
| `POST /api/admin/financial-relief/requests/:id/decide` | Same Stripe-retrieve loop in a transaction | **Needs hardening** |
| `GET /api/og/game/:matchId` | Play Cricket calls + sponsor-logo `fetch` with no timeout, then sharp; public + crawler-hit; typical <5s, unbounded tail | **Needs hardening** (fetch timeouts) |
| `GET /api/matchday/:matchId/team-news-image` | Same pattern, heavier compositing | **Needs hardening** |
| `GET /api/play-cricket/league-table`; `GET /api/games*` cold cache | Bare `fetch` to Play Cricket, no timeout (TTL cache mitigates) | **Needs hardening** |
| `GET /api/admin/charges/unpaid-pdf` | `@react-pdf` `renderToBuffer` inline on the event loop; scales with unpaid charges | **Needs hardening** (worker offload, like scout reports) |
| `POST /api/scout/knowledge/documents/:id/commit` | Inline S3 read up to 25 MB + hash (in-VPC, seconds); ingest already an ECS one-shot task | Fine |
| `POST /api/play-cricket/admin/sync` | 202 + ECS RunTask, launch capped at 10s | Fine |
| Scout report generation, KB ingest | Offloaded to one-shot ECS tasks; frontend polls | Fine |
| `POST /api/stripe/webhook` | Signature verify + handler, bounded inline SES; 2-5s | Fine |
| `/api/auth/*` (better-auth) | Hashing + occasional inline SES; 1-3s | Fine |
| Stripe read routes (payments, membership, members) | 1-4 bounded Stripe calls | Fine |
| Everything else | DB-only, sub-second | Fine |
| Payloads | Fastify `bodyLimit` is the 1 MiB default; responses buffered JSON/images far below 10 MB; large objects go via presigned S3 URLs | Fine (10 MB cap not a factor) |
| WebSockets / SSE consumers / long idle connections | None beyond the two chat routes above | Fine |

The two **blockers** gate the flip: the scout and content-author chat transports must move to an async job + polling pattern (or an alternate egress) first. The **needs async** set would 504 at the gateway while work completes server-side; all are admin/captain surfaces, not member checkout/auth. **Needs hardening** items are tail-risk-only and are latent bugs behind the ALB too.

## Runbook

### 1. Verify on `api-gw-test.percymain.org` (after this PR deploys)

- `curl -sv https://api-gw-test.percymain.org/health/ready` -> 200; `/health` (DB ping) -> 200.
- Cert SANs: `openssl s_client -connect api-gw-test.percymain.org:443 -servername api-gw-test.percymain.org </dev/null | openssl x509 -noout -ext subjectAltName` -> both api.v2 and the test hostname.
- Auth cookie flow: `POST /api/auth/sign-in/email` with a test account (curl -c jar) -> `Set-Cookie` with `Domain=.percymain.org; Secure`; `GET /api/auth/get-session` (curl -b jar) -> session. Repeat with a 2FA-enabled account and complete TOTP. Browser check: run the web SPA locally with its API base URL pointed at the test hostname; login and confirm the CORS preflight is answered by the app (not the gateway). Note: Google OAuth will redirect back to api.v2 (better-auth baseURL) - expected on a test hostname; email+password + TOTP is the flow to verify here.
- Stripe webhook byte-integrity: replay an event signed with the production signing secret (from Secrets Manager) as a raw POST to `/api/stripe/webhook` on the test hostname; expect the same response api.v2 gives. Signature is HMAC over the raw body, so success proves the gateway does not alter bytes. Use an event type the handler ignores to stay side-effect free.
- Matchday PWA: point a local matchday dev build's API base at the test hostname; load availability/squad screens with a session cookie.
- Client IP: confirm app logs/rate limiting see the real client IP (X-Forwarded-For via the gateway) by comparing with the gateway access log `ip` field.
- Ops: access logs flowing in `/aws/apigateway/percy-main-production-api`; `percy-main-production-api-gateway-5xx-errors` alarm exists and is OK.
- Expected failures pre-remediation (do not treat as gateway faults): scout chat and content-author chat will buffer/time out; image confirms >30s will 504.

### 2. Flip PR (later, after verification AND the blocker/needs-async remediations)

- `modules/api-gateway`: add a second `aws_apigatewayv2_domain_name` for `api.v2.percymain.org` (same cert, dualstack) + `aws_apigatewayv2_api_mapping`.
- `environments/production`: repoint `aws_route53_record.api_v2_a`/`api_v2_aaaa` aliases from `module.ecs.alb_dns_name`/`alb_zone_id` to the new domain's `target_domain_name`/`hosted_zone_id` (`evaluate_target_health = false`; API GW alias targets do not support health evaluation).
- Nothing else changes: Stripe webhook URL, better-auth baseURL, SPA/PWA API base URLs and the shared Route 53 health check all key off the unchanged hostname.
- ALB + listeners + target group + shared ALB cert + logs bucket stay untouched for the rollback window.
- Watch after the flip: gateway 5xx alarm, the shared Route 53 health check, Stripe webhook delivery dashboard, a live login.

### 3. Rollback (tested during the overlap window)

- Revert the flip commit (aliases back to the ALB) and apply; propagation ~1 minute. Verify health check, a login and a webhook delivery.
- Do one deliberate rollback + re-flip during the window so the path is proven, per the acceptance criteria in #722.

### 4. ALB removal PR (after the rollback window closes)

- `modules/ecs-service`: remove `aws_lb.main`, both listeners, the target group, the alb-logs bucket resources, the `load_balancer` block + `health_check_grace_period_seconds` on the service, `alb_security_group_id` var, and the alb outputs (`alb_dns_name`, `alb_arn`, `alb_arn_suffix`, `target_group_arn_suffix`, `alb_zone_id`).
- `modules/vpc`: remove the ALB SG + its rules and `ecs_ingress_from_alb`.
- `modules/monitoring`: remove the six ALB alarms + dashboard ALB widgets; drop the `alb_arn_suffix`/`target_group_arn_suffix` vars.
- `environments/shared`: remove the ALB ACM cert + validation records + `acm_alb_certificate_arn` output. The teardown deletes the api.v2 validation CNAME that the api-gateway cert also renews through; the deploy chain applies shared then production, and production's apply restores the record (its copy has `allow_overwrite`). Confirm the record exists afterwards.
- `environments/production`: drop the ALB wiring/outputs; optionally retire the test hostname or keep it as a canary.
- Keep: the Route 53 health check (hostname-based), Cloud Map, the ECS service.
- This is where the saving lands.

## Cost

~$27/mo saved once the ALB goes (~$19.83/mo ALB hourly + ~$7.45/mo for its two public IPv4s). The stand-up itself costs pennies: HTTP API ~$1.11/million requests with no traffic on it, one Cloud Map namespace/private hosted zone (~$0.50/mo), no hourly VPC Link charge for HTTP APIs, one alarm ($0.10/mo), 14-day CloudWatch logs at near-zero volume.

## Verification done here

- `terraform fmt -recursive` clean; `terraform init -backend=false -input=false` + `terraform validate` pass for `environments/production` (validates both touched modules; `shared` untouched) in an isolated copy, zero `.terraform`/lockfile churn.
- Read-only AWS checks with the `percy-main` profile: no existing Cloud Map namespaces to collide with; `production-api` runs the `ECS` rolling deployment controller with empty `serviceRegistries` (so registration is the in-place UpdateService path).
- `pnpm format` run before committing.

Refs #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)
