### PR TITLE
cost(infra): storage and retention housekeeping (#723)

### DIFF
--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -414,6 +414,15 @@ module "prerender" {
   alarms_sns_topic_arn = module.monitoring.sns_topic_arn
 }
 
+# Adopts the Lambda-auto-created prerenderer log group (infinite
+# retention) into state so the module's 14-day retention applies (#723).
+# One-shot: delete this block once the apply that performs the import
+# has landed.
+import {
+  to = module.prerender.aws_cloudwatch_log_group.prerenderer
+  id = "/aws/lambda/percy-main-production-prerenderer"
+}
+
 # Matchday PWA distribution - separate from the main marketing site so a
 # matchday deploy invalidates only matchday's cache. Reuses the wildcard
 # us-east-1 ACM cert (*.percymain.org SAN). DNS for matchday.percymain.org

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -66,11 +66,11 @@ resource "aws_ecr_lifecycle_policy" "api" {
     rules = [
       {
         rulePriority = 1
-        description  = "Keep last 25 images"
+        description  = "Keep last 10 images"
         selection = {
           tagStatus   = "any"
           countType   = "imageCountMoreThan"
-          countNumber = 25
+          countNumber = 10
         }
         action = {
           type = "expire"

--- a/infra/modules/prerender/main.tf
+++ b/infra/modules/prerender/main.tf
@@ -160,6 +160,15 @@ resource "aws_iam_role_policy" "prerenderer" {
 # Lambda function
 # ------------------------------------------------------------------------------
 
+# Explicit log group so retention is controlled - Lambda otherwise
+# auto-creates it with infinite retention (which is how the production
+# group came to exist; adopted via an import block in the root module).
+resource "aws_cloudwatch_log_group" "prerenderer" {
+  name              = "/aws/lambda/${local.function_name}"
+  retention_in_days = 14
+  tags              = local.tags
+}
+
 # Placeholder package so Terraform can create the function before the
 # first deploy-web run pushes the real bundle.
 data "archive_file" "placeholder" {
@@ -204,6 +213,10 @@ resource "aws_lambda_function" "prerenderer" {
     # deploy-web pushes the real bundle with update-function-code.
     ignore_changes = [filename, source_code_hash]
   }
+
+  # The log group must exist before the function's first invocation, or
+  # Lambda auto-creates it and the Terraform-managed one conflicts.
+  depends_on = [aws_cloudwatch_log_group.prerenderer]
 
   tags = local.tags
 }

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -182,7 +182,12 @@ resource "aws_db_instance" "main" {
 
   allocated_storage     = var.allocated_storage
   max_allocated_storage = var.max_allocated_storage > 0 ? var.max_allocated_storage : null
-  storage_encrypted     = true
+  # gp3 is cheaper per GB than the gp2 default and has a 3000 IOPS
+  # baseline regardless of size. gp2 -> gp3 is an online storage
+  # modification (no downtime), but RDS enforces a ~6h cooldown before
+  # the next storage modification.
+  storage_type      = "gp3"
+  storage_encrypted = true
 
   db_name  = "percy_main"
   username = "percy"
@@ -217,11 +222,10 @@ resource "aws_db_instance" "main" {
   # instance.
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 
-  # Enhanced monitoring - 60s OS-level metrics (load avg, IOPS by
-  # process, network). Performance Insights covers query-level; this
-  # covers the host. Valid intervals: 1/5/10/15/30/60.
-  monitoring_interval = 60
-  monitoring_role_arn = aws_iam_role.rds_enhanced_monitoring.arn
+  # Enhanced monitoring disabled (#723) - the 60s OS-level metrics cost
+  # ~$1/mo in CloudWatch logs and were never looked at. Performance
+  # Insights (free tier) still covers query-level visibility.
+  monitoring_interval = 0
 
   skip_final_snapshot       = var.environment != "production"
   final_snapshot_identifier = var.environment == "production" ? "${local.name_prefix}-db-final" : null
@@ -229,32 +233,6 @@ resource "aws_db_instance" "main" {
   tags = merge(local.common_tags, {
     Name = "${local.name_prefix}-db"
   })
-}
-
-# -----------------------------------------------------------------------------
-# Enhanced Monitoring IAM role
-# -----------------------------------------------------------------------------
-
-data "aws_iam_policy_document" "rds_em_assume" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["monitoring.rds.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "rds_enhanced_monitoring" {
-  name               = "${local.name_prefix}-rds-enhanced-monitoring"
-  assume_role_policy = data.aws_iam_policy_document.rds_em_assume.json
-  tags               = local.common_tags
-}
-
-resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
-  role       = aws_iam_role.rds_enhanced_monitoring.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
 
 # -----------------------------------------------------------------------------

--- a/infra/modules/spa-cdn/main.tf
+++ b/infra/modules/spa-cdn/main.tf
@@ -114,6 +114,23 @@ resource "aws_s3_bucket_versioning" "frontend" {
   }
 }
 
+# Every deploy's `sync --delete` turns the previous build into noncurrent
+# versions, which accumulate forever without an expiry. 30 days is ample
+# rollback window and mirrors the uploads bucket's rule (cdn module).
+resource "aws_s3_bucket_lifecycle_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "frontend" {
   bucket = aws_s3_bucket.frontend.id
 


### PR DESCRIPTION
Batches four small fixed-cost and silently-growing-storage fixes into one PR.

## Changes

- **RDS storage: gp3** (`infra/modules/rds/main.tf`) - `storage_type` was unset, defaulting to gp2; gp3 is cheaper per GB with a 3000 IOPS baseline. **This is an online storage modification - no downtime.** Note: RDS enforces a ~6h cooldown between storage modifications, so any follow-up storage change must wait. ~$0.5/mo.
- **RDS enhanced monitoring: off** (`infra/modules/rds/main.tf`) - `monitoring_interval` 60 -> 0, `monitoring_role_arn` dropped, and the enhanced-monitoring IAM role + policy attachment + assume-role policy document deleted (nothing else referenced the role). Performance Insights (free tier) still covers query-level visibility. ~$1/mo of CloudWatch log ingestion.
- **Prerender Lambda log group: 14d retention** (`infra/modules/prerender/main.tf` + import block in `infra/environments/production/main.tf`) - `/aws/lambda/percy-main-production-prerenderer` was auto-created by Lambda with INFINITE retention (verified: no `retentionInDays`, ~3.7MB stored). Now declared in the module (named from the same `local.function_name` the Lambda uses) with `retention_in_days = 14`, and the Lambda gets an explicit `depends_on` so a fresh environment cannot race the auto-creation. **The import block adopts the existing group into state on the CI apply - no manual state surgery. Follow-up: delete the import block after that apply lands.**
- **Matchday frontend bucket: noncurrent-version expiry** (`infra/modules/spa-cdn/main.tf`) - the bucket is versioned and every deploy's `sync --delete` turns the previous build into noncurrent versions with no expiry; added a 30-day `noncurrent_version_expiration` mirroring the uploads bucket's rule. `spa-cdn` is instantiated exactly once (matchday), so no other distribution is affected. The main web frontend bucket (`modules/cdn`) is unversioned and needs nothing.
- **ECR: keep last 10 images** (`infra/environments/shared/main.tf`) - was 25. ~$0.60/mo.

## Deliberately not done

Pausing the Play Cricket sync (`state = "DISABLED"` in `modules/scheduling`) is skipped: the cricket season runs into September and disabling it now would break live results. Revisit at end of season - it saves pennies and silences 2 alarms when done.

## Verification

- `terraform fmt -recursive` - no changes needed
- `terraform init -backend=false` + `terraform validate` pass in both `environments/production` and `environments/shared`
- `pnpm format` - clean

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Improvements**
  * Prerenderer logs now have a 14-day retention period.
  * SPA frontend buckets automatically remove older object versions after 30 days.
  * API container image storage now retains the 10 most recent images.
  * Database storage uses the newer gp3 type, with enhanced monitoring disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->